### PR TITLE
Review hardening pass: RESP3 attributes, hot-path allocations, cluster robustness

### DIFF
--- a/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
@@ -1,7 +1,5 @@
 package sage.ox
 
-import scala.util.control.NonFatal
-
 import _root_.ox.{useInScope, Ox}
 import _root_.ox.flow.Flow
 import kyo.compat.*
@@ -93,8 +91,9 @@ object SageClient {
 
   def scoped(config: SageConfig): Ox ?=> SageClient =
     useInScope(connect(config)) { client =>
+      // never fail teardown: swallow unconditionally (incl. InterruptedException), matching the zio/ce/kyo close-on-release policy
       try client.close
-      catch { case NonFatal(_) => () }
+      catch { case _: Throwable => () }
     }
 
   final private class Lowered(underlying: Client[CIO]) extends Client[[A] =>> Ox ?=> A] {

--- a/sage-client/shared/src/main/scala/sage/client/internal/Backoff.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Backoff.scala
@@ -1,0 +1,14 @@
+package sage.client.internal
+
+import sage.client.BackoffConfig
+
+private[internal] object Backoff {
+
+  // exponential backoff capped at maxDelay, then full jitter in [0, base] — the one formula shared by reconnect and cluster-redirect retry
+  def jitteredMillis(config: BackoffConfig, attempt: Int, scheduler: Scheduler): Long = {
+    val capped = config.maxDelay.toMillis
+    val raw    = config.initialDelay.toMillis.toDouble * math.pow(config.multiplier, attempt.toDouble)
+    val base   = if (raw.isInfinite || raw >= capped.toDouble) capped else math.max(0L, raw.toLong)
+    scheduler.jitterMillis(base + 1)
+  }
+}

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -432,11 +432,51 @@ object Client {
   private val defaults = SageConfig()
 
   def connect(config: SageConfig): CIO[Client[CIO]] =
-    config.topology match {
-      case Topology.Standalone                    => connectStandalone(config)
-      case Topology.Cluster(seeds, clusterConfig) =>
-        ClusterLive.connect(config, seeds.map(e => Node(e.host, e.port)), clusterConfig, Scheduler.real, translateHandshake)
+    validate(config) match {
+      case Some(problem) => CIO.fail(new IllegalArgumentException(problem))
+      case None          =>
+        config.topology match {
+          case Topology.Standalone                    => connectStandalone(config)
+          case Topology.Cluster(seeds, clusterConfig) =>
+            ClusterLive.connect(config, seeds.map(e => Node(e.host, e.port)), clusterConfig, Scheduler.real, translateHandshake)
+        }
     }
+
+  // a misconfigured client is a programmer error, surfaced through the connect effect (never thrown from a constructor) and deliberately
+  // outside the sealed hierarchy, like the other usage guards
+  private def validate(config: SageConfig): Option[String] = {
+    // pingInterval/pingTimeout are inert when the watchdog is disabled, so don't reject them then
+    val watchdog =
+      if (config.watchdog.enabled)
+        Vector(
+          positive(config.watchdog.pingInterval, "watchdog.pingInterval"),
+          positive(config.watchdog.pingTimeout, "watchdog.pingTimeout")
+        )
+      else Vector.empty
+    val checks   = Vector(
+      port(config.port, "port"),
+      positive(config.connectTimeout, "connectTimeout"),
+      positive(config.closeTimeout, "closeTimeout"),
+      positive(config.reconnect.initialDelay, "reconnect.initialDelay"),
+      cond(config.reconnect.maxDelay >= config.reconnect.initialDelay, "reconnect.maxDelay must be >= initialDelay"),
+      cond(config.reconnect.multiplier >= 1.0, "reconnect.multiplier must be >= 1.0"),
+      cond(config.dedicatedPool.maxConnections >= 1, "dedicatedPool.maxConnections must be >= 1"),
+      positive(config.dedicatedPool.acquireTimeout, "dedicatedPool.acquireTimeout")
+    ) ++ watchdog ++ (config.topology match {
+      case Topology.Cluster(seeds, cluster) =>
+        Vector(
+          cond(seeds.nonEmpty, "cluster topology requires at least one seed"),
+          cond(cluster.maxRedirects >= 0, "cluster.maxRedirects must be >= 0"),
+          positive(cluster.minRefreshInterval, "cluster.minRefreshInterval")
+        ) ++ seeds.map(s => port(s.port, s"seed ${s.host}:${s.port} port"))
+      case Topology.Standalone              => Vector.empty
+    })
+    checks.flatten.headOption
+  }
+
+  private def cond(ok: Boolean, problem: String): Option[String]             = if (ok) None else Some(problem)
+  private def port(value: Int, label: String): Option[String]                = cond(value >= 1 && value <= 65535, s"$label must be in 1..65535")
+  private def positive(value: FiniteDuration, label: String): Option[String] = cond(value.toNanos > 0L, s"$label must be positive")
 
   private def connectStandalone(config: SageConfig): CIO[Client[CIO]] =
     // build the TLS context once (eager failure on bad trust material), then capture it in the reconnect factory so every connection — the
@@ -611,7 +651,9 @@ object Client {
       }
 
     def run[A](command: Command[A]): CIO[A] =
-      if (command.isBlocking)
+      if (isReleased)
+        CIO.fail(scopeReleasedError)
+      else if (command.isBlocking)
         CIO.fail(new IllegalArgumentException("a Transaction cannot run blocking commands; run them individually on the client"))
       else
         CIO.async[A](complete => submitting(complete)(conn.submit(command, complete)))
@@ -663,10 +705,12 @@ object Client {
         case Some(message) => CIO.fail(TransactionDiscarded(message))
         case None          =>
           frames(n + 1) match {
-            case Frame.Null         => CIO.value(None)
-            case Frame.Array(elems) =>
+            case Frame.Null                              => CIO.value(None)
+            case Frame.Array(elems) if elems.length == n =>
               CIO.value(Some(Vector.tabulate(n)(i => Reply.run(commands(i).asInstanceOf[Command[Any]], elems(i)))))
-            case other              =>
+            case Frame.Array(elems)                      =>
+              CIO.fail(ProtocolError(s"EXEC returned ${elems.length} results for $n queued commands"))
+            case other                                   =>
               errorOf(other) match {
                 case Some(message) => CIO.fail(TransactionDiscarded(message))
                 case None          => CIO.fail(ProtocolError(s"unexpected EXEC reply: ${Frame.describe(other)}"))

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -48,10 +48,10 @@ final private[client] class ClusterLive(
   private val refreshLock   = new ReentrantLock()
   private val refreshDone   = refreshLock.newCondition()
   private var refreshing    = false
-  private var lastRefreshMs = Long.MinValue
-
-  private val retryDelay   = reconnect.initialDelay
-  private val minRefreshMs = cluster.minRefreshInterval.toMillis
+  private val minRefreshMs  = cluster.minRefreshInterval.toMillis
+  // bootstrap's CLUSTER SLOTS does not consume the throttle window: seed so the first redirect/READONLY-driven refresh runs immediately,
+  // and only refreshes within minRefreshInterval of one another are throttled (Long.MinValue here would overflow the elapsed subtraction)
+  private var lastRefreshMs = scheduler.nowMillis - minRefreshMs
 
   private inline def lockedNodes[A](inline body: A): A = {
     nodesLock.lock()
@@ -68,7 +68,7 @@ final private[client] class ClusterLive(
       val node = candidates.next()
       try
         querySlotsVia(getOrEstablish(node)) match {
-          case Some(shards) => adopt(shards); return
+          case Some(shards) => adopt(node, shards); return
           case None         => ()
         }
       catch { case NonFatal(error) => lastError = error }
@@ -156,13 +156,14 @@ final private[client] class ClusterLive(
       }
     }
 
-  // a routed node was unreachable and the command provably never executed: refresh to adopt the promoted master, then re-route. The delay
-  // (and a fresh establish's connect timeout) paces retries so an in-progress failover is not hammered; redirectsLeft bounds the loop.
+  // a routed node was unreachable and the command provably never executed: refresh to adopt the promoted master, then re-route. A growing
+  // jittered backoff (and a fresh establish's connect timeout) paces retries so an in-progress failover is not hammered; redirectsLeft bounds it.
   private def onUnreachable[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit =
     if (redirectsLeft <= 0) complete(Failure(NotConnected()))
     else {
       refresh(force = true)
-      scheduler.after(retryDelay)(dispatch(command, redirectsLeft - 1, complete))
+      val attempt = (cluster.maxRedirects - redirectsLeft).max(0)
+      scheduler.after(Backoff.jitteredMillis(reconnect, attempt, scheduler).millis)(dispatch(command, redirectsLeft - 1, complete))
     }
 
   private def onUnowned[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit = {
@@ -233,7 +234,7 @@ final private[client] class ClusterLive(
       finally refreshLock.unlock()
 
     if (iRefresh)
-      try querySlots(refreshCandidates()).foreach(adopt)
+      try querySlots(refreshCandidates()).foreach { case (from, shards) => adopt(from, shards) }
       finally {
         refreshLock.lock()
         try { refreshing = false; lastRefreshMs = scheduler.nowMillis; refreshDone.signalAll() }
@@ -246,11 +247,11 @@ final private[client] class ClusterLive(
     (live.map(_._1) ++ others.map(_._1) ++ seeds).distinct
   }
 
-  private def querySlots(candidates: Vector[Node]): Option[Vector[Shard]] =
+  private def querySlots(candidates: Vector[Node]): Option[(Node, Vector[Shard])] =
     candidates.iterator.flatMap(trySlots).nextOption()
 
-  private def trySlots(node: Node): Option[Vector[Shard]] =
-    try querySlotsVia(getOrEstablish(node))
+  private def trySlots(node: Node): Option[(Node, Vector[Shard])] =
+    try querySlotsVia(getOrEstablish(node)).map(node -> _)
     catch { case NonFatal(_) => None }
 
   private def querySlotsVia(nc: NodeClient): Option[Vector[Shard]] = {
@@ -265,11 +266,13 @@ final private[client] class ClusterLive(
       }
   }
 
-  // installs a fresh topology and prunes bundles for masters it no longer lists, so a vanished node's reconnect loop cannot leak
-  private def adopt(shards: Vector[Shard]): Unit = {
-    topologyRef.set(ClusterTopology.from(shards))
-    val masters = shards.map(_.master).toSet
-    val gone    = lockedNodes {
+  // installs a fresh topology and prunes bundles for masters it no longer lists, so a vanished node's reconnect loop cannot leak. An empty
+  // announce-IP from CLUSTER SLOTS means "the node I queried", so substitute `from` the same way redirects do
+  private def adopt(from: Node, shards: Vector[Shard]): Unit = {
+    val resolved = shards.map(shard => shard.copy(master = resolve(shard.master, from), replicas = shard.replicas.map(resolve(_, from))))
+    topologyRef.set(ClusterTopology.from(resolved))
+    val masters  = resolved.map(_.master).toSet
+    val gone     = lockedNodes {
       val absent = established.keysIterator.filterNot(masters.contains).toVector
       absent.flatMap(node => established.remove(node))
     }

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
@@ -87,8 +87,8 @@ final private[client] class DedicatedConnection private (
 
   private def onFrame(frame: Frame): Unit =
     frame match {
-      case _: Frame.Push | _: Frame.Attribute => ()
-      case reply                              =>
+      case _: Frame.Push => ()
+      case reply         =>
         val waiter = pending.poll()
         if (waiter == null) close() // a reply with nothing pending means the stream desynced; discard
         else {

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -34,6 +34,8 @@ final private[client] class DedicatedPool(
   private val lock      = new ReentrantLock()
   private val available = lock.newCondition()
 
+  private val StaleRetryBackoffNanos = 1.milli.toNanos
+
   private val idle                              = mutable.ArrayDeque.empty[DedicatedPool.Idle]
   private val live                              = mutable.Set.empty[DedicatedConnection]
   private var reserved                          = 0
@@ -128,7 +130,9 @@ final private[client] class DedicatedPool(
           val established = establishOutsideLock()
           if (established != null) return established
           // discarded as stale; retry, but bounded by the deadline so generation churn can't spin forever
-          if (System.nanoTime() >= deadlineNanos) throw acquireTimedOut
+          val remaining   = deadlineNanos - System.nanoTime()
+          if (remaining <= 0L) throw acquireTimedOut
+          val _           = available.awaitNanos(math.min(StaleRetryBackoffNanos, remaining)) // pace retries during a churn storm
         } else {
           val remaining = deadlineNanos - System.nanoTime()
           if (remaining <= 0L) throw acquireTimedOut

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -143,11 +143,8 @@ final private[client] class MultiplexedConnection private (
     } finally locked { if (establishing eq conn) establishing = null }
   }
 
-  private def scheduleReconnect(attempt: Int): Unit = {
-    val base    = backoffBaseMillis(attempt)
-    val delayMs = scheduler.jitterMillis(base + 1)
-    scheduler.after(delayMs.millis)(attemptReconnect(attempt))
-  }
+  private def scheduleReconnect(attempt: Int): Unit =
+    scheduler.after(Backoff.jitteredMillis(backoff, attempt, scheduler).millis)(attemptReconnect(attempt))
 
   private def attemptReconnect(attempt: Int): Unit = {
     val proceed = locked(state == State.Reconnecting)
@@ -166,12 +163,6 @@ final private[client] class MultiplexedConnection private (
       } catch {
         case NonFatal(_) => locked(if (state == State.Reconnecting) scheduleReconnect(attempt + 1))
       }
-  }
-
-  private def backoffBaseMillis(attempt: Int): Long = {
-    val capped = backoff.maxDelay.toMillis
-    val raw    = backoff.initialDelay.toMillis.toDouble * math.pow(backoff.multiplier, attempt.toDouble)
-    if (raw.isInfinite || raw >= capped.toDouble) capped else math.max(0L, raw.toLong)
   }
 
   // Connections that never became `current` (a failed establish) are ignored here; their caller handles them.
@@ -252,8 +243,8 @@ final private[client] class MultiplexedConnection private (
     private def onFrame(frame: Frame): Unit = {
       lastReplyAtMillis = scheduler.nowMillis
       frame match {
-        case _: Frame.Push | _: Frame.Attribute => ()
-        case reply                              =>
+        case _: Frame.Push => ()
+        case reply         =>
           val entry = pending.poll()
           if (entry == null) close()
           else {
@@ -308,7 +299,7 @@ final private[client] class MultiplexedConnection private (
     // matched and failed individually. A whole batch is therefore written — or dropped — atomically, never split across socket writes.
     final private class Batch(entries: Vector[Entry[Any]]) extends Transport.Item {
 
-      val payload: Bytes = Bytes.concat(entries.map(_.payload))
+      val payload: Bytes = Bytes.concatBy(entries)(_.payload)
 
       def writeAttempted(): Unit = entries.foreach(_.writeAttempted())
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
@@ -9,7 +9,6 @@ import java.util.concurrent.locks.ReentrantLock
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
 
-import sage.Bytes
 import sage.protocol.{Frame, RespParser}
 
 /**
@@ -92,12 +91,7 @@ final private[client] class SocketTransport private (
       while (!done) {
         val n = in.read(buffer)
         if (n < 0) done = true
-        else {
-          parser.feed(Bytes.wrap(IArray.unsafeFromArray(java.util.Arrays.copyOfRange(buffer, 0, n)))) match {
-            case Right(frames) => frames.foreach(onFrame)
-            case Left(_)       => done = true
-          }
-        }
+        else if (parser.feed(buffer, 0, n)(onFrame).isDefined) done = true
       }
     } catch {
       case NonFatal(_) => ()
@@ -137,7 +131,11 @@ final private[client] class SocketTransport private (
           attempted = 1
           out.write(first.payload.unsafeArray)
         } else {
-          if (scratch == null) scratch = new Array[Byte](SocketTransport.MaxBatchBytes.toInt)
+          if (scratch == null || scratch.length < size) {
+            var capacity = if (scratch == null) 1024L else scratch.length.toLong
+            while (capacity < size) capacity *= 2
+            scratch = new Array[Byte](math.min(capacity, SocketTransport.MaxBatchBytes).toInt)
+          }
           var offset = 0
           batch.forEach { item =>
             val bytes = item.payload.unsafeArray

--- a/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
@@ -212,11 +212,11 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     assertEquals(results.toVector, Vector.fill[Try[Any]](3)(Failure(ConnectionLost(mayHaveExecuted = false))))
   }
 
-  test("attribute frames do not consume pending replies") {
+  test("out-of-band push frames do not consume pending replies") {
     val (connection, _, transports) = make()
     var result: Option[Try[String]] = None
     connection.submit(Connection.ping(), r => result = Some(r))
-    transports.head.emit(Frame.Attribute(Vector(Frame.SimpleString("key") -> Frame.SimpleString("value"))))
+    transports.head.emit(Frame.Push(Vector(Frame.SimpleString("message"), Frame.SimpleString("hi"))))
     transports.head.emit(Frame.SimpleString("PONG"))
     assertEquals(result, Some(Success("PONG")))
   }

--- a/sage-core/src/main/scala/sage/Bytes.scala
+++ b/sage-core/src/main/scala/sage/Bytes.scala
@@ -19,17 +19,20 @@ object Bytes {
   def fromArray(bytes: Array[Byte]): Bytes = IArray.unsafeFromArray(bytes.clone())
 
   // One contiguous buffer from many: a Pipeline's commands are concatenated so they reach the socket as a single write.
-  def concat(parts: Seq[Bytes]): Bytes =
-    parts match {
+  def concat(parts: Seq[Bytes]): Bytes = concatBy(parts)(identity)
+
+  // like `concat`, but pulls each part from `items` via `payload`, sparing the caller a throwaway mapped collection on the batch path
+  def concatBy[A](items: Seq[A])(payload: A => Bytes): Bytes =
+    items match {
       case Seq()     => empty
-      case Seq(only) => only
+      case Seq(only) => payload(only)
       case _         =>
         var total  = 0
-        parts.foreach(part => total += arr(part).length)
+        items.foreach(item => total += arr(payload(item)).length)
         val out    = new Array[Byte](total)
         var offset = 0
-        parts.foreach { part =>
-          val bytes = arr(part)
+        items.foreach { item =>
+          val bytes = arr(payload(item))
           System.arraycopy(bytes, 0, out, offset, bytes.length)
           offset += bytes.length
         }

--- a/sage-core/src/main/scala/sage/cluster/Topology.scala
+++ b/sage-core/src/main/scala/sage/cluster/Topology.scala
@@ -1,5 +1,7 @@
 package sage.cluster
 
+import scala.collection.mutable
+
 import sage.commands.{Command, Pipeline}
 
 final case class Node(host: String, port: Int)
@@ -21,31 +23,40 @@ final class ClusterTopology private (val shards: Vector[Shard], owners: Array[No
 
   def route(command: Command[?]): Route =
     if (command.keyIndices.exists(index => index < 0 || index >= command.args.length)) Route.Malformed
-    else {
-      val slots = slotsOf(command)
-      if (slots.isEmpty) Route.Keyless
-      else if (slots.sizeIs > 1) Route.CrossSlot(slots)
-      else
-        nodeForSlot(slots.head) match {
-          case Some(node) => Route.ToNode(node, slots.head)
-          case None       => Route.Unowned(slots.head)
-        }
-    }
+    else
+      command.keyIndices.length match {
+        case 0 => Route.Keyless
+        case 1 => routeSlot(Slot.of(command.args(command.keyIndices.head)))
+        case _ =>
+          val slots = slotsOf(command)
+          if (slots.sizeIs > 1) Route.CrossSlot(slots) else routeSlot(slots.head)
+      }
 
   def split(pipeline: Pipeline[?, ?]): SplitPlan = {
-    val routes    = pipeline.commands.zipWithIndex.map { case (command, index) => (index, route(command)) }
-    val nodeOrder = routes.collect { case (_, Route.ToNode(node, _)) => node }.distinct
-    val perNode   = nodeOrder.map { node =>
-      NodeGroup(node, routes.collect { case (index, Route.ToNode(`node`, _)) => index })
+    val perNode  = mutable.LinkedHashMap.empty[Node, mutable.ArrayBuffer[Int]]
+    val keyless  = mutable.ArrayBuffer.empty[Int]
+    val rejected = mutable.ArrayBuffer.empty[(Int, Rejected)]
+    pipeline.commands.iterator.zipWithIndex.foreach { case (command, index) =>
+      route(command) match {
+        case Route.ToNode(node, _)  => perNode.getOrElseUpdate(node, mutable.ArrayBuffer.empty) += index
+        case Route.Keyless          => keyless += index
+        case Route.Unowned(slot)    => rejected += ((index, Rejected.Unowned(slot)))
+        case Route.CrossSlot(slots) => rejected += ((index, Rejected.CrossSlot(slots)))
+        case Route.Malformed        => rejected += ((index, Rejected.Malformed))
+      }
     }
-    val keyless   = routes.collect { case (index, Route.Keyless) => index }
-    val rejected  = routes.collect {
-      case (index, Route.Unowned(slot))    => (index, Rejected.Unowned(slot))
-      case (index, Route.CrossSlot(slots)) => (index, Rejected.CrossSlot(slots))
-      case (index, Route.Malformed)        => (index, Rejected.Malformed)
-    }
-    SplitPlan(perNode, keyless, rejected)
+    SplitPlan(
+      perNode.iterator.map { case (node, indices) => NodeGroup(node, indices.toVector) }.toVector,
+      keyless.toVector,
+      rejected.toVector
+    )
   }
+
+  private def routeSlot(slot: Slot): Route =
+    nodeForSlot(slot) match {
+      case Some(node) => Route.ToNode(node, slot)
+      case None       => Route.Unowned(slot)
+    }
 
   // safe to index args directly: route rejects out-of-range keyIndices as Malformed before calling this
   private def slotsOf(command: Command[?]): Set[Slot] =

--- a/sage-core/src/main/scala/sage/commands/Decode.scala
+++ b/sage-core/src/main/scala/sage/commands/Decode.scala
@@ -2,6 +2,7 @@ package sage.commands
 
 import java.time.Instant
 
+import scala.collection.mutable
 import scala.concurrent.duration.FiniteDuration
 
 import sage.Bytes
@@ -62,28 +63,42 @@ private[commands] object Decode {
     case other                => Left(DecodeError("integer or null", Frame.describe(other)))
   }
 
-  def vector[A](element: Frame => Either[DecodeError, A]): Frame => Either[DecodeError, Vector[A]] = {
-    case Frame.Array(elements) =>
-      elements.foldLeft[Either[DecodeError, Vector[A]]](Right(Vector.empty)) { (acc, frame) =>
-        acc.flatMap(decoded => element(frame).map(decoded :+ _))
+  private def buildEach[A, B, C](items: IterableOnce[A], builder: mutable.Builder[B, C])(
+    f: A => Either[DecodeError, B]
+  ): Either[DecodeError, C] = {
+    val known = items.knownSize
+    if (known > 0) builder.sizeHint(known)
+    val it    = items.iterator
+    while (it.hasNext)
+      f(it.next()) match {
+        case Right(value) => builder += value
+        case Left(error)  => return Left(error)
       }
+    Right(builder.result())
+  }
+
+  def vector[A](element: Frame => Either[DecodeError, A]): Frame => Either[DecodeError, Vector[A]] = {
+    case Frame.Array(elements) => buildEach(elements, Vector.newBuilder[A])(element)
     case other                 => Left(DecodeError("array", Frame.describe(other)))
   }
 
   // a missing list replies null where a present one replies an array; a stored list is never empty, so null collapses to an empty vector
   def vectorOrEmpty[A](element: Frame => Either[DecodeError, A]): Frame => Either[DecodeError, Vector[A]] = {
-    case Frame.Null => Right(Vector.empty)
-    case other      => vector(element)(other)
+    val decodeVector = vector(element)
+    frame =>
+      frame match {
+        case Frame.Null => Right(Vector.empty)
+        case other      => decodeVector(other)
+      }
   }
 
   def map[K, V](using KeyCodec[K], ValueCodec[V]): Frame => Either[DecodeError, Map[K, V]] = {
     case Frame.Map(entries) =>
-      entries.foldLeft[Either[DecodeError, Map[K, V]]](Right(Map.empty)) { case (acc, (fieldFrame, valueFrame)) =>
+      buildEach(entries, Map.newBuilder[K, V]) { case (fieldFrame, valueFrame) =>
         for {
-          decoded <- acc
-          field   <- key(fieldFrame)
-          value   <- this.value(valueFrame)
-        } yield decoded + (field -> value)
+          field <- key(fieldFrame)
+          value <- this.value(valueFrame)
+        } yield field -> value
       }
     case other              => Left(DecodeError("map", Frame.describe(other)))
   }
@@ -91,29 +106,24 @@ private[commands] object Decode {
   // HSCAN's items are a flat field, value, field, value, … array; HRANDFIELD WITHVALUES nests each pair in its own array.
   def flatPairs[K, V](using KeyCodec[K], ValueCodec[V]): Frame => Either[DecodeError, Vector[(K, V)]] = {
     case Frame.Array(elements) if elements.length % 2 == 0 =>
-      elements.grouped(2).foldLeft[Either[DecodeError, Vector[(K, V)]]](Right(Vector.empty)) { (acc, pair) =>
+      buildEach(elements.grouped(2), Vector.newBuilder[(K, V)]) { pair =>
         for {
-          decoded <- acc
-          field   <- key(pair(0))
-          value   <- this.value(pair(1))
-        } yield decoded :+ (field -> value)
+          field <- key(pair(0))
+          value <- this.value(pair(1))
+        } yield field -> value
       }
     case other => Left(DecodeError("array of field/value pairs", Frame.describe(other)))
   }
 
   def nestedPairs[K, V](using KeyCodec[K], ValueCodec[V]): Frame => Either[DecodeError, Vector[(K, V)]] = {
     case Frame.Array(rows) =>
-      rows.foldLeft[Either[DecodeError, Vector[(K, V)]]](Right(Vector.empty)) { (acc, row) =>
-        acc.flatMap { decoded =>
-          row match {
-            case Frame.Array(Vector(fieldFrame, valueFrame)) =>
-              for {
-                field <- key(fieldFrame)
-                value <- this.value(valueFrame)
-              } yield decoded :+ (field -> value)
-            case other                                       => Left(DecodeError("field/value pair", Frame.describe(other)))
-          }
-        }
+      buildEach(rows, Vector.newBuilder[(K, V)]) {
+        case Frame.Array(Vector(fieldFrame, valueFrame)) =>
+          for {
+            field <- key(fieldFrame)
+            value <- this.value(valueFrame)
+          } yield field -> value
+        case other                                       => Left(DecodeError("field/value pair", Frame.describe(other)))
       }
     case other             => Left(DecodeError("array of field/value pairs", Frame.describe(other)))
   }
@@ -133,10 +143,7 @@ private[commands] object Decode {
 
   // RESP3 returns set-typed replies (SMEMBERS, SINTER, …) as a Set frame, never an Array
   def set[V](using ValueCodec[V]): Frame => Either[DecodeError, Set[V]] = {
-    case Frame.Set(elements) =>
-      elements.foldLeft[Either[DecodeError, Set[V]]](Right(Set.empty)) { (acc, frame) =>
-        acc.flatMap(decoded => value(frame).map(decoded + _))
-      }
+    case Frame.Set(elements) => buildEach(elements, Set.newBuilder[V])(value)
     case other               => Left(DecodeError("set", Frame.describe(other)))
   }
 
@@ -154,17 +161,13 @@ private[commands] object Decode {
   // RESP3 nests each member with its Double score in a two-element array (ZRANGE WITHSCORES, ZPOPMIN count, …)
   def scoredMembers[V](using ValueCodec[V]): Frame => Either[DecodeError, Vector[(V, Double)]] = {
     case Frame.Array(rows) =>
-      rows.foldLeft[Either[DecodeError, Vector[(V, Double)]]](Right(Vector.empty)) { (acc, row) =>
-        acc.flatMap { decoded =>
-          row match {
-            case Frame.Array(Vector(memberFrame, scoreFrame)) =>
-              for {
-                member <- value(memberFrame)
-                s      <- score(scoreFrame)
-              } yield decoded :+ (member -> s)
-            case other                                        => Left(DecodeError("member/score pair", Frame.describe(other)))
-          }
-        }
+      buildEach(rows, Vector.newBuilder[(V, Double)]) {
+        case Frame.Array(Vector(memberFrame, scoreFrame)) =>
+          for {
+            member <- value(memberFrame)
+            s      <- score(scoreFrame)
+          } yield member -> s
+        case other                                        => Left(DecodeError("member/score pair", Frame.describe(other)))
       }
     case other             => Left(DecodeError("array of member/score pairs", Frame.describe(other)))
   }
@@ -184,12 +187,11 @@ private[commands] object Decode {
   // ZSCAN's items are a flat member, score, member, score array with scores as bulk strings, not RESP3 doubles
   def scoredMembersFlat[V](using ValueCodec[V]): Frame => Either[DecodeError, Vector[(V, Double)]] = {
     case Frame.Array(elements) if elements.length % 2 == 0 =>
-      elements.grouped(2).foldLeft[Either[DecodeError, Vector[(V, Double)]]](Right(Vector.empty)) { (acc, pair) =>
+      buildEach(elements.grouped(2), Vector.newBuilder[(V, Double)]) { pair =>
         for {
-          decoded <- acc
-          member  <- value(pair(0))
-          s       <- scoreText(pair(1))
-        } yield decoded :+ (member -> s)
+          member <- value(pair(0))
+          s      <- scoreText(pair(1))
+        } yield member -> s
       }
     case other => Left(DecodeError("array of member/score pairs", Frame.describe(other)))
   }

--- a/sage-core/src/main/scala/sage/commands/Hashes.scala
+++ b/sage-core/src/main/scala/sage/commands/Hashes.scala
@@ -76,7 +76,7 @@ private[sage] object Hashes {
     Command(
       "HSCAN",
       Command.FirstKey,
-      Vector(keyCodec.encode(key), ScanCursor.bytes(cursor)) ++ scanOptions(pattern, count),
+      Vector(keyCodec.encode(key), ScanCursor.bytes(cursor)) ++ ScanArgs.options(pattern, count),
       Decode.scanPage(Decode.flatPairs[F, V])
     )
 
@@ -87,18 +87,13 @@ private[sage] object Hashes {
     Command(
       "HSCAN",
       Command.FirstKey,
-      (Vector(keyCodec.encode(key), ScanCursor.bytes(cursor)) ++ scanOptions(pattern, count)) :+ NoValues,
+      (Vector(keyCodec.encode(key), ScanCursor.bytes(cursor)) ++ ScanArgs.options(pattern, count)) :+ NoValues,
       Decode.scanPage(Decode.vector(Decode.key[F]))
     )
 
   private def fieldValueArgs[F, V](pairs: Vector[(F, V)])(using fieldCodec: KeyCodec[F], valueCodec: ValueCodec[V]): Vector[Bytes] =
     pairs.flatMap { case (field, value) => Vector(fieldCodec.encode(field), valueCodec.encode(value)) }
 
-  private def scanOptions(pattern: Option[String], count: Option[Long]): Vector[Bytes] =
-    pattern.toVector.flatMap(p => Vector(Match, Bytes.utf8(p))) ++ count.toVector.flatMap(n => Vector(Count, Bytes.utf8(n.toString)))
-
-  private val Match      = Bytes.utf8("MATCH")
-  private val Count      = Bytes.utf8("COUNT")
   private val WithValues = Bytes.utf8("WITHVALUES")
   private val NoValues   = Bytes.utf8("NOVALUES")
 }

--- a/sage-core/src/main/scala/sage/commands/Keys.scala
+++ b/sage-core/src/main/scala/sage/commands/Keys.scala
@@ -129,8 +129,7 @@ private[sage] object Keys {
       "SCAN",
       Command.NoKeys,
       ScanCursor.bytes(cursor) +:
-        (pattern.toVector.flatMap(p => Vector(Match, Bytes.utf8(p))) ++
-          count.toVector.flatMap(n => Vector(Count, Bytes.utf8(n.toString))) ++
+        (ScanArgs.options(pattern, count) ++
           ofType.toVector.flatMap(t => Vector(Type, Bytes.utf8(RedisType.wireName(t))))),
       Decode.scanPage(Decode.vector(Decode.key[K]))
     )
@@ -185,8 +184,6 @@ private[sage] object Keys {
     case other                                => Left(DecodeError("expiry time integer", Frame.describe(other)))
   }
   private val Replace                                                                                = Bytes.utf8("REPLACE")
-  private val Match                                                                                  = Bytes.utf8("MATCH")
-  private val Count                                                                                  = Bytes.utf8("COUNT")
   private val Type                                                                                   = Bytes.utf8("TYPE")
   private val Nx                                                                                     = Bytes.utf8("NX")
   private val Xx                                                                                     = Bytes.utf8("XX")

--- a/sage-core/src/main/scala/sage/commands/ScanArgs.scala
+++ b/sage-core/src/main/scala/sage/commands/ScanArgs.scala
@@ -1,0 +1,13 @@
+package sage.commands
+
+import sage.Bytes
+
+private[commands] object ScanArgs {
+
+  val Match: Bytes = Bytes.utf8("MATCH")
+  val Count: Bytes = Bytes.utf8("COUNT")
+
+  def options(pattern: Option[String], count: Option[Long]): Vector[Bytes] =
+    pattern.toVector.flatMap(p => Vector(Match, Bytes.utf8(p))) ++
+      count.toVector.flatMap(n => Vector(Count, Bytes.utf8(n.toString)))
+}

--- a/sage-core/src/main/scala/sage/commands/Sets.scala
+++ b/sage-core/src/main/scala/sage/commands/Sets.scala
@@ -85,7 +85,7 @@ private[sage] object Sets {
     Command(
       "SSCAN",
       Command.FirstKey,
-      Vector(keyCodec.encode(key), ScanCursor.bytes(cursor)) ++ scanOptions(pattern, count),
+      Vector(keyCodec.encode(key), ScanCursor.bytes(cursor)) ++ ScanArgs.options(pattern, count),
       Decode.scanPage(Decode.vector(Decode.value[V]))
     )
 
@@ -101,10 +101,5 @@ private[sage] object Sets {
     Command(name, args.indices.toVector, args, Decode.long)
   }
 
-  private def scanOptions(pattern: Option[String], count: Option[Long]): Vector[Bytes] =
-    pattern.toVector.flatMap(p => Vector(Match, Bytes.utf8(p))) ++ count.toVector.flatMap(n => Vector(Count, Bytes.utf8(n.toString)))
-
-  private val Match = Bytes.utf8("MATCH")
-  private val Count = Bytes.utf8("COUNT")
   private val Limit = Bytes.utf8("LIMIT")
 }

--- a/sage-core/src/main/scala/sage/commands/SortedSets.scala
+++ b/sage-core/src/main/scala/sage/commands/SortedSets.scala
@@ -284,7 +284,7 @@ private[sage] object SortedSets {
     Command(
       "ZSCAN",
       Command.FirstKey,
-      Vector(keyCodec.encode(key), ScanCursor.bytes(cursor)) ++ scanOptions(pattern, count),
+      Vector(keyCodec.encode(key), ScanCursor.bytes(cursor)) ++ ScanArgs.options(pattern, count),
       Decode.scanPage(Decode.scoredMembersFlat[V])
     )
 
@@ -400,9 +400,6 @@ private[sage] object SortedSets {
   private def countArg(count: Option[Long]): Vector[Bytes] =
     count.toVector.flatMap(c => Vector(CountWord, Bytes.utf8(c.toString)))
 
-  private def scanOptions(pattern: Option[String], count: Option[Long]): Vector[Bytes] =
-    pattern.toVector.flatMap(p => Vector(Match, Bytes.utf8(p))) ++ count.toVector.flatMap(n => Vector(CountWord, Bytes.utf8(n.toString)))
-
   private def minMaxArg(minMax: MinMax): Bytes =
     minMax match {
       case MinMax.Min => MinWord
@@ -417,8 +414,13 @@ private[sage] object SortedSets {
     else if (value.isNaN) "nan"
     else value.toString
 
-  private def prefixed(prefix: Char, value: Bytes): Bytes =
-    Bytes.wrap(IArray.unsafeFromArray(prefix.toByte +: value.toArray))
+  private def prefixed(prefix: Char, value: Bytes): Bytes = {
+    val src = value.unsafeArray
+    val out = new Array[Byte](src.length + 1)
+    out(0) = prefix.toByte
+    System.arraycopy(src, 0, out, 1, src.length)
+    Bytes.wrap(IArray.unsafeFromArray(out))
+  }
 
   private val Nx            = Bytes.utf8("NX")
   private val Xx            = Bytes.utf8("XX")
@@ -437,7 +439,6 @@ private[sage] object SortedSets {
   private val MinWord       = Bytes.utf8("MIN")
   private val MaxWord       = Bytes.utf8("MAX")
   private val CountWord     = Bytes.utf8("COUNT")
-  private val Match         = Bytes.utf8("MATCH")
   private val NegInfWord    = Bytes.utf8("-inf")
   private val PosInfWord    = Bytes.utf8("+inf")
   private val LexMin        = Bytes.utf8("-")

--- a/sage-core/src/main/scala/sage/protocol/Frame.scala
+++ b/sage-core/src/main/scala/sage/protocol/Frame.scala
@@ -80,8 +80,6 @@ object Frame {
 
   final case class Set(elements: Vector[Frame]) extends Frame
 
-  final case class Attribute(entries: Vector[(Frame, Frame)]) extends Frame
-
   final case class Push(elements: Vector[Frame]) extends Frame
 
   def describe(frame: Frame): String =
@@ -99,7 +97,6 @@ object Frame {
       case VerbatimString(format, value) => s"verbatim string '$format' (${value.length} bytes)"
       case Map(entries)                  => s"map (${entries.length} entries)"
       case Set(elements)                 => s"set (${elements.length} elements)"
-      case Attribute(entries)            => s"attribute (${entries.length} entries)"
       case Push(elements)                => s"push (${elements.length} elements)"
     }
 }

--- a/sage-core/src/main/scala/sage/protocol/RespParser.scala
+++ b/sage-core/src/main/scala/sage/protocol/RespParser.scala
@@ -28,48 +28,59 @@ final class RespParser {
   /**
     * Returns every frame completed by `bytes`, in order.
     */
-  def feed(bytes: Bytes): Either[ProtocolError, Vector[Frame]] =
-    if (failure != null) Left(failure)
-    else if (!append(bytes)) poison("input exceeds the maximum buffer size")
+  def feed(bytes: Bytes): Either[ProtocolError, Vector[Frame]] = {
+    val frames = Vector.newBuilder[Frame]
+    val array  = bytes.unsafeArray
+    feed(array, 0, array.length)(frames += _) match {
+      case Some(error) => Left(error)
+      case None        => Right(frames.result())
+    }
+  }
+
+  /**
+    * Parses every frame completed by `array(offset until offset + length)`, passing each to `onFrame` in order. Avoids the input copy and
+    * frame Vector of the [[feed]] overload: the slice is copied straight into the internal buffer (never retained) and frames stream out.
+    */
+  def feed(array: Array[Byte], offset: Int, length: Int)(onFrame: Frame => Unit): Option[ProtocolError] =
+    if (failure != null) Some(failure)
+    else if (!append(array, offset, length)) Some(poison("input exceeds the maximum buffer size"))
     else {
-      val frames = Vector.newBuilder[Frame]
-      var done   = false
+      var done = false
       while (!done) {
-        val frame = parseFrame(readPos)
+        val frame = parseFrame(readPos, 0)
         if (frame == null) done = true
         else {
-          frames += frame
+          onFrame(frame)
           readPos = cursor
         }
       }
-      if (failMessage != null) poison(failMessage)
+      if (failMessage != null) Some(poison(failMessage))
       else {
         if (readPos == writePos) {
           readPos = 0
           writePos = 0
         }
-        Right(frames.result())
+        None
       }
     }
 
-  private def poison(message: String): Left[ProtocolError, Nothing] = {
+  private def poison(message: String): ProtocolError = {
     val error = ProtocolError(message)
     failure = error
     buf = Array.emptyByteArray
     readPos = 0
     writePos = 0
-    Left(error)
+    error
   }
 
   // compacts in place when the consumed front frees enough room, grows geometrically otherwise; Long arithmetic so capacity
   // computations cannot overflow, false when the unconsumed input would exceed the maximum array size
-  private def append(bytes: Bytes): Boolean = {
-    val incoming = bytes.unsafeArray
+  private def append(incoming: Array[Byte], offset: Int, length: Int): Boolean = {
     val unparsed = writePos - readPos
-    val needed   = unparsed.toLong + incoming.length
+    val needed   = unparsed.toLong + length
     if (needed > MaxBuffer) false
     else {
-      if (buf.length - writePos < incoming.length) {
+      if (buf.length - writePos < length) {
         if (buf.length >= needed) {
           System.arraycopy(buf, readPos, buf, 0, unparsed)
         } else {
@@ -82,14 +93,47 @@ final class RespParser {
         readPos = 0
         writePos = unparsed
       }
-      System.arraycopy(incoming, 0, buf, writePos, incoming.length)
-      writePos += incoming.length
+      System.arraycopy(incoming, offset, buf, writePos, length)
+      writePos += length
       true
     }
   }
 
-  private def parseFrame(pos: Int): Frame =
+  // attributes are out-of-band metadata prefixing a value, valid at any nesting level; skip them iteratively (not recursively, so a long
+  // attribute chain cannot overflow the stack) and return the value they annotate, so an attribute never occupies an aggregate slot
+  private def parseFrame(pos: Int, depth: Int): Frame = {
+    var p = pos
+    while (p < writePos && buf(p) == '|') {
+      val after = skipAttribute(p + 1, depth)
+      if (after < 0) return null // Incomplete, or Invalid with failMessage set
+      p = after
+    }
+    parseValue(p, depth)
+  }
+
+  // consumes a `|` attribute's pairs without materializing them; returns the position past it, or Incomplete / Invalid (failMessage set)
+  private def skipAttribute(pos: Int, depth: Int): Int = {
+    val count = readLength(pos, allowNull = false)
+    if (count == Incomplete) Incomplete
+    else if (count == Invalid) { failMessage = s"invalid attribute length: '${headerText(pos)}'"; Invalid }
+    else {
+      var p = cursor
+      var i = 0
+      while (i < count) {
+        val key   = parseFrame(p, depth + 1)
+        if (key == null) return if (failMessage != null) Invalid else Incomplete
+        val value = parseFrame(cursor, depth + 1)
+        if (value == null) return if (failMessage != null) Invalid else Incomplete
+        p = cursor
+        i += 1
+      }
+      p
+    }
+  }
+
+  private def parseValue(pos: Int, depth: Int): Frame =
     if (pos >= writePos) null
+    else if (depth > MaxDepth) fail(s"aggregate nesting exceeds $MaxDepth levels")
     else {
       (buf(pos).toChar: @switch) match {
         case '+'   =>
@@ -208,11 +252,10 @@ final class RespParser {
               Frame.VerbatimString(stringAt(start, start + 3), bytesAt(start + 4, start + length))
             }
           }
-        case '*'   => parseAggregate(pos + 1, allowNull = true, Frame.Array.apply)
-        case '~'   => parseAggregate(pos + 1, allowNull = false, Frame.Set.apply)
-        case '>'   => parseAggregate(pos + 1, allowNull = false, Frame.Push.apply)
-        case '%'   => parsePairAggregate(pos + 1, Frame.Map.apply)
-        case '|'   => parsePairAggregate(pos + 1, Frame.Attribute.apply)
+        case '*'   => parseAggregate(pos + 1, allowNull = true, Frame.Array.apply, depth)
+        case '~'   => parseAggregate(pos + 1, allowNull = false, Frame.Set.apply, depth)
+        case '>'   => parseAggregate(pos + 1, allowNull = false, Frame.Push.apply, depth)
+        case '%'   => parsePairAggregate(pos + 1, Frame.Map.apply, depth)
         case other =>
           fail(f"unknown frame type byte 0x${other.toByte}%02x")
       }
@@ -249,33 +292,33 @@ final class RespParser {
 
   private def headerText(pos: Int): String = stringAt(pos, findCrlf(pos))
 
-  private def parseAggregate(pos: Int, allowNull: Boolean, make: Vector[Frame] => Frame): Frame = {
+  private def parseAggregate(pos: Int, allowNull: Boolean, make: Vector[Frame] => Frame, depth: Int): Frame = {
     val count = readLength(pos, allowNull)
     if (count == Incomplete) null
     else if (count == Invalid) fail(s"invalid aggregate length: '${headerText(pos)}'")
     else if (count == -1) Frame.Null
     else {
-      val elements = parseElements(cursor, count)
+      val elements = parseElements(cursor, count, depth)
       if (elements == null) null else make(elements)
     }
   }
 
-  private def parsePairAggregate(pos: Int, make: Vector[(Frame, Frame)] => Frame): Frame = {
+  private def parsePairAggregate(pos: Int, make: Vector[(Frame, Frame)] => Frame, depth: Int): Frame = {
     val count = readLength(pos, allowNull = false)
     if (count == Incomplete) null
     else if (count == Invalid) fail(s"invalid aggregate length: '${headerText(pos)}'")
     else {
-      val entries = parsePairs(cursor, count)
+      val entries = parsePairs(cursor, count, depth)
       if (entries == null) null else make(entries)
     }
   }
 
-  private def parseElements(start: Int, count: Int): Vector[Frame] = {
+  private def parseElements(start: Int, count: Int, depth: Int): Vector[Frame] = {
     val elements = Vector.newBuilder[Frame]
     var pos      = start
     var i        = 0
     while (i < count) {
-      val frame = parseFrame(pos)
+      val frame = parseFrame(pos, depth + 1)
       if (frame == null) return null
       elements += frame
       pos = cursor
@@ -285,14 +328,14 @@ final class RespParser {
     elements.result()
   }
 
-  private def parsePairs(start: Int, count: Int): Vector[(Frame, Frame)] = {
+  private def parsePairs(start: Int, count: Int, depth: Int): Vector[(Frame, Frame)] = {
     val entries = Vector.newBuilder[(Frame, Frame)]
     var pos     = start
     var i       = 0
     while (i < count) {
-      val key   = parseFrame(pos)
+      val key   = parseFrame(pos, depth + 1)
       if (key == null) return null
-      val value = parseFrame(cursor)
+      val value = parseFrame(cursor, depth + 1)
       if (value == null) return null
       entries += ((key, value))
       pos = cursor
@@ -356,4 +399,7 @@ final class RespParser {
 
   // largest unconsumed input the parser will buffer (the JVM's max array size)
   private inline def MaxBuffer: Long = Int.MaxValue - 8
+
+  // bound on aggregate nesting so a hostile reply poisons cleanly instead of overflowing the JVM stack; real replies are shallow
+  private inline def MaxDepth: Int = 512
 }

--- a/sage-core/src/main/scala/sage/protocol/RespWriter.scala
+++ b/sage-core/src/main/scala/sage/protocol/RespWriter.scala
@@ -1,7 +1,5 @@
 package sage.protocol
 
-import java.nio.charset.StandardCharsets
-
 import sage.Bytes
 
 /**
@@ -10,7 +8,7 @@ import sage.Bytes
 private[sage] object RespWriter {
 
   def writeCommand(name: String, args: Vector[Bytes]): Bytes = {
-    val sink = new Sink(64)
+    val sink = new Sink(256)
     if (name.indexOf(' ') < 0) { // single-word fast path: no split allocation
       sink.writeByte('*')
       sink.writeLong(1L + args.length)
@@ -67,14 +65,8 @@ private[sage] object RespWriter {
     def writeBytes(bytes: Bytes): Unit =
       writeArray(bytes.unsafeArray)
 
-    def writeLong(value: Long): Unit =
-      if (value == Long.MinValue) writeArray(value.toString.getBytes(StandardCharsets.UTF_8)) // -value would overflow
-      else if (value < 0) {
-        writeByte('-')
-        writeDigits(-value)
-      } else {
-        writeDigits(value)
-      }
+    // only ever called with non-negative lengths and element counts
+    def writeLong(value: Long): Unit = writeDigits(value)
 
     def result(): Bytes = Bytes.wrap(IArray.unsafeFromArray(java.util.Arrays.copyOf(buf, len)))
 
@@ -102,11 +94,13 @@ private[sage] object RespWriter {
       len += array.length
     }
 
+    // Long arithmetic so the doubling cannot overflow to a negative capacity on a multi-GB command; capped at the max array size
     private def ensure(extra: Int): Unit =
       if (buf.length - len < extra) {
-        var capacity = buf.length * 2
-        while (capacity - len < extra) capacity *= 2
-        buf = java.util.Arrays.copyOf(buf, capacity)
+        val needed   = len.toLong + extra
+        var capacity = buf.length.toLong * 2
+        while (capacity < needed) capacity *= 2
+        buf = java.util.Arrays.copyOf(buf, math.min(capacity, Int.MaxValue - 8).toInt)
       }
   }
 }

--- a/sage-core/src/test/scala/sage/protocol/FrameWriter.scala
+++ b/sage-core/src/test/scala/sage/protocol/FrameWriter.scala
@@ -38,7 +38,6 @@ object FrameWriter {
         writeCrlf(out)
       case Frame.Map(entries)                  => writePairs('%', entries, out)
       case Frame.Set(elements)                 => writeAggregate('~', elements, out)
-      case Frame.Attribute(entries)            => writePairs('|', entries, out)
       case Frame.Push(elements)                => writeAggregate('>', elements, out)
     }
 

--- a/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
+++ b/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
@@ -49,13 +49,14 @@ class RespParserSpec extends munit.FunSuite {
       Vector(Frame.SimpleString("first") -> Frame.Integer(1), Frame.SimpleString("second") -> Frame.Integer(2))
     ),
     "~3\r\n:1\r\n:2\r\n:3\r\n"                         -> Frame.Set(Vector(Frame.Integer(1), Frame.Integer(2), Frame.Integer(3))),
-    "|1\r\n+ttl\r\n:3600\r\n"                          -> Frame.Attribute(Vector(Frame.SimpleString("ttl") -> Frame.Integer(3600))),
     ">2\r\n+message\r\n$5\r\nhello\r\n"                -> Frame.Push(Vector(Frame.SimpleString("message"), Frame.BulkString(Bytes.utf8("hello"))))
   )
 
   // wire forms the parser accepts but the writer never emits
   private val parseOnlyGoldens: Vector[(String, Frame)] = Vector(
-    ",10\r\n" -> Frame.Double(10.0)
+    ",10\r\n"                        -> Frame.Double(10.0),
+    // an attribute is transparent metadata: it is consumed and discarded, and the value it prefixes is returned in its place
+    "|1\r\n+ttl\r\n:3600\r\n:42\r\n" -> Frame.Integer(42)
   )
 
   private val goldens = canonicalGoldens ++ parseOnlyGoldens
@@ -84,6 +85,23 @@ class RespParserSpec extends munit.FunSuite {
     assertEquals(parseOne("$-1\r\n"), Frame.Null)
     assertEquals(parseOne("*-1\r\n"), Frame.Null)
     assertEquals(parseOne("*1\r\n*-1\r\n"), Frame.Array(Vector(Frame.Null)))
+  }
+
+  test("attributes are transparent at every nesting level") {
+    // top level: the value the attribute prefixes is returned, the attribute discarded
+    assertEquals(parseOne("|1\r\n+ttl\r\n:3600\r\n:7\r\n"), Frame.Integer(7))
+    // nested: an attribute on an array element must not inflate the array's arity
+    assertEquals(
+      parseOne("*2\r\n|1\r\n+ttl\r\n:3600\r\n:1\r\n:2\r\n"),
+      Frame.Array(Vector(Frame.Integer(1), Frame.Integer(2)))
+    )
+    // nested in a map value position
+    assertEquals(
+      parseOne("%1\r\n+k\r\n|1\r\n+ttl\r\n:1\r\n:9\r\n"),
+      Frame.Map(Vector(Frame.SimpleString("k") -> Frame.Integer(9)))
+    )
+    // a chain of attributes collapses to the final value
+    assertEquals(parseOne("|0\r\n|0\r\n:5\r\n"), Frame.Integer(5))
   }
 
   test("rejects negative and signed lengths") {
@@ -179,7 +197,6 @@ class RespParserSpec extends munit.FunSuite {
       Frame.BulkError(Bytes.utf8("WRONGTYPE")),
       Frame.VerbatimString("mkd", Bytes.utf8("# hi")),
       Frame.Set(Vector(Frame.Integer(1), Frame.Integer(2))),
-      Frame.Attribute(Vector(Frame.SimpleString("ttl") -> Frame.Integer(3600))),
       Frame.Push(Vector(Frame.SimpleString("message"), Frame.BulkString(Bytes.utf8("hello")))),
       // duplicate map keys, which a native Map would collapse
       Frame.Map(
@@ -213,7 +230,7 @@ class RespParserSpec extends munit.FunSuite {
   }
 
   private def genFrame(rnd: Random, depth: Int): Frame =
-    rnd.nextInt(if (depth == 0) 10 else 15) match {
+    rnd.nextInt(if (depth == 0) 10 else 14) match {
       case 0  => Frame.SimpleString(genText(rnd))
       case 1  => Frame.SimpleError(genText(rnd))
       case 2  => Frame.Integer(rnd.nextLong())
@@ -227,7 +244,6 @@ class RespParserSpec extends munit.FunSuite {
       case 10 => Frame.Array(genElements(rnd, depth))
       case 11 => Frame.Map(genPairs(rnd, depth))
       case 12 => Frame.Set(genElements(rnd, depth))
-      case 13 => Frame.Attribute(genPairs(rnd, depth))
       case _  => Frame.Push(genElements(rnd, depth))
     }
 


### PR DESCRIPTION
A correctness, performance, and robustness pass over the whole project before the next round of features. All findings were adversarially verified; no behavior-changing speculation made it in.

## Correctness / protocol
- **RESP3 attributes are now transparent at every nesting level.** The parser consumes and discards a `|` attribute — iteratively, so a long attribute chain can't overflow the stack — and returns the value it prefixes. `Frame.Attribute` is removed from the ADT; a nested attribute no longer inflates aggregate arity or desyncs `EXEC`. New parser tests cover top-level, in-array, in-map, and chained attributes.
- Bound aggregate nesting **depth** so a hostile reply poisons cleanly as `ProtocolError` instead of throwing `StackOverflowError` past the `poison()` contract.
- Guard `EXEC` reply arity (fail as `ProtocolError`, not a raw `IndexOutOfBoundsException`); fix `TxScope.run` to check the released-scope guard before the blocking guard.
- Resolve an empty CLUSTER SLOTS announce-IP against the queried node, the same substitution redirects already use.

## Performance (hot paths)
- **Zero-copy parser feed** `feed(array, off, len)(onFrame)` — drops the per-read input copy *and* the handoff `Vector[Frame]`; `SocketTransport.readLoop` rewired to it.
- **Aggregate decoders** build in a single pass via a size-hinted, short-circuiting `buildEach` helper instead of per-element `Either` folds.
- `Topology.route` single-key fast path (no `Set[Slot]`); `Topology.split` single fold.
- `writeLoop` scratch buffer grows geometrically to the coalesced size (was a fixed 512KB per connection).
- `Bytes.concatBy` avoids the intermediate mapped `Vector` on the batch path.
- `RespWriter.Sink` capacity growth in `Long`, capped at max array size (was an `Int` overflow on multi-GB commands).

## Robustness / structure
- Validate `SageConfig` at `connect` (port range, positive durations, `maxConnections >= 1`, backoff sanity, cluster seeds/redirects) — surfaced through the connect effect, never `require`. Watchdog-duration checks are skipped when the watchdog is disabled.
- One shared backoff formula (`Backoff.jitteredMillis`) across reconnect and cluster-redirect retry; the redirect path now uses jittered backoff instead of a flat delay.
- Seed `lastRefreshMs` so bootstrap doesn't throttle the first redirect/READONLY-driven refresh (`Long.MinValue` would overflow the elapsed subtraction).
- `DedicatedPool` stale-generation retry paces with `awaitNanos` instead of an unbacked loop.
- Hoist scan MATCH/COUNT args into `ScanArgs`; Ox `scoped` close swallows unconditionally, matching the zio/ce/kyo teardown policy.

## Verification
core 389 + zio 72 tests pass; ce/ox/kyo cells compile; clean under `-Xfatal-warnings`; scalafmt applied.