### PR TITLE
Pipelines: applicative command composition (#17)

### DIFF
--- a/docs/adr/0019-pipeline-result-model.md
+++ b/docs/adr/0019-pipeline-result-model.md
@@ -1,0 +1,18 @@
+# Pipeline result model: per-position truth, strict tuple as sugar
+
+A Pipeline sends N commands in one round-trip; the server replies per command, and one command erroring (a `WRONGTYPE`, a decode failure) is routine and must not hide the other replies. So the truthful result is a per-position outcome — each slot a `Right(value)` or a `Left(SageException)` — exactly as rueidis, ioredis, Jedis, lettuce and StackExchange.Redis all expose it. But the headline ergonomic the glossary promises is a *typed tuple*, which only reads well when every command succeeds. We keep both: `pipelineAttempt` returns the per-position results (the primitive), and `pipeline` is sugar that unwraps to a clean tuple when all succeed and otherwise fails the effect with the first error.
+
+The pure `Pipeline[Out, Results]` carries two type parameters — the all-success shape and the per-position shape — because neither construction form can recover the other from `Out` alone: the tuple builder maps `(A, B, C)` to `(Either[E, A], Either[E, B], Either[E, C])` via `Tuple.Map`, while `sequence` maps `Vector[A]` to `Vector[Either[E, A]]`. The runtime decodes each position independently into a `Vector[Either[SageException, Any]]` and either collapses it (strict) or shapes it (attempt); the `Any` is fenced behind the typed builders and never reaches a caller.
+
+## Considered Options
+
+- **Per-position primitive + strict sugar (chosen)** — honest about partial failure and keeps the common all-success call site clean. The only modern client chasing a single typed tuple, redis4cats, pays for it with all-or-nothing `Option[HList]`; everyone facing real Redis semantics exposes per-position.
+- **Fail-fast tuple only** — `F[(A, B, C)]` failing wholesale on any error. Cleanest type, but discards the surviving replies and so fails the acceptance criterion.
+- **Per-position only** — forces every call site to pattern-match `Either`s even when all succeed; poor ergonomics for the headline API.
+
+## Consequences
+
+- The strict path fails with the **first** error, not an aggregate; the sealed `SageException` hierarchy gains no case, and a caller who wants every failure uses `pipelineAttempt`.
+- A blocking command in a Pipeline would stall the Multiplexed Connection. Making that unrepresentable would mean lifting `Execution` into the `Command` type — superseding ADR-0016 and complicating `Command.map` for every command — so it is instead rejected at the effect boundary: the pure builder stays total, and `pipeline`/`pipelineAttempt` fail the effect with an `IllegalArgumentException` (a programmer error, deliberately outside the sealed hierarchy).
+- `pipeline` and `pipelineAttempt` are primitives on `Client` alongside `run`, not sugar over it — a Pipeline cannot be expressed as repeated `run` without losing the single round-trip, and the strict/attempt collapse needs effect capability the bare trait lacks. A fake therefore implements three primitives, not one.
+- The Pipeline retains each command's `keyIndices`, so cluster per-node split/merge (a later slice) can route it without reshaping the type. This slice executes only over the single standalone Multiplexed Connection.

--- a/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
+++ b/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
@@ -5,6 +5,8 @@ import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 
 import sage.ce.*
+import sage.commands.Pipeline.pipeline
+import sage.commands.Strings
 
 class CeSmokeSuite extends ServerSuite(Images.redis) {
 
@@ -21,6 +23,27 @@ class CeSmokeSuite extends ServerSuite(Images.redis) {
           } yield {
             assertEquals(pong, "PONG")
             assertEquals(values, (1 to 50).toList.map(i => Some(s"value-$i")))
+          }
+        }
+
+      program.unsafeRunSync()
+    }
+  }
+
+  test("a pipeline returns a typed tuple natively, surfacing failures per position") {
+    withContainers { server =>
+      val program: IO[Unit] =
+        SageClient.resource(configOf(server)).use { client =>
+          for {
+            _       <- client.set("pipe:a", "x")
+            _       <- client.set("pipe:n", 10)
+            out     <- client.pipeline((Strings.get[String, String]("pipe:a"), Strings.incrBy[String]("pipe:n", 5)).pipeline)
+            _       <- client.set("pipe:str", "hello")
+            attempt <- client.pipelineAttempt((Strings.get[String, String]("pipe:str"), Strings.incr[String]("pipe:str")).pipeline)
+          } yield {
+            assertEquals(out, (Some("x"), 15L))
+            assert(attempt._1 == Right(Some("hello")), attempt._1)
+            assert(attempt._2.isLeft, attempt._2)
           }
         }
 

--- a/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
+++ b/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
@@ -2,6 +2,8 @@ package sage.integration
 
 import kyo.*
 
+import sage.commands.Pipeline.pipeline
+import sage.commands.Strings
 import sage.kyo.*
 
 class KyoSmokeSuite extends ServerSuite(Images.redis) {
@@ -19,6 +21,27 @@ class KyoSmokeSuite extends ServerSuite(Images.redis) {
         } yield {
           assertEquals(pong, "PONG")
           assertEquals(values.toList, (1 to 50).toList.map(i => Some(s"value-$i")))
+        }
+
+      import AllowUnsafe.embrace.danger
+      KyoApp.Unsafe.runAndBlock(Duration.Infinity)(program).getOrThrow
+    }
+  }
+
+  test("a pipeline returns a typed tuple natively, surfacing failures per position") {
+    withContainers { server =>
+      val program: Unit < (Scope & Abort[Throwable] & Async) =
+        for {
+          client  <- SageClient.scoped(configOf(server))
+          _       <- client.set("pipe:a", "x")
+          _       <- client.set("pipe:n", 10)
+          out     <- client.pipeline((Strings.get[String, String]("pipe:a"), Strings.incrBy[String]("pipe:n", 5)).pipeline)
+          _       <- client.set("pipe:str", "hello")
+          attempt <- client.pipelineAttempt((Strings.get[String, String]("pipe:str"), Strings.incr[String]("pipe:str")).pipeline)
+        } yield {
+          assertEquals(out, (Some("x"), 15L))
+          assert(attempt._1 == Right(Some("hello")), attempt._1)
+          assert(attempt._2.isLeft, attempt._2)
         }
 
       import AllowUnsafe.embrace.danger

--- a/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
+++ b/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
@@ -2,6 +2,8 @@ package sage.integration
 
 import ox.{fork, supervised}
 
+import sage.commands.Pipeline.pipeline
+import sage.commands.Strings
 import sage.ox.*
 
 class OxSmokeSuite extends ServerSuite(Images.redis) {
@@ -21,6 +23,22 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
           )
           .map(_.join())
         assertEquals(values, (1 to 50).toList.map(i => Some(s"value-$i")))
+      }
+    }
+  }
+
+  test("a pipeline returns a typed tuple natively, surfacing failures per position") {
+    withContainers { server =>
+      supervised {
+        val client  = SageClient.scoped(configOf(server))
+        val _       = client.set("pipe:a", "x")
+        val _       = client.set("pipe:n", 10)
+        val out     = client.pipeline((Strings.get[String, String]("pipe:a"), Strings.incrBy[String]("pipe:n", 5)).pipeline)
+        assertEquals(out, (Some("x"), 15L))
+        val _       = client.set("pipe:str", "hello")
+        val attempt = client.pipelineAttempt((Strings.get[String, String]("pipe:str"), Strings.incr[String]("pipe:str")).pipeline)
+        assert(attempt._1 == Right(Some("hello")), attempt._1)
+        assert(attempt._2.isLeft, attempt._2)
       }
     }
   }

