### PR TITLE
Cluster runtime: topology, redirects, per-node Multiplexers (#23)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,8 +61,8 @@ lazy val client = (projectMatrix in file("sage-client"))
   .compatLibrary(ZioLib, CeLib, OxLib)(VirtualAxis.jvm)(Seq(scala3Version))
 
 // the shared testcontainers suite runs once per backend cell, catching backend-specific lowering bugs against real servers;
-// command-behavior (sage.integration.commands) and security (sage.integration.security) suites run on one designated cell only — neither
-// per-command behavior nor TLS/auth (which live in the shared socket layer) can differ per backend
+// command-behavior (sage.integration.commands), security (sage.integration.security), and cluster (sage.integration.cluster) suites run on
+// one designated cell only — none of per-command behavior, TLS/auth, nor cluster routing (all in the shared layer) can differ per backend
 lazy val integrationTests = (projectMatrix in file("integration-tests"))
   .dependsOn(client, core % "test->test")
   .settings(name := "integration-tests")
@@ -74,7 +74,7 @@ lazy val integrationTests = (projectMatrix in file("integration-tests"))
     Test / testOptions += {
       val isAnchor     = moduleName.value.endsWith("-future")
       val isDesignated = moduleName.value.endsWith("-zio")
-      val onceOnly     = Set("sage.integration.commands.", "sage.integration.security.")
+      val onceOnly     = Set("sage.integration.commands.", "sage.integration.security.", "sage.integration.cluster.")
       Tests.Filter(name => !isAnchor && (isDesignated || !onceOnly.exists(name.startsWith)))
     }
   )

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
@@ -1,0 +1,88 @@
+package sage.integration.cluster
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.*
+
+import com.dimafeng.testcontainers.GenericContainer
+import com.dimafeng.testcontainers.munit.TestContainerForAll
+import kyo.compat.*
+
+import sage.Bytes
+import sage.SageException.DecodeError
+import sage.client.{Endpoint, SageConfig, Topology}
+import sage.client.internal.Client
+import sage.commands.Command
+import sage.integration.{ContainerClient, Images}
+import sage.protocol.Frame
+
+/**
+  * Drives the cluster runtime against a real cluster-enabled server. One node owns all 16384 slots, with `cluster-announce` pointed at the
+  * testcontainers-mapped host port so the address the node reports in `CLUSTER SLOTS` is reachable from the test. This exercises topology
+  * discovery, the `CLUSTER SLOTS` decoder against real wire output, and single-key routing; redirects and failover need multiple nodes.
+  */
+abstract class ClusterSuite(image: String, serverBinary: String) extends munit.FunSuite with TestContainerForAll with ContainerClient {
+
+  override val containerDef: GenericContainer.Def[GenericContainer] =
+    GenericContainer.Def(image, exposedPorts = Seq(6379), command = Seq(serverBinary, "--cluster-enabled", "yes"))
+
+  given ExecutionContext = munitExecutionContext
+
+  private def admin(name: String, args: String*): Command[Unit] =
+    Command(name, Command.NoKeys, args.toVector.map(Bytes.utf8), _ => Right(()))
+
+  private val clusterInfo: Command[String] =
+    Command(
+      "CLUSTER",
+      Command.NoKeys,
+      Vector(Bytes.utf8("INFO")),
+      {
+        case Frame.BulkString(bytes)        => Right(bytes.asUtf8String)
+        case Frame.VerbatimString(_, bytes) => Right(bytes.asUtf8String)
+        case other                          => Left(DecodeError("bulk or verbatim string", Frame.describe(other)))
+      }
+    )
+
+  // a single node owning every slot, announcing the host-mapped endpoint so the address it reports is reachable from the test
+  private def formSingleNodeCluster(admin0: Client[CIO], host: String, port: Int): CIO[Unit] =
+    for {
+      _ <- admin0.run(admin("CONFIG", "SET", "cluster-announce-ip", host))
+      _ <- admin0.run(admin("CONFIG", "SET", "cluster-announce-port", port.toString))
+      _ <- admin0.run(admin("CLUSTER", "ADDSLOTSRANGE", "0", "16383"))
+      _ <- awaitClusterOk(admin0, 50)
+    } yield ()
+
+  private def awaitClusterOk(admin0: Client[CIO], attempts: Int): CIO[Unit] =
+    admin0.run(clusterInfo).flatMap { info =>
+      if (info.contains("cluster_state:ok")) CIO.value(())
+      else if (attempts <= 0) CIO.fail(new RuntimeException(s"cluster did not converge: $info"))
+      else CIO.sleep(100.millis).flatMap(_ => awaitClusterOk(admin0, attempts - 1))
+    }
+
+  test("single-key commands route against a real cluster") {
+    withContainers { server =>
+      val host       = server.host
+      val port       = server.mappedPort(6379)
+      val standalone = SageConfig(host = host, port = port)
+      val clustered  = SageConfig(host = host, port = port, topology = Topology.Cluster(Vector(Endpoint(host, port))))
+
+      val program =
+        connectAndUse(standalone)(formSingleNodeCluster(_, host, port)).flatMap { _ =>
+          connectAndUse(clustered) { client =>
+            for {
+              _     <- client.set("greeting", "hello")
+              value <- client.get[String, String]("greeting")
+              count <- client.incr("counter")
+            } yield {
+              assertEquals(value, Some("hello"))
+              assertEquals(count, 1L)
+            }
+          }
+        }
+      program.unsafeRun
+    }
+  }
+}
+
+class RedisClusterSuite extends ClusterSuite(Images.redis, "redis-server")
+
+class ValkeyClusterSuite extends ClusterSuite(Images.valkey, "valkey-server")

