### PR TITLE
Golden write-direction assertions for the RESP3 test oracle

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,7 +55,7 @@ A Pipeline executed atomically via `MULTI`/`EXEC` on a Dedicated Connection, opt
 _Avoid_: batch (that's a Pipeline)
 
 **Codec**:
-A typeclass converting one user type to/from its wire bytes at a command boundary. A boundary converter, not a serialization framework; keys and values have separate codec typeclasses (keys must also be hashable to cluster slots).
+A typeclass converting one user type to/from its wire bytes at a command boundary. A boundary converter, not a serialization framework; keys and values have separate codec typeclasses (keys must also be hashable to cluster slots). The RESP3 parser/writer is not a Codec — that layer converts wire bytes to/from Frames, not user types.
 _Avoid_: serializer, schema
 
 ## Example dialogue

--- a/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
+++ b/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
@@ -23,8 +23,8 @@ class RespParserSpec extends munit.FunSuite {
     parser.feed(Bytes.utf8(input)).fold(identity, frames => fail(s"expected a protocol error, got $frames"))
   }
 
-  // golden frames, one per RESP3 type, reused by the chunk-split tests
-  private val goldens: Vector[(String, Frame)] = Vector(
+  // golden frames, one per RESP3 type, reused by the chunk-split tests; the writer emits exactly these bytes
+  private val canonicalGoldens: Vector[(String, Frame)] = Vector(
     "+OK\r\n"                                          -> Frame.SimpleString("OK"),
     "-ERR something went wrong\r\n"                    -> Frame.SimpleError("ERR something went wrong"),
     ":1234\r\n"                                        -> Frame.Integer(1234L),
@@ -36,9 +36,9 @@ class RespParserSpec extends munit.FunSuite {
     "#t\r\n"                                           -> Frame.Bool(true),
     "#f\r\n"                                           -> Frame.Bool(false),
     ",3.14\r\n"                                        -> Frame.Double(3.14),
-    ",10\r\n"                                          -> Frame.Double(10.0),
     ",inf\r\n"                                         -> Frame.Double(Double.PositiveInfinity),
     ",-inf\r\n"                                        -> Frame.Double(Double.NegativeInfinity),
+    ",nan\r\n"                                         -> Frame.Double(Double.NaN),
     "(3492890328409238509324850943850943825024385\r\n" -> Frame.BigNumber(BigInt("3492890328409238509324850943850943825024385")),
     "!21\r\nSYNTAX invalid syntax\r\n"                 -> Frame.BulkError(Bytes.utf8("SYNTAX invalid syntax")),
     "=15\r\ntxt:Some string\r\n"                       -> Frame.VerbatimString("txt", Bytes.utf8("Some string")),
@@ -53,14 +53,23 @@ class RespParserSpec extends munit.FunSuite {
     ">2\r\n+message\r\n$5\r\nhello\r\n"                -> Frame.Push(Vector(Frame.SimpleString("message"), Frame.BulkString(Bytes.utf8("hello"))))
   )
 
+  // wire forms the parser accepts but the writer never emits
+  private val parseOnlyGoldens: Vector[(String, Frame)] = Vector(
+    ",10\r\n" -> Frame.Double(10.0)
+  )
+
+  private val goldens = canonicalGoldens ++ parseOnlyGoldens
+
   goldens.foreach { case (wire, expected) =>
     test(s"parses ${expected.getClass.getSimpleName}: ${wire.replace("\r\n", "\\r\\n")}") {
       assertEquals(parseOne(wire), expected)
     }
   }
 
-  test("parses nan as a NaN double") {
-    assertEquals(parseOne(",nan\r\n"), Frame.Double(Double.NaN))
+  canonicalGoldens.foreach { case (wire, frame) =>
+    test(s"writes ${frame.getClass.getSimpleName} as: ${wire.replace("\r\n", "\\r\\n")}") {
+      assertEquals(FrameWriter.write(frame).asUtf8String, wire)
+    }
   }
 
   test("Frame.Double equality treats NaNs as equal and keeps 0.0 == -0.0, with matching hashes") {


### PR DESCRIPTION
## What

Closes #6.

The "skeleton" PR (#29) over-delivered: the full RESP3 type system — doubles, booleans, big numbers, verbatim strings, maps, sets, nulls, attributes, push frames — already parses on `main`, with golden parse tests, exhaustive chunk-boundary split tests, and seeded round-trip properties. Push frames are a distinct `Frame` case and the Multiplexer already routes them out-of-band.

The one remaining gap: writer output was only ever round-tripped, never compared against golden wire bytes. If `FrameWriter` drifted into emitting forms no real server sends (e.g. `2.5E0`), the round-trip property would still pass but quietly stop exercising the parser on representative input.

This PR adds a write-direction golden assertion over the existing golden table (excluding the intentionally non-canonical `,10` integer-form double), plus a NaN write assertion.

Also updates `CONTEXT.md`: the RESP3 parser/writer is not a **Codec** — that term is reserved for the user-type boundary typeclasses (#7).