### PR TITLE
TLS and AUTH/ACL support (#10)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,8 @@ lazy val client = (projectMatrix in file("sage-client"))
   .compatLibrary(ZioLib, CeLib, OxLib)(VirtualAxis.jvm)(Seq(scala3Version))
 
 // the shared testcontainers suite runs once per backend cell, catching backend-specific lowering bugs against real servers;
-// command-behavior suites (sage.integration.commands) run on one designated cell only — per-command behavior cannot differ per backend
+// command-behavior (sage.integration.commands) and security (sage.integration.security) suites run on one designated cell only — neither
+// per-command behavior nor TLS/auth (which live in the shared socket layer) can differ per backend
 lazy val integrationTests = (projectMatrix in file("integration-tests"))
   .dependsOn(client, core % "test->test")
   .settings(name := "integration-tests")
@@ -73,7 +74,8 @@ lazy val integrationTests = (projectMatrix in file("integration-tests"))
     Test / testOptions += {
       val isAnchor     = moduleName.value.endsWith("-future")
       val isDesignated = moduleName.value.endsWith("-zio")
-      Tests.Filter(name => !isAnchor && (isDesignated || !name.startsWith("sage.integration.commands.")))
+      val onceOnly     = Set("sage.integration.commands.", "sage.integration.security.")
+      Tests.Filter(name => !isAnchor && (isDesignated || !onceOnly.exists(name.startsWith)))
     }
   )
   .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq(scala3NextVersion))

--- a/integration-tests/shared/src/test/scala/sage/integration/ContainerClient.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/ContainerClient.scala
@@ -1,0 +1,26 @@
+package sage.integration
+
+import com.dimafeng.testcontainers.GenericContainer
+import kyo.compat.*
+
+import sage.client.SageConfig
+import sage.client.internal.Client
+
+/**
+  * Shared connect-and-teardown helpers for the testcontainers suites: build a config for a started container, and run a body against a
+  * client that is always closed afterwards.
+  */
+trait ContainerClient {
+
+  protected def configOf(server: GenericContainer): SageConfig =
+    SageConfig(host = server.host, port = server.mappedPort(6379))
+
+  // CIO.acquireReleaseWith fails to compile on the Ox/Future cells when its type argument nests CIO (Client[CIO]); fold instead
+  protected def connectAndUse[A](config: SageConfig)(body: Client[CIO] => CIO[A]): CIO[A] =
+    Client.connect(config).flatMap { client =>
+      body(client).fold(
+        result => client.close.map(_ => result),
+        error => client.close.flatMap(_ => CIO.fail(error))
+      )
+    }
+}

--- a/integration-tests/shared/src/test/scala/sage/integration/ServerSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/ServerSuite.scala
@@ -6,28 +6,15 @@ import com.dimafeng.testcontainers.GenericContainer
 import com.dimafeng.testcontainers.munit.TestContainerForAll
 import kyo.compat.*
 
-import sage.client.SageConfig
 import sage.client.internal.Client
 
