### PR TITLE
Transactions: MULTI/EXEC/WATCH via a leased scope

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -63,8 +63,12 @@ _Avoid_: request, operation
 An applicative composition of Commands sent in one round-trip, yielding a typed tuple of results. Not a transaction — no atomicity.
 
 **Transaction**:
-A Pipeline executed atomically via `MULTI`/`EXEC` on a Dedicated Connection, optionally guarded by `WATCH`.
+A Pipeline executed atomically via `MULTI`/`EXEC` on a Dedicated Connection, optionally guarded by `WATCH`. A watched key changing before `EXEC` aborts it — a normal optimistic-concurrency outcome the caller retries, not a failure. A queueing-phase rejection discards the whole transaction (nothing runs); an execution-phase error leaves the other commands committed (Redis does not roll back), surfaced per-position like a Pipeline.
 _Avoid_: batch (that's a Pipeline)
+
+**Transaction Scope**:
+The handle opened by `transaction { scope => … }`, holding one leased Dedicated Connection for the block. Within it the caller may `watch`, `run` reads, then `exec` a Pipeline (or `discard`) — enough to read, decide, and commit on the one connection that `WATCH` requires. The lease is always released; a scope abandoned with watches still armed discards its connection rather than recycling it.
+_Avoid_: transaction context, session
 
 **Family**:
 A group of Commands mirroring one of the server's documented command groups (strings, keys, hashes, …): one Core object of command builders plus matching Client sugar, built and reviewed as a unit.

--- a/docs/adr/0020-transactions-as-a-leased-scope.md
+++ b/docs/adr/0020-transactions-as-a-leased-scope.md
@@ -1,0 +1,27 @@
+# Transactions as a leased scope, abort as an outcome not an error
+
+A Transaction leases one Dedicated Connection for a caller-supplied block — `transaction { scope => … }` — rather than executing a fixed `(watchKeys, Pipeline)` bundle. The bundled form cannot express correct optimistic concurrency: `WATCH` guards a key only against changes *after* the watch, so a real read-modify-write must `WATCH`, then read, then decide, then `EXEC`, all on the one connection `WATCH`'s state lives on. A single bundled call leaves no room to read-and-decide between `WATCH` and `MULTI`, so its guard has a time-of-check/time-of-use gap. ADR-0016 already deferred transactions to "a separate leased-connection API"; this is that API. `TransactionScope[F]` exposes `watch`/`run`/`exec`/`execAttempt`/`discard`; `transaction` is a fourth `Client` primitive alongside `run`/`pipeline`/`pipelineAttempt` (a fake now implements four).
+
+`exec` returns `F[Option[Out]]`: `None` is a `WATCH`-abort. Abort is normal optimistic-concurrency control flow the caller retries, not a failure, so it stays out of the sealed `SageException` hierarchy (consistent with ADR-0019's reluctance to grow it) — an `Option` the retry loop pattern-matches, not an exception it must catch.
+
+The two server-side error phases map to different places, reflecting that Redis does not roll back:
+
+- **Queueing phase** — a command rejected after `MULTI` (unknown command, arity) flags the transaction dirty; `EXEC` replies `EXECABORT` and nothing runs. This fails the effect with a new sealed case, `SageException.TransactionDiscarded`, carrying the offending reply.
+- **Execution phase** — every command queued, `EXEC` ran them all, and an individual command erred in place. The transaction committed; the error is per-position, exactly the Pipeline model (`exec` strict-collapses on the first; `execAttempt` yields `Left` slots). `Reply.run` already lets errors nested in an `EXEC` array reach decoders.
+
+## Considered Options
+
+- **Leased scope (chosen)** — the only shape that supports interactive read-modify-write on the connection `WATCH` requires.
+- **Bundled `transaction(watch)(pipeline)`** — simplest, one round-trip, but cannot read between `WATCH` and `MULTI`; its guard has a TOCTOU gap, failing PRD story 11.
+- **Structured RMW combinator** `transaction(watch)(read)(build)` — captures the one-read loop without leaking a handle, but can't express multi-step interactive transactions.
+- **Abort as a sealed exception** — uniform with other failures, but conflates expected control flow with errors and forces catch-style retry.
+
+## Consequences
+
+- The lease is bracketed around the block and released on success, effect failure, and interruption. Connection hygiene is tracked, not reset: `exec`/`discard` clear all `WATCH`/`MULTI` state server-side, so a clean exit returns the connection to the idle pool; a scope abandoned with watches still armed (read, decided not to proceed, never `exec`/`discard`/`unwatch`) is discarded via the pool's existing `scheduleClose` path rather than recycled. No `UNWATCH` reset round-trip, and no `UNWATCH` command is needed in core. Quiescence is counted from *submit* time, not write time: the transport queues writes asynchronously, so recycling on "no pending replies" alone could hand back a connection whose `MULTI`…`EXEC` is still queued (e.g. an interrupted transaction) and let it execute under the next borrower — the connection counts work in-flight the moment a command is submitted.
+- `exec` pipelines `MULTI` + the body + `EXEC` in one round-trip; the read-phase `run` calls are separate awaited round-trips. `DedicatedConnection` therefore needs a batched submit (a single aggregate callback over `MULTI` … `EXEC`) alongside its existing single `submit`.
+- `tx.run` accepts blocking commands in the read phase: the connection is exclusively held, so a blocking read stalls only this scope's own connection. `exec` still rejects blocking commands through the Pipeline's existing guard.
+- Acquisition is gated on client liveness and bounded by `acquireTimeout`, identical to the blocking-command path (ADR-0017); on `close`, an in-flight transaction is force-closed → `ConnectionLost(true)`.
+- The handle can be captured and used after the block returns; this is unsupported and rejected at runtime — the finalizer sets a `released` flag the scope checks before every operation, failing with an `IllegalStateException` (a programmer error, outside the sealed hierarchy) rather than touching a recycled connection.
+- An empty pipeline is a true no-op that never touches the socket *only when no keys are watched*; with watches armed, `exec` still issues `MULTI`/`EXEC` so a concurrent change to a watched key is observed as an abort (`None`) rather than reported as a vacuous success.
+- Standalone only this slice. Like the Pipeline (ADR-0019), the body retains each command's `keyIndices` so a later cluster slice can enforce single-slot routing without reshaping the types.

--- a/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
+++ b/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
@@ -51,6 +51,26 @@ class CeSmokeSuite extends ServerSuite(Images.redis) {
     }
   }
 
+  test("a transaction commits atomically with native cats-effect, guarded by WATCH") {
+    withContainers { server =>
+      val program: IO[Unit] =
+        SageClient.resource(configOf(server)).use { client =>
+          for {
+            _   <- client.set("tx:n", 1)
+            out <- client.transaction { tx =>
+                     for {
+                       _   <- tx.watch("tx:n")
+                       _   <- tx.run(Strings.get[String, Int]("tx:n"))
+                       res <- tx.exec((Strings.incr[String]("tx:n"), Strings.incrBy[String]("tx:n", 4)).pipeline)
+                     } yield res
+                   }
+          } yield assertEquals(out, Some((2L, 6L)))
+        }
+
+      program.unsafeRunSync()
+    }
+  }
+
   test("scanAll streams every key as a native fs2 Stream") {
     withContainers { server =>
       val program: IO[Unit] =

--- a/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
+++ b/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
@@ -49,6 +49,26 @@ class KyoSmokeSuite extends ServerSuite(Images.redis) {
     }
   }
 
+  test("a transaction commits atomically with native Kyo, guarded by WATCH") {
+    withContainers { server =>
+      val program: Unit < (Scope & Abort[Throwable] & Async) =
+        for {
+          client <- SageClient.scoped(configOf(server))
+          _      <- client.set("tx:n", 1)
+          out    <- client.transaction { tx =>
+                      for {
+                        _   <- tx.watch("tx:n")
+                        _   <- tx.run(Strings.get[String, Int]("tx:n"))
+                        res <- tx.exec((Strings.incr[String]("tx:n"), Strings.incrBy[String]("tx:n", 4)).pipeline)
+                      } yield res
+                    }
+        } yield assertEquals(out, Some((2L, 6L)))
+
+      import AllowUnsafe.embrace.danger
+      KyoApp.Unsafe.runAndBlock(Duration.Infinity)(program).getOrThrow
+    }
+  }
+
   test("scanAll streams every key as a native Kyo Stream") {
     withContainers { server =>
       val program: Unit < (Scope & Abort[Throwable] & Async) =

--- a/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
+++ b/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
@@ -43,6 +43,21 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
     }
   }
 
+  test("a transaction commits atomically with direct-style Ox, guarded by WATCH") {
+    withContainers { server =>
+      supervised {
+        val client = SageClient.scoped(configOf(server))
+        val _      = client.set("tx:n", 1)
+        val out    = client.transaction { tx =>
+          val _ = tx.watch("tx:n")
+          val _ = tx.run(Strings.get[String, Int]("tx:n"))
+          tx.exec((Strings.incr[String]("tx:n"), Strings.incrBy[String]("tx:n", 4)).pipeline)
+        }
+        assertEquals(out, Some((2L, 6L)))
+      }
+    }
+  }
+
   test("scanAll streams every key as a native Ox Flow") {
     withContainers { server =>
       supervised {

--- a/integration-tests/shared/src/test/scala/sage/integration/RoundTripSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/RoundTripSuite.scala
@@ -113,6 +113,73 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
     }
   }
 
+  test("a transaction commits atomically and returns typed results") {
+    withClient { client =>
+      for {
+        _   <- client.set("t:n", 10)
+        out <- client.transaction(tx => tx.exec((Strings.incr[String]("t:n"), Strings.incrBy[String]("t:n", 5)).pipeline))
+      } yield assertEquals(out, Some((11L, 16L)))
+    }
+  }
+
+  test("a read-modify-write transaction commits when the watched key is unchanged") {
+    withClient { client =>
+      for {
+        _      <- client.set("t:rmw", 5)
+        out    <- client.transaction { tx =>
+                    for {
+                      _   <- tx.watch("t:rmw")
+                      cur <- tx.run(Strings.get[String, Int]("t:rmw"))
+                      res <- tx.exec(Pipeline.sequence(Vector(Strings.set[String, Int]("t:rmw", cur.getOrElse(0) + 1))))
+                    } yield res
+                  }
+        stored <- client.get[String, Int]("t:rmw")
+      } yield {
+        assert(out.isDefined, s"expected a committed transaction, got $out")
+        assertEquals(stored, Some(6))
+      }
+    }
+  }
+
+  test("WATCH aborts the transaction when a watched key is modified concurrently") {
+    withContainers { server =>
+      connectAndUse(configOf(server)) { client =>
+        for {
+          other  <- Client.connect(configOf(server))
+          _      <- client.set("t:w", 1)
+          out    <- client.transaction { tx =>
+                      for {
+                        _   <- tx.watch("t:w")
+                        _   <- tx.run(Strings.get[String, Int]("t:w"))
+                        _   <- other.set("t:w", 99) // a different connection changes the watched key before EXEC
+                        res <- tx.exec(Pipeline.sequence(Vector(Strings.incr[String]("t:w"))))
+                      } yield res
+                    }
+          _      <- other.close
+          stored <- client.get[String, Int]("t:w")
+        } yield {
+          assertEquals(out, None)        // aborted
+          assertEquals(stored, Some(99)) // the INCR never ran
+        }
+      }.unsafeRun
+    }
+  }
+
+  test("an execution-phase error surfaces per-position while the other commands commit") {
+    withClient { client =>
+      for {
+        _   <- client.set("t:str", "x")
+        res <- client.transaction(tx => tx.execAttempt((Strings.incr[String]("t:fresh"), Strings.incr[String]("t:str")).pipeline))
+        ok  <- client.get[String, Int]("t:fresh")
+      } yield {
+        val (a, b) = res.getOrElse(fail("expected a committed transaction"))
+        assertEquals(a, Right(1L))
+        assert(b.isLeft, s"expected the INCR on a string to fail, got $b")
+        assertEquals(ok, Some(1)) // the first INCR committed despite the second erroring — Redis does not roll back
+      }
+    }
+  }
+
   test("closing the client releases its server connection") {
     withContainers { server =>
       connectAndUse(configOf(server)) { observer =>

--- a/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
+++ b/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
@@ -51,6 +51,27 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
     }
   }
 
+  test("a transaction commits atomically with native ZIO, guarded by WATCH") {
+    withContainers { server =>
+      val program: Task[Unit] =
+        ZIO.scoped {
+          for {
+            client <- SageClient.scoped(configOf(server))
+            _      <- client.set("tx:n", 1)
+            out    <- client.transaction { tx =>
+                        for {
+                          _   <- tx.watch("tx:n")
+                          _   <- tx.run(Strings.get[String, Int]("tx:n"))
+                          res <- tx.exec((Strings.incr[String]("tx:n"), Strings.incrBy[String]("tx:n", 4)).pipeline)
+                        } yield res
+                      }
+          } yield assertEquals(out, Some((2L, 6L)))
+        }
+
+      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    }
+  }
+
   test("scanAll streams every key as a native ZStream") {
     withContainers { server =>
       val program: Task[Unit] =

--- a/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
+++ b/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
@@ -4,7 +4,7 @@ import cats.effect.{IO, Resource}
 import kyo.compat.*
 
 import sage.client.SageConfig
-import sage.client.internal.Client
+import sage.client.internal.{Client, TransactionScope}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.{Command, Hashes, Keys, Pipeline, RedisType, ScanCursor, Sets, SortedSets}
 
@@ -99,6 +99,18 @@ object SageClient {
     def pipeline[Out, R](p: Pipeline[Out, R]): IO[Out] = underlying.pipeline(p).lower
 
     def pipelineAttempt[Out, R](p: Pipeline[Out, R]): IO[R] = underlying.pipelineAttempt(p).lower
+
+    def transaction[A](body: TransactionScope[IO] => IO[A]): IO[A] =
+      underlying.transaction[A](scope => CIO.lift(body(lower(scope)))).lower
+
+    private def lower(scope: TransactionScope[CIO]): TransactionScope[IO] =
+      new TransactionScope[IO] {
+        def watch[K: KeyCodec](key: K, rest: K*): IO[Unit]          = scope.watch(key, rest*).lower
+        def run[A](command: Command[A]): IO[A]                      = scope.run(command).lower
+        def exec[Out, R](p: Pipeline[Out, R]): IO[Option[Out]]      = scope.exec(p).lower
+        def execAttempt[Out, R](p: Pipeline[Out, R]): IO[Option[R]] = scope.execAttempt(p).lower
+        def discard: IO[Unit]                                       = scope.discard.lower
+      }
 
     def close: IO[Unit] = underlying.close.lower
   }

--- a/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
+++ b/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
@@ -4,7 +4,7 @@ import _root_.kyo.{<, Abort, Async, Scope, Stream, Tag}
 import _root_.kyo.compat.*
 
 import sage.client.SageConfig
-import sage.client.internal.Client
+import sage.client.internal.{Client, TransactionScope}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.{Command, Hashes, Keys, Pipeline, RedisType, ScanCursor, Sets, SortedSets}
 
@@ -99,6 +99,20 @@ object SageClient {
     def pipeline[Out, R](p: Pipeline[Out, R]): Out < (Abort[Throwable] & Async) = underlying.pipeline(p).lower
 
     def pipelineAttempt[Out, R](p: Pipeline[Out, R]): R < (Abort[Throwable] & Async) = underlying.pipelineAttempt(p).lower
+
+    def transaction[A](
+      body: TransactionScope[[X] =>> X < (Abort[Throwable] & Async)] => A < (Abort[Throwable] & Async)
+    ): A < (Abort[Throwable] & Async) =
+      underlying.transaction[A](scope => CIO.lift(body(lower(scope)))).lower
+
+    private def lower(scope: TransactionScope[CIO]): TransactionScope[[X] =>> X < (Abort[Throwable] & Async)] =
+      new TransactionScope[[X] =>> X < (Abort[Throwable] & Async)] {
+        def watch[K: KeyCodec](key: K, rest: K*): Unit < (Abort[Throwable] & Async)          = scope.watch(key, rest*).lower
+        def run[A](command: Command[A]): A < (Abort[Throwable] & Async)                      = scope.run(command).lower
+        def exec[Out, R](p: Pipeline[Out, R]): Option[Out] < (Abort[Throwable] & Async)      = scope.exec(p).lower
+        def execAttempt[Out, R](p: Pipeline[Out, R]): Option[R] < (Abort[Throwable] & Async) = scope.execAttempt(p).lower
+        def discard: Unit < (Abort[Throwable] & Async)                                       = scope.discard.lower
+      }
 
     def close: Unit < (Abort[Throwable] & Async) = underlying.close.lower
   }

--- a/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
@@ -7,7 +7,7 @@ import _root_.ox.flow.Flow
 import kyo.compat.*
 
 import sage.client.SageConfig
-import sage.client.internal.Client
+import sage.client.internal.{Client, TransactionScope}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.{Command, Hashes, Keys, Pipeline, RedisType, ScanCursor, Sets, SortedSets}
 
@@ -104,6 +104,18 @@ object SageClient {
     def pipeline[Out, R](p: Pipeline[Out, R]): Ox ?=> Out = underlying.pipeline(p).lower
 
     def pipelineAttempt[Out, R](p: Pipeline[Out, R]): Ox ?=> R = underlying.pipelineAttempt(p).lower
+
+    def transaction[A](body: TransactionScope[[X] =>> Ox ?=> X] => (Ox ?=> A)): Ox ?=> A =
+      underlying.transaction[A](scope => CIO.lift(body(lower(scope)))).lower
+
+    private def lower(scope: TransactionScope[CIO]): TransactionScope[[X] =>> Ox ?=> X] =
+      new TransactionScope[[X] =>> Ox ?=> X] {
+        def watch[K: KeyCodec](key: K, rest: K*): Ox ?=> Unit          = scope.watch(key, rest*).lower
+        def run[A](command: Command[A]): Ox ?=> A                      = scope.run(command).lower
+        def exec[Out, R](p: Pipeline[Out, R]): Ox ?=> Option[Out]      = scope.exec(p).lower
+        def execAttempt[Out, R](p: Pipeline[Out, R]): Ox ?=> Option[R] = scope.execAttempt(p).lower
+        def discard: Ox ?=> Unit                                       = scope.discard.lower
+      }
 
     def close: Ox ?=> Unit = underlying.close.lower
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -1,18 +1,21 @@
 package sage.client.internal
 
 import java.time.Instant
-import java.util.concurrent.atomic.{AtomicInteger, AtomicReferenceArray}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReferenceArray}
+import java.util.concurrent.locks.ReentrantLock
 
 import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
 
 import kyo.compat.*
 
 import sage.SageException
-import sage.SageException.{NotConnected, ServerError, UnsupportedServer}
+import sage.SageException.{ConnectionLost, NotConnected, ProtocolError, ServerError, TimedOut, TransactionDiscarded, UnsupportedServer}
 import sage.client.{BackoffConfig, DedicatedPoolConfig, SageConfig, WatchdogConfig}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
+import sage.protocol.Frame
 
 /**
   * The user-facing handle owning all connections to one server. Per-command methods are concrete sugar delegating to [[run]], so anything
@@ -25,6 +28,8 @@ trait Client[F[_]] {
   def pipeline[Out, R](p: Pipeline[Out, R]): F[Out]
 
   def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R]
+
+  def transaction[A](body: TransactionScope[F] => F[A]): F[A]
 
   def close: F[Unit]
 
@@ -466,6 +471,17 @@ object Client {
       case other                                                                                                    => other
     }
 
+  // the strict-collapse step shared by `pipeline` and a transaction's `exec`
+  private def collapseStrict[Out](results: Vector[Either[SageException, Any]], toOut: Vector[Any] => Out): CIO[Out] =
+    results.collectFirst { case Left(error) => error } match {
+      case Some(error) => CIO.fail(error)
+      case None        => CIO.value(toOut(results.collect { case Right(value) => value }))
+    }
+
+  // a programmer error, deliberately outside the sealed hierarchy (like the blocking-command guard): a scope captured past its block
+  private def scopeReleasedError: IllegalStateException =
+    new IllegalStateException("transaction scope used after its block returned")
+
   final private class Live(connection: MultiplexedConnection, pool: DedicatedPool) extends Client[CIO] {
 
     def run[A](command: Command[A]): CIO[A] =
@@ -475,15 +491,29 @@ object Client {
       }
 
     def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out] =
-      submitPipeline(p).flatMap { results =>
-        results.collectFirst { case Left(error) => error } match {
-          case Some(error) => CIO.fail(error)
-          case None        => CIO.value(p.toOut(results.collect { case Right(value) => value }))
-        }
-      }
+      submitPipeline(p).flatMap(collapseStrict(_, p.toOut))
 
     def pipelineAttempt[Out, R](p: Pipeline[Out, R]): CIO[R] =
       submitPipeline(p).map(p.toResults)
+
+    // The lease is bracketed: release runs on success, failure, and interruption (IO.bracket). A clean exit (exec/discard cleared the
+    // connection's WATCH/MULTI state, no reply outstanding) recycles the connection; a scope left armed or interrupted mid-command is
+    // discarded rather than handed to the next borrower dirty.
+    def transaction[A](body: TransactionScope[CIO] => CIO[A]): CIO[A] =
+      CIO.acquireReleaseWith(acquireScope)(releaseScope)(scope => body(scope))
+
+    private def acquireScope: CIO[TxScope] =
+      CIO.blocking {
+        try new TxScope(pool.acquireForTransaction())
+        catch {
+          case e: NotConnected => throw e
+          case e: TimedOut     => throw e
+          case NonFatal(_)     => throw ConnectionLost(mayHaveExecuted = false)
+        }
+      }
+
+    private def releaseScope(scope: TxScope): CIO[Unit] =
+      CIO.blocking(pool.releaseTransaction(scope.conn, scope.sealAndReusable()))
 
     private def submitPipeline[Out, R](p: Pipeline[Out, R]): CIO[Vector[Either[SageException, Any]]] =
       if (p.commands.isEmpty)
@@ -512,5 +542,115 @@ object Client {
       }
 
     def close: CIO[Unit] = CIO.blocking { pool.close(); connection.close() }
+  }
+
+  final private class TxScope(val conn: DedicatedConnection) extends TransactionScope[CIO] {
+
+    // tracks whether watched keys may still be armed on the connection; set as soon as WATCH is attempted, cleared by EXEC/UNWATCH
+    val armed = new AtomicBoolean(false)
+
+    // The lock makes "reject if released, else submit" atomic with the finalizer's seal-and-decide ([[sealAndReusable]]): a command
+    // submitted under it is in-flight before the finalizer reads quiescence, so a handle captured past the block and raced against release
+    // either submits onto a connection the finalizer then declines to recycle, or is rejected outright — never onto a re-borrowed one.
+    private val lock     = new ReentrantLock()
+    private var released = false
+
+    private def submitting[A](complete: Try[A] => Unit)(submit: => Unit): Unit = {
+      lock.lock()
+      try if (released) complete(Failure(scopeReleasedError)) else submit
+      finally lock.unlock()
+    }
+
+    // run once by the lease finalizer: seals the scope against further operations and reports whether the connection may be recycled
+    private[Client] def sealAndReusable(): Boolean = {
+      lock.lock()
+      try {
+        released = true
+        conn.isHealthy && conn.isQuiescent && !armed.get
+      } finally lock.unlock()
+    }
+
+    private def isReleased: Boolean = {
+      lock.lock()
+      try released
+      finally lock.unlock()
+    }
+
+    def watch[K: KeyCodec](key: K, rest: K*): CIO[Unit] =
+      CIO.async[Unit] { complete =>
+        submitting(complete) {
+          armed.set(true)
+          conn.submit(Connection.watch(key, rest*), complete)
+        }
+      }
+
+    def run[A](command: Command[A]): CIO[A] =
+      CIO.async[A](complete => submitting(complete)(conn.submit(command, complete)))
+
+    def discard: CIO[Unit] =
+      CIO.async[Unit] { complete =>
+        submitting(complete) {
+          armed.set(false)
+          conn.submit(Connection.unwatch, complete)
+        }
+      }
+
+    def exec[Out, R](p: Pipeline[Out, R]): CIO[Option[Out]] =
+      runExec(p).flatMap {
+        case None          => CIO.value(None)
+        case Some(results) => collapseStrict(results, p.toOut).map(Some(_))
+      }
+
+    def execAttempt[Out, R](p: Pipeline[Out, R]): CIO[Option[R]] =
+      runExec(p).map(_.map(p.toResults))
+
+    // None = WATCH abort; Some = the per-position decoded results. A queueing-phase error fails the effect (nothing ran).
+    private def runExec[Out, R](p: Pipeline[Out, R]): CIO[Option[Vector[Either[SageException, Any]]]] =
+      if (isReleased)
+        CIO.fail(scopeReleasedError)
+      // a truly empty no-op only when nothing is watched; with watches armed we must still MULTI/EXEC so a concurrent change can abort it
+      else if (p.commands.isEmpty && !armed.get)
+        CIO.value(Some(Vector.empty))
+      else if (p.commands.exists(_.execution != Execution.Ordinary))
+        CIO.fail(new IllegalArgumentException("a Transaction cannot carry blocking commands; run them in the read phase instead"))
+      else
+        CIO
+          .async[Vector[Frame]] { complete =>
+            submitting(complete)(conn.submitRaw(Connection.multi +: p.commands :+ Connection.exec, complete))
+          }
+          .flatMap { frames =>
+            armed.set(false) // EXEC clears WATCH/MULTI state server-side whether it committed or aborted
+            interpretExec(p.commands, frames)
+          }
+
+    private def interpretExec(
+      commands: Vector[Command[?]],
+      frames: Vector[Frame]
+    ): CIO[Option[Vector[Either[SageException, Any]]]] = {
+      val n          = commands.length
+      // frames: MULTI reply, then one queue reply per command, then the EXEC reply
+      val queueError = (0 to n).iterator.map(i => errorOf(frames(i))).collectFirst { case Some(message) => message }
+      queueError match {
+        case Some(message) => CIO.fail(TransactionDiscarded(message))
+        case None          =>
+          frames(n + 1) match {
+            case Frame.Null         => CIO.value(None)
+            case Frame.Array(elems) =>
+              CIO.value(Some(Vector.tabulate(n)(i => Reply.run(commands(i).asInstanceOf[Command[Any]], elems(i)))))
+            case other              =>
+              errorOf(other) match {
+                case Some(message) => CIO.fail(TransactionDiscarded(message))
+                case None          => CIO.fail(ProtocolError(s"unexpected EXEC reply: ${Frame.describe(other)}"))
+              }
+          }
+      }
+    }
+
+    private def errorOf(frame: Frame): Option[String] =
+      frame match {
+        case Frame.SimpleError(message) => Some(message)
+        case Frame.BulkError(message)   => Some(message.asUtf8String)
+        case _                          => None
+      }
   }
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
@@ -1,7 +1,7 @@
 package sage.client.internal
 
 import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference, AtomicReferenceArray}
 
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
@@ -13,10 +13,10 @@ import sage.commands.{Command, Reply}
 import sage.protocol.Frame
 
 /**
-  * A single connection held exclusively for one blocking command at a time, borrowed from the [[DedicatedPool]]. Unlike the Multiplexed
+  * A single connection held exclusively by one borrower at a time, borrowed from the [[DedicatedPool]]. Unlike the Multiplexed
   * Connection it carries no reconnect loop and no watchdog: on any connection loss it is marked dead and the pool discards it, failing the
-  * in-flight command `ConnectionLost(mayHaveExecuted = true)` per ADR-0006 (the command may have run before the reply was lost). Replies
-  * are still matched FIFO so the synchronous HELLO bootstrap can run on it before it is handed out.
+  * in-flight work `ConnectionLost(mayHaveExecuted = true)` per ADR-0006. Replies are matched FIFO so the synchronous HELLO bootstrap can
+  * run on it before it is handed out, and so a transaction's `MULTI`/queue/`EXEC` replies line up with the commands that produced them.
   */
 final private[client] class DedicatedConnection private (
   factory: MultiplexedConnection.TransportFactory,
@@ -24,14 +24,30 @@ final private[client] class DedicatedConnection private (
   val generation: Long
 ) {
 
-  private val pending                 = new ConcurrentLinkedQueue[Entry[?]]()
+  private val pending                 = new ConcurrentLinkedQueue[DedicatedConnection.Waiter]()
   private val transportRef            = new AtomicReference[Transport]()
   @volatile private var dead: Boolean = false
+  // counts work from submit time, not write time: the transport queues asynchronously, so a command sits here before `writeAttempted`
+  // moves it to `pending`. Recycling on `pending.isEmpty` alone could hand back a connection with a queued-but-unwritten batch.
+  private val inFlight                = new AtomicInteger(0)
 
   def isHealthy: Boolean = !dead
 
-  def submit[A](command: Command[A], callback: Try[A] => Unit): Unit =
+  def isQuiescent: Boolean = !dead && inFlight.get() == 0
+
+  def submit[A](command: Command[A], callback: Try[A] => Unit): Unit = {
+    inFlight.incrementAndGet()
     transportRef.get().send(new Entry(command, callback))
+  }
+
+  /**
+    * Sends `commands` as a single pipelined write and hands back their raw reply frames in order. Used for a transaction's `MULTI` … `EXEC`
+    * batch, whose `EXEC` array the caller decodes per-position against the original commands; the frames are returned undecoded.
+    */
+  def submitRaw(commands: Vector[Command[?]], callback: Try[Vector[Frame]] => Unit): Unit = {
+    inFlight.incrementAndGet()
+    transportRef.get().send(new RawBatch(commands, callback))
+  }
 
   def close(): Unit = {
     dead = true
@@ -73,31 +89,32 @@ final private[client] class DedicatedConnection private (
     frame match {
       case _: Frame.Push | _: Frame.Attribute => ()
       case reply                              =>
-        val entry = pending.poll()
-        if (entry == null) close() // a reply with nothing pending means the stream desynced; discard
+        val waiter = pending.poll()
+        if (waiter == null) close() // a reply with nothing pending means the stream desynced; discard
         else {
           // poison before delivering so release discards it rather than recycling it
           if (Poison.isReadonly(reply)) close()
-          entry.complete(reply)
+          waiter.complete(reply)
         }
     }
 
   private def onClosed(): Unit = {
     dead = true
-    var entry = pending.poll()
-    while (entry != null) {
-      entry.fail(ConnectionLost(mayHaveExecuted = true))
-      entry = pending.poll()
+    var waiter = pending.poll()
+    while (waiter != null) {
+      waiter.fail(ConnectionLost(mayHaveExecuted = true))
+      waiter = pending.poll()
     }
   }
 
-  final private class Entry[A](command: Command[A], callback: Try[A] => Unit) extends Transport.Item {
+  final private class Entry[A](command: Command[A], callback: Try[A] => Unit) extends Transport.Item with DedicatedConnection.Waiter {
 
     val payload: Bytes = command.encode
 
     def writeAttempted(): Unit = { val _ = pending.add(this) }
 
-    def dropped(): Unit = callback(Failure(ConnectionLost(mayHaveExecuted = false)))
+    // exactly one of dropped/complete/fail fires per entry; each retires the in-flight count before delivering the result
+    def dropped(): Unit = { inFlight.decrementAndGet(); callback(Failure(ConnectionLost(mayHaveExecuted = false))) }
 
     def complete(frame: Frame): Unit = {
       val result =
@@ -109,14 +126,55 @@ final private[client] class DedicatedConnection private (
         catch {
           case NonFatal(error) => Failure(error)
         }
+      inFlight.decrementAndGet()
       callback(result)
     }
 
-    def fail(error: SageException): Unit = callback(Failure(error))
+    def fail(error: SageException): Unit = { inFlight.decrementAndGet(); callback(Failure(error)) }
+  }
+
+  // One write, N waiters: the batch is written (or dropped) atomically, and each reply frame fills its slot. The shared collector fires the
+  // single callback once every frame has arrived, or once on the first failure.
+  final private class RawBatch(commands: Vector[Command[?]], callback: Try[Vector[Frame]] => Unit) extends Transport.Item {
+
+    private val n         = commands.length
+    private val frames    = new AtomicReferenceArray[Frame](n)
+    private val remaining = new AtomicInteger(n)
+    private val done      = new AtomicBoolean(false)
+
+    val payload: Bytes = Bytes.concat(commands.map(_.encode))
+
+    def writeAttempted(): Unit = {
+      var i = 0
+      while (i < n) { val _ = pending.add(new Slot(i)); i += 1 }
+    }
+
+    def dropped(): Unit = finish(Failure(ConnectionLost(mayHaveExecuted = false)))
+
+    private def finish(result: Try[Vector[Frame]]): Unit =
+      if (done.compareAndSet(false, true)) {
+        inFlight.decrementAndGet()
+        callback(result)
+      }
+
+    final private class Slot(index: Int) extends DedicatedConnection.Waiter {
+
+      def complete(frame: Frame): Unit = {
+        frames.set(index, frame)
+        if (remaining.decrementAndGet() == 0) finish(Success(Vector.tabulate(n)(frames.get)))
+      }
+
+      def fail(error: SageException): Unit = finish(Failure(error))
+    }
   }
 }
 
 private[client] object DedicatedConnection {
+
+  private trait Waiter {
+    def complete(frame: Frame): Unit
+    def fail(error: SageException): Unit
+  }
 
   /**
     * Connects and runs the bootstrap synchronously; throws (no retry) if the connect or handshake fails.

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -72,6 +72,28 @@ final private[client] class DedicatedPool(
         }
       }
 
+  /**
+    * Borrows a connection to lease across a transaction's many commands (rather than the single command [[use]] runs). Blocks the calling
+    * fiber while it waits for a slot or opens a socket, so callers must offload it; gated on liveness like [[use]].
+    */
+  def acquireForTransaction(): DedicatedConnection = {
+    if (!isLive()) throw NotConnected()
+    acquire()
+  }
+
+  /**
+    * Returns a leased connection. `reusable` recycles it to the idle set; otherwise (a transaction left with watches armed, or interrupted
+    * mid-command) it is discarded outright rather than handed to the next borrower with residual `WATCH`/`MULTI` state.
+    */
+  def releaseTransaction(connection: DedicatedConnection, reusable: Boolean): Unit =
+    if (reusable) release(connection)
+    else
+      locked {
+        live -= connection
+        scheduleClose(connection)
+        available.signalAll()
+      }
+
   def close(): Unit = {
     val toClose = locked {
       closing = true

--- a/sage-client/shared/src/main/scala/sage/client/internal/TransactionScope.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/TransactionScope.scala
@@ -1,0 +1,39 @@
+package sage.client.internal
+
+import sage.codec.KeyCodec
+import sage.commands.{Command, Pipeline}
+
+/**
+  * The handle opened by `transaction { scope => … }`: one leased Dedicated Connection, held for the whole block. Reads (`watch`, `run`)
+  * execute immediately on that connection — the one `WATCH` requires — so a caller can read, decide, and only then `exec` a Pipeline as an
+  * atomic `MULTI`/`EXEC`. `exec` returns `None` when a watched key changed before `EXEC` (an aborted optimistic-concurrency attempt the
+  * caller retries, not a failure); `execAttempt` mirrors a Pipeline's per-position results. A queueing-phase rejection fails the effect with
+  * `TransactionDiscarded` (nothing ran), distinct from an execution-phase error, which leaves the other commands committed.
+  */
+trait TransactionScope[F[_]] {
+
+  /**
+    * Watches keys for the duration of the scope; a later `exec` aborts if any changed.
+    */
+  def watch[K: KeyCodec](key: K, rest: K*): F[Unit]
+
+  /**
+    * Runs a command immediately on the leased connection — a read in the optimistic-concurrency loop, before any `exec`.
+    */
+  def run[A](command: Command[A]): F[A]
+
+  /**
+    * Executes the Pipeline atomically. `None` means a watched key changed and the transaction aborted.
+    */
+  def exec[Out, R](pipeline: Pipeline[Out, R]): F[Option[Out]]
+
+  /**
+    * Like `exec`, but yields the per-position results (each slot a `Right`/`Left`) on commit. `None` still means aborted.
+    */
+  def execAttempt[Out, R](pipeline: Pipeline[Out, R]): F[Option[R]]
+
+  /**
+    * Abandons the scope without committing, clearing any watched keys so the connection can be recycled (issues `UNWATCH`).
+    */
+  def discard: F[Unit]
+}

--- a/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
@@ -167,4 +167,35 @@ class DedicatedPoolSpec extends munit.FunSuite {
     scheduler.advance(31.seconds)
     assertEquals(transports.head.closeCount, 1)
   }
+
+  test("a transaction lease returns a reusable connection to the pool") {
+    val (pool, scheduler, transports) = make(replyWith(Seq(popReply)))
+    val conn                          = pool.acquireForTransaction()
+    assertEquals(transports.size, 1)
+
+    pool.releaseTransaction(conn, reusable = true)
+    val reused = pool.acquireForTransaction()
+    scheduler.advance(Duration.Zero)
+    assertEquals(transports.size, 1)
+    pool.releaseTransaction(reused, reusable = true)
+  }
+
+  test("a transaction lease discards a non-reusable connection and opens a fresh one next time") {
+    val (pool, scheduler, transports) = make(replyWith(Seq(popReply)))
+    val conn                          = pool.acquireForTransaction()
+    assertEquals(transports.size, 1)
+
+    pool.releaseTransaction(conn, reusable = false)
+    scheduler.advance(Duration.Zero)
+    assertEquals(transports.head.closeCount, 1)
+
+    val _ = pool.acquireForTransaction()
+    assertEquals(transports.size, 2)
+  }
+
+  test("a transaction lease issued while not connected fails fast NotConnected") {
+    val (pool, _, transports) = make(replyWith(Nil), isLive = () => false)
+    intercept[NotConnected](pool.acquireForTransaction())
+    assertEquals(transports.size, 0)
+  }
 }

--- a/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
+++ b/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
@@ -5,7 +5,7 @@ import zio.*
 import zio.stream.ZStream
 
 import sage.client.SageConfig
-import sage.client.internal.Client
+import sage.client.internal.{Client, TransactionScope}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.{Command, Hashes, Keys, Pipeline, RedisType, ScanCursor, Sets, SortedSets}
 
@@ -103,6 +103,18 @@ object SageClient {
     def pipeline[Out, R](p: Pipeline[Out, R]): Task[Out] = underlying.pipeline(p).lower
 
     def pipelineAttempt[Out, R](p: Pipeline[Out, R]): Task[R] = underlying.pipelineAttempt(p).lower
+
+    def transaction[A](body: TransactionScope[Task] => Task[A]): Task[A] =
+      underlying.transaction[A](scope => CIO.lift(body(lower(scope)))).lower
+
+    private def lower(scope: TransactionScope[CIO]): TransactionScope[Task] =
+      new TransactionScope[Task] {
+        def watch[K: KeyCodec](key: K, rest: K*): Task[Unit]          = scope.watch(key, rest*).lower
+        def run[A](command: Command[A]): Task[A]                      = scope.run(command).lower
+        def exec[Out, R](p: Pipeline[Out, R]): Task[Option[Out]]      = scope.exec(p).lower
+        def execAttempt[Out, R](p: Pipeline[Out, R]): Task[Option[R]] = scope.execAttempt(p).lower
+        def discard: Task[Unit]                                       = scope.discard.lower
+      }
 
     def close: Task[Unit] = underlying.close.lower
   }

--- a/sage-client/zio/src/test/scala/sage/client/TransactionSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/TransactionSpec.scala
@@ -1,0 +1,168 @@
+package sage.client
+
+import scala.concurrent.ExecutionContext
+
+import kyo.compat.*
+
+import sage.Bytes
+import sage.SageException.{ServerError, TransactionDiscarded}
+import sage.client.internal.{Client, FakeTransport, MultiplexedConnection}
+import sage.commands.{Command, Execution, Pipeline, Strings}
+import sage.commands.Pipeline.pipeline
+import sage.protocol.Frame
+
+class TransactionSpec extends munit.FunSuite {
+
+  private given ExecutionContext = munitExecutionContext
+
+  private val helloReply: Frame =
+    Frame.Map(
+      Vector(
+        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
+        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
+        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
+        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
+      )
+    )
+
+  private val ok: Frame     = Frame.SimpleString("OK")
+  private val queued: Frame = Frame.SimpleString("QUEUED")
+
+  // Scripts a dedicated connection: HELLO bootstraps, WATCH/UNWATCH answer OK, the pipelined MULTI…EXEC batch (one write) answers with the
+  // supplied frame sequence, and a read GET answers a value. The batch carries "MULTI", so it is matched before the bare command names.
+  private def scripted(execReplies: Seq[Frame], getReply: Frame = Frame.BulkString(Bytes.utf8("v"))): MultiplexedConnection.TransportFactory =
+    (onFrame, onClosed) =>
+      new FakeTransport(
+        onFrame,
+        onClosed,
+        respond = payload => {
+          val text = payload.asUtf8String
+          if (text.contains("HELLO")) Seq(helloReply)
+          else if (text.contains("MULTI")) execReplies
+          else if (text.contains("UNWATCH")) Seq(ok)
+          else if (text.contains("WATCH")) Seq(ok)
+          else if (text.contains("GET")) Seq(getReply)
+          else Seq(ok)
+        }
+      )
+
+  // wraps a factory so the most-recently-created transport (the dedicated connection) can be inspected after the run
+  private def capturing(factory: MultiplexedConnection.TransportFactory): (MultiplexedConnection.TransportFactory, () => FakeTransport) = {
+    var last: FakeTransport                             = null
+    val wrapped: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
+      last = factory(onFrame, onClosed).asInstanceOf[FakeTransport]
+      last
+    }
+    (wrapped, () => last)
+  }
+
+  private val twoIncrements = (Strings.incr[String]("a"), Strings.incr[String]("b")).pipeline
+
+  private val emptyPipeline = Pipeline.sequence(Vector.empty[Command[Long]])
+
+  test("a transaction commits and returns the typed tuple") {
+    val factory = scripted(Seq(ok, queued, queued, Frame.Array(Vector(Frame.Integer(1), Frame.Integer(2)))))
+    Client.connectWith(factory).flatMap(_.transaction(_.exec(twoIncrements))).unsafeRun.map { result =>
+      assertEquals(result, Some((1L, 2L)))
+    }
+  }
+
+  test("a watched key change aborts the transaction with None") {
+    val factory = scripted(Seq(ok, queued, queued, Frame.Null))
+    Client
+      .connectWith(factory)
+      .flatMap(client => client.transaction(tx => tx.watch("a").flatMap(_ => tx.exec(twoIncrements))))
+      .unsafeRun
+      .map(result => assertEquals(result, None))
+  }
+
+  test("a queueing-phase error discards the whole transaction") {
+    val factory = scripted(
+      Seq(ok, Frame.SimpleError("ERR unknown command 'FOO'"), Frame.SimpleError("EXECABORT Transaction discarded because of previous errors"))
+    )
+    val single  = Pipeline.sequence(Vector(Strings.incr[String]("a")))
+    Client.connectWith(factory).flatMap(_.transaction(_.exec(single))).unsafeRun.failed.map { error =>
+      assertEquals(error, TransactionDiscarded("ERR unknown command 'FOO'"))
+    }
+  }
+
+  test("an execution-phase error fails strict exec with the first error") {
+    val factory = scripted(Seq(ok, queued, queued, Frame.Array(Vector(Frame.Integer(1), Frame.SimpleError("WRONGTYPE nope")))))
+    Client.connectWith(factory).flatMap(_.transaction(_.exec(twoIncrements))).unsafeRun.failed.map { error =>
+      assertEquals(error, ServerError("WRONGTYPE nope"))
+    }
+  }
+
+  test("execAttempt surfaces execution-phase errors per-position while other commands commit") {
+    val factory = scripted(Seq(ok, queued, queued, Frame.Array(Vector(Frame.Integer(1), Frame.SimpleError("WRONGTYPE nope")))))
+    Client.connectWith(factory).flatMap(_.transaction(_.execAttempt(twoIncrements))).unsafeRun.map { result =>
+      val (a, b) = result.getOrElse(fail("expected a committed transaction"))
+      assertEquals(a, Right(1L))
+      assertEquals(b, Left(ServerError("WRONGTYPE nope")))
+    }
+  }
+
+  test("discard issues UNWATCH and runs no EXEC") {
+    val (factory, transport) = capturing(scripted(Seq(ok)))
+    Client
+      .connectWith(factory)
+      .flatMap(client => client.transaction(tx => tx.watch("a").flatMap(_ => tx.discard)))
+      .unsafeRun
+      .map { _ =>
+        assert(transport().written.exists(_.asUtf8String.contains("UNWATCH")), "expected an UNWATCH")
+        assert(!transport().written.exists(_.asUtf8String.contains("EXEC")), "expected no EXEC")
+      }
+  }
+
+  test("a scope captured beyond the block rejects further use") {
+    val factory = scripted(Seq(ok))
+    Client
+      .connectWith(factory)
+      .flatMap(client => client.transaction(tx => CIO.value(tx)).flatMap(escaped => escaped.run(Strings.incr[String]("a"))))
+      .unsafeRun
+      .failed
+      .map(error => assert(error.isInstanceOf[IllegalStateException], s"unexpected error: $error"))
+  }
+
+  test("a captured scope rejects exec even of an empty pipeline after the block") {
+    val factory = scripted(Seq(ok))
+    Client
+      .connectWith(factory)
+      .flatMap(client => client.transaction(tx => CIO.value(tx)).flatMap(escaped => escaped.exec(emptyPipeline)))
+      .unsafeRun
+      .failed
+      .map(error => assert(error.isInstanceOf[IllegalStateException], s"unexpected error: $error"))
+  }
+
+  test("an empty transaction with watches still issues MULTI/EXEC so a concurrent change can abort it") {
+    val (factory, transport) = capturing(scripted(Seq(ok, Frame.Null))) // MULTI ok, EXEC null = watched key changed
+    Client
+      .connectWith(factory)
+      .flatMap(client => client.transaction(tx => tx.watch("a").flatMap(_ => tx.exec(emptyPipeline))))
+      .unsafeRun
+      .map { result =>
+        assertEquals(result, None)
+        assert(transport().written.exists(_.asUtf8String.contains("MULTI")), "expected MULTI/EXEC for an empty watched transaction")
+      }
+  }
+
+  test("an empty transaction with no watch is a no-op that never reaches the socket") {
+    val (factory, transport) = capturing(scripted(Seq(ok)))
+    Client
+      .connectWith(factory)
+      .flatMap(_.transaction(_.exec(emptyPipeline)))
+      .unsafeRun
+      .map { result =>
+        assertEquals(result, Some(Vector.empty[Long]))
+        assert(!transport().written.exists(_.asUtf8String.contains("MULTI")), "an empty no-watch transaction must not touch the socket")
+      }
+  }
+
+  test("a transaction carrying a blocking command fails fast without reaching the socket") {
+    val factory  = scripted(Seq(ok))
+    val blocking = Pipeline.sequence(Vector(Command("BLPOP", Command.NoKeys, Vector.empty, _ => Right(()), Execution.Blocking)))
+    Client.connectWith(factory).flatMap(_.transaction(_.exec(blocking))).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+    }
+  }
+}

--- a/sage-core/src/main/scala/sage/SageException.scala
+++ b/sage-core/src/main/scala/sage/SageException.scala
@@ -33,4 +33,10 @@ object SageException {
   final case class CrossSlot(message: String) extends SageException(message)
 
   final case class TimedOut(message: String) extends SageException(message)
+
+  /**
+    * A transaction was discarded server-side because a command could not be queued (`EXECABORT`): nothing ran. Distinct from an
+    * execution-phase error, which leaves the other commands committed (Redis does not roll back) and surfaces per-position.
+    */
+  final case class TransactionDiscarded(message: String) extends SageException(message)
 }

--- a/sage-core/src/main/scala/sage/commands/Connection.scala
+++ b/sage-core/src/main/scala/sage/commands/Connection.scala
@@ -2,9 +2,22 @@ package sage.commands
 
 import sage.Bytes
 import sage.SageException.DecodeError
+import sage.codec.KeyCodec
 import sage.protocol.Frame
 
 object Connection {
+
+  val multi: Command[Unit] = Command("MULTI", keyIndices = Command.NoKeys, args = Vector.empty, decode = Decode.ok)
+
+  // the reply (an array of per-command results, or a null array on WATCH abort) is interpreted by the runtime, not this passthrough decoder
+  val exec: Command[Frame] = Command("EXEC", keyIndices = Command.NoKeys, args = Vector.empty, decode = frame => Right(frame))
+
+  val unwatch: Command[Unit] = Command("UNWATCH", keyIndices = Command.NoKeys, args = Vector.empty, decode = Decode.ok)
+
+  def watch[K](first: K, rest: K*)(using keyCodec: KeyCodec[K]): Command[Unit] = {
+    val keys = (first +: rest.toVector).map(keyCodec.encode)
+    Command("WATCH", keyIndices = Vector.range(0, keys.length), args = keys, decode = Decode.ok)
+  }
 
   def ping(message: Option[String] = None): Command[String] =
     Command(


### PR DESCRIPTION
Closes #19.

Adds the **Transaction** primitive from the glossary: a Pipeline executed atomically via `MULTI`/`EXEC` on a Dedicated Connection, optionally guarded by `WATCH` for optimistic concurrency. Covers PRD story 11.

## API

```scala
client.transaction { tx =>
  for {
    _   <- tx.watch("balance")
    bal <- tx.run(get[Long]("balance"))
    out <- if (bal >= 10) tx.exec((decrBy("balance", 10), incrBy("spent", 10)).pipeline)
           else            tx.discard.as(None)
  } yield out
}
```

`transaction { tx => … }` leases one Dedicated Connection for the block. Inside, `tx.watch`/`tx.run` execute immediately (the read phase, on the connection `WATCH` requires); `tx.exec`/`tx.execAttempt` commit a Pipeline as `MULTI`/`EXEC` in one round-trip; `tx.discard` abandons it.

## Behaviour (the acceptance criteria)

- **Atomic, typed results** — `exec` pipelines `MULTI` + body + `EXEC` in a single round-trip and decodes the array per-position against the original commands.
- **WATCH abort is a distinct, matchable outcome** — `exec` returns `F[Option[Out]]`; `None` means a watched key changed (retryable optimistic-concurrency control flow, deliberately *not* an exception). `execAttempt` mirrors the Pipeline per-position model.
- **Queueing- vs execution-phase errors are distinguished** — a queueing rejection fails the effect with the new `SageException.TransactionDiscarded` (nothing ran); execution-phase errors surface per-position, since Redis does not roll back.
- **The connection is always released** — the lease is bracketed (release on success, failure, and interruption). It is recycled only when clean (no armed watches, quiescent, healthy) and discarded otherwise. Quiescence is counted from *submit* time, so an interrupted-but-still-queued `MULTI`…`EXEC` can never be recycled onto the next borrower. A handle captured beyond the block is rejected with `IllegalStateException`.

## Changes

- **Core**: `Connection.multi`/`exec`/`watch`/`unwatch` builders; `SageException.TransactionDiscarded`.
- **Runtime**: `TransactionScope[F]`; `transaction` as a fourth `Client` primitive; `DedicatedConnection.submitRaw` + submit-time in-flight accounting; a `DedicatedPool` lease (`acquireForTransaction`/`releaseTransaction`); a per-scope lock making "reject-if-released else submit" atomic with the finalizer's seal-and-recycle.
- **Backends**: lowered across ZIO, cats-effect, Kyo, and Ox.
- **Docs**: `CONTEXT.md` (Transaction / Transaction Scope) and `docs/adr/0020-transactions-as-a-leased-scope.md`.

## Tests

- `TransactionSpec` (scripted): commit, abort, both error phases, discard→`UNWATCH`, blocking-command rejection, escaped-scope rejection, empty±watch semantics.
- `DedicatedPoolSpec`: lease recycle / dirty-discard / not-connected.
- `RoundTripSuite` + all four backend SmokeSuites — green on Redis and Valkey.