### PR TITLE
Multiplexer hardening: auto-pipelining under concurrency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # Working on sage
 
+## Formatting
+
+Run `sbt scalafmtAll` before committing Scala changes.
+
 ## Comments
 
 Default to zero comments; when unsure, omit. Comment only what is non-obvious and cannot be expressed in code: contracts (copy vs zero-copy, mutation rules, poisoning), surprising design decisions, and protocol subtleties. One or two lines, not paragraphs.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,6 +31,10 @@ _Avoid_: connection (a Client holds several)
 The single auto-pipelined connection per node that carries ordinary commands from all fibers, replies matched in FIFO order.
 _Avoid_: shared connection, main connection
 
+**Auto-pipelining**:
+The Multiplexed Connection's transparent behavior: commands from concurrent fibers are written without waiting for prior replies, coalesced into fewer socket writes. Invisible to users — a Pipeline, by contrast, is a value the user builds.
+_Avoid_: batching, implicit pipelining
+
 **Dedicated Connection**:
 A connection exclusively held for commands with per-connection state or blocking behavior (`WATCH`/`MULTI`/`EXEC`, `BLPOP`, …), acquired transparently from an on-demand pool.
 _Avoid_: exclusive connection, pooled connection

--- a/integration-tests/shared/src/test/scala/sage/integration/RoundTripSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/RoundTripSuite.scala
@@ -73,6 +73,19 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
     }
   }
 