-abstract class ServerSuite(image: String) extends munit.FunSuite with TestContainerForAll {
+abstract class ServerSuite(image: String) extends munit.FunSuite with TestContainerForAll with ContainerClient {
 
   override val containerDef: GenericContainer.Def[GenericContainer] = GenericContainer.Def(image, exposedPorts = Seq(6379))
-
-  protected def configOf(server: GenericContainer): SageConfig =
-    SageConfig(host = server.host, port = server.mappedPort(6379))
 
   // not private: only the Ox cell's unsafeRun consumes it, and a private given would be flagged unused on the other cells
   given ExecutionContext = munitExecutionContext
 
   protected def withClient[A](body: Client[CIO] => CIO[A]): Future[A] =
     withContainers(server => connectAndUse(configOf(server))(body).unsafeRun)
-
-  // CIO.acquireReleaseWith fails to compile on the Ox/Future cells when its type argument nests CIO (Client[CIO]); fold instead
-  protected def connectAndUse[A](config: SageConfig)(body: Client[CIO] => CIO[A]): CIO[A] =
-    Client.connect(config).flatMap { client =>
-      body(client).fold(
-        result => client.close.map(_ => result),
-        error => client.close.flatMap(_ => CIO.fail(error))
-      )
-    }
 }

--- a/integration-tests/shared/src/test/scala/sage/integration/security/TlsAuthSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/security/TlsAuthSuite.scala
@@ -1,0 +1,112 @@
+package sage.integration.security
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import com.dimafeng.testcontainers.GenericContainer
+import com.dimafeng.testcontainers.munit.TestContainerForAll
+import kyo.compat.*
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.images.builder.Transferable
+
+import sage.SageException.{ServerError, TlsError}
+import sage.client.{AuthConfig, SageConfig, TlsConfig, TrustSource}
+import sage.integration.{ContainerClient, Images}
+
+/**
+  * One TLS+ACL server hosts every case. The args start with `-`, so the redis and valkey entrypoints each prepend their own server
+  * binary; `--port 0` makes the single exposed port speak only TLS. The cert is generated per run with the Docker host in its SAN
+  * ([[TlsFixture]]), so hostname verification passes whatever host Testcontainers reports.
+  */
+abstract class TlsAuthSuite(image: String) extends munit.FunSuite with TestContainerForAll with ContainerClient {
+
+  // certs are copied in over the Docker API rather than bind-mounted, so the suite works against a remote daemon too (a bind mount would
+  // look for the path on the daemon host, not the test runner)
+  override val containerDef: GenericContainer.Def[GenericContainer] =
+    new GenericContainer.Def[GenericContainer]({
+      val container = GenericContainer(
+        image,
+        exposedPorts = Seq(6379),
+        command = Seq(
+          "--tls-port",
+          "6379",
+          "--port",
+          "0",
+          "--tls-cert-file",
+          "/tls/server.crt",
+          "--tls-key-file",
+          "/tls/server.key",
+          "--tls-ca-cert-file",
+          "/tls/server.crt",
+          "--tls-auth-clients",
+          "no",
+          "--user",
+          "default",
+          "on",
+          ">defaultpass",
+          "~*",
+          "+@all",
+          "--user",
+          "app",
+          "on",
+          ">apppass",
+          "~*",
+          "+@all"
+        ),
+        waitStrategy = Wait.forLogMessage(".*Ready to accept connections.*", 1)
+      )
+      container.underlyingUnsafeContainer
+        .withCopyToContainer(Transferable.of(TlsFixture.serverCertPem), "/tls/server.crt")
+        .withCopyToContainer(Transferable.of(TlsFixture.serverKeyPem), "/tls/server.key")
+      container
+    }) {}
+
+  given ExecutionContext = munitExecutionContext
+
+  private val caPath = TlsFixture.serverCert
+  private val app    = AuthConfig(username = "app", password = "apppass")
+
+  private def configWith(server: GenericContainer, trust: TrustSource = TrustSource.System, auth: AuthConfig = app): SageConfig =
+    configOf(server).copy(tls = Some(TlsConfig(trust)), auth = Some(auth))
+
+  private def connectAndPing(config: SageConfig): Future[String] = connectAndUse(config)(_.ping()).unsafeRun
+
+  test("rejects the server certificate by default: the private CA is not in the system trust store") {
+    withContainers { server =>
+      connectAndPing(configWith(server)).failed.map(error => assert(error.isInstanceOf[TlsError], error))
+    }
+  }
+
+  test("connects when the private CA is supplied as PEM trust material") {
+    withContainers { server =>
+      connectAndPing(configWith(server, TrustSource.Pem(caPath))).map(pong => assertEquals(pong, "PONG"))
+    }
+  }
+
+  test("connects with verification disabled") {
+    withContainers { server =>
+      connectAndPing(configWith(server, TrustSource.Insecure)).map(pong => assertEquals(pong, "PONG"))
+    }
+  }
+
+  test("ACL auth over TLS succeeds for a named user via HELLO, and round-trips a command") {
+    withContainers { server =>
+      connectAndUse(configWith(server, TrustSource.Pem(caPath))) { client =>
+        for {
+          _     <- client.set("tls:key", "value")
+          value <- client.get[String, String]("tls:key")
+        } yield value
+      }.unsafeRun.map(value => assertEquals(value, Some("value")))
+    }
+  }
+
+  test("bad credentials fail with a server error") {
+    withContainers { server =>
+      val config = configWith(server, TrustSource.Pem(caPath), AuthConfig(username = "app", password = "wrong"))
+      connectAndPing(config).failed.map(error => assert(error.isInstanceOf[ServerError], error))
+    }
+  }
+}
+
+class RedisTlsAuthSuite extends TlsAuthSuite(Images.redis)
+
+class ValkeyTlsAuthSuite extends TlsAuthSuite(Images.valkey)

--- a/integration-tests/shared/src/test/scala/sage/integration/security/TlsFixture.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/security/TlsFixture.scala
@@ -1,0 +1,97 @@
+package sage.integration.security
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{Files, Path}
+import java.security.KeyStore
+import java.util.Base64
+
+import org.testcontainers.DockerClientFactory
+
+/**
+  * A self-signed server certificate generated once at test time, with the Docker host baked into the SAN alongside localhost/127.0.0.1, so
+  * hostname verification passes whatever host Testcontainers reports (local daemon, Docker Desktop, or a remote `DOCKER_HOST`). keytool
+  * ships with every JDK; the PEM forms are extracted from the resulting PKCS12 in pure Java, so there is no openssl dependency.
+  *
+  * The cert/key reach the container as bytes over the Docker API (a bind mount would resolve on the daemon host, not the test runner — it
+  * fails against a remote daemon). The client trusts the cert from a local file, which is correct: the client runs on the test runner.
+  */
+object TlsFixture {
+
+  private lazy val material = generate()
+
+  /**
+    * A local file holding the server certificate, for the client's PEM trust material.
+    */
+  def serverCert: Path = material.certFile
+
+  /**
+    * The server certificate in PEM, to copy into the container as `--tls-cert-file`.
+    */
+  def serverCertPem: Array[Byte] = material.certPem
+
+  /**
+    * The server private key in PEM, to copy into the container as `--tls-key-file`.
+    */
+  def serverKeyPem: Array[Byte] = material.keyPem
+
+  final private case class Material(certFile: Path, certPem: Array[Byte], keyPem: Array[Byte])
+
+  private def generate(): Material = {
+    val dir       = Files.createTempDirectory("sage-tls")
+    val keystore  = dir.resolve("server.p12")
+    val storePass = "changeit"
+    val keytool   = Path.of(System.getProperty("java.home"), "bin", "keytool").toString
+
+    runOrThrow(
+      Seq(
+        keytool,
+        "-genkeypair",
+        "-alias",
+        "server",
+        "-keyalg",
+        "RSA",
+        "-keysize",
+        "2048",
+        "-validity",
+        "3650",
+        "-storetype",
+        "PKCS12",
+        "-keystore",
+        keystore.toString,
+        "-storepass",
+        storePass,
+        "-dname",
+        "CN=localhost",
+        "-ext",
+        s"san=${sanEntries.mkString(",")}"
+      )
+    )
+
+    val ks = KeyStore.getInstance("PKCS12")
+    val in = Files.newInputStream(keystore)
+    try ks.load(in, storePass.toCharArray)
+    finally in.close()
+
+    val certPem  = pem("CERTIFICATE", ks.getCertificate("server").getEncoded)
+    val keyPem   = pem("PRIVATE KEY", ks.getKey("server", storePass.toCharArray).getEncoded)
+    val certFile = Files.write(dir.resolve("server.crt"), certPem)
+    Material(certFile, certPem, keyPem)
+  }
+
+  // getHost() returns the docker host ip address (or localhost); cover it plus the loopback names so the connect host is always in the SAN
+  private def sanEntries: Set[String] = {
+    val hosts = Set("localhost", "127.0.0.1", DockerClientFactory.instance().dockerHostIpAddress())
+    hosts.map(h => if (h.matches("""\d{1,3}(\.\d{1,3}){3}""")) s"ip:$h" else s"dns:$h")
+  }
+
+  private def pem(label: String, der: Array[Byte]): Array[Byte] = {
+    val body = Base64.getMimeEncoder(64, Array('\n'.toByte)).encodeToString(der)
+    s"-----BEGIN $label-----\n$body\n-----END $label-----\n".getBytes(UTF_8)
+  }
+
+  private def runOrThrow(command: Seq[String]): Unit = {
+    val process = new ProcessBuilder(command*).redirectErrorStream(true).start()
+    val output  = new String(process.getInputStream.readAllBytes())
+    if (process.waitFor() != 0) throw new IllegalStateException(s"keytool failed: $output")
+  }
+}

--- a/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
+++ b/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
@@ -1,5 +1,8 @@
 package sage.client
 
+import java.nio.file.Path
+import javax.net.ssl.SSLContext
+
 import scala.concurrent.duration.*
 
 /**
@@ -30,6 +33,38 @@ final case class DedicatedPoolConfig(
   idleTimeout: Duration = 30.seconds
 )
 
+/**
+  * Credentials sent via `HELLO 3 AUTH`. Legacy `requirepass` is the default user with a password, hence the `"default"` username.
+  */
+final case class AuthConfig(password: String, username: String = "default") {
+  // keep the secret out of logs and error messages that print a SageConfig
+  override def toString: String = s"AuthConfig(username=$username, password=<redacted>)"
+}
+
+/**
+  * Where TLS finds the certificates it trusts. The handshake verifies the server's hostname in every mode except [[TrustSource.Insecure]].
+  */
+sealed trait TrustSource
+object TrustSource {
+
+  case object System extends TrustSource
+
+  final case class TrustStore(path: Path, password: Option[String] = None) extends TrustSource {
+    // keep the keystore password out of logs and error messages that print a SageConfig
+    override def toString: String = s"TrustStore($path, password=${password.fold("None")(_ => "<redacted>")})"
+  }
+
+  final case class Pem(path: Path) extends TrustSource
+
+  // the escape hatch, and the path for mutual TLS via the caller's own key managers
+  final case class Custom(context: SSLContext) extends TrustSource
+
+  // development only: trusts every certificate and skips hostname verification, so it is open to machine-in-the-middle attacks
+  case object Insecure extends TrustSource
+}
+
+final case class TlsConfig(trust: TrustSource = TrustSource.System)
+
 final case class SageConfig(
   host: String = "localhost",
   port: Int = 6379,
@@ -37,5 +72,7 @@ final case class SageConfig(
   reconnect: BackoffConfig = BackoffConfig(),
   watchdog: WatchdogConfig = WatchdogConfig(),
   closeTimeout: FiniteDuration = 5.seconds,
-  dedicatedPool: DedicatedPoolConfig = DedicatedPoolConfig()
+  dedicatedPool: DedicatedPoolConfig = DedicatedPoolConfig(),
+  auth: Option[AuthConfig] = None,
+  tls: Option[TlsConfig] = None
 )

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -3,6 +3,7 @@ package sage.client.internal
 import java.time.Instant
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReferenceArray}
 import java.util.concurrent.locks.ReentrantLock
+import javax.net.ssl.SSLException
 
 import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success, Try}
