### PR TITLE
Parallelize CI tests across per-backend jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,29 @@ jobs:
       - name: Lint code
         run: sbt check
 
-  test:
+  unit:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup Scala and Java
+        uses: coursier/setup-action@v3
+        with:
+          jvm: temurin:21
+          apps: sbt
+      - name: Cache scala dependencies
+        uses: coursier/cache-action@v8
+      - name: Run unit tests
+        run: sbt testUnit
+
+  integration:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+      matrix:
+        backend: [Zio, Ce, Ox, Kyo]
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v6
@@ -62,15 +81,15 @@ jobs:
       - name: Load server images
         if: steps.images.outputs.cache-hit == 'true'
         run: for f in ~/.docker-images/*.tar; do docker load -i "$f"; done
-      - name: Run tests
-        run: sbt test
+      - name: Run integration tests
+        run: sbt it${{ matrix.backend }}
         env:
           # ryuk adds a mandatory Docker Hub pull per run (rate-limit exposure) and ephemeral runners need no reaper
           TESTCONTAINERS_RYUK_DISABLED: "true"
   # re-enable when publishing is set up (requires PGP/Sonatype secrets)
   # publish:
   #   runs-on: ubuntu-24.04
-  #   needs: [lint, test]
+  #   needs: [lint, unit, integration]
   #   if: github.event_name != 'pull_request'
   #   steps:
   #     - name: Checkout current branch

--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,16 @@ name := "sage"
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 
+addCommandAlias(
+  "testUnit",
+  "core/test; clientZio/test; clientCe/test; clientOx/test; clientKyo3_8_3/test; " +
+    "clientFuture/Test/compile; integrationTestsFuture/Test/compile"
+)
+addCommandAlias("itZio", "integrationTestsZio/test")
+addCommandAlias("itCe", "integrationTestsCe/test")
+addCommandAlias("itOx", "integrationTestsOx/test")
+addCommandAlias("itKyo", "integrationTestsKyo3_8_3/test")
+
 lazy val root = project
   .in(file("."))
   .settings(publish / skip := true)
@@ -54,8 +64,8 @@ lazy val client = (projectMatrix in file("sage-client"))
   .settings(name := "sage-client")
   .settings(commonSettings)
   .settings(
-    // the Scala Next compatLibrary call adds an implicit Future anchor row; only the LTS one is published
-    publish / skip := scalaVersion.value != scala3Version && moduleName.value.endsWith("-future")
+    // compatLibrary emits an implicit Future anchor row; it's a compile-only baseline, never published
+    publish / skip := moduleName.value.endsWith("-future")
   )
   .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq(scala3NextVersion))
   .compatLibrary(ZioLib, CeLib, OxLib)(VirtualAxis.jvm)(Seq(scala3Version))

--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ lazy val root = project
 lazy val core = (projectMatrix in file("sage-core"))
   .settings(name := "sage-core")
   .settings(commonSettings)
+  .settings(parallelUnitTests)
   .defaultAxes(VirtualAxis.jvm, VirtualAxis.scalaVersionAxis(scala3Version, scala3Version))
   .customRow(
     autoScalaLibrary = true,
@@ -63,6 +64,7 @@ lazy val client = (projectMatrix in file("sage-client"))
   .dependsOn(core)
   .settings(name := "sage-client")
   .settings(commonSettings)
+  .settings(parallelUnitTests)
   .settings(
     // compatLibrary emits an implicit Future anchor row; it's a compile-only baseline, never published
     publish / skip := moduleName.value.endsWith("-future")
@@ -107,3 +109,7 @@ lazy val commonSettings = Def.settings(
   libraryDependencies += "org.scalameta" %% "munit" % munitVersion % Test,
   Test / fork                            := true
 )
+
+// only for container-free cells: integration suites each boot their own container, so running them in
+// parallel would multiply peak load and invite timing races
+lazy val parallelUnitTests = Def.settings(Test / testForkedParallel := true)

--- a/build.sbt
+++ b/build.sbt
@@ -27,8 +27,8 @@ addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck"
 
 addCommandAlias(
   "testUnit",
-  "core/test; clientZio/test; clientCe/test; clientOx/test; clientKyo3_8_3/test; " +
-    "clientFuture/Test/compile; integrationTestsFuture/Test/compile"
+  "all core/test clientZio/test clientCe/test clientOx/test clientKyo3_8_3/test " +
+    "clientFuture/Test/compile integrationTestsFuture/Test/compile"
 )
 addCommandAlias("itZio", "integrationTestsZio/test")
 addCommandAlias("itCe", "integrationTestsCe/test")


### PR DESCRIPTION
## What

The single serial `sbt test` job ran the entire build matrix (core ×2 Scala, client ×5 cells, integration-tests ×5 cells) on one runner. This splits it into parallel jobs.

### CI jobs
- **lint** — `sbt check` (scalafmt), unchanged
- **unit** — container-free, **no Docker**: `core/test` + all four published client cells + the compile-only Future anchor. Fast feedback, zero Docker Hub rate-limit exposure.
- **integration** — matrix over `[Zio, Ce, Ox, Kyo]`, each running only its testcontainers suite.

### build.sbt
- Shard task lists live in `addCommandAlias` definitions (`testUnit`, `itZio`/`itCe`/`itOx`/`itKyo`) next to the project ids, so they're a single source of truth and runnable locally (`sbt testUnit`).
- Stop publishing the **Future** build on LTS. It's a compile-only baseline emitted by `compatLibrary`, not a backend we ship; CI just compile-guards it now (both Scala versions skip publishing).

## Coverage notes
- `core` unit tests run once on LTS. Scala Next compilation of core is still validated transitively via the kyo build.
- Dropped the redundant Next byproducts (`core3_8_3/test` and the Next Future anchors) — identical pure tests / non-published cells already covered by the kyo build.

## Known limitation
The **zio integration job remains the long pole**: `build.sbt`'s once-only filter pins the `commands`/`security`/`cluster` suites to the zio cell. This PR runs work alongside it but doesn't shorten that critical path — sharding those suites is a possible follow-up.