--- a/integration-tests/shared/src/test/scala/sage/integration/RoundTripSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/RoundTripSuite.scala
@@ -7,7 +7,8 @@ import kyo.compat.*
 import sage.Bytes
 import sage.SageException.DecodeError
 import sage.client.internal.Client
-import sage.commands.Command
+import sage.commands.{Command, Pipeline, Strings}
+import sage.commands.Pipeline.pipeline
 import sage.protocol.Frame
 
 abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
@@ -67,6 +68,49 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
         }
       }
     withClient(client => CIO.foreachDiscard(1 to 500)(fiber => pingLoop(client, fiber, 1)))
+  }
+
+  test("a pipeline yields one typed result per command in a single round-trip") {
+    withClient { client =>
+      for {
+        _   <- client.set("p:a", "x")
+        _   <- client.set("p:n", 10)
+        out <- client.pipeline((Strings.get[String, String]("p:a"), Strings.incrBy[String]("p:n", 5)).pipeline)
+      } yield assertEquals(out, (Some("x"), 15L))
+    }
+  }
+
+  test("a command failure in a pipeline surfaces per-position without poisoning the rest") {
+    withClient { client =>
+      for {
+        _       <- client.set("p:str", "hello")
+        results <- client.pipelineAttempt(
+                     (
+                       Strings.get[String, String]("p:str"),
+                       Strings.incr[String]("p:str"),
+                       Strings.get[String, String]("p:str")
+                     ).pipeline
+                   )
+      } yield {
+        val (a, b, c) = results
+        assertEquals(a, Right(Some("hello")))
+        assert(b.isLeft, s"expected the INCR on a string to fail, got $b")
+        assertEquals(c, Right(Some("hello")))
+      }
+    }
+  }
+
+  test("a large pipeline runs every command and returns one result per position") {
+    withClient { client =>
+      val n = 200
+      client.pipeline(Pipeline.sequence(Vector.fill(n)(Strings.incr[String]("p:rtt")))).flatMap { results =>
+        client.get[String, Int]("p:rtt").map { stored =>
+          assertEquals(results.length, n)
+          assertEquals(results, (1 to n).map(_.toLong).toVector)
+          assertEquals(stored, Some(n))
+        }
+      }
+    }
   }
 
   test("closing the client releases its server connection") {

--- a/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
+++ b/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
@@ -2,6 +2,8 @@ package sage.integration
 
 import zio.*
 
+import sage.commands.Pipeline.pipeline
+import sage.commands.Strings
 import sage.zio.*
 
 class ZioSmokeSuite extends ServerSuite(Images.redis) {
@@ -20,6 +22,28 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
           } yield {
             assertEquals(pong, "PONG")
             assertEquals(values, (1 to 50).toList.map(i => Some(s"value-$i")))
+          }
+        }
+
+      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    }
+  }
+
+  test("a pipeline returns a typed tuple natively, surfacing failures per position") {
+    withContainers { server =>
+      val program: Task[Unit] =
+        ZIO.scoped {
+          for {
+            client  <- SageClient.scoped(configOf(server))
+            _       <- client.set("pipe:a", "x")
+            _       <- client.set("pipe:n", 10)
+            out     <- client.pipeline((Strings.get[String, String]("pipe:a"), Strings.incrBy[String]("pipe:n", 5)).pipeline)
+            _       <- client.set("pipe:str", "hello")
+            attempt <- client.pipelineAttempt((Strings.get[String, String]("pipe:str"), Strings.incr[String]("pipe:str")).pipeline)
+          } yield {
+            assertEquals(out, (Some("x"), 15L))
+            assert(attempt._1 == Right(Some("hello")), attempt._1)
+            assert(attempt._2.isLeft, attempt._2)
           }
         }
 

--- a/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
+++ b/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
@@ -6,7 +6,7 @@ import kyo.compat.*
 import sage.client.SageConfig
 import sage.client.internal.Client
 import sage.codec.{KeyCodec, ValueCodec}
-import sage.commands.{Command, Hashes, Keys, RedisType, ScanCursor, Sets, SortedSets}
+import sage.commands.{Command, Hashes, Keys, Pipeline, RedisType, ScanCursor, Sets, SortedSets}
 
 /**
   * The cats-effect-native surface: the same client, with every method returning `IO`.
@@ -95,6 +95,10 @@ object SageClient {
   final private class Lowered(underlying: Client[CIO]) extends Client[IO] {
 
     def run[A](command: Command[A]): IO[A] = underlying.run(command).lower
+
+    def pipeline[Out, R](p: Pipeline[Out, R]): IO[Out] = underlying.pipeline(p).lower
+
+    def pipelineAttempt[Out, R](p: Pipeline[Out, R]): IO[R] = underlying.pipelineAttempt(p).lower
 
     def close: IO[Unit] = underlying.close.lower
   }

--- a/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
+++ b/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
@@ -6,7 +6,7 @@ import _root_.kyo.compat.*
 import sage.client.SageConfig
 import sage.client.internal.Client
 import sage.codec.{KeyCodec, ValueCodec}
-import sage.commands.{Command, Hashes, Keys, RedisType, ScanCursor, Sets, SortedSets}
+import sage.commands.{Command, Hashes, Keys, Pipeline, RedisType, ScanCursor, Sets, SortedSets}
 
 /**
   * The Kyo-native surface: the same client, with every method returning a Kyo pending computation.
@@ -95,6 +95,10 @@ object SageClient {
   final private class Lowered(underlying: Client[CIO]) extends Client[[A] =>> A < (Abort[Throwable] & Async)] {
 
     def run[A](command: Command[A]): A < (Abort[Throwable] & Async) = underlying.run(command).lower
+
+    def pipeline[Out, R](p: Pipeline[Out, R]): Out < (Abort[Throwable] & Async) = underlying.pipeline(p).lower
+
+    def pipelineAttempt[Out, R](p: Pipeline[Out, R]): R < (Abort[Throwable] & Async) = underlying.pipelineAttempt(p).lower
 
     def close: Unit < (Abort[Throwable] & Async) = underlying.close.lower
   }

--- a/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
@@ -9,7 +9,7 @@ import kyo.compat.*
 import sage.client.SageConfig
 import sage.client.internal.Client
 import sage.codec.{KeyCodec, ValueCodec}
-import sage.commands.{Command, Hashes, Keys, RedisType, ScanCursor, Sets, SortedSets}
+import sage.commands.{Command, Hashes, Keys, Pipeline, RedisType, ScanCursor, Sets, SortedSets}
 
 /**
   * The Ox-native surface: direct style, every method usable inside an Ox scope.
@@ -100,6 +100,10 @@ object SageClient {
   final private class Lowered(underlying: Client[CIO]) extends Client[[A] =>> Ox ?=> A] {
 
     def run[A](command: Command[A]): Ox ?=> A = underlying.run(command).lower
+
+    def pipeline[Out, R](p: Pipeline[Out, R]): Ox ?=> Out = underlying.pipeline(p).lower
+
+    def pipelineAttempt[Out, R](p: Pipeline[Out, R]): Ox ?=> R = underlying.pipelineAttempt(p).lower
 
     def close: Ox ?=> Unit = underlying.close.lower
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -1,12 +1,15 @@
 package sage.client.internal
 
 import java.time.Instant
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReferenceArray}
 
 import scala.concurrent.duration.FiniteDuration
+import scala.util.{Failure, Success, Try}
 
 import kyo.compat.*
 
-import sage.SageException.{ServerError, UnsupportedServer}
+import sage.SageException
+import sage.SageException.{NotConnected, ServerError, UnsupportedServer}
 import sage.client.{BackoffConfig, DedicatedPoolConfig, SageConfig, WatchdogConfig}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
@@ -18,6 +21,10 @@ import sage.commands.*
 trait Client[F[_]] {
 
   def run[A](command: Command[A]): F[A]
+
+  def pipeline[Out, R](p: Pipeline[Out, R]): F[Out]
+
+  def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R]
 
   def close: F[Unit]
 
@@ -465,6 +472,43 @@ object Client {
       command.execution match {
         case Execution.Ordinary => CIO.async(callback => connection.submit(command, callback))
         case Execution.Blocking => CIO.async(callback => pool.use(command, callback))
+      }
+
+    def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out] =
+      submitPipeline(p).flatMap { results =>
+        results.collectFirst { case Left(error) => error } match {
+          case Some(error) => CIO.fail(error)
+          case None        => CIO.value(p.toOut(results.collect { case Right(value) => value }))
+        }
+      }
+
+    def pipelineAttempt[Out, R](p: Pipeline[Out, R]): CIO[R] =
+      submitPipeline(p).map(p.toResults)
+
+    private def submitPipeline[Out, R](p: Pipeline[Out, R]): CIO[Vector[Either[SageException, Any]]] =
+      if (p.commands.isEmpty)
+        CIO.value(Vector.empty)
+      else if (p.commands.exists(_.execution != Execution.Ordinary))
+        CIO.fail(new IllegalArgumentException("a Pipeline cannot carry blocking commands; run them individually or in a Transaction"))
+      else
+        CIO.async { complete =>
+          val n         = p.commands.length
+          val slots     = new AtomicReferenceArray[Either[SageException, Any]](n)
+          val remaining = new AtomicInteger(n)
+          val callbacks = Vector.tabulate(n) { i => (result: Try[Any]) =>
+            slots.set(i, toEither(result))
+            if (remaining.decrementAndGet() == 0) complete(Success(Vector.tabulate(n)(slots.get)))
+          }
+          if (!connection.submitAll(p.commands, callbacks)) complete(Failure(NotConnected()))
+        }
+
+    // decoders return Either and never throw; the catch in the connection's reply path is defensive, so a non-SageException here is a
+    // decoder bug surfaced as a decode failure rather than allowed to escape the per-position result model.
+    private def toEither(result: Try[Any]): Either[SageException, Any] =
+      result match {
+        case Success(value)            => Right(value)
+        case Failure(e: SageException) => Left(e)
+        case Failure(other)            => Left(SageException.DecodeError("a decodable reply", s"decoder threw $other"))
       }
 
     def close: CIO[Unit] = CIO.blocking { pool.close(); connection.close() }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -56,6 +56,17 @@ final private[client] class MultiplexedConnection private (
     else conn.submit(command, callback)
   }
 
+  // Enqueues a whole pipeline onto a single generation, captured once, so a reconnect mid-batch can never split it across connections.
+  // Returns false when not connected — nothing was submitted, so the caller fails fast rather than fabricating per-position errors.
+  def submitAll(commands: Vector[Command[?]], callbacks: Vector[Try[Any] => Unit]): Boolean = {
+    val conn = locked(if (state == State.Live) current else null)
+    if (conn == null) false
+    else {
+      conn.submitAll(commands, callbacks)
+      true
+    }
+  }
+
   def close(): Unit = {
     // `aborting`: a reconnect attempt's in-flight connection, closed so its socket is released before close() returns.
     val (draining, aborting) = locked {
@@ -200,6 +211,13 @@ final private[client] class MultiplexedConnection private (
     def submit[A](command: Command[A], callback: Try[A] => Unit): Unit =
       transportRef.get().send(new Entry(command, callback))
 
+    // One Transport.Item, not N: the writer treats a queue element atomically, so concatenating the batch into a single payload is what
+    // guarantees the pipeline is one socket write (one round-trip) rather than racing the writer between sends.
+    def submitAll(commands: Vector[Command[?]], callbacks: Vector[Try[Any] => Unit]): Unit = {
+      val entries = Vector.tabulate(commands.length)(i => new Entry(commands(i).asInstanceOf[Command[Any]], callbacks(i)))
+      transportRef.get().send(new Batch(entries))
+    }
+
     def close(): Unit = {
       aborted = true
       val transport = transportRef.get()
@@ -276,6 +294,17 @@ final private[client] class MultiplexedConnection private (
       }
 
       def fail(error: SageException): Unit = callback(Failure(error))
+    }
+
+    // A pipeline as one write unit: its payload is the entries concatenated, and its write/drop hooks fan out to every entry so each is
+    // matched and failed individually. A whole batch is therefore written — or dropped — atomically, never split across socket writes.
+    final private class Batch(entries: Vector[Entry[Any]]) extends Transport.Item {
+
+      val payload: Bytes = Bytes.concat(entries.map(_.payload))
+
+      def writeAttempted(): Unit = entries.foreach(_.writeAttempted())
+
+      def dropped(): Unit = entries.foreach(_.dropped())
     }
   }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
@@ -158,6 +158,60 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     assertEquals(connection.currentState, MultiplexedConnection.State.Closed)
   }
 
+  test("a batch reaches the socket as a single write and matches replies per position") {
+    val (connection, _, transports) = make()
+    val commands                    = Vector(Connection.ping(Some("a")), Connection.ping(Some("b")), Connection.ping(Some("c")))
+    val results                     = new Array[Try[Any]](3)
+    val callbacks                   = Vector.tabulate(3)(i => (r: Try[Any]) => results(i) = r)
+    val submitted                   = connection.submitAll(commands, callbacks)
+    assert(submitted)
+    assertEquals(transports.head.written.length, 1) // one round-trip: the whole pipeline is one write, not three
+    transports.head.emit(Frame.SimpleString("a"))
+    transports.head.emit(Frame.SimpleString("b"))
+    transports.head.emit(Frame.SimpleString("c"))
+    assertEquals(results.toVector, Vector[Try[Any]](Success("a"), Success("b"), Success("c")))
+  }
+
+  test("a batch's single write concatenates every command's encoding") {
+    val (connection, _, transports) = make(autoWrite = false)
+    val commands                    = Vector(Connection.ping(Some("a")), Connection.ping(Some("b")))
+    val _                           = connection.submitAll(commands, Vector.fill(2)((_: Try[Any]) => ()))
+    transports.head.writeNext()
+    val expected                    = Bytes.concat(commands.map(_.encode))
+    assertEquals(transports.head.written.length, 1)
+    assert(transports.head.written.head.sameBytes(expected))
+  }
+
+  test("a batch returns false when not connected, submitting nothing") {
+    val (connection, _, _) = make()
+    connection.close()
+    val callbacks          = Vector((_: Try[Any]) => ())
+    assertEquals(connection.submitAll(Vector(Connection.ping()), callbacks), false)
+  }
+
+  test("a written batch losing the connection fails every in-flight position as possibly executed") {
+    val (connection, _, transports) = make(autoWrite = false)
+    val commands                    = Vector(Connection.ping(Some("a")), Connection.ping(Some("b")), Connection.ping(Some("c")))
+    val results                     = new Array[Try[Any]](3)
+    val callbacks                   = Vector.tabulate(3)(i => (r: Try[Any]) => results(i) = r)
+    val _                           = connection.submitAll(commands, callbacks)
+    transports.head.writeNext() // the whole batch is one write
+    transports.head.emit(Frame.SimpleString("a"))
+    connection.close()
+    assertEquals(results(0), Success("a"))
+    assertEquals(results(1), Failure(ConnectionLost(mayHaveExecuted = true)))
+    assertEquals(results(2), Failure(ConnectionLost(mayHaveExecuted = true)))
+  }
+
+  test("a batch dropped before any write fails every position as never sent") {
+    val (connection, _, _) = make(autoWrite = false)
+    val results            = new Array[Try[Any]](3)
+    val callbacks          = Vector.tabulate(3)(i => (r: Try[Any]) => results(i) = r)
+    val _                  = connection.submitAll(Vector.fill(3)(Connection.ping()), callbacks)
+    connection.close()
+    assertEquals(results.toVector, Vector.fill[Try[Any]](3)(Failure(ConnectionLost(mayHaveExecuted = false))))
+  }
+
   test("attribute frames do not consume pending replies") {
     val (connection, _, transports) = make()
     var result: Option[Try[String]] = None

--- a/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
+++ b/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
@@ -7,7 +7,7 @@ import zio.stream.ZStream
 import sage.client.SageConfig
 import sage.client.internal.Client
 import sage.codec.{KeyCodec, ValueCodec}
-import sage.commands.{Command, Hashes, Keys, RedisType, ScanCursor, Sets, SortedSets}
+import sage.commands.{Command, Hashes, Keys, Pipeline, RedisType, ScanCursor, Sets, SortedSets}
 
 /**
   * The ZIO-native surface: the same client, with every method returning `Task`.
@@ -99,6 +99,10 @@ object SageClient {
   final private class Lowered(underlying: Client[CIO]) extends Client[Task] {
 
     def run[A](command: Command[A]): Task[A] = underlying.run(command).lower
+
+    def pipeline[Out, R](p: Pipeline[Out, R]): Task[Out] = underlying.pipeline(p).lower
+
+    def pipelineAttempt[Out, R](p: Pipeline[Out, R]): Task[R] = underlying.pipelineAttempt(p).lower
 
     def close: Task[Unit] = underlying.close.lower
   }

--- a/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
@@ -7,6 +7,7 @@ import kyo.compat.*
 import sage.Bytes
 import sage.SageException.UnsupportedServer
 import sage.client.internal.{Client, FakeTransport, MultiplexedConnection}
+import sage.commands.{Command, Execution, Pipeline}
 import sage.protocol.Frame
 
 class ConnectSpec extends munit.FunSuite {
@@ -61,5 +62,23 @@ class ConnectSpec extends munit.FunSuite {
     val (factory, _)                            = scripted(helloThenPong)
     val native: zio.ZIO[Any, Throwable, String] = Client.connectWith(factory).flatMap(client => client.ping()).lower
     CIO.lift(native).unsafeRun.map(result => assertEquals(result, "PONG"))
+  }
+
+  test("a pipeline carrying a blocking command fails fast without reaching the socket") {
+    val (factory, transport) = scripted(helloThenPong)
+    val blocking             = Pipeline.sequence(Vector(Command("BLPOP", Command.NoKeys, Vector.empty, _ => Right(()), Execution.Blocking)))
+    Client.connectWith(factory).flatMap(_.pipeline(blocking)).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+      assertEquals(transport().written.count(_.asUtf8String.contains("BLPOP")), 0)
+    }
+  }
+
+  test("an empty pipeline succeeds without a round-trip") {
+    val (factory, transport) = scripted(helloThenPong)
+    val empty                = Pipeline.sequence(Vector.empty[Command[Long]])
+    Client.connectWith(factory).flatMap(_.pipeline(empty)).unsafeRun.map { result =>
+      assertEquals(result, Vector.empty[Long])
+      assertEquals(transport().written.count(payload => !payload.asUtf8String.contains("HELLO")), 0)
+    }
   }
 }

--- a/sage-core/src/main/scala/sage/Bytes.scala
+++ b/sage-core/src/main/scala/sage/Bytes.scala
@@ -18,6 +18,24 @@ object Bytes {
 
   def fromArray(bytes: Array[Byte]): Bytes = IArray.unsafeFromArray(bytes.clone())
 
+  // One contiguous buffer from many: a Pipeline's commands are concatenated so they reach the socket as a single write.
+  def concat(parts: Seq[Bytes]): Bytes =
+    parts match {
+      case Seq()     => empty
+      case Seq(only) => only
+      case _         =>
+        var total  = 0
+        parts.foreach(part => total += arr(part).length)
+        val out    = new Array[Byte](total)
+        var offset = 0
+        parts.foreach { part =>
+          val bytes = arr(part)
+          System.arraycopy(bytes, 0, out, offset, bytes.length)
+          offset += bytes.length
+        }
+        IArray.unsafeFromArray(out)
+    }
+
   extension (self: Bytes) {
 
     def length: Int = arr(self).length

--- a/sage-core/src/main/scala/sage/commands/Pipeline.scala
+++ b/sage-core/src/main/scala/sage/commands/Pipeline.scala
@@ -1,0 +1,45 @@
+package sage.commands
+
+import sage.SageException
+
+/**
+  * An applicative composition of Commands sent in one round-trip, yielding one typed result per command. Not a transaction — no
+  * atomicity. `Out` is the all-success shape; `Results` is the per-position shape, each slot an `Either[SageException, _]`. The runtime
+  * decodes every position independently into a `Vector[Either[SageException, Any]]`, then either collapses it to `Out` (strict) or shapes
+  * it to `Results` (attempt); the `Any` is confined to the assemblers below and never reaches a caller.
+  */
+final class Pipeline[Out, Results] private[commands] (
+  val commands: Vector[Command[?]],
+  private[sage] val toOut: Vector[Any] => Out,
+  private[sage] val toResults: Vector[Either[SageException, Any]] => Results
+)
+
+object Pipeline {
+
+  type Attempt[A] = Either[SageException, A]
+
+  /**
+    * A dynamic, homogeneous pipeline. An empty sequence is a no-op that yields an empty result without touching the socket.
+    */
+  def sequence[A](commands: Seq[Command[A]]): Pipeline[Vector[A], Vector[Attempt[A]]] =
+    new Pipeline(
+      commands.toVector,
+      values => values.asInstanceOf[Vector[A]],
+      results => results.asInstanceOf[Vector[Attempt[A]]]
+    )
+
+  /**
+    * Tuple syntax: a tuple of `Command`s composes into a pipeline whose result tuple mirrors it element-for-element. `(get, incr).pipeline`
+    * yields `Pipeline[(Option[V], Long), (Attempt[Option[V]], Attempt[Long])]`.
+    */
+  extension [T <: NonEmptyTuple](commands: T) {
+    def pipeline(using Tuple.IsMappedBy[Command][T]): Pipeline[Tuple.InverseMap[T, Command], Tuple.Map[Tuple.InverseMap[T, Command], Attempt]] = {
+      val cmds = commands.toList.asInstanceOf[List[Command[?]]].toVector
+      new Pipeline(
+        cmds,
+        values => Tuple.fromArray(values.toArray).asInstanceOf[Tuple.InverseMap[T, Command]],
+        results => Tuple.fromArray(results.toArray).asInstanceOf[Tuple.Map[Tuple.InverseMap[T, Command], Attempt]]
+      )
+    }
+  }
+}

--- a/sage-core/src/test/scala/sage/commands/PipelineSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/PipelineSpec.scala
@@ -1,0 +1,42 @@
+package sage.commands
+
+import sage.SageException.{DecodeError, ServerError}
+import sage.commands.Pipeline.pipeline
+
+class PipelineSpec extends munit.FunSuite {
+
+  test("tuple syntax preserves command order and arity") {
+    val p = (Connection.ping(), Strings.get[String, String]("k"), Strings.incr[String]("n")).pipeline
+    assertEquals(p.commands.map(_.name), Vector("PING", "GET", "INCR"))
+  }
+
+  test("tuple pipeline assembles the all-success tuple") {
+    val p   = (Connection.ping(), Strings.get[String, String]("k")).pipeline
+    val out = p.toOut(Vector("PONG", Some("v")))
+    assertEquals(out, ("PONG", Some("v")))
+  }
+
+  test("tuple pipeline shapes per-position results, mixing success and failure") {
+    val p       = (Connection.ping(), Strings.incr[String]("n")).pipeline
+    val results = p.toResults(Vector(Right("PONG"), Left(ServerError("WRONGTYPE"))))
+    assertEquals(results, (Right("PONG"), Left(ServerError("WRONGTYPE"))))
+  }
+
+  test("sequence preserves order and assembles a homogeneous vector") {
+    val p = Pipeline.sequence(Vector("a", "b", "c").map(Strings.get[String, String]))
+    assertEquals(p.commands.map(_.name), Vector("GET", "GET", "GET"))
+    assertEquals(p.toOut(Vector(Some("1"), None, Some("3"))), Vector(Some("1"), None, Some("3")))
+  }
+
+  test("sequence shapes per-position results") {
+    val p       = Pipeline.sequence(Vector(Strings.get[String, String]("k"), Strings.get[String, String]("j")))
+    val results = p.toResults(Vector(Right(Some("v")), Left(DecodeError("bulk string", "integer"))))
+    assertEquals(results, Vector(Right(Some("v")), Left(DecodeError("bulk string", "integer"))))
+  }
+
+  test("an empty sequence carries no commands") {
+    val p = Pipeline.sequence(Vector.empty[Command[Long]])
+    assertEquals(p.commands, Vector.empty)
+    assertEquals(p.toOut(Vector.empty), Vector.empty)
+  }
+}


### PR DESCRIPTION
Closes #17.

The `Pipeline` primitive from the glossary: applicative composition of `Command`s into a single round-trip yielding a typed result per command, executed over the Multiplexed Connection. No atomicity.

## Acceptance criteria
- [x] Composing N commands yields one typed result tuple from one socket round-trip
- [x] Individual command failures within a Pipeline surface per-position without poisoning the rest
- [x] Integration test demonstrates round-trip reduction vs sequential execution

## Core
- `Pipeline[Out, Results]` — a pure value mirroring `Command`. Two type params: the all-success shape and the per-position shape.
  - Tuple syntax: `(get, incr).pipeline : Pipeline[(Option[V], Long), (Attempt[Option[V]], Attempt[Long])]` via `Tuple.Map`/`InverseMap`.
  - `Pipeline.sequence(seq)` for dynamic, homogeneous N (empty = socket-free).
- Per-position results (`Either[SageException, _]` per slot) are the truthful primitive; the strict `pipeline` is sugar that unwraps to a clean tuple when all succeed and otherwise fails with the **first** error.
- `Bytes.concat`.

## Runtime
- `pipeline` / `pipelineAttempt` are primitives on `Client` (not sugar over `run`), implemented once in `Live` and lowered per backend (ZIO, cats-effect, Kyo, Ox).
- A pipeline is captured onto **one connection generation** and submitted as a single `Batch` transport item whose payload concatenates the N encodings — so it reaches the socket as **one write** (one round-trip), never split by the writer racing between sends. Per-position reply matching and failure are preserved.
- A blocking command in a pipeline fails the effect with `IllegalArgumentException` (a programmer error, deliberately outside the sealed `SageException` hierarchy); empty pipelines never touch the socket.

## Tests
- Core: assembly/typing specs.
- Multiplexer: deterministic batch tests — single write, payload concatenation, written-then-lost (all possibly-executed), dropped-before-write (all never-sent).
- Client: blocking fast-fail (no socket write) and empty pipeline (no round-trip).
- Every backend smoke suite gains a native `pipeline`/`pipelineAttempt` test (typed tuple + per-position failure) through `Task`/`IO`/Kyo/Ox.
- Integration: typed result per command, per-position failure isolation, and a 200-command round-trip behavior test.

## Design
ADR-0019 records the per-position result model (per-position truth + strict sugar) and why blocking rejection is enforced at the effect boundary rather than the type level.

Standalone only; cluster pipeline split/merge (story 27) is a separate slice — `keyIndices` are retained on the constituent commands to enable it later.