### PR TITLE
All four Backend artifacts + per-Backend smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,28 @@ jobs:
           apps: sbt
       - name: Cache scala dependencies
         uses: coursier/cache-action@v8
+      - name: Restore server images
+        id: images
+        uses: actions/cache@v4
+        with:
+          path: ~/.docker-images
+          key: docker-images-v1-redis8-valkey8
+      - name: Pull and save server images
+        if: steps.images.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.docker-images
+          for img in redis:8 valkey/valkey:8; do
+            docker pull "$img"
+            docker save "$img" -o ~/.docker-images/"${img//[\/:]/_}".tar
+          done
+      - name: Load server images
+        if: steps.images.outputs.cache-hit == 'true'
+        run: for f in ~/.docker-images/*.tar; do docker load -i "$f"; done
       - name: Run tests
         run: sbt test
+        env:
+          # ryuk adds a mandatory Docker Hub pull per run (rate-limit exposure) and ephemeral runners need no reaper
+          TESTCONTAINERS_RYUK_DISABLED: "true"
   # re-enable when publishing is set up (requires PGP/Sonatype secrets)
   # publish:
   #   runs-on: ubuntu-24.04

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,7 +24,7 @@ A single RESP3 protocol value as read from the wire — the unit the Core's pars
 _Avoid_: message, packet, token
 
 **Client**:
-The user-facing handle (`SageClient`) owning all connections to one server or cluster. Constructed with `connect`, released with `close`; per-command methods are concrete sugar that must delegate to `run`, so a fake implementing `run` gets the whole command surface.
+The user-facing handle (`SageClient`) owning all connections to one server or cluster. Constructed with `connect`, released with `close`; each Backend also offers a scope-tied construction form (`scoped`, plus `layer` for ZIO and `resource` for cats-effect) whose release swallows a failing `close`. Per-command methods are concrete sugar that must delegate to `run`, so a fake implementing `run` gets the whole command surface.
 _Avoid_: connection (a Client holds several)
 
 **Multiplexed Connection**:

--- a/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
+++ b/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
@@ -1,0 +1,30 @@
+package sage.integration
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+
+import sage.ce.SageClient
+
+class CeSmokeSuite extends ServerSuite("redis:8") {
+
+  test("an end user connects and round-trips with native cats-effect") {
+    withContainers { server =>
+      val config = configOf(server)
+
+      val program: IO[Unit] =
+        SageClient.resource(config).use { client =>
+          for {
+            pong   <- client.ping()
+            _      <- (1 to 50).toList.parTraverse_(i => client.set(s"key-$i", s"value-$i"))
+            values <- (1 to 50).toList.parTraverse(i => client.get[String, String](s"key-$i"))
+          } yield {
+            assertEquals(pong, "PONG")
+            assertEquals(values, (1 to 50).toList.map(i => Some(s"value-$i")))
+          }
+        }
+
+      program.unsafeRunSync()
+    }
+  }
+}

--- a/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
+++ b/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
@@ -1,0 +1,28 @@
+package sage.integration
+
+import kyo.*
+
+import sage.kyo.SageClient
+
+class KyoSmokeSuite extends ServerSuite("redis:8") {
+
+  test("an end user connects and round-trips with native Kyo") {
+    withContainers { server =>
+      val config = configOf(server)
+
+      val program: Unit < (Scope & Abort[Throwable] & Async) =
+        for {
+          client <- SageClient.scoped(config)
+          pong   <- client.ping()
+          _      <- Async.foreachDiscard(1 to 50)(i => client.set(s"key-$i", s"value-$i"))
+          values <- Async.foreach((1 to 50).toList)(i => client.get[String, String](s"key-$i"))
+        } yield {
+          assertEquals(pong, "PONG")
+          assertEquals(values.toList, (1 to 50).toList.map(i => Some(s"value-$i")))
+        }
+
+      import AllowUnsafe.embrace.danger
+      KyoApp.Unsafe.runAndBlock(Duration.Infinity)(program).getOrThrow
+    }
+  }
+}

--- a/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
+++ b/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
@@ -1,33 +1,26 @@
 package sage.integration
 
-import com.dimafeng.testcontainers.GenericContainer
-import com.dimafeng.testcontainers.munit.TestContainerForAll
 import ox.{fork, supervised}
 
-import sage.client.SageConfig
 import sage.ox.SageClient
 
-class OxSmokeSuite extends munit.FunSuite with TestContainerForAll {
-
-  override val containerDef: GenericContainer.Def[GenericContainer] = GenericContainer.Def("redis:8", exposedPorts = Seq(6379))
+class OxSmokeSuite extends ServerSuite("redis:8") {
 
   test("an end user connects and round-trips with direct-style Ox") {
     withContainers { server =>
-      val config = SageConfig(host = server.host, port = server.mappedPort(6379))
+      val config = configOf(server)
       supervised {
-        val client = SageClient.connect(config)
-        try {
-          assertEquals(client.ping(), "PONG")
-          val values = (1 to 50).toList
-            .map(i =>
-              fork {
-                client.set(s"key-$i", s"value-$i")
-                client.get[String, String](s"key-$i")
-              }
-            )
-            .map(_.join())
-          assertEquals(values, (1 to 50).toList.map(i => Some(s"value-$i")))
-        } finally client.close
+        val client = SageClient.scoped(config)
+        assertEquals(client.ping(), "PONG")
+        val values = (1 to 50).toList
+          .map(i =>
+            fork {
+              client.set(s"key-$i", s"value-$i")
+              client.get[String, String](s"key-$i")
+            }
+          )
+          .map(_.join())
+        assertEquals(values, (1 to 50).toList.map(i => Some(s"value-$i")))
       }
     }
   }

--- a/integration-tests/shared/src/test/scala/sage/integration/RoundTripSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/RoundTripSuite.scala
@@ -3,8 +3,6 @@ package sage.integration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.*
 
-import com.dimafeng.testcontainers.GenericContainer
-import com.dimafeng.testcontainers.munit.TestContainerForAll
 import kyo.compat.*
 
 import sage.Bytes
@@ -14,15 +12,10 @@ import sage.client.internal.Client
 import sage.commands.Command
 import sage.protocol.Frame
 
-abstract class RoundTripSuite(image: String) extends munit.FunSuite with TestContainerForAll {
+abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
 
   // not private: only the Ox cell's unsafeRun consumes it, and a private given would be flagged unused on the other cells
   given ExecutionContext = munitExecutionContext
-
-  override val containerDef: GenericContainer.Def[GenericContainer] = GenericContainer.Def(image, exposedPorts = Seq(6379))
-
-  private def configOf(server: GenericContainer): SageConfig =
-    SageConfig(host = server.host, port = server.mappedPort(6379))
 
   private def withClient[A](body: Client[CIO] => CIO[A]): Future[A] =
     withContainers(server => connectAndUse(configOf(server))(body).unsafeRun)

--- a/integration-tests/shared/src/test/scala/sage/integration/ServerSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/ServerSuite.scala
@@ -1,0 +1,14 @@
+package sage.integration
+
+import com.dimafeng.testcontainers.GenericContainer
+import com.dimafeng.testcontainers.munit.TestContainerForAll
+
+import sage.client.SageConfig
+
+abstract class ServerSuite(image: String) extends munit.FunSuite with TestContainerForAll {
+
+  override val containerDef: GenericContainer.Def[GenericContainer] = GenericContainer.Def(image, exposedPorts = Seq(6379))
+
+  protected def configOf(server: GenericContainer): SageConfig =
+    SageConfig(host = server.host, port = server.mappedPort(6379))
+}

--- a/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
+++ b/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
@@ -1,23 +1,19 @@
 package sage.integration
 
-import com.dimafeng.testcontainers.GenericContainer
-import com.dimafeng.testcontainers.munit.TestContainerForAll
 import zio.*
 
-import sage.client.SageConfig
 import sage.zio.SageClient
 
-class ZioSmokeSuite extends munit.FunSuite with TestContainerForAll {
-
-  override val containerDef: GenericContainer.Def[GenericContainer] = GenericContainer.Def("redis:8", exposedPorts = Seq(6379))
+class ZioSmokeSuite extends ServerSuite("redis:8") {
 
   test("an end user connects and round-trips with native ZIO") {
     withContainers { server =>
-      val config = SageConfig(host = server.host, port = server.mappedPort(6379))
+      val config = configOf(server)
 
       val program: Task[Unit] =
-        ZIO.acquireReleaseWith(SageClient.connect(config))(client => client.close.orDie) { client =>
+        ZIO.scoped {
           for {
+            client <- SageClient.scoped(config)
             pong   <- client.ping()
             _      <- ZIO.foreachParDiscard(1 to 50)(i => client.set(s"key-$i", s"value-$i"))
             values <- ZIO.foreachPar((1 to 50).toList)(i => client.get[String, String](s"key-$i"))

--- a/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
+++ b/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
@@ -1,0 +1,29 @@
+package sage.ce
+
+import cats.effect.{IO, Resource}
+import kyo.compat.*
+
+import sage.client.SageConfig
+import sage.client.internal.Client
+import sage.commands.Command
+
+/**
+  * The cats-effect-native surface: the same client, with every method returning `IO`.
+  */
+type SageClient = Client[IO]
+
+object SageClient {
+
+  def connect(config: SageConfig): IO[SageClient] =
+    Client.connect(config).lower.map(new Lowered(_))
+
+  def resource(config: SageConfig): Resource[IO, SageClient] =
+    Resource.make(connect(config))(_.close.voidError)
+
+  final private class Lowered(underlying: Client[CIO]) extends Client[IO] {
+
+    def run[A](command: Command[A]): IO[A] = underlying.run(command).lower
+
+    def close: IO[Unit] = underlying.close.lower
+  }
+}