@@ -11,8 +12,8 @@ import scala.util.control.NonFatal
 import kyo.compat.*
 
 import sage.SageException
-import sage.SageException.{ConnectionLost, NotConnected, ProtocolError, ServerError, TimedOut, TransactionDiscarded, UnsupportedServer}
-import sage.client.{BackoffConfig, DedicatedPoolConfig, SageConfig, WatchdogConfig}
+import sage.SageException.{ConnectionLost, NotConnected, ProtocolError, ServerError, TimedOut, TlsError, TransactionDiscarded, UnsupportedServer}
+import sage.client.{AuthConfig, BackoffConfig, DedicatedPoolConfig, SageConfig, WatchdogConfig}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
 import sage.protocol.Frame
@@ -430,15 +431,20 @@ object Client {
   private val defaults = SageConfig()
 
   def connect(config: SageConfig): CIO[Client[CIO]] =
-    connectWith(
-      (onFrame, onClosed) => SocketTransport.connect(config.host, config.port, config.connectTimeout, onFrame, onClosed),
-      Scheduler.real,
-      config.reconnect,
-      config.watchdog,
-      config.connectTimeout,
-      config.closeTimeout,
-      config.dedicatedPool
-    )
+    // build the TLS context once (eager failure on bad trust material), then capture it in the reconnect factory so every connection — the
+    // multiplexed one and each dedicated one — is upgraded identically
+    CIO.blocking(Tls.buildUpgrade(config.tls, config.host, config.port)).flatMap { upgrade =>
+      connectWith(
+        (onFrame, onClosed) => SocketTransport.connect(config.host, config.port, config.connectTimeout, upgrade, onFrame, onClosed),
+        Scheduler.real,
+        config.reconnect,
+        config.watchdog,
+        config.connectTimeout,
+        config.closeTimeout,
+        config.dedicatedPool,
+        config.auth
+      )
+    }
 
   // The HELLO 3 handshake is the bootstrap re-run on every (re)connection; the first connect propagates its failure, reconnects retry it.
   private[client] def connectWith(
@@ -448,9 +454,10 @@ object Client {
     watchdog: WatchdogConfig = defaults.watchdog,
     connectTimeout: FiniteDuration = defaults.connectTimeout,
     closeTimeout: FiniteDuration = defaults.closeTimeout,
-    dedicatedPool: DedicatedPoolConfig = defaults.dedicatedPool
+    dedicatedPool: DedicatedPoolConfig = defaults.dedicatedPool,
+    auth: Option[AuthConfig] = None
   ): CIO[Client[CIO]] = {
-    val bootstrap = Vector(Connection.hello())
+    val bootstrap = Vector(Connection.hello(auth.map(a => a.username -> a.password)))
     CIO
       .blocking(
         MultiplexedConnection.connect(factory, scheduler, bootstrap, reconnect, watchdog, connectTimeout, closeTimeout)
@@ -470,11 +477,15 @@ object Client {
       .mapError(translateHandshake)
   }
 
-  // pre-6.0 Redis answers HELLO with an unknown-command error; newer servers reject an unsupported protocol version with NOPROTO
+  // pre-6.0 Redis answers HELLO with an unknown-command error; newer servers reject an unsupported protocol version with NOPROTO. A
+  // rejected certificate or hostname mismatch surfaces from the handshake as an SSLException, which would otherwise escape the sealed
+  // hierarchy.
   private def translateHandshake(error: Throwable): Throwable =
     error match {
       case ServerError(message) if message.startsWith("NOPROTO") || message.toLowerCase.contains("unknown command") =>
         UnsupportedServer(s"sage requires RESP3 (Redis 6.0+ or any Valkey); server rejected HELLO 3: $message")
+      case e: SSLException                                                                                          =>
+        TlsError(s"TLS handshake failed: ${e.getMessage}")
       case other                                                                                                    => other
     }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
@@ -14,14 +14,16 @@ import sage.protocol.{Frame, RespParser}
 
 /**
   * A plain blocking socket pumped by two virtual threads — a reader feeding the RESP3 parser, a writer draining the send queue.
-  * `start` resolves the hostname and connects; `close` aborts an in-progress connect by closing the socket, and never lets the I/O
-  * threads start once it has run. Caveat: a hung DNS lookup inside `start` cannot be interrupted (a JDK limitation) — it unwinds when the
-  * OS resolver times out; `close` closing the socket then prevents the TCP connect that would have followed.
+  * `start` resolves the hostname, connects, then hands the connected socket to `upgrade` (identity for plaintext, a TLS handshake for
+  * `SSLSocket`); `close` aborts an in-progress connect or handshake by closing the plain socket, and never lets the I/O threads start once
+  * it has run. Caveat: a hung DNS lookup inside `start` cannot be interrupted (a JDK limitation) — it unwinds when the OS resolver times
+  * out; `close` closing the socket then prevents the TCP connect that would have followed.
   */
 final private[client] class SocketTransport private (
   host: String,
   port: Int,
   connectTimeoutMillis: Int,
+  upgrade: Socket => Socket,
   onFrame: Frame => Unit,
   onClosed: () => Unit
 ) extends Transport {
@@ -29,6 +31,11 @@ final private[client] class SocketTransport private (
   private val socket = new Socket()
   private val queue  = new LinkedBlockingQueue[Transport.Item]()
   private val closed = new AtomicBoolean(false)
+
+  // the socket whose streams the I/O threads use: the plain socket for plaintext, the SSLSocket after a TLS handshake. Assigned in `start`
+  // before the threads launch (so a plain `var` is safely published via thread-start); `close` always tears down the plain `socket`, which
+  // closes a layered SSLSocket too (autoClose).
+  private var ioSocket: Socket = socket
 
   // serializes the I/O-thread start against termination so threads are either started-and-joined by close() or never started at all
   private val lifecycle      = new ReentrantLock()
@@ -44,6 +51,9 @@ final private[client] class SocketTransport private (
     try {
       socket.setTcpNoDelay(true)
       socket.connect(new InetSocketAddress(host, port), connectTimeoutMillis) // resolves the hostname here, fresh on every attempt
+      socket.setSoTimeout(connectTimeoutMillis)                               // bound a TLS handshake's reads like the connect
+      ioSocket = upgrade(socket)
+      socket.setSoTimeout(0)                                                  // steady state: blocking reads with no timeout
     } catch {
       case NonFatal(error) =>
         terminate()
@@ -77,7 +87,7 @@ final private[client] class SocketTransport private (
     val parser = new RespParser
     val buffer = new Array[Byte](8192)
     try {
-      val in   = socket.getInputStream
+      val in   = ioSocket.getInputStream
       var done = false
       while (!done) {
         val n = in.read(buffer)
@@ -102,7 +112,7 @@ final private[client] class SocketTransport private (
     var attempted             = 0
     var scratch: Array[Byte]  = null
     try {
-      val out = socket.getOutputStream
+      val out = ioSocket.getOutputStream
       while (true) {
         // consuming a carried item bypasses take(), the writer's only interruption point: re-check for close first
         if (carry != null && closed.get()) throw new InterruptedException
@@ -197,8 +207,16 @@ private[client] object SocketTransport {
 
   /**
     * Builds an unconnected transport; `start()` resolves the host and connects, so the connect happens after the transport is published
-    * and `close()` can reach the socket to abort it.
+    * and `close()` can reach the socket to abort it. `upgrade` turns the connected plain socket into the one the I/O threads use (identity
+    * for plaintext, a TLS handshake otherwise).
     */
-  def connect(host: String, port: Int, connectTimeout: FiniteDuration, onFrame: Frame => Unit, onClosed: () => Unit): SocketTransport =
-    new SocketTransport(host, port, math.min(connectTimeout.toMillis, Int.MaxValue).toInt, onFrame, onClosed)
+  def connect(
+    host: String,
+    port: Int,
+    connectTimeout: FiniteDuration,
+    upgrade: Socket => Socket,
+    onFrame: Frame => Unit,
+    onClosed: () => Unit
+  ): SocketTransport =
+    new SocketTransport(host, port, math.min(connectTimeout.toMillis, Int.MaxValue).toInt, upgrade, onFrame, onClosed)
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Tls.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Tls.scala
@@ -1,0 +1,104 @@
+package sage.client.internal
+
+import java.io.InputStream
+import java.net.Socket
+import java.nio.file.{Files, Path}
+import java.security.{KeyStore, SecureRandom}
+import java.security.cert.X509Certificate
+import javax.net.ssl.{SSLContext, SSLSocket, TrustManager, TrustManagerFactory, X509TrustManager}
+
+import scala.jdk.CollectionConverters.*
+import scala.util.control.NonFatal
+
+import sage.SageException.TlsError
+import sage.client.{TlsConfig, TrustSource}
+
+private[client] object Tls {
+
+  private val plaintext: Socket => Socket = socket => socket
+
+  /**
+    * The per-client socket upgrade. The `SSLContext` is built once here, so unusable trust material fails eagerly as a [[TlsError]]; the
+    * returned closure layers an `SSLSocket` over an already-connected plain socket and runs the handshake, preserving the plain connect's
+    * timeout/abort contract. `host` drives SNI and hostname verification, so it must be the host the socket connected to.
+    */
+  def buildUpgrade(tls: Option[TlsConfig], host: String, port: Int): Socket => Socket =
+    tls match {
+      case None         => plaintext
+      case Some(config) =>
+        val (context, verifyHostname) = contextFor(config.trust)
+        val factory                   = context.getSocketFactory
+        plain => {
+          val ssl = factory.createSocket(plain, host, port, /*autoClose*/ true).asInstanceOf[SSLSocket]
+          if (verifyHostname) {
+            val params = ssl.getSSLParameters
+            params.setEndpointIdentificationAlgorithm("HTTPS")
+            ssl.setSSLParameters(params)
+          }
+          ssl.startHandshake()
+          ssl
+        }
+    }
+
+  private def contextFor(trust: TrustSource): (SSLContext, Boolean) =
+    try
+      trust match {
+        case TrustSource.System              => (SSLContext.getDefault, true)
+        case TrustSource.Custom(context)     => (context, true)
+        case TrustSource.Insecure            => (trustAllContext(), false)
+        case TrustSource.TrustStore(path, p) => (contextOf(trustManagersOfKeyStore(path, p)), true)
+        case TrustSource.Pem(path)           => (contextOf(trustManagersOfPem(path)), true)
+      }
+    catch {
+      case e: TlsError => throw e
+      case NonFatal(e) => throw TlsError(s"unusable TLS trust material: $e")
+    }
+
+  private def contextOf(trustManagers: Array[TrustManager]): SSLContext = {
+    val context = SSLContext.getInstance("TLS")
+    context.init(null, trustManagers, new SecureRandom)
+    context
+  }
+
+  private def reading[A](path: Path)(f: InputStream => A): A = {
+    val in = Files.newInputStream(path)
+    try f(in)
+    finally in.close()
+  }
+
+  private def trustManagersOfKeyStore(path: Path, password: Option[String]): Array[TrustManager] = {
+    val keyStore = KeyStore.getInstance(keyStoreType(path))
+    reading(path)(in => keyStore.load(in, password.map(_.toCharArray).orNull))
+    factoryFor(keyStore).getTrustManagers
+  }
+
+  private def trustManagersOfPem(path: Path): Array[TrustManager] = {
+    val factory  = java.security.cert.CertificateFactory.getInstance("X.509")
+    val certs    = reading(path)(in => factory.generateCertificates(in).asScala.toVector)
+    if (certs.isEmpty) throw TlsError(s"no certificates found in PEM file $path")
+    val keyStore = KeyStore.getInstance(KeyStore.getDefaultType)
+    keyStore.load(null, null)
+    certs.iterator.zipWithIndex.foreach { case (cert, i) => keyStore.setCertificateEntry(s"ca-$i", cert) }
+    factoryFor(keyStore).getTrustManagers
+  }
+
+  private def factoryFor(keyStore: KeyStore): TrustManagerFactory = {
+    val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+    tmf.init(keyStore)
+    tmf
+  }
+
+  private def keyStoreType(path: Path): String = {
+    val name = path.getFileName.toString.toLowerCase
+    if (name.endsWith(".p12") || name.endsWith(".pfx")) "PKCS12"
+    else if (name.endsWith(".jks")) "JKS"
+    else KeyStore.getDefaultType
+  }
+
+  private def trustAllContext(): SSLContext =
+    contextOf(Array(new X509TrustManager {
+      def checkClientTrusted(chain: Array[X509Certificate], authType: String): Unit = ()
+      def checkServerTrusted(chain: Array[X509Certificate], authType: String): Unit = ()
+      def getAcceptedIssuers: Array[X509Certificate]                                = Array.empty
+    }))
+}

--- a/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
@@ -26,7 +26,7 @@ class SocketTransportSpec extends munit.FunSuite {
   )(body: (SocketTransport, Socket) => Unit): Unit = {
     val server = new ServerSocket(0)
     try {
-      val transport = SocketTransport.connect("127.0.0.1", server.getLocalPort, 5.seconds, onFrame, onClosed)
+      val transport = SocketTransport.connect("127.0.0.1", server.getLocalPort, 5.seconds, identity, onFrame, onClosed)
       beforeStart(transport)
       transport.start()
       val peer      = server.accept()

--- a/sage-core/src/main/scala/sage/SageException.scala
+++ b/sage-core/src/main/scala/sage/SageException.scala
@@ -30,6 +30,12 @@ object SageException {
     */
   final case class UnsupportedServer(message: String) extends SageException(message)
 
+  /**
+    * TLS could not be established: the certificate was rejected (wrong trust material or a hostname mismatch), or the configured trust
+    * material itself was unusable.
+    */
+  final case class TlsError(message: String) extends SageException(message)
+
   final case class CrossSlot(message: String) extends SageException(message)
 
   final case class TimedOut(message: String) extends SageException(message)


### PR DESCRIPTION
Closes #10.

Adds TLS in the socket layer and ACL/`requirepass` authentication, both routed through the single `SageConfig` entry point. Implements the design recorded in ADR-0022.

## Config
- `AuthConfig(password, username = "default")` — threaded into the shared `HELLO 3 AUTH` bootstrap, so auth is re-applied on every (re)connection of every connection type. `requirepass` is `AuthConfig(password = …)`; ACL is `AuthConfig(user, pass)`. Password redacted in `toString`.
- `TlsConfig(trust)` with sealed `TrustSource = System | TrustStore | Pem | Custom | Insecure`. Hostname verification (`endpointIdentificationAlgorithm = "HTTPS"`) is on for every mode **except** `Insecure`; `Custom(SSLContext)` carries mutual TLS. `TrustStore` redacts its password in `toString`.

## Socket layer
- `Tls.buildUpgrade` builds the `SSLContext` **once per client** (eager `TlsError` on unusable trust material) and returns a `Socket => Socket` that layers an `SSLSocket` over the already-connected plain socket and runs the handshake — preserving `SocketTransport`'s connect-timeout/abort contract. Captured in the reconnect factory, so the multiplexed, dedicated, and (future) subscription connections are upgraded identically.
- `SocketTransport` runs the upgrade inside `start()` bounded by `connectTimeout`; `close()` aborts an in-flight handshake by closing the plain socket.

## Errors
- New sealed `SageException.TlsError` for handshake failure and unusable trust material; `translateHandshake` maps `SSLException` to it. Bad credentials surface as `ServerError` carrying the server's `WRONGPASS` wording.

## Tests
- `sage.integration.security.{Redis,Valkey}TlsAuthSuite` cover all acceptance criteria against a TLS+ACL container (pinned to the designated cell): cert rejection by default, custom PEM trust, disabled verification, ACL auth over TLS, and bad credentials.
- The server certificate is generated per run with `keytool` (no openssl dependency), with the Docker host baked into the SAN, and copied into the container over the Docker API (no bind mount) — so the suite works against local and remote daemons alike.

## Verification
All cells compile; core + client unit tests and both TLS+auth integration suites (redis + valkey) pass.