--- a/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
+++ b/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
@@ -65,6 +65,30 @@ object TrustSource {
 
 final case class TlsConfig(trust: TrustSource = TrustSource.System)
 
+/**
+  * A server address. In cluster mode the seeds are contacted to discover the topology; thereafter the cluster's own reported node
+  * addresses are used.
+  */
+final case class Endpoint(host: String, port: Int = 6379)
+
+/**
+  * Cluster tuning. `maxRedirects` bounds how many `MOVED`/`ASK` hops a single command follows before failing (the same default as
+  * lettuce); `minRefreshInterval` throttles topology refreshes so a redirect storm triggers at most one `CLUSTER SLOTS` per window.
+  */
+final case class ClusterConfig(
+  maxRedirects: Int = 5,
+  minRefreshInterval: FiniteDuration = 5.seconds
+)
+
+/**
+  * Standalone connects to one server (`SageConfig.host`/`port`); cluster discovers its topology from `seeds` and routes every command to
+  * the owning node. The client type is the same either way — only this selects the runtime.
+  */
+enum Topology {
+  case Standalone
+  case Cluster(seeds: Vector[Endpoint], config: ClusterConfig = ClusterConfig())
+}
+
 final case class SageConfig(
   host: String = "localhost",
   port: Int = 6379,
@@ -74,5 +98,6 @@ final case class SageConfig(
   closeTimeout: FiniteDuration = 5.seconds,
   dedicatedPool: DedicatedPoolConfig = DedicatedPoolConfig(),
   auth: Option[AuthConfig] = None,
-  tls: Option[TlsConfig] = None
+  tls: Option[TlsConfig] = None,
+  topology: Topology = Topology.Standalone
 )

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -13,7 +13,8 @@ import kyo.compat.*
 
 import sage.SageException
 import sage.SageException.{ConnectionLost, NotConnected, ProtocolError, ServerError, TimedOut, TlsError, TransactionDiscarded, UnsupportedServer}
-import sage.client.{AuthConfig, BackoffConfig, DedicatedPoolConfig, SageConfig, WatchdogConfig}
+import sage.client.{AuthConfig, BackoffConfig, DedicatedPoolConfig, SageConfig, Topology, WatchdogConfig}
+import sage.cluster.Node
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
 import sage.protocol.Frame
@@ -431,6 +432,13 @@ object Client {
   private val defaults = SageConfig()
 
   def connect(config: SageConfig): CIO[Client[CIO]] =
+    config.topology match {
+      case Topology.Standalone                    => connectStandalone(config)
+      case Topology.Cluster(seeds, clusterConfig) =>
+        ClusterLive.connect(config, seeds.map(e => Node(e.host, e.port)), clusterConfig, Scheduler.real, translateHandshake)
+    }
+
+  private def connectStandalone(config: SageConfig): CIO[Client[CIO]] =
     // build the TLS context once (eager failure on bad trust material), then capture it in the reconnect factory so every connection — the
     // multiplexed one and each dedicated one — is upgraded identically
     CIO.blocking(Tls.buildUpgrade(config.tls, config.host, config.port)).flatMap { upgrade =>

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -1,0 +1,334 @@
+package sage.client.internal
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.locks.ReentrantLock
+
+import scala.collection.mutable
+import scala.concurrent.duration.*
+import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
+
+import kyo.compat.*
+
+import sage.SageException.{ConnectionLost, CrossSlot, NotConnected, ServerError}
+import sage.client.{BackoffConfig, ClusterConfig, DedicatedPoolConfig, SageConfig, WatchdogConfig}
+import sage.cluster.{ClusterTopology, Node, Redirect, RedirectKind, Route, Shard}
+import sage.commands.{Cluster, Command, Connection, Pipeline}
+
+/**
+  * The cluster runtime: one [[NodeClient]] bundle per master, a refreshable [[ClusterTopology]], and the routing/redirect/failover state
+  * machine that executes the pure engine's [[Route]] classifications. The same `Client` type as standalone; only configuration selects it.
+  * Pipelines and Transactions are rejected in cluster mode.
+  *
+  * Routing and redirect-following run on offloaded virtual threads (never the reply thread), since establishing a node and refreshing the
+  * topology both block. A submit's reply callback re-offloads before any blocking continuation.
+  */
+final private[client] class ClusterLive(
+  nodeFactory: Node => MultiplexedConnection.TransportFactory,
+  scheduler: Scheduler,
+  bootstrap: Vector[Command[?]],
+  reconnect: BackoffConfig,
+  watchdog: WatchdogConfig,
+  connectTimeout: FiniteDuration,
+  closeTimeout: FiniteDuration,
+  dedicatedPool: DedicatedPoolConfig,
+  cluster: ClusterConfig,
+  seeds: Vector[Node]
+) extends Client[CIO] {
+
+  private val topologyRef = new AtomicReference[ClusterTopology](ClusterTopology.from(Vector.empty))
+
+  private val nodesLock        = new ReentrantLock()
+  private val established      = mutable.HashMap.empty[Node, NodeClient]
+  private val pendingEstablish = mutable.HashMap.empty[Node, ClusterLive.Establish]
+  // set once by close; routing and node establishment refuse afterwards, so close is terminal like the standalone client's
+  @volatile private var closed = false
+
+  private val refreshLock   = new ReentrantLock()
+  private val refreshDone   = refreshLock.newCondition()
+  private var refreshing    = false
+  private var lastRefreshMs = Long.MinValue
+
+  private val retryDelay   = reconnect.initialDelay
+  private val minRefreshMs = cluster.minRefreshInterval.toMillis
+
+  private inline def lockedNodes[A](inline body: A): A = {
+    nodesLock.lock()
+    try body
+    finally nodesLock.unlock()
+  }
+
+  // discovers the topology from the seeds; if none answers, throws the last failure so the first connect surfaces a handshake or TLS error
+  // the same way a standalone connect would, rather than swallowing it
+  private[client] def bootstrapTopology(): Unit = {
+    var lastError: Throwable = NotConnected()
+    val candidates           = seeds.iterator
+    while (candidates.hasNext) {
+      val node = candidates.next()
+      try
+        querySlotsVia(getOrEstablish(node)) match {
+          case Some(shards) => adopt(shards); return
+          case None         => ()
+        }
+      catch { case NonFatal(error) => lastError = error }
+    }
+    closeAll()
+    throw lastError
+  }
+
+  def run[A](command: Command[A]): CIO[A] =
+    CIO.async[A](complete => offload(dispatch(command, cluster.maxRedirects, complete)))
+
+  def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out]               = CIO.fail(unsupported("Pipelines"))
+  def pipelineAttempt[Out, R](p: Pipeline[Out, R]): CIO[R]          = CIO.fail(unsupported("Pipelines"))
+  def transaction[A](body: TransactionScope[CIO] => CIO[A]): CIO[A] = CIO.fail(unsupported("Transactions"))
+
+  def close: CIO[Unit] = CIO.blocking(closeAll())
+
+  // a deliberate programmer-facing limitation, outside the sealed hierarchy like the other client guards
+  private def unsupported(what: String): UnsupportedOperationException =
+    new UnsupportedOperationException(s"$what are not yet supported in cluster mode")
+
+  // --- routing -------------------------------------------------------------------------------------------------------------------------
+
+  private def dispatch[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit =
+    if (closed) complete(Failure(NotConnected()))
+    else {
+      val topology = topologyRef.get()
+      topology.route(command) match {
+        case Route.ToNode(node, _)  => sendTo(node, command, asking = false, redirectsLeft, complete)
+        case Route.Keyless          => sendToAny(topology, command, redirectsLeft, complete)
+        case Route.Unowned(_)       => onUnowned(command, redirectsLeft, complete)
+        case Route.CrossSlot(slots) =>
+          complete(Failure(CrossSlot(s"${command.name}: keys span ${slots.size} slots; a single command must touch exactly one")))
+        case Route.Malformed        =>
+          complete(Failure(new IllegalArgumentException(s"${command.name}: declared key positions fall outside its arguments")))
+      }
+    }
+
+  // sends to a live node if one is connected, else any master in the topology; used for keyless commands and as the still-unowned fallback
+  private def sendToAny[A](topology: ClusterTopology, command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit =
+    pickNode(topology) match {
+      case Some(node) => sendTo(node, command, asking = false, redirectsLeft, complete)
+      case None       => complete(Failure(NotConnected()))
+    }
+
+  private def sendTo[A](node: Node, command: Command[A], asking: Boolean, redirectsLeft: Int, complete: Try[A] => Unit): Unit = {
+    val nc =
+      try getOrEstablish(node)
+      catch { case NonFatal(_) => null }
+    if (nc == null) onUnreachable(command, redirectsLeft, complete)
+    else
+      nc.submit[A](
+        command,
+        asking,
+        {
+          case Success(value) => complete(Success(value))
+          case Failure(error) => offload(onFailure(node, command, error, redirectsLeft, complete))
+        }
+      )
+  }
+
+  private def onFailure[A](node: Node, command: Command[A], error: Throwable, redirectsLeft: Int, complete: Try[A] => Unit): Unit =
+    error match {
+      case ServerError(message)  =>
+        Redirect.parse(message) match {
+          case Some(redirect) => onRedirect(node, redirect, command, redirectsLeft, complete)
+          case None           =>
+            if (message.startsWith("READONLY")) triggerRefresh() // a demoted master: adopt the new owner for subsequent commands
+            complete(Failure(error)) // fail fast, no retry
+        }
+      case NotConnected()        => onUnreachable(command, redirectsLeft, complete)
+      case ConnectionLost(false) => onUnreachable(command, redirectsLeft, complete) // never reached the wire: safe to retry
+      case ConnectionLost(true)  => triggerRefresh(); complete(Failure(error))      // may have executed: fail fast
+      case other                 => complete(Failure(other))
+    }
+
+  private def onRedirect[A](from: Node, redirect: Redirect, command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit =
+    if (redirectsLeft <= 0)
+      complete(Failure(ServerError(s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
+    else {
+      val target = resolve(redirect.target, from)
+      redirect.kind match {
+        case RedirectKind.Moved => triggerRefresh(); sendTo(target, command, asking = false, redirectsLeft - 1, complete)
+        case RedirectKind.Ask   => sendTo(target, command, asking = true, redirectsLeft - 1, complete)
+      }
+    }
+
+  // a routed node was unreachable and the command provably never executed: refresh to adopt the promoted master, then re-route. The delay
+  // (and a fresh establish's connect timeout) paces retries so an in-progress failover is not hammered; redirectsLeft bounds the loop.
+  private def onUnreachable[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit =
+    if (redirectsLeft <= 0) complete(Failure(NotConnected()))
+    else {
+      refresh(force = true)
+      scheduler.after(retryDelay)(dispatch(command, redirectsLeft - 1, complete))
+    }
+
+  private def onUnowned[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit = {
+    refresh(force = false)
+    val topology = topologyRef.get()
+    topology.route(command) match {
+      case Route.ToNode(node, _) => sendTo(node, command, asking = false, redirectsLeft, complete)
+      // still unowned after refresh: send to an arbitrary master and trust the server's reply (a MOVED to follow, or CLUSTERDOWN)
+      case _                     => sendToAny(topology, command, redirectsLeft, complete)
+    }
+  }
+
+  // an empty redirect host means "the node I just talked to" (e.g. `MOVED 3999 :6381`)
+  private def resolve(target: Node, from: Node): Node = if (target.host.isEmpty) Node(from.host, target.port) else target
+
+  private def pickNode(topology: ClusterTopology): Option[Node] =
+    lockedNodes(established.collectFirst { case (node, nc) if nc.isLive => node })
+      .orElse(topology.shards.headOption.map(_.master))
+
+  private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
+
+  // --- node registry (single-flight establish) -----------------------------------------------------------------------------------------
+
+  private def getOrEstablish(node: Node): NodeClient = {
+    var existing: NodeClient          = null
+    var waitOn: ClusterLive.Establish = null
+    var mine: ClusterLive.Establish   = null
+    lockedNodes {
+      if (closed) throw NotConnected()
+      established.get(node) match {
+        case Some(nc) => existing = nc
+        case None     =>
+          pendingEstablish.get(node) match {
+            case Some(p) => waitOn = p
+            case None    => mine = new ClusterLive.Establish; pendingEstablish.put(node, mine)
+          }
+      }
+    }
+    if (existing != null) existing
+    else if (waitOn != null) waitOn.get()
+    else
+      try {
+        val nc    = NodeClient.connect(nodeFactory(node), scheduler, bootstrap, reconnect, watchdog, connectTimeout, closeTimeout, dedicatedPool)
+        // re-check under the lock: a close that landed during the blocking connect must not re-publish this bundle into a closed client
+        val stale = lockedNodes { pendingEstablish.remove(node); if (closed) true else { established.put(node, nc); false } }
+        if (stale) { nc.close(); throw NotConnected() }
+        mine.succeed(nc)
+        nc
+      } catch {
+        case error: Throwable =>
+          lockedNodes(pendingEstablish.remove(node))
+          mine.fail(error)
+          throw error
+      }
+  }
+
+  // --- topology refresh (single-flight, throttled) -------------------------------------------------------------------------------------
+
+  private def triggerRefresh(): Unit = offload(refresh(force = false))
+
+  private def refresh(force: Boolean): Unit = {
+    refreshLock.lock()
+    val iRefresh =
+      try
+        if (refreshing) { while (refreshing) refreshDone.awaitUninterruptibly(); false }
+        else if (!force && scheduler.nowMillis - lastRefreshMs < minRefreshMs) false
+        else { refreshing = true; true }
+      finally refreshLock.unlock()
+
+    if (iRefresh)
+      try querySlots(refreshCandidates()).foreach(adopt)
+      finally {
+        refreshLock.lock()
+        try { refreshing = false; lastRefreshMs = scheduler.nowMillis; refreshDone.signalAll() }
+        finally refreshLock.unlock()
+      }
+  }
+
+  private def refreshCandidates(): Vector[Node] = {
+    val (live, others) = lockedNodes(established.toVector).partition(_._2.isLive)
+    (live.map(_._1) ++ others.map(_._1) ++ seeds).distinct
+  }
+
+  private def querySlots(candidates: Vector[Node]): Option[Vector[Shard]] =
+    candidates.iterator.flatMap(trySlots).nextOption()
+
+  private def trySlots(node: Node): Option[Vector[Shard]] =
+    try querySlotsVia(getOrEstablish(node))
+    catch { case NonFatal(_) => None }
+
+  private def querySlotsVia(nc: NodeClient): Option[Vector[Shard]] = {
+    val latch   = new CountDownLatch(1)
+    val outcome = new AtomicReference[Try[Vector[Shard]]]()
+    nc.submit[Vector[Shard]](Cluster.slots, asking = false, result => { outcome.set(result); latch.countDown() })
+    if (!latch.await(connectTimeout.toMillis, TimeUnit.MILLISECONDS)) None
+    else
+      outcome.get() match {
+        case Success(shards) => Some(shards)
+        case Failure(_)      => None
+      }
+  }
+
+  // installs a fresh topology and prunes bundles for masters it no longer lists, so a vanished node's reconnect loop cannot leak
+  private def adopt(shards: Vector[Shard]): Unit = {
+    topologyRef.set(ClusterTopology.from(shards))
+    val masters = shards.map(_.master).toSet
+    val gone    = lockedNodes {
+      val absent = established.keysIterator.filterNot(masters.contains).toVector
+      absent.flatMap(node => established.remove(node))
+    }
+    gone.foreach(nc => offload(nc.close()))
+  }
+
+  private def closeAll(): Unit = {
+    val all = lockedNodes { closed = true; val snapshot = established.values.toVector; established.clear(); snapshot }
+    all.foreach(_.close())
+  }
+}
+
+private[client] object ClusterLive {
+
+  // one-shot single-flight cell: the establisher fills it, concurrent callers block on `get` and observe the same success or failure
+  final private class Establish {
+    private val latch                                           = new CountDownLatch(1)
+    @volatile private var result: Either[Throwable, NodeClient] = null
+
+    def succeed(nc: NodeClient): Unit = { result = Right(nc); latch.countDown() }
+    def fail(error: Throwable): Unit  = { result = Left(error); latch.countDown() }
+
+    def get(): NodeClient = {
+      latch.await()
+      result match {
+        case Right(nc)   => nc
+        case Left(error) => throw error
+      }
+    }
+  }
+
+  def connect(
+    config: SageConfig,
+    seeds: Vector[Node],
+    cluster: ClusterConfig,
+    scheduler: Scheduler,
+    translate: Throwable => Throwable
+  ): CIO[Client[CIO]] =
+    CIO.blocking[Client[CIO]] {
+      val bootstrap                                               = Vector(Connection.hello(config.auth.map(a => a.username -> a.password)))
+      val factory: Node => MultiplexedConnection.TransportFactory = node => {
+        val upgrade = Tls.buildUpgrade(config.tls, node.host, node.port)
+        (onFrame, onClosed) => SocketTransport.connect(node.host, node.port, config.connectTimeout, upgrade, onFrame, onClosed)
+      }
+      val live                                                    = new ClusterLive(
+        factory,
+        scheduler,
+        bootstrap,
+        config.reconnect,
+        config.watchdog,
+        config.connectTimeout,
+        config.closeTimeout,
+        config.dedicatedPool,
+        cluster,
+        seeds
+      )
+      // discovery's handshake/TLS failures are translated here (a NOPROTO/SSL surfaces like a standalone connect) rather than via mapError,
+      // which the per-backend CIO alias does not reconcile through `Client`'s invariant type parameter
+      try { live.bootstrapTopology(); live }
+      catch { case NonFatal(error) => throw translate(error) }
+    }
+}

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -9,7 +9,7 @@ import scala.util.control.NonFatal
 
 import sage.SageException.{ConnectionLost, NotConnected, TimedOut}
 import sage.client.DedicatedPoolConfig
-import sage.commands.Command
+import sage.commands.{Command, Connection}
 
 /**
   * The on-demand pool of Dedicated Connections that carry blocking commands. A connection is created lazily, used by exactly one blocking
@@ -48,7 +48,15 @@ final private[client] class DedicatedPool(
     * Runs a blocking command on a borrowed Dedicated Connection, releasing it when the reply (or a failure) arrives. Returns immediately;
     * the acquire — which may wait for a slot or open a socket — is offloaded so the calling fiber is never blocked.
     */
-  def use[A](command: Command[A], callback: Try[A] => Unit): Unit =
+  def use[A](command: Command[A], callback: Try[A] => Unit): Unit = lease(command, asking = false, callback)
+
+  /**
+    * Runs a blocking command redirected by `ASK`: `ASKING` then the command, back-to-back on one exclusively-leased connection, so their
+    * wire adjacency is automatic. The `ASKING` reply is discarded; the command's reply releases the connection.
+    */
+  def useAsking[A](command: Command[A], callback: Try[A] => Unit): Unit = lease(command, asking = true, callback)
+
+  private def lease[A](command: Command[A], asking: Boolean, callback: Try[A] => Unit): Unit =
     if (!isLive()) callback(scala.util.Failure(NotConnected()))
     else
       scheduler.after(Duration.Zero) {
@@ -62,6 +70,7 @@ final private[client] class DedicatedPool(
         acquired match {
           case Left(error) => callback(scala.util.Failure(error))
           case Right(conn) =>
+            if (asking) conn.submit[Unit](Connection.asking, _ => ())
             conn.submit(
               command,
               result => {

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -56,6 +56,14 @@ final private[client] class MultiplexedConnection private (
     else conn.submit(command, callback)
   }
 
+  // ASKING must immediately precede its command on the wire (it arms the target node for the next command on the connection). Writing the
+  // pair as one batch keeps them adjacent and FIFO-matched even though every fiber shares this connection; the ASKING reply is discarded.
+  def submitAsking[A](command: Command[A], callback: Try[A] => Unit): Unit = {
+    val conn = locked(if (state == State.Live) current else null)
+    if (conn == null) callback(Failure(NotConnected()))
+    else conn.submitAll(Vector(Connection.asking, command), Vector(_ => (), callback.asInstanceOf[Try[Any] => Unit]))
+  }
+
   // Enqueues a whole pipeline onto a single generation, captured once, so a reconnect mid-batch can never split it across connections.
   // Returns false when not connected — nothing was submitted, so the caller fails fast rather than fabricating per-position errors.
   def submitAll(commands: Vector[Command[?]], callbacks: Vector[Try[Any] => Unit]): Boolean = {

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
@@ -1,0 +1,56 @@
+package sage.client.internal
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Try
+
+import sage.client.{BackoffConfig, DedicatedPoolConfig, WatchdogConfig}
+import sage.commands.Command
+
+/**
+  * One cluster Node's connection bundle: the same Multiplexed Connection + Dedicated Pool a standalone client uses, pinned to a single
+  * node. The cluster runtime holds one per master it routes to. `asking` prefixes the command with `ASKING` to follow an `ASK` redirect.
+  */
+final private[client] class NodeClient(connection: MultiplexedConnection, pool: DedicatedPool) {
+
+  def submit[A](command: Command[A], asking: Boolean, callback: Try[A] => Unit): Unit =
+    if (command.isBlocking) { if (asking) pool.useAsking(command, callback) else pool.use(command, callback) }
+    else if (asking) connection.submitAsking(command, callback)
+    else connection.submit(command, callback)
+
+  def isLive: Boolean = connection.currentState == MultiplexedConnection.State.Live
+
+  def close(): Unit = {
+    pool.close()
+    connection.close()
+  }
+}
+
+private[client] object NodeClient {
+
+  /**
+    * Connects to the node and runs the bootstrap synchronously, throwing (no retry) if the first handshake fails — exactly like a
+    * standalone client. The caller offloads this blocking establish and treats a failure as the node being unreachable.
+    */
+  def connect(
+    factory: MultiplexedConnection.TransportFactory,
+    scheduler: Scheduler,
+    bootstrap: Vector[Command[?]],
+    reconnect: BackoffConfig,
+    watchdog: WatchdogConfig,
+    connectTimeout: FiniteDuration,
+    closeTimeout: FiniteDuration,
+    dedicatedPool: DedicatedPoolConfig
+  ): NodeClient = {
+    val connection = MultiplexedConnection.connect(factory, scheduler, bootstrap, reconnect, watchdog, connectTimeout, closeTimeout)
+    val pool       = new DedicatedPool(
+      factory,
+      bootstrap,
+      scheduler,
+      () => connection.currentState == MultiplexedConnection.State.Live,
+      () => connection.currentGeneration,
+      dedicatedPool,
+      connectTimeout.toMillis
+    )
+    new NodeClient(connection, pool)
+  }
+}

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -1,0 +1,184 @@
+package sage.client
+
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.*
+
+import kyo.compat.*
+
+import sage.Bytes
+import sage.SageException.{CrossSlot, NotConnected}
+import sage.client.internal.{ClusterLive, FakeTransport, MultiplexedConnection, Scheduler}
+import sage.cluster.{Node, Slot}
+import sage.commands.{Command, Connection, Pipeline, Strings}
+import sage.protocol.Frame
+
+class ClusterClientSpec extends munit.FunSuite {
+
+  private given ExecutionContext = munitExecutionContext
+
+  private val nodeA    = Node("a", 6379)
+  private val nodeB    = Node("b", 6379)
+  private val nodeDead = Node("dead", 6379)
+
+  private val helloReply: Frame =
+    Frame.Map(
+      Vector(
+        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
+        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
+        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
+        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
+      )
+    )
+
+  private def nodeFrame(node: Node): Frame =
+    Frame.Array(Vector(Frame.BulkString(Bytes.utf8(node.host)), Frame.Integer(node.port.toLong), Frame.BulkString(Bytes.utf8(s"${node.host}-id"))))
+
+  private def slotsFrame(ranges: (Node, Int, Int)*): Frame =
+    Frame.Array(ranges.toVector.map { case (node, start, end) =>
+      Frame.Array(Vector(Frame.Integer(start.toLong), Frame.Integer(end.toLong), nodeFrame(node)))
+    })
+
+  /**
+    * A cluster of fake per-node transports. `behaviour` scripts each node's reply to a written command (HELLO and CLUSTER SLOTS are
+    * answered here); `written(node)` exposes what reached that node so routing can be asserted.
+    */
+  final private class Fixture(behaviour: (Node, String) => Seq[Frame], seeds: Vector[Node], unreachable: Set[Node] = Set.empty) {
+
+    private val transports = mutable.Map.empty[Node, FakeTransport]
+
+    private val factory: Node => MultiplexedConnection.TransportFactory = node =>
+      (onFrame, onClosed) => {
+        val respond: Bytes => Seq[Frame] = payload => {
+          val text = payload.asUtf8String
+          if (text.contains("HELLO")) if (unreachable(node)) Seq(Frame.SimpleError("ERR node is down")) else Seq(helloReply)
+          else behaviour(node, text)
+        }
+        val transport                    = new FakeTransport(onFrame, onClosed, respond)
+        transports(node) = transport
+        transport
+      }
+
+    val live: ClusterLive =
+      new ClusterLive(
+        factory,
+        Scheduler.real,
+        Vector(Connection.hello(None)),
+        BackoffConfig(),
+        WatchdogConfig(enabled = false),
+        1.second,
+        Duration.Zero,
+        DedicatedPoolConfig(),
+        ClusterConfig(),
+        seeds
+      )
+
+    live.bootstrapTopology()
+
+    def written(node: Node): Vector[String] = transports.get(node).toVector.flatMap(_.written.map(_.asUtf8String))
+  }
+
+  private def wholeClusterOn(node: Node): Frame = slotsFrame((node, 0, Slot.Count - 1))
+
+  test("routes a single-key command to the slot's owner") {
+    // nodeA owns the lower half, nodeB the upper half
+    val mid       = Slot.Count / 2
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else Seq(Frame.BulkString(Bytes.utf8(node.host)))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    val key   = "foo"
+    val owner = if (Slot.of(Bytes.utf8(key)).value < mid) nodeA else nodeB
+    val other = if (owner == nodeA) nodeB else nodeA
+
+    fixture.live.run(Strings.get[String, String](key)).unsafeRun.map { result =>
+      assertEquals(result, Some(owner.host))
+      assert(fixture.written(owner).exists(_.contains("GET")), "owner did not receive GET")
+      assert(!fixture.written(other).exists(_.contains("GET")), "non-owner received GET")
+    }
+  }
+
+  test("follows a MOVED redirect to the named node and refreshes") {
+    // topology says nodeA owns everything, but nodeA reports the slot has MOVED to nodeB
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (node == nodeA) Seq(Frame.SimpleError(s"MOVED ${Slot.of(Bytes.utf8("foo")).value} b:6379"))
+      else Seq(Frame.BulkString(Bytes.utf8("from-b")))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
+      assertEquals(result, Some("from-b"))
+      assert(fixture.written(nodeB).exists(_.contains("GET")), "redirect target did not receive GET")
+    }
+  }
+
+  test("follows an ASK redirect with an ASKING prefix on the target") {
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (node == nodeA) Seq(Frame.SimpleError(s"ASK ${Slot.of(Bytes.utf8("foo")).value} b:6379"))
+      else Seq(Frame.SimpleString("OK"), Frame.BulkString(Bytes.utf8("asked"))) // ASKING reply, then the command's
+    val fixture = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
+      assertEquals(result, Some("asked"))
+      val toB = fixture.written(nodeB).filterNot(_.contains("HELLO"))
+      assert(toB.exists(p => p.contains("ASKING") && p.contains("GET")), s"ASKING did not precede the command: $toB")
+    }
+  }
+
+  test("a single command whose keys span slots fails CrossSlot") {
+    val behaviour                = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.Integer(1))
+    val fixture                  = new Fixture(behaviour, Vector(nodeA))
+    val crossSlot: Command[Long] =
+      Command("MSET", Vector(0, 2), Vector("{a}", "v", "{b}", "v").map(Bytes.utf8), _ => Right(1L))
+
+    fixture.live.run(crossSlot).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[CrossSlot], s"unexpected error: $error")
+    }
+  }
+
+  test("absorbs a failover: an unreachable owner triggers a refresh and the command retries on the new master") {
+    val key                  = "foo"
+    val mid                  = Slot.of(Bytes.utf8(key)).value // the upper range starts here, so `key` lands in it
+    @volatile var failedOver = false
+    val behaviour            = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (if (failedOver) nodeB else nodeDead, mid, Slot.Count - 1)))
+      else Seq(Frame.BulkString(Bytes.utf8(node.host)))
+    val fixture              = new Fixture(behaviour, Vector(nodeA), unreachable = Set(nodeDead))
+
+    failedOver = true // the master for `key` has been replaced by nodeB; the stale topology still points at the dead node
+    fixture.live.run(Strings.get[String, String](key)).unsafeRun.map { result =>
+      assertEquals(result, Some(nodeB.host))
+      assert(fixture.written(nodeB).exists(_.contains("GET")), "command did not retry on the promoted master")
+    }
+  }
+
+  test("close is terminal: a command after close fails rather than reconnecting") {
+    val behaviour =
+      (node: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.BulkString(Bytes.utf8(node.host)))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.close.unsafeRun.flatMap { _ =>
+      fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.failed.map { error =>
+        assert(error.isInstanceOf[NotConnected], s"expected NotConnected after close, got: $error")
+      }
+    }
+  }
+
+  test("pipelines and transactions are rejected in cluster mode") {
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    val pipelineFailed    = fixture.live.pipeline(Pipeline.sequence(Vector(Strings.get[String, String]("k")))).unsafeRun.failed
+    val transactionFailed = fixture.live.transaction(_ => CIO.value(())).unsafeRun.failed
+
+    for {
+      p <- pipelineFailed
+      t <- transactionFailed
+    } yield {
+      assert(p.isInstanceOf[UnsupportedOperationException], s"pipeline: $p")
+      assert(t.isInstanceOf[UnsupportedOperationException], s"transaction: $t")
+    }
+  }
+}

--- a/sage-core/src/main/scala/sage/commands/Cluster.scala
+++ b/sage-core/src/main/scala/sage/commands/Cluster.scala
@@ -1,0 +1,65 @@
+package sage.commands
+
+import sage.Bytes
+import sage.SageException.DecodeError
+import sage.cluster.{Node, Shard, Slot, SlotRange}
+import sage.protocol.Frame
+
+private[sage] object Cluster {
+
+  val slots: Command[Vector[Shard]] =
+    Command("CLUSTER", keyIndices = Command.NoKeys, args = Vector(Bytes.utf8("SLOTS")), decode = decodeSlots)
+
+  final private case class Range(master: Node, replicas: Vector[Node], slots: SlotRange)
+
+  // CLUSTER SLOTS replies with an array of ranges, each `[start, end, master, replica*]` where a node is `[ip, port, id, meta?]` and the
+  // first node is the master. The reply is the topology authority, so an unparseable entry fails the whole decode rather than dropping a
+  // range and routing off a partial map. Ranges sharing a master are merged into one Shard, in first-seen master order.
+  private def decodeSlots(frame: Frame): Either[DecodeError, Vector[Shard]] =
+    Decode.vector(decodeRange)(frame).map(merge)
+
+  private def decodeRange(frame: Frame): Either[DecodeError, Range] =
+    frame match {
+      case Frame.Array(elements) if elements.length >= 3 =>
+        for {
+          start <- slotOf(elements(0))
+          end   <- slotOf(elements(1))
+          nodes <- Decode.vector(decodeNode)(Frame.Array(elements.drop(2)))
+        } yield Range(nodes.head, nodes.tail, SlotRange(start, end))
+      case other                                         => Left(DecodeError("array of [start, end, master, replicas...]", Frame.describe(other)))
+    }
+
+  private def decodeNode(frame: Frame): Either[DecodeError, Node] =
+    frame match {
+      case Frame.Array(elements) if elements.length >= 2 =>
+        for {
+          host <- stringOf(elements(0))
+          port <- intOf(elements(1))
+        } yield Node(host, port)
+      case other                                         => Left(DecodeError("node array [ip, port, id, ...]", Frame.describe(other)))
+    }
+
+  private def merge(ranges: Vector[Range]): Vector[Shard] =
+    ranges.map(_.master).distinct.map { master =>
+      val forMaster = ranges.filter(_.master == master)
+      Shard(master, forMaster.flatMap(_.replicas).distinct, forMaster.map(_.slots))
+    }
+
+  private def slotOf(frame: Frame): Either[DecodeError, Slot] =
+    intOf(frame).flatMap(index => Slot.at(index).toRight(DecodeError("slot in [0, 16384)", index.toString)))
+
+  private def intOf(frame: Frame): Either[DecodeError, Int] =
+    frame match {
+      case Frame.Integer(value) if value.isValidInt =>
+        Right(value.toInt) // guard the narrowing: a Long outside Int range must not wrap into a valid slot or port
+      case Frame.Integer(value) => Left(DecodeError("integer within Int range", value.toString))
+      case other                => Left(DecodeError("integer", Frame.describe(other)))
+    }
+
+  private def stringOf(frame: Frame): Either[DecodeError, String] =
+    frame match {
+      case Frame.BulkString(bytes)  => Right(bytes.asUtf8String)
+      case Frame.SimpleString(text) => Right(text)
+      case other                    => Left(DecodeError("string", Frame.describe(other)))
+    }
+}

--- a/sage-core/src/main/scala/sage/commands/Connection.scala
+++ b/sage-core/src/main/scala/sage/commands/Connection.scala
@@ -14,6 +14,9 @@ private[sage] object Connection {
 
   val unwatch: Command[Unit] = Command("UNWATCH", keyIndices = Command.NoKeys, args = Vector.empty, decode = Decode.ok)
 
+  // prefixes a single command redirected by `ASK`, telling the target node to serve the key it is importing for this one command
+  val asking: Command[Unit] = Command("ASKING", keyIndices = Command.NoKeys, args = Vector.empty, decode = Decode.ok)
+
   def watch[K](first: K, rest: K*)(using keyCodec: KeyCodec[K]): Command[Unit] = {
     val keys = (first +: rest.toVector).map(keyCodec.encode)
     Command("WATCH", keyIndices = Vector.range(0, keys.length), args = keys, decode = Decode.ok)

--- a/sage-core/src/test/scala/sage/commands/ClusterSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ClusterSpec.scala
@@ -1,0 +1,78 @@
+package sage.commands
+
+import sage.Bytes
+import sage.SageException.DecodeError
+import sage.cluster.{Node, Shard, Slot, SlotRange}
+import sage.protocol.Frame
+
+class ClusterSpec extends munit.FunSuite {
+
+  private def int(value: Long): Frame                          = Frame.Integer(value)
+  private def bulk(text: String): Frame                        = Frame.BulkString(Bytes.utf8(text))
+  private def node(host: String, port: Int, id: String): Frame =
+    Frame.Array(Vector(bulk(host), int(port.toLong), bulk(id)))
+
+  private def run(frame: Frame): Either[DecodeError, Vector[Shard]] = Cluster.slots.decode(frame)
+
+  test("decodes a range into a Shard with master and replicas") {
+    val reply = Frame.Array(
+      Vector(
+        Frame.Array(Vector(int(0), int(5460), node("10.0.0.1", 6379, "m1"), node("10.0.0.2", 6379, "r1")))
+      )
+    )
+    assertEquals(
+      run(reply),
+      Right(Vector(Shard(Node("10.0.0.1", 6379), Vector(Node("10.0.0.2", 6379)), Vector(SlotRange(Slot.unsafe(0), Slot.unsafe(5460))))))
+    )
+  }
+
+  test("merges multiple ranges owned by the same master into one Shard") {
+    val master = node("10.0.0.1", 6379, "m1")
+    val reply  = Frame.Array(
+      Vector(
+        Frame.Array(Vector(int(0), int(10), master)),
+        Frame.Array(Vector(int(100), int(110), master))
+      )
+    )
+    assertEquals(
+      run(reply),
+      Right(
+        Vector(
+          Shard(
+            Node("10.0.0.1", 6379),
+            Vector.empty,
+            Vector(SlotRange(Slot.unsafe(0), Slot.unsafe(10)), SlotRange(Slot.unsafe(100), Slot.unsafe(110)))
+          )
+        )
+      )
+    )
+  }
+
+  test("keeps distinct masters in first-seen order") {
+    val reply = Frame.Array(
+      Vector(
+        Frame.Array(Vector(int(0), int(10), node("a", 6379, "a1"))),
+        Frame.Array(Vector(int(11), int(20), node("b", 6379, "b1")))
+      )
+    )
+    assertEquals(run(reply).map(_.map(_.master)), Right(Vector(Node("a", 6379), Node("b", 6379))))
+  }
+
+  test("an empty topology decodes to no shards") {
+    assertEquals(run(Frame.Array(Vector.empty)), Right(Vector.empty))
+  }
+
+  test("a slot index out of range fails the whole decode") {
+    val reply = Frame.Array(Vector(Frame.Array(Vector(int(0), int(20000), node("a", 6379, "a1")))))
+    assert(run(reply).isLeft)
+  }
+
+  test("a non-array reply fails") {
+    assert(run(Frame.SimpleString("OK")).isLeft)
+  }
+
+  test("a slot value outside Int range fails decode rather than wrapping into a valid slot") {
+    val reply = Frame.Array(Vector(Frame.Array(Vector(int(0), int(Int.MaxValue.toLong + 1L), node("a", 6379, "a1")))))
+    assert(run(reply).isLeft)
+  }
+}


### PR DESCRIPTION
Closes #23.

Builds the effectful cluster layer on top of the pure slot engine (#22). One client type, selected by `Topology.Cluster(seeds)` configuration — per ADR-0007 — with the routing/redirect/failover behaviour recorded in ADR-0023.

## Core
- `Cluster.slots` — `CLUSTER SLOTS` command + decoder into `Vector[Shard]`. Uses `SLOTS` (not `SHARDS`) so it works on Redis 6, the matrix floor. Rejects out-of-`Int`-range values rather than truncating.
- `Connection.asking`.

## Runtime
- **`ClusterLive`** — topology discovery from seeds, single-flight throttled refresh, the `Route` → action state machine, `MOVED` (refresh + resend) and `ASK` (`ASKING` prefix) redirects, failover via refresh-on-unreachable with a provably-not-executed retry rule (honours ADR-0006), dead-node eviction on refresh, and a terminal `close`.
- **`NodeClient`** — per-node bundle reusing `MultiplexedConnection` + `DedicatedPool`. `MultiplexedConnection.submitAsking` (one atomic batch on the shared connection) and `DedicatedPool.useAsking` keep `ASKING` adjacent to its command on the wire.
- Pipelines and Transactions **fail fast** in cluster mode; cross-slot single commands fail `CrossSlot`. Cluster pipeline split/merge + cross-slot transaction rejection arrive in #24.
- `Client.connect` branches on `config.topology`; the standalone path is unchanged.

## Config
`Endpoint`, `ClusterConfig(maxRedirects = 5, minRefreshInterval = 5s)`, and a `Topology` enum on `SageConfig`.

## Tests
- `ClusterSpec` (core) — the `CLUSTER SLOTS` decoder, including the out-of-range guard.
- `ClusterClientSpec` (designated cell) — routing to the owner, `MOVED`, `ASK` with the `ASKING` prefix, cross-slot rejection, failover absorption, terminal close, and pipeline/transaction rejection, via fake per-node transports.
- `ClusterSuite` (integration, designated cell) — discovery + single-key routing against **real Redis and Valkey** cluster-mode servers (one node owning all slots, `cluster-announce` pointed at the mapped host port). Cluster suites run once on the designated cell, like the command-behaviour and security suites, since cluster routing lives in the shared layer.

## Acceptance criteria
- [x] Same application code runs against standalone and cluster by changing configuration only
- [x] Single-key commands route to the correct node (cluster container integration test)
- [x] `MOVED` triggers redirect plus topology refresh; `ASK` is followed per protocol
- [x] Node failover is absorbed via reconnect semantics and refreshed topology

## Follow-up
Keyless node-local commands (`KEYS`, `SCAN`, `RANDOMKEY`, `DBSIZE`) currently route to one node and return that node's partial view. Correct whole-keyspace fan-out is the deferred scan-all-nodes sub-API; tracking separately rather than adding a drift-prone command denylist.