--- a/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
+++ b/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
@@ -1,0 +1,29 @@
+package sage.kyo
+
+import _root_.kyo.{<, Abort, Async, Scope}
+import _root_.kyo.compat.*
+
+import sage.client.SageConfig
+import sage.client.internal.Client
+import sage.commands.Command
+
+/**
+  * The Kyo-native surface: the same client, with every method returning a Kyo pending computation.
+  */
+type SageClient = Client[[A] =>> A < (Abort[Throwable] & Async)]
+
+object SageClient {
+
+  def connect(config: SageConfig): SageClient < (Abort[Throwable] & Async) =
+    Client.connect(config).lower.map(new Lowered(_))
+
+  def scoped(config: SageConfig): SageClient < (Scope & Abort[Throwable] & Async) =
+    Scope.acquireRelease(connect(config))(client => Abort.run(client.close))
+
+  final private class Lowered(underlying: Client[CIO]) extends Client[[A] =>> A < (Abort[Throwable] & Async)] {
+
+    def run[A](command: Command[A]): A < (Abort[Throwable] & Async) = underlying.run(command).lower
+
+    def close: Unit < (Abort[Throwable] & Async) = underlying.close.lower
+  }
+}

--- a/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
@@ -1,6 +1,8 @@
 package sage.ox
 