+  test("no reply misattribution under high fiber concurrency") {
+    def pingLoop(client: Client[CIO], fiber: Int, i: Int): CIO[Unit] =
+      if (i > 100) CIO.value(())
+      else {
+        val token = s"$fiber-$i"
+        client.ping(Some(token)).flatMap { reply =>
+          assertEquals(reply, token)
+          pingLoop(client, fiber, i + 1)
+        }
+      }
+    withClient(client => CIO.foreachDiscard(1 to 500)(fiber => pingLoop(client, fiber, 1)))
+  }
+
   test("closing the client releases its server connection") {
     withContainers { server =>
       connectAndUse(configOf(server)) { observer =>

--- a/sage-client/shared/src/main/scala/sage/client/internal/Multiplexer.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Multiplexer.scala
@@ -13,8 +13,8 @@ import sage.protocol.Frame
 
 /**
   * FIFO reply matching over a [[Transport]]. Wire order equals `pending` order because only the writer thread appends to `pending` (via
-  * `writeAttempted`, just before each write) — `submit` never touches it, so racing fibers cannot misalign the two. No reconnect: once the
-  * connection is gone this Multiplexer is permanently dead.
+  * `writeAttempted`, in batch order just before each batch's write) — `submit` never touches it, so racing fibers cannot misalign the two.
+  * No reconnect: once the connection is gone this Multiplexer is permanently dead.
   */
 final private[client] class Multiplexer(factory: Multiplexer.TransportFactory) {
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
@@ -20,6 +20,8 @@ final private[client] class SocketTransport private (socket: Socket, onFrame: Fr
   private val queue  = new LinkedBlockingQueue[Transport.Item]()
   private val closed = new AtomicBoolean(false)
 
+  @volatile private[internal] var writeCount: Long = 0
+
   private val id                       = SocketTransport.ids.incrementAndGet()
   private[internal] val reader: Thread = Thread.ofVirtual().name(s"sage-reader-$id").unstarted(() => readLoop())
   private[internal] val writer: Thread = Thread.ofVirtual().name(s"sage-writer-$id").unstarted(() => writeLoop())
@@ -62,13 +64,29 @@ final private[client] class SocketTransport private (socket: Socket, onFrame: Fr
     } finally terminate()
   }
 
+  // Auto-pipelining: everything queued while the previous write was in flight goes out as one socket write.
   private def writeLoop(): Unit =
     try {
-      val out = socket.getOutputStream
+      val out   = socket.getOutputStream
+      val batch = new java.util.ArrayList[Transport.Item]()
       while (true) {
-        val item = queue.take()
-        item.writeAttempted()
-        out.write(item.payload.unsafeArray)
+        batch.add(queue.take())
+        queue.drainTo(batch)
+        var size = 0
+        batch.forEach { item =>
+          item.writeAttempted()
+          size += item.payload.length
+        }
+        val payload = new Array[Byte](size)
+        var offset  = 0
+        batch.forEach { item =>
+          val bytes = item.payload.unsafeArray
+          System.arraycopy(bytes, 0, payload, offset, bytes.length)
+          offset += bytes.length
+        }
+        out.write(payload)
+        writeCount += 1
+        batch.clear()
       }
     } catch {
       case _: InterruptedException => ()

--- a/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
@@ -73,7 +73,7 @@ final private[client] class SocketTransport private (socket: Socket, onFrame: Fr
     try {
       val out = socket.getOutputStream
       while (true) {
-        val first = if (carry != null) carry else queue.take()
+        val first      = if (carry != null) carry else queue.take()
         carry = null
         batch.add(first)
         var size: Long = first.payload.length

--- a/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
@@ -73,6 +73,8 @@ final private[client] class SocketTransport private (socket: Socket, onFrame: Fr
     try {
       val out = socket.getOutputStream
       while (true) {
+        // consuming a carried item bypasses take(), the writer's only interruption point: re-check for close first
+        if (carry != null && closed.get()) throw new InterruptedException
         val first      = if (carry != null) carry else queue.take()
         carry = null
         batch.add(first)

--- a/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
@@ -72,20 +72,27 @@ final private[client] class SocketTransport private (socket: Socket, onFrame: Fr
       while (true) {
         batch.add(queue.take())
         queue.drainTo(batch)
-        var size = 0
+        var size = 0L
         batch.forEach { item =>
           item.writeAttempted()
           size += item.payload.length
         }
-        val payload = new Array[Byte](size)
-        var offset  = 0
-        batch.forEach { item =>
-          val bytes = item.payload.unsafeArray
-          System.arraycopy(bytes, 0, payload, offset, bytes.length)
-          offset += bytes.length
-        }
-        out.write(payload)
-        writeCount += 1
+        // a batch too large for one array degrades to per-item writes rather than poisoning the connection
+        if (size <= SocketTransport.MaxSingleWrite) {
+          val payload = new Array[Byte](size.toInt)
+          var offset  = 0
+          batch.forEach { item =>
+            val bytes = item.payload.unsafeArray
+            System.arraycopy(bytes, 0, payload, offset, bytes.length)
+            offset += bytes.length
+          }
+          out.write(payload)
+          writeCount += 1
+        } else
+          batch.forEach { item =>
+            out.write(item.payload.unsafeArray)
+            writeCount += 1
+          }
         batch.clear()
       }
     } catch {
@@ -117,6 +124,8 @@ final private[client] class SocketTransport private (socket: Socket, onFrame: Fr
 private[client] object SocketTransport {
 
   private val ids = new AtomicLong(0)
+
+  private val MaxSingleWrite: Long = Int.MaxValue - 8
 
   /**
     * Blocking connect; the returned transport is not started.

--- a/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
@@ -64,21 +64,29 @@ final private[client] class SocketTransport private (socket: Socket, onFrame: Fr
     } finally terminate()
   }
 
-  // Auto-pipelining: everything queued while the previous write was in flight goes out as one socket write.
-  private def writeLoop(): Unit =
+  // Auto-pipelining: items queued while the previous write was in flight are coalesced, up to MaxBatchBytes per socket write.
+  // `attempted` tracks how many batch items have had writeAttempted: anything past it never reached a write and is dropped on unwind.
+  private def writeLoop(): Unit = {
+    val batch     = new java.util.ArrayList[Transport.Item]()
+    var attempted = 0
     try {
-      val out   = socket.getOutputStream
-      val batch = new java.util.ArrayList[Transport.Item]()
+      val out = socket.getOutputStream
       while (true) {
-        batch.add(queue.take())
-        queue.drainTo(batch)
-        var size = 0L
-        batch.forEach { item =>
-          item.writeAttempted()
-          size += item.payload.length
+        val first = queue.take()
+        batch.add(first)
+        var size: Long = first.payload.length
+        var next       = if (size < SocketTransport.MaxBatchBytes) queue.poll() else null
+        while (next != null) {
+          batch.add(next)
+          size += next.payload.length
+          next = if (size < SocketTransport.MaxBatchBytes) queue.poll() else null
         }
-        // a batch too large for one array degrades to per-item writes rather than poisoning the connection
-        if (size <= SocketTransport.MaxSingleWrite) {
+        if (batch.size == 1) {
+          first.writeAttempted()
+          attempted = 1
+          out.write(first.payload.unsafeArray)
+          writeCount += 1
+        } else if (size <= SocketTransport.MaxSingleWrite) {
           val payload = new Array[Byte](size.toInt)
           var offset  = 0
           batch.forEach { item =>
@@ -86,19 +94,38 @@ final private[client] class SocketTransport private (socket: Socket, onFrame: Fr
             System.arraycopy(bytes, 0, payload, offset, bytes.length)
             offset += bytes.length
           }
+          batch.forEach { item =>
+            item.writeAttempted()
+            attempted += 1
+          }
           out.write(payload)
           writeCount += 1
-        } else
-          batch.forEach { item =>
+        } else {
+          var i = 0
+          while (i < batch.size) {
+            val item = batch.get(i)
+            item.writeAttempted()
+            attempted = i + 1
             out.write(item.payload.unsafeArray)
             writeCount += 1
+            i += 1
           }
+        }
+        attempted = 0
         batch.clear()
       }
     } catch {
       case _: InterruptedException => ()
       case NonFatal(_)             => ()
-    } finally terminate()
+    } finally {
+      var i = attempted
+      while (i < batch.size) {
+        batch.get(i).dropped()
+        i += 1
+      }
+      terminate()
+    }
+  }
 
   private def terminate(): Unit =
     if (closed.compareAndSet(false, true)) {
@@ -125,6 +152,8 @@ private[client] object SocketTransport {
 
   private val ids = new AtomicLong(0)
 
+  // bounds the coalescing drain (and so the concat buffer); one over-sized item may still exceed it, hence the per-item fallback
+  private val MaxBatchBytes: Long  = 512 * 1024
   private val MaxSingleWrite: Long = Int.MaxValue - 8
 
   /**

--- a/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
@@ -64,29 +64,36 @@ final private[client] class SocketTransport private (socket: Socket, onFrame: Fr
     } finally terminate()
   }
 
-  // Auto-pipelining: items queued while the previous write was in flight are coalesced, up to MaxBatchBytes per socket write.
-  // `attempted` tracks how many batch items have had writeAttempted: anything past it never reached a write and is dropped on unwind.
+  // Auto-pipelining: queued items are coalesced up to MaxBatchBytes per concat buffer; an item that would overflow the cap is
+  // carried into the next batch. Items past `attempted` (and a carried item) never reached a write and are dropped on unwind.
   private def writeLoop(): Unit = {
-    val batch     = new java.util.ArrayList[Transport.Item]()
-    var attempted = 0
+    val batch                 = new java.util.ArrayList[Transport.Item]()
+    var carry: Transport.Item = null
+    var attempted             = 0
     try {
       val out = socket.getOutputStream
       while (true) {
-        val first = queue.take()
+        val first = if (carry != null) carry else queue.take()
+        carry = null
         batch.add(first)
         var size: Long = first.payload.length
-        var next       = if (size < SocketTransport.MaxBatchBytes) queue.poll() else null
-        while (next != null) {
-          batch.add(next)
-          size += next.payload.length
-          next = if (size < SocketTransport.MaxBatchBytes) queue.poll() else null
+        var draining   = size < SocketTransport.MaxBatchBytes
+        while (draining) {
+          val item = queue.poll()
+          if (item == null) draining = false
+          else if (size + item.payload.length > SocketTransport.MaxBatchBytes) {
+            carry = item
+            draining = false
+          } else {
+            batch.add(item)
+            size += item.payload.length
+          }
         }
         if (batch.size == 1) {
           first.writeAttempted()
           attempted = 1
           out.write(first.payload.unsafeArray)
-          writeCount += 1
-        } else if (size <= SocketTransport.MaxSingleWrite) {
+        } else {
           val payload = new Array[Byte](size.toInt)
           var offset  = 0
           batch.forEach { item =>
@@ -99,18 +106,8 @@ final private[client] class SocketTransport private (socket: Socket, onFrame: Fr
             attempted += 1
           }
           out.write(payload)
-          writeCount += 1
-        } else {
-          var i = 0
-          while (i < batch.size) {
-            val item = batch.get(i)
-            item.writeAttempted()
-            attempted = i + 1
-            out.write(item.payload.unsafeArray)
-            writeCount += 1
-            i += 1
-          }
         }
+        writeCount += 1
         attempted = 0
         batch.clear()
       }
@@ -123,6 +120,7 @@ final private[client] class SocketTransport private (socket: Socket, onFrame: Fr
         batch.get(i).dropped()
         i += 1
       }
+      if (carry != null) carry.dropped()
       terminate()
     }
   }
@@ -152,9 +150,8 @@ private[client] object SocketTransport {
 
   private val ids = new AtomicLong(0)
 
-  // bounds the coalescing drain (and so the concat buffer); one over-sized item may still exceed it, hence the per-item fallback
-  private val MaxBatchBytes: Long  = 512 * 1024
-  private val MaxSingleWrite: Long = Int.MaxValue - 8
+  // strict bound on multi-item concat buffers; a single over-sized payload is always a batch of one, written zero-copy
+  private val MaxBatchBytes: Long = 512 * 1024
 
   /**
     * Blocking connect; the returned transport is not started.

--- a/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
@@ -70,6 +70,7 @@ final private[client] class SocketTransport private (socket: Socket, onFrame: Fr
     val batch                 = new java.util.ArrayList[Transport.Item]()
     var carry: Transport.Item = null
     var attempted             = 0
+    var scratch: Array[Byte]  = null
     try {
       val out = socket.getOutputStream
       while (true) {
@@ -96,22 +97,23 @@ final private[client] class SocketTransport private (socket: Socket, onFrame: Fr
           attempted = 1
           out.write(first.payload.unsafeArray)
         } else {
-          val payload = new Array[Byte](size.toInt)
-          var offset  = 0
+          if (scratch == null) scratch = new Array[Byte](SocketTransport.MaxBatchBytes.toInt)
+          var offset = 0
           batch.forEach { item =>
             val bytes = item.payload.unsafeArray
-            System.arraycopy(bytes, 0, payload, offset, bytes.length)
+            System.arraycopy(bytes, 0, scratch, offset, bytes.length)
             offset += bytes.length
           }
           batch.forEach { item =>
             item.writeAttempted()
             attempted += 1
           }
-          out.write(payload)
+          out.write(scratch, 0, offset)
         }
         writeCount += 1
-        attempted = 0
+        // clear before resetting: the finally's drop range must stay empty if anything is ever inserted here
         batch.clear()
+        attempted = 0
       }
     } catch {
       case _: InterruptedException => ()

--- a/sage-client/shared/src/test/scala/sage/client/internal/MultiplexerSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/MultiplexerSpec.scala
@@ -30,6 +30,69 @@ class MultiplexerSpec extends munit.FunSuite {
     assertEquals(second, Some(Success(Some("value"))))
   }
 
+  test("replies interleaved with new submissions stay matched") {
+    val (multiplexer, transport)    = make()
+    var first: Option[Try[String]]  = None
+    var second: Option[Try[String]] = None
+    var third: Option[Try[String]]  = None
+    multiplexer.submit(Connection.ping(Some("a")), r => first = Some(r))
+    multiplexer.submit(Connection.ping(Some("b")), r => second = Some(r))
+    transport.emit(Frame.SimpleString("a"))
+    multiplexer.submit(Connection.ping(Some("c")), r => third = Some(r))
+    transport.emit(Frame.SimpleString("b"))
+    transport.emit(Frame.SimpleString("c"))
+    assertEquals(first, Some(Success("a")))
+    assertEquals(second, Some(Success("b")))
+    assertEquals(third, Some(Success("c")))
+  }
+
+  test("a reply arriving while a later command is unwritten matches the written one") {
+    val (multiplexer, transport)    = make(autoWrite = false)
+    var first: Option[Try[String]]  = None
+    var second: Option[Try[String]] = None
+    multiplexer.submit(Connection.ping(Some("a")), r => first = Some(r))
+    multiplexer.submit(Connection.ping(Some("b")), r => second = Some(r))
+    transport.writeNext()
+    transport.emit(Frame.SimpleString("a"))
+    assertEquals(first, Some(Success("a")))
+    assertEquals(second, None)
+    transport.writeNext()
+    transport.emit(Frame.SimpleString("b"))
+    assertEquals(second, Some(Success("b")))
+  }
+
+  test("push frames between writes do not consume pending replies") {
+    val (multiplexer, transport)    = make(autoWrite = false)
+    var first: Option[Try[String]]  = None
+    var second: Option[Try[String]] = None
+    multiplexer.submit(Connection.ping(Some("a")), r => first = Some(r))
+    multiplexer.submit(Connection.ping(Some("b")), r => second = Some(r))
+    transport.writeNext()
+    transport.emit(Frame.Push(Vector(Frame.SimpleString("message"))))
+    transport.writeNext()
+    transport.emit(Frame.SimpleString("a"))
+    transport.emit(Frame.SimpleString("b"))
+    assertEquals(first, Some(Success("a")))
+    assertEquals(second, Some(Success("b")))
+  }
+
+  test("loss mid-interleave: replied commands keep their results, written and unwritten fail apart") {
+    val (multiplexer, transport)    = make(autoWrite = false)
+    var first: Option[Try[String]]  = None
+    var second: Option[Try[String]] = None
+    var third: Option[Try[String]]  = None
+    multiplexer.submit(Connection.ping(Some("a")), r => first = Some(r))
+    multiplexer.submit(Connection.ping(Some("b")), r => second = Some(r))
+    multiplexer.submit(Connection.ping(Some("c")), r => third = Some(r))
+    transport.writeNext()
+    transport.emit(Frame.SimpleString("a"))
+    transport.writeNext()
+    multiplexer.close()
+    assertEquals(first, Some(Success("a")))
+    assertEquals(second, Some(Failure(ConnectionLost(mayHaveExecuted = true))))
+    assertEquals(third, Some(Failure(ConnectionLost(mayHaveExecuted = false))))
+  }
+
   test("a server error fails only that command") {
     val (multiplexer, transport)    = make()
     var first: Option[Try[String]]  = None

--- a/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
@@ -67,6 +67,25 @@ class SocketTransportSpec extends munit.FunSuite {
     }
   }
 
+  test("items queued together are batched into a single socket write") {
+    val server = new ServerSocket(0)
+    try {
+      val transport = SocketTransport.connect("127.0.0.1", server.getLocalPort, 5.seconds, _ => (), () => ())
+      try {
+        val items = (1 to 10).map(i => new RecordingItem(s"PING $i\r\n"))
+        items.foreach(transport.send)
+        transport.start()
+        val peer = server.accept()
+        try {
+          val expected = items.map(item => item.payload.asUtf8String).mkString
+          assertEquals(readExactly(peer.getInputStream, expected.length), expected)
+          assertEquals(transport.writeCount, 1L)
+          items.foreach(item => assertEquals(item.writeAttempts, 1))
+        } finally peer.close()
+      } finally transport.close()
+    } finally server.close()
+  }
+
   test("a malformed frame poisons the connection") {
     @volatile var closedCount = 0
     withTransport(onClosed = () => closedCount += 1) { (transport, peer) =>

--- a/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
@@ -49,6 +49,11 @@ class SocketTransportSpec extends munit.FunSuite {
     assert(condition, s"timed out waiting for: $label")
   }
 
+  private def assertAllArrive(peer: Socket, items: Seq[RecordingItem]): Unit = {
+    val expected = items.map(item => item.payload.asUtf8String).mkString
+    assertEquals(readExactly(peer.getInputStream, expected.length), expected)
+  }
+
   test("writes payloads, delivers parsed frames, and joins its threads on close") {
     @volatile var frames      = Vector.empty[Frame]
     @volatile var closedCount = 0
@@ -72,8 +77,7 @@ class SocketTransportSpec extends munit.FunSuite {
   test("items queued together are batched into a single socket write") {
     val items = (1 to 10).map(i => new RecordingItem(s"PING $i\r\n"))
     withTransport(onClosed = () => (), beforeStart = transport => items.foreach(transport.send)) { (transport, peer) =>
-      val expected = items.map(item => item.payload.asUtf8String).mkString
-      assertEquals(readExactly(peer.getInputStream, expected.length), expected)
+      assertAllArrive(peer, items)
       assertEquals(transport.writeCount, 1L)
       items.foreach(item => assertEquals(item.writeAttempts, 1))
       transport.close()
@@ -84,11 +88,19 @@ class SocketTransportSpec extends munit.FunSuite {
     val sizes = Vector(200, 200, 600, 200).map(_ * 1024)
     val items = sizes.zipWithIndex.map { case (size, i) => new RecordingItem((i + 1).toString * size) }
     withTransport(onClosed = () => (), beforeStart = transport => items.foreach(transport.send)) { (transport, peer) =>
-      val expected = items.map(item => item.payload.asUtf8String).mkString
       // [1,2] coalesce under the cap; 3 would overflow it and goes alone; 4 follows alone
-      assertEquals(readExactly(peer.getInputStream, expected.length), expected)
+      assertAllArrive(peer, items)
       assertEquals(transport.writeCount, 3L)
       items.foreach(item => assertEquals(item.writeAttempts, 1))
+      transport.close()
+    }
+  }
+
+  test("items summing exactly to the byte cap coalesce into one write") {
+    val items = (1 to 2).map(i => new RecordingItem(i.toString * (256 * 1024)))
+    withTransport(onClosed = () => (), beforeStart = transport => items.foreach(transport.send)) { (transport, peer) =>
+      assertAllArrive(peer, items)
+      assertEquals(transport.writeCount, 1L)
       transport.close()
     }
   }
@@ -97,8 +109,7 @@ class SocketTransportSpec extends munit.FunSuite {
     @volatile var closedCount = 0
     val items                 = (1 to 3).map(i => new RecordingItem(s"PING $i\r\n"))
     withTransport(onClosed = () => closedCount += 1, beforeStart = transport => items.foreach(transport.send)) { (transport, peer) =>
-      val expected = items.map(item => item.payload.asUtf8String).mkString
-      assertEquals(readExactly(peer.getInputStream, expected.length), expected)
+      assertAllArrive(peer, items)
       peer.close()
       awaitUntil(closedCount == 1, "the transport to observe the disconnect")
       items.foreach { item =>

--- a/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
@@ -80,12 +80,14 @@ class SocketTransportSpec extends munit.FunSuite {
     }
   }
 
-  test("a batch stops coalescing at the byte cap and continues in the next write") {
-    val items = (1 to 3).map(i => new RecordingItem(i.toString * (300 * 1024)))
+  test("coalescing never exceeds the byte cap and an over-sized item is written alone") {
+    val sizes = Vector(200, 200, 600, 200).map(_ * 1024)
+    val items = sizes.zipWithIndex.map { case (size, i) => new RecordingItem((i + 1).toString * size) }
     withTransport(onClosed = () => (), beforeStart = transport => items.foreach(transport.send)) { (transport, peer) =>
       val expected = items.map(item => item.payload.asUtf8String).mkString
+      // [1,2] coalesce under the cap; 3 would overflow it and goes alone; 4 follows alone
       assertEquals(readExactly(peer.getInputStream, expected.length), expected)
-      assertEquals(transport.writeCount, 2L)
+      assertEquals(transport.writeCount, 3L)
       items.foreach(item => assertEquals(item.writeAttempts, 1))
       transport.close()
     }

--- a/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
@@ -80,6 +80,17 @@ class SocketTransportSpec extends munit.FunSuite {
     }
   }
 
+  test("a batch stops coalescing at the byte cap and continues in the next write") {
+    val items = (1 to 3).map(i => new RecordingItem(i.toString * (300 * 1024)))
+    withTransport(onClosed = () => (), beforeStart = transport => items.foreach(transport.send)) { (transport, peer) =>
+      val expected = items.map(item => item.payload.asUtf8String).mkString
+      assertEquals(readExactly(peer.getInputStream, expected.length), expected)
+      assertEquals(transport.writeCount, 2L)
+      items.foreach(item => assertEquals(item.writeAttempts, 1))
+      transport.close()
+    }
+  }
+
   test("connection loss after a batched write leaves every item with exactly one hook fired") {
     @volatile var closedCount = 0
     val items                 = (1 to 3).map(i => new RecordingItem(s"PING $i\r\n"))

--- a/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
@@ -21,11 +21,13 @@ class SocketTransportSpec extends munit.FunSuite {
 
   private def withTransport(
     onClosed: () => Unit,
-    onFrame: Frame => Unit = _ => ()
+    onFrame: Frame => Unit = _ => (),
+    beforeStart: SocketTransport => Unit = _ => ()
   )(body: (SocketTransport, Socket) => Unit): Unit = {
     val server = new ServerSocket(0)
     try {
       val transport = SocketTransport.connect("127.0.0.1", server.getLocalPort, 5.seconds, onFrame, onClosed)
+      beforeStart(transport)
       transport.start()
       val peer      = server.accept()
       try body(transport, peer)
@@ -68,22 +70,30 @@ class SocketTransportSpec extends munit.FunSuite {
   }
 
   test("items queued together are batched into a single socket write") {
-    val server = new ServerSocket(0)
-    try {
-      val transport = SocketTransport.connect("127.0.0.1", server.getLocalPort, 5.seconds, _ => (), () => ())
-      try {
-        val items = (1 to 10).map(i => new RecordingItem(s"PING $i\r\n"))
-        items.foreach(transport.send)
-        transport.start()
-        val peer = server.accept()
-        try {
-          val expected = items.map(item => item.payload.asUtf8String).mkString
-          assertEquals(readExactly(peer.getInputStream, expected.length), expected)
-          assertEquals(transport.writeCount, 1L)
-          items.foreach(item => assertEquals(item.writeAttempts, 1))
-        } finally peer.close()
-      } finally transport.close()
-    } finally server.close()
+    val items = (1 to 10).map(i => new RecordingItem(s"PING $i\r\n"))
+    withTransport(onClosed = () => (), beforeStart = transport => items.foreach(transport.send)) { (transport, peer) =>
+      val expected = items.map(item => item.payload.asUtf8String).mkString
+      assertEquals(readExactly(peer.getInputStream, expected.length), expected)
+      assertEquals(transport.writeCount, 1L)
+      items.foreach(item => assertEquals(item.writeAttempts, 1))
+      transport.close()
+    }
+  }
+
+  test("connection loss after a batched write leaves every item with exactly one hook fired") {
+    @volatile var closedCount = 0
+    val items                 = (1 to 3).map(i => new RecordingItem(s"PING $i\r\n"))
+    withTransport(onClosed = () => closedCount += 1, beforeStart = transport => items.foreach(transport.send)) { (transport, peer) =>
+      val expected = items.map(item => item.payload.asUtf8String).mkString
+      assertEquals(readExactly(peer.getInputStream, expected.length), expected)
+      peer.close()
+      awaitUntil(closedCount == 1, "the transport to observe the disconnect")
+      items.foreach { item =>
+        assertEquals(item.writeAttempts, 1)
+        assertEquals(item.drops, 0)
+      }
+      transport.close()
+    }
   }
 
   test("a malformed frame poisons the connection") {


### PR DESCRIPTION
Closes #8

## What changed

**Write batching (`SocketTransport`)**: the writer loop blocks for one item, then polls the queue while the batch stays under **512KiB** — an item that would overflow the cap is carried into the next batch, so multi-item concat buffers never exceed the cap and an over-sized payload is always a batch of one, written zero-copy. Hooks fire late: the payload is built first, and `writeAttempted()` runs only once a write is imminent — so an allocation/copy failure drops every batched item as never-sent (`mayHaveExecuted = false`) instead of misclassifying them as possibly executed. Items the writer holds when it unwinds (batch tail past the `attempted` watermark, plus any carried item) are dropped as never-sent, keeping the exactly-one-hook contract.

The `Multiplexer` and the `Transport` seam are unchanged: FIFO safety still rests on the single writer thread being the only appender to `pending`. A `private[internal]` write counter makes batching observable to tests.

## Acceptance criteria

- **Interleaved state-machine tests** — four new deterministic `MultiplexerSpec` cases: replies interleaved with new submissions; a reply arriving while a later command is unwritten; push frames between writes; connection loss mid-interleave with mixed replied/written/unwritten commands.
- **Stress test** — `RoundTripSuite`: 500 concurrent fibers × 100 sequential `PING <token>` calls each (50k commands), every reply asserted against its own token, against both Redis and Valkey. Runs in ~1.5s.
- **Batching proof** — `SocketTransportSpec`: 10 items queued before `start()` arrive at the peer concatenated, in order, in exactly one socket write; a 200KB+200KB+600KB+200KB sequence coalesces [1,2] under the cap and writes the over-sized item alone (exactly three writes); connection loss after a batched write leaves every item with exactly one hook fired. All deterministic, no sleeps.

## Docs

CONTEXT.md gains an **Auto-pipelining** entry, disambiguating the runtime's transparent write coalescing from the user-facing **Pipeline** value.

## Note

`CIO.foreachDiscard`'s `concurrency` parameter is unusable from outside kyo-compat on the Future backend: the inline expansion references `private[compat] FutureSemaphore` and fails to compile (kyo-compat snapshot bug, worth reporting upstream). The stress test uses explicit recursion per fiber instead.