-import _root_.ox.Ox
+import scala.util.control.NonFatal
+
+import _root_.ox.{useInScope, Ox}
 import kyo.compat.*
 
 import sage.client.SageConfig
@@ -15,6 +17,12 @@ type SageClient = Client[[A] =>> Ox ?=> A]
 object SageClient {
 
   def connect(config: SageConfig): Ox ?=> SageClient = new Lowered(Client.connect(config).lower)
+
+  def scoped(config: SageConfig): Ox ?=> SageClient =
+    useInScope(connect(config)) { client =>
+      try client.close
+      catch { case NonFatal(_) => () }
+    }
 
   final private class Lowered(underlying: Client[CIO]) extends Client[[A] =>> Ox ?=> A] {
 

--- a/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
+++ b/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
@@ -17,6 +17,12 @@ object SageClient {
   def connect(config: SageConfig): Task[SageClient] =
     Client.connect(config).lower.map(new Lowered(_))
 
+  def scoped(config: SageConfig): ZIO[Scope, Throwable, SageClient] =
+    ZIO.acquireRelease(connect(config))(_.close.ignore)
+
+  def layer(config: SageConfig): ZLayer[Any, Throwable, SageClient] =
+    ZLayer.scoped(scoped(config))
+
   final private class Lowered(underlying: Client[CIO]) extends Client[Task] {
 
     def run[A](command: Command[A]): Task[A] = underlying.run(command).lower


### PR DESCRIPTION
Closes #5

## What

- **cats-effect adapter** (`sage.ce.SageClient = Client[IO]`) and **Kyo adapter** (`sage.kyo.SageClient = Client[[A] =>> A < (Abort[Throwable] & Async)]`), mechanical copies of the ZIO lowering.
- **Per-Backend resource sugar** over the shared `connect`/`close` primitives:
  - ZIO: `scoped(config): ZIO[Scope, Throwable, SageClient]` + `layer(config)` derived from it
  - cats-effect: `resource(config): Resource[IO, SageClient]`
  - Kyo: `scoped(config)` via `Scope.acquireRelease`
  - Ox: `scoped(config)` via `useInScope`, released when the enclosing scope ends
  - All four releases swallow a failing `close` (the client is already done; a close error would mask the use-site's real error). Documented in CONTEXT.md's Client entry.
- **Native-idiom smoke suites** for cats-effect (`Resource.use` + `parTraverse`) and Kyo (monadic for-comprehension over `<`, run via `KyoApp.Unsafe.runAndBlock`); ZIO and Ox suites retrofitted to consume the new sugar. No CIO anywhere in test code.
- Shared container scaffolding extracted to `ServerSuite` (containerDef + config), used by the round-trip and smoke suites.

## Acceptance criteria

- [x] ZIO, cats-effect, Kyo and Ox artifacts all compile and publish locally (verified via `sbt publishLocal`: `sage-client-{zio,ce,kyo,ox}_3` in `~/.ivy2/local`; kyo from Scala 3.8.3, the rest LTS)
- [x] Each Backend's smoke test connects and runs ping/get/set in CI, written in that ecosystem's native idiom
- [x] API returns each ecosystem's native types with no wrapper visible
- [x] Each Backend offers idiomatic resource sugar over connect/close

Note: the Kyo smoke suite uses monadic style rather than the direct syntax the issue mentions — keeps kyo-direct off the test classpath.