### PR TITLE
Cluster Pipelines split/merge + cross-slot Transaction rejection (#24)

### DIFF
--- a/docs/adr/0027-cluster-transaction-lazy-slot-pinning.md
+++ b/docs/adr/0027-cluster-transaction-lazy-slot-pinning.md
@@ -1,0 +1,16 @@
+# Cluster transactions pin lazily to the slot of their first key
+
+A cluster Transaction is the same leased-scope API as standalone (ADR-0020), but it holds no connection at scope start: the Dedicated Connection is acquired lazily on the first operation that touches a key (`watch`, a keyed read, or `exec`), pinned to the slot's owning node, and every later key — in any `watch`, read, or the `exec` pipeline — must hash to that same slot or fail with the sealed `CrossSlot` error. We pin lazily rather than ask the caller to declare a slot up front because the interactive read-modify-write the scope exists for (ADR-0020) does not know its slot until it touches a key, and forcing a slot parameter would leak cluster topology into a call that ADR-0007 keeps topology-agnostic. The unit is the slot, not the node: Redis rejects a `MULTI`/`EXEC` whose keys span slots even within one node, so pinning to a node would let cross-slot transactions through to a server-side `EXEC` error instead of failing fast.
+
+## Considered Options
+
+- **Lazy pin on the first key (chosen)** — matches how an interactive RMW actually flows, keeps the API identical to standalone, and fails cross-slot fast on the client.
+- **Require a slot/key up front** (`transaction(slot) { … }`) — deterministic and acquires eagerly like standalone, but leaks topology into the call site, contradicting ADR-0007, and is redundant when the first key already names the slot.
+- **Pin to the node, not the slot** — fewer false rejections (two slots on one node would pass), but lets a transaction Redis will reject reach the wire, defeating the fail-fast acceptance criterion.
+
+## Consequences
+
+- Validation has two points, both raising `CrossSlot`: each `watch`/keyed read is checked as issued (a mismatch sends nothing for it, while earlier same-slot reads have legitimately run — honest RMW behavior), and `exec` validates the whole pipeline against the pin *before* sending `MULTI`, so the atomic batch is rejected before a byte of it is written. That second point is where "rejected before any command is sent" holds precisely.
+- A keyless operation routes to the pinned connection; one issued before any key, and an all-keyless transaction, route to an arbitrary live master (`pickNode`). These are unusual patterns supported permissively rather than rejected.
+- A transaction never follows a redirect or auto-retries: a `MOVED`/`ASK`, `NotConnected`, or `ConnectionLost` during the scope surfaces as-is and triggers a background topology refresh so the *next* attempt pins correctly — transparently re-pinning mid-scope would break `WATCH`/`MULTI` atomicity. The caller's existing retry loop (already needed for the `None` watch-abort) absorbs it.
+- Acquisition is deferred, so the lease bracket acquires an unpinned scope and the release is a no-op when no key was ever touched; once pinned, the standalone lease hygiene (quiescence, discard-if-armed, force-close on `close`) runs unchanged against the pinning node's pool.

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
@@ -59,7 +59,7 @@ abstract class ClusterSuite(image: String, serverBinary: String) extends munit.F
       else CIO.sleep(100.millis).flatMap(_ => awaitClusterOk(admin0, attempts - 1))
     }
 
-  // one shared container per suite (TestContainerForAll), so the cluster is formed once and all routing exercised in a single test
+  // one shared container per suite, so the cluster is formed once and all routing exercised in a single test
   test("single-key commands, pipelines, and transactions route against a real cluster") {
     withContainers { server =>
       val host       = server.host
@@ -67,7 +67,6 @@ abstract class ClusterSuite(image: String, serverBinary: String) extends munit.F
       val standalone = SageConfig(host = host, port = port)
       val clustered  = SageConfig(host = host, port = port, topology = Topology.Cluster(Vector(Endpoint(host, port))))
 
-      // hash tags keep a pipeline/transaction on one slot; a single-node cluster can't exercise cross-slot splitting (that needs multiple nodes)
       val program =
         connectAndUse(standalone)(formSingleNodeCluster(_, host, port)).flatMap { _ =>
           connectAndUse(clustered) { client =>

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
@@ -11,7 +11,8 @@ import sage.Bytes
 import sage.SageException.DecodeError
 import sage.client.{Endpoint, SageConfig, Topology}
 import sage.client.internal.Client
-import sage.commands.Command
+import sage.commands.{Command, Commands, Pipeline}
+import sage.commands.Pipeline.pipeline
 import sage.integration.{ContainerClient, Images}
 import sage.protocol.Frame
 
@@ -75,6 +76,32 @@ abstract class ClusterSuite(image: String, serverBinary: String) extends munit.F
             } yield {
               assertEquals(value, Some("hello"))
               assertEquals(count, 1L)
+            }
+          }
+        }
+      program.unsafeRun
+    }
+  }
+
+  test("a single-slot pipeline and transaction run against a real cluster") {
+    withContainers { server =>
+      val host       = server.host
+      val port       = server.mappedPort(6379)
+      val standalone = SageConfig(host = host, port = port)
+      val clustered  = SageConfig(host = host, port = port, topology = Topology.Cluster(Vector(Endpoint(host, port))))
+
+      // hash tags keep every key on one slot; a single-node cluster can't exercise cross-slot splitting (that needs multiple nodes)
+      val program =
+        connectAndUse(standalone)(formSingleNodeCluster(_, host, port)).flatMap { _ =>
+          connectAndUse(clustered) { client =>
+            for {
+              _      <- client.set("{t}a", "1")
+              _      <- client.set("{t}b", "2")
+              piped  <- client.pipeline((Commands.get[String, String]("{t}a"), Commands.get[String, String]("{t}b")).pipeline)
+              commit <- client.transaction(tx => tx.exec(Pipeline.sequence(Vector(Commands.incr[String]("{t}c"), Commands.incr[String]("{t}c")))))
+            } yield {
+              assertEquals(piped, (Some("1"), Some("2")))
+              assertEquals(commit, Some(Vector(1L, 2L)))
             }
           }
         }

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
@@ -59,47 +59,29 @@ abstract class ClusterSuite(image: String, serverBinary: String) extends munit.F
       else CIO.sleep(100.millis).flatMap(_ => awaitClusterOk(admin0, attempts - 1))
     }
 
-  test("single-key commands route against a real cluster") {
+  // one shared container per suite (TestContainerForAll), so the cluster is formed once and all routing exercised in a single test
+  test("single-key commands, pipelines, and transactions route against a real cluster") {
     withContainers { server =>
       val host       = server.host
       val port       = server.mappedPort(6379)
       val standalone = SageConfig(host = host, port = port)
       val clustered  = SageConfig(host = host, port = port, topology = Topology.Cluster(Vector(Endpoint(host, port))))
 
+      // hash tags keep a pipeline/transaction on one slot; a single-node cluster can't exercise cross-slot splitting (that needs multiple nodes)
       val program =
         connectAndUse(standalone)(formSingleNodeCluster(_, host, port)).flatMap { _ =>
           connectAndUse(clustered) { client =>
             for {
-              _     <- client.set("greeting", "hello")
-              value <- client.get[String, String]("greeting")
-              count <- client.incr("counter")
-            } yield {
-              assertEquals(value, Some("hello"))
-              assertEquals(count, 1L)
-            }
-          }
-        }
-      program.unsafeRun
-    }
-  }
-
-  test("a single-slot pipeline and transaction run against a real cluster") {
-    withContainers { server =>
-      val host       = server.host
-      val port       = server.mappedPort(6379)
-      val standalone = SageConfig(host = host, port = port)
-      val clustered  = SageConfig(host = host, port = port, topology = Topology.Cluster(Vector(Endpoint(host, port))))
-
-      // hash tags keep every key on one slot; a single-node cluster can't exercise cross-slot splitting (that needs multiple nodes)
-      val program =
-        connectAndUse(standalone)(formSingleNodeCluster(_, host, port)).flatMap { _ =>
-          connectAndUse(clustered) { client =>
-            for {
+              _      <- client.set("greeting", "hello")
+              value  <- client.get[String, String]("greeting")
+              count  <- client.incr("counter")
               _      <- client.set("{t}a", "1")
               _      <- client.set("{t}b", "2")
               piped  <- client.pipeline((Commands.get[String, String]("{t}a"), Commands.get[String, String]("{t}b")).pipeline)
               commit <- client.transaction(tx => tx.exec(Pipeline.sequence(Vector(Commands.incr[String]("{t}c"), Commands.incr[String]("{t}c")))))
             } yield {
+              assertEquals(value, Some("hello"))
+              assertEquals(count, 1L)
               assertEquals(piped, (Some("1"), Some("2")))
               assertEquals(commit, Some(Vector(1L, 2L)))
             }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -12,7 +12,7 @@ import scala.util.control.NonFatal
 import kyo.compat.*
 
 import sage.{Bytes, Message, PatternMessage, SageException}
-import sage.SageException.{ConnectionLost, NotConnected, ProtocolError, ServerError, TimedOut, TlsError, TransactionDiscarded, UnsupportedServer}
+import sage.SageException.{ConnectionLost, NotConnected, ServerError, TimedOut, TlsError, UnsupportedServer}
 import sage.client.{AuthConfig, BackoffConfig, DedicatedPoolConfig, PubSubConfig, SageConfig, Topology, WatchdogConfig}
 import sage.cluster.Node
 import sage.codec.{KeyCodec, ValueCodec}
@@ -698,17 +698,6 @@ object Client {
       case other                                                                                                    => other
     }
 
-  // the strict-collapse step shared by `pipeline` and a transaction's `exec`
-  private def collapseStrict[Out](results: Vector[Either[SageException, Any]], toOut: Vector[Any] => Out): CIO[Out] =
-    results.collectFirst { case Left(error) => error } match {
-      case Some(error) => CIO.fail(error)
-      case None        => CIO.value(toOut(results.collect { case Right(value) => value }))
-    }
-
-  // a programmer error, deliberately outside the sealed hierarchy (like the blocking-command guard): a scope captured past its block
-  private def scopeReleasedError: IllegalStateException =
-    new IllegalStateException("transaction scope used after its block returned")
-
   final private class Live(connection: MultiplexedConnection, pool: DedicatedPool, subscriptions: SubscriptionConnection) extends Client[CIO] {
 
     def run[A](command: Command[A]): CIO[A] =
@@ -718,7 +707,7 @@ object Client {
       }
 
     def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out] =
-      submitPipeline(p).flatMap(collapseStrict(_, p.toOut))
+      submitPipeline(p).flatMap(TxSupport.collapseStrict(_, p.toOut))
 
     def pipelineAttempt[Out, R](p: Pipeline[Out, R]): CIO[R] =
       submitPipeline(p).map(p.toResults)
@@ -753,20 +742,11 @@ object Client {
           val slots     = new AtomicReferenceArray[Either[SageException, Any]](n)
           val remaining = new AtomicInteger(n)
           val callbacks = Vector.tabulate(n) { i => (result: Try[Any]) =>
-            slots.set(i, toEither(result))
+            slots.set(i, TxSupport.toEither(result))
             if (remaining.decrementAndGet() == 0) complete(Success(Vector.tabulate(n)(slots.get)))
           }
           if (!connection.submitAll(p.commands, callbacks)) complete(Failure(NotConnected()))
         }
-
-    // decoders return Either and never throw; the catch in the connection's reply path is defensive, so a non-SageException here is a
-    // decoder bug surfaced as a decode failure rather than allowed to escape the per-position result model.
-    private def toEither(result: Try[Any]): Either[SageException, Any] =
-      result match {
-        case Success(value)            => Right(value)
-        case Failure(e: SageException) => Left(e)
-        case Failure(other)            => Left(SageException.DecodeError("a decodable reply", s"decoder threw $other"))
-      }
 
     def subscribeChannels[V: ValueCodec](channel: String, rest: String*): CIO[Subscription[CIO, Message[V]]] =
       CIO.blocking {
@@ -821,7 +801,7 @@ object Client {
 
     private def submitting[A](complete: Try[A] => Unit)(submit: => Unit): Unit = {
       lock.lock()
-      try if (released) complete(Failure(scopeReleasedError)) else submit
+      try if (released) complete(Failure(TxSupport.scopeReleasedError)) else submit
       finally lock.unlock()
     }
 
@@ -850,7 +830,7 @@ object Client {
 
     def run[A](command: Command[A]): CIO[A] =
       if (isReleased)
-        CIO.fail(scopeReleasedError)
+        CIO.fail(TxSupport.scopeReleasedError)
       else if (command.isBlocking)
         CIO.fail(new IllegalArgumentException("a Transaction cannot run blocking commands; run them individually on the client"))
       else
@@ -867,7 +847,7 @@ object Client {
     def exec[Out, R](p: Pipeline[Out, R]): CIO[Option[Out]] =
       runExec(p).flatMap {
         case None          => CIO.value(None)
-        case Some(results) => collapseStrict(results, p.toOut).map(Some(_))
+        case Some(results) => TxSupport.collapseStrict(results, p.toOut).map(Some(_))
       }
 
     def execAttempt[Out, R](p: Pipeline[Out, R]): CIO[Option[R]] =
@@ -876,7 +856,7 @@ object Client {
     // None = WATCH abort; Some = the per-position decoded results. A queueing-phase error fails the effect (nothing ran).
     private def runExec[Out, R](p: Pipeline[Out, R]): CIO[Option[Vector[Either[SageException, Any]]]] =
       if (isReleased)
-        CIO.fail(scopeReleasedError)
+        CIO.fail(TxSupport.scopeReleasedError)
       // a truly empty no-op only when nothing is watched; with watches armed we must still MULTI/EXEC so a concurrent change can abort it
       else if (p.commands.isEmpty && !armed.get)
         CIO.value(Some(Vector.empty))
@@ -889,39 +869,7 @@ object Client {
           }
           .flatMap { frames =>
             armed.set(false) // EXEC clears WATCH/MULTI state server-side whether it committed or aborted
-            interpretExec(p.commands, frames)
+            TxSupport.interpretExec(p.commands, frames)
           }
-
-    private def interpretExec(
-      commands: Vector[Command[?]],
-      frames: Vector[Frame]
-    ): CIO[Option[Vector[Either[SageException, Any]]]] = {
-      val n          = commands.length
-      // frames: MULTI reply, then one queue reply per command, then the EXEC reply
-      val queueError = (0 to n).iterator.map(i => errorOf(frames(i))).collectFirst { case Some(message) => message }
-      queueError match {
-        case Some(message) => CIO.fail(TransactionDiscarded(message))
-        case None          =>
-          frames(n + 1) match {
-            case Frame.Null                              => CIO.value(None)
-            case Frame.Array(elems) if elems.length == n =>
-              CIO.value(Some(Vector.tabulate(n)(i => Reply.run(commands(i).asInstanceOf[Command[Any]], elems(i)))))
-            case Frame.Array(elems)                      =>
-              CIO.fail(ProtocolError(s"EXEC returned ${elems.length} results for $n queued commands"))
-            case other                                   =>
-              errorOf(other) match {
-                case Some(message) => CIO.fail(TransactionDiscarded(message))
-                case None          => CIO.fail(ProtocolError(s"unexpected EXEC reply: ${Frame.describe(other)}"))
-              }
-          }
-      }
-    }
-
-    private def errorOf(frame: Frame): Option[String] =
-      frame match {
-        case Frame.SimpleError(message) => Some(message)
-        case Frame.BulkError(message)   => Some(message.asUtf8String)
-        case _                          => None
-      }
   }
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -1,7 +1,7 @@
 package sage.client.internal
 
 import java.util.concurrent.{CountDownLatch, TimeUnit}
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference, AtomicReferenceArray}
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.collection.mutable
@@ -11,17 +11,21 @@ import scala.util.control.NonFatal
 
 import kyo.compat.*
 
-import sage.{Message, PatternMessage}
+import sage.{Message, PatternMessage, SageException}
 import sage.SageException.{ConnectionLost, CrossSlot, NotConnected, ServerError}
 import sage.client.{BackoffConfig, ClusterConfig, DedicatedPoolConfig, SageConfig, WatchdogConfig}
-import sage.cluster.{ClusterTopology, Node, Redirect, RedirectKind, Route, Shard}
-import sage.codec.ValueCodec
+import sage.cluster.{ClusterTopology, Node, NodeGroup, Redirect, RedirectKind, Rejected, Route, Shard, Slot}
+import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.{Cluster, Command, Connection, Pipeline}
+import sage.protocol.Frame
 
 /**
   * The cluster runtime: one [[NodeClient]] bundle per master, a refreshable [[ClusterTopology]], and the routing/redirect/failover state
   * machine that executes the pure engine's [[Route]] classifications. The same `Client` type as standalone; only configuration selects it.
-  * Pipelines and Transactions are rejected in cluster mode.
+  *
+  * A Pipeline is split per node (the pure [[ClusterTopology.split]]), each group sent as one batch, and the results scattered back into
+  * submission order; positions a stale topology can't resolve fall back to per-command [[dispatch]]. A Transaction leases one Dedicated
+  * Connection, pinned lazily to the slot of its first key, and rejects any key on another slot with [[CrossSlot]].
   *
   * Routing and redirect-following run on offloaded virtual threads (never the reply thread), since establishing a node and refreshing the
   * topology both block. A submit's reply callback re-offloads before any blocking continuation.
@@ -82,9 +86,11 @@ final private[client] class ClusterLive(
   def run[A](command: Command[A]): CIO[A] =
     CIO.async[A](complete => offload(dispatch(command, cluster.maxRedirects, complete)))
 
-  def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out]               = CIO.fail(unsupported("Pipelines"))
-  def pipelineAttempt[Out, R](p: Pipeline[Out, R]): CIO[R]          = CIO.fail(unsupported("Pipelines"))
-  def transaction[A](body: TransactionScope[CIO] => CIO[A]): CIO[A] = CIO.fail(unsupported("Transactions"))
+  def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out]      = submitPipeline(p).flatMap(TxSupport.collapseStrict(_, p.toOut))
+  def pipelineAttempt[Out, R](p: Pipeline[Out, R]): CIO[R] = submitPipeline(p).map(p.toResults)
+
+  def transaction[A](body: TransactionScope[CIO] => CIO[A]): CIO[A] =
+    CIO.acquireReleaseWith(acquireScope)(releaseScope)(scope => body(scope))
 
   // classic and sharded pub/sub in cluster mode arrive with the cluster pub/sub work; standalone subscriptions build the machinery first
   def subscribeChannels[V: ValueCodec](channel: String, rest: String*): CIO[Subscription[CIO, Message[V]]] =
@@ -109,8 +115,7 @@ final private[client] class ClusterLive(
         case Route.ToNode(node, _)  => sendTo(node, command, asking = false, redirectsLeft, complete)
         case Route.Keyless          => sendToAny(topology, command, redirectsLeft, complete)
         case Route.Unowned(_)       => onUnowned(command, redirectsLeft, complete)
-        case Route.CrossSlot(slots) =>
-          complete(Failure(CrossSlot(s"${command.name}: keys span ${slots.size} slots; a single command must touch exactly one")))
+        case Route.CrossSlot(slots) => complete(Failure(crossSlot(command.name, slots)))
         case Route.Malformed        =>
           complete(Failure(new IllegalArgumentException(s"${command.name}: declared key positions fall outside its arguments")))
       }
@@ -140,18 +145,30 @@ final private[client] class ClusterLive(
   }
 
   private def onFailure[A](node: Node, command: Command[A], error: Throwable, redirectsLeft: Int, complete: Try[A] => Unit): Unit =
+    classify(error) match {
+      case ClusterLive.Disposition.Reroute             =>
+        error match {
+          // classify only reroutes a ServerError when it parses as a redirect, so `.get` is safe here
+          case ServerError(message) => onRedirect(node, Redirect.parse(message).get, command, redirectsLeft, complete)
+          case _                    => onUnreachable(command, redirectsLeft, complete)
+        }
+      case ClusterLive.Disposition.RefreshThenTerminal => triggerRefresh(); complete(Failure(error))
+      case ClusterLive.Disposition.Terminal            => complete(Failure(error))
+    }
+
+  // The single failure taxonomy a routed command can meet, shared by single-command [[onFailure]] and a Pipeline batch's per-position
+  // callbacks so the two cannot drift: a redirect or a provably-unexecuted loss is re-routed; a demoted master (`READONLY`) or a
+  // may-have-executed loss refreshes the topology but still fails its own command; anything else fails fast in place.
+  private def classify(error: Throwable): ClusterLive.Disposition =
     error match {
       case ServerError(message)  =>
-        Redirect.parse(message) match {
-          case Some(redirect) => onRedirect(node, redirect, command, redirectsLeft, complete)
-          case None           =>
-            if (message.startsWith("READONLY")) triggerRefresh() // a demoted master: adopt the new owner for subsequent commands
-            complete(Failure(error)) // fail fast, no retry
-        }
-      case NotConnected()        => onUnreachable(command, redirectsLeft, complete)
-      case ConnectionLost(false) => onUnreachable(command, redirectsLeft, complete) // never reached the wire: safe to retry
-      case ConnectionLost(true)  => triggerRefresh(); complete(Failure(error))      // may have executed: fail fast
-      case other                 => complete(Failure(other))
+        if (Redirect.parse(message).isDefined) ClusterLive.Disposition.Reroute
+        else if (message.startsWith("READONLY")) ClusterLive.Disposition.RefreshThenTerminal
+        else ClusterLive.Disposition.Terminal
+      case NotConnected()        => ClusterLive.Disposition.Reroute
+      case ConnectionLost(false) => ClusterLive.Disposition.Reroute
+      case ConnectionLost(true)  => ClusterLive.Disposition.RefreshThenTerminal
+      case _                     => ClusterLive.Disposition.Terminal
     }
 
   private def onRedirect[A](from: Node, redirect: Redirect, command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit =
@@ -193,6 +210,290 @@ final private[client] class ClusterLive(
       .orElse(topology.shards.headOption.map(_.master))
 
   private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
+
+  private def isMalformed(command: Command[?]): Boolean =
+    command.keyIndices.exists(index => index < 0 || index >= command.args.length)
+
+  private def crossSlot(name: String, slots: Set[Slot]): CrossSlot =
+    CrossSlot(s"$name: keys span ${slots.size} slots; a single command must touch exactly one")
+
+  // a transaction never follows a redirect, so the caller's retry depends on the topology actually refreshing — bypass the throttle window
+  // (the single-flight guard still collapses concurrent refreshes). Ordinary commands use the throttled triggerRefresh, since they re-route.
+  private def forceRefresh(): Unit = offload(refresh(force = true))
+
+  // --- pipelines (split per node, batch each, merge in submission order) ----------------------------------------------------------------
+
+  private def submitPipeline[Out, R](p: Pipeline[Out, R]): CIO[Vector[Either[SageException, Any]]] =
+    if (p.commands.isEmpty)
+      CIO.value(Vector.empty)
+    // blocking commands and malformed key indices are programmer errors: they fail the whole effect up front, never a single position
+    else if (p.commands.exists(_.isBlocking))
+      CIO.fail(new IllegalArgumentException("a Pipeline cannot carry blocking commands; run them individually on the client"))
+    else if (p.commands.exists(isMalformed))
+      CIO.fail(new IllegalArgumentException("a Pipeline command declares key positions that fall outside its arguments"))
+    else
+      CIO.async(complete => offload(runPipeline(p, complete)))
+
+  // offloaded (getOrEstablish blocks): split the pipeline, send one batch per node, and scatter each reply into its submission-order slot.
+  // A per-command CrossSlot fails only its own slot; a position a stale topology can't resolve (redirect, unreachable node, Unowned) falls
+  // back to per-command dispatch. The countdown completes the effect once every position has landed terminally — once, never on a redirect.
+  private def runPipeline[Out, R](p: Pipeline[Out, R], complete: Try[Vector[Either[SageException, Any]]] => Unit): Unit = {
+    val n                                                             = p.commands.length
+    val results                                                       = new AtomicReferenceArray[Either[SageException, Any]](n)
+    val remaining                                                     = new AtomicInteger(n)
+    def finish(index: Int, outcome: Either[SageException, Any]): Unit = {
+      results.set(index, outcome)
+      if (remaining.decrementAndGet() == 0) complete(Success(Vector.tabulate(n)(results.get)))
+    }
+    def reroute(index: Int): Unit                                     =
+      offload(dispatch(p.commands(index).asInstanceOf[Command[Any]], cluster.maxRedirects, result => finish(index, TxSupport.toEither(result))))
+
+    val plan = topologyRef.get().split(p)
+    plan.rejected.foreach {
+      case (index, Rejected.CrossSlot(slots)) => finish(index, Left(crossSlot(p.commands(index).name, slots)))
+      case (index, Rejected.Unowned(_))       => reroute(index) // dispatch refreshes then re-routes
+      // a programmer error: fail the whole effect, like single-command dispatch and the up-front guard, never a per-position result
+      case (index, Rejected.Malformed)        =>
+        complete(Failure(new IllegalArgumentException(s"${p.commands(index).name}: declared key positions fall outside its arguments")))
+    }
+    // keyless positions ride along on the first node group's batch; with no keyed group, dispatch routes each to any node
+    if (plan.perNode.isEmpty) plan.keyless.foreach(reroute)
+    plan.perNode.zipWithIndex.foreach { case (NodeGroup(node, positions), groupIndex) =>
+      // sorted: keep each node's batch in submission order even when keyless positions are folded into the first group
+      sendBatch(node, if (groupIndex == 0) (positions ++ plan.keyless).sorted else positions, p, finish, reroute)
+    }
+  }
+
+  private def sendBatch[Out, R](
+    node: Node,
+    indices: Vector[Int],
+    p: Pipeline[Out, R],
+    finish: (Int, Either[SageException, Any]) => Unit,
+    reroute: Int => Unit
+  ): Unit = {
+    val callbacks: Vector[Try[Any] => Unit] = indices.map { index => (result: Try[Any]) =>
+      result match {
+        case Success(value) => finish(index, Right(value))
+        case Failure(error) =>
+          classify(error) match {
+            case ClusterLive.Disposition.Reroute             => reroute(index)
+            case ClusterLive.Disposition.RefreshThenTerminal => triggerRefresh(); finish(index, TxSupport.toEither(result))
+            case ClusterLive.Disposition.Terminal            => finish(index, TxSupport.toEither(result))
+          }
+      }
+    }
+    val nc                                  =
+      try getOrEstablish(node)
+      catch { case NonFatal(_) => null }
+    // node unreachable, or not connected when the batch reached it: nothing was sent, so re-route every position individually
+    if (nc == null || !nc.submitAll(indices.map(p.commands), callbacks)) indices.foreach(reroute)
+  }
+
+  // --- transactions (one leased connection, pinned lazily to the first key's slot) ------------------------------------------------------
+
+  private def acquireScope: CIO[ClusterTxScope] =
+    if (closed) CIO.fail(NotConnected()) else CIO.value(new ClusterTxScope)
+
+  private def releaseScope(scope: ClusterTxScope): CIO[Unit] = CIO.blocking(scope.release())
+
+  /**
+    * A cluster Transaction scope. It holds no connection until the first key is touched, then leases one Dedicated Connection on that
+    * slot's node and pins to the slot; every later key must hash to the pin or fail [[CrossSlot]]. Keyless commands ride the pinned
+    * connection (or, before any key, an arbitrary master). Redirects and losses are never followed — they surface and refresh the topology
+    * in the background — so the caller retries the whole block, as it already must for a `WATCH` abort.
+    */
+  final private class ClusterTxScope extends TransactionScope[CIO] {
+
+    private val lock                      = new ReentrantLock()
+    private var released                  = false
+    private var nodeClient: NodeClient    = null
+    private var conn: DedicatedConnection = null
+    private var pinnedNode: Node          = null
+    private var pinnedSlot: Option[Slot]  = None
+    private val armed                     = new AtomicBoolean(false)
+
+    def watch[K: KeyCodec](key: K, rest: K*): CIO[Unit] = {
+      val command = Connection.watch(key, rest*)
+      CIO.async[Unit](complete => offload(withConn(command, complete) { c => armed.set(true); c.submit(command, faulting(complete)) }))
+    }
+
+    def run[A](command: Command[A]): CIO[A] =
+      if (command.isBlocking)
+        CIO.fail(new IllegalArgumentException("a Transaction cannot run blocking commands; run them individually on the client"))
+      else
+        CIO.async[A](complete => offload(withConn(command, complete)(c => c.submit(command, faulting(complete)))))
+
+    def discard: CIO[Unit] =
+      CIO.async[Unit] { complete =>
+        offload {
+          lock.lock()
+          try
+            if (released) complete(Failure(TxSupport.scopeReleasedError))
+            else if (conn == null) complete(Success(())) // nothing leased, nothing watched
+            else { armed.set(false); conn.submit(Connection.unwatch, faulting(complete)) }
+          finally lock.unlock()
+        }
+      }
+
+    // A transaction never follows a redirect (that would break MULTI/EXEC atomicity), but on any ownership or connection fault — a MOVED/ASK,
+    // a READONLY from a demoted master, a lost connection, or a failed acquire — it refreshes the topology in the background so the caller's
+    // retry re-pins to the new owner. Without it a retry would loop on the same stale node. A data error (WRONGTYPE, decode) refreshes nothing.
+    private def refreshOnFault(error: Throwable): Unit =
+      classify(error) match {
+        case ClusterLive.Disposition.Terminal => ()
+        case _                                => forceRefresh()
+      }
+
+    private def faulting[A](complete: Try[A] => Unit): Try[A] => Unit = {
+      case failure @ Failure(error) => refreshOnFault(error); complete(failure)
+      case success                  => complete(success)
+    }
+
+    // EXEC replies arrive as a Success carrying raw frames, so an ownership fault (MOVED/ASK at queue time, READONLY, or one nested in the
+    // EXEC array at exec time) is an error *frame*, invisible to `faulting`. Scan those frames — top level and the EXEC array — and refresh
+    // the topology on any non-terminal one so the caller's retry re-pins, mirroring `refreshOnFault` for the decoded-reply path.
+    private def refreshOnExecFault(frames: Vector[Frame]): Unit = {
+      val nested = frames.lastOption match { case Some(Frame.Array(elems)) => elems.iterator; case _ => Iterator.empty[Frame] }
+      val fault  = (frames.iterator ++ nested).flatMap(TxSupport.errorOf).exists(m => classify(ServerError(m)) != ClusterLive.Disposition.Terminal)
+      if (fault) forceRefresh()
+    }
+
+    def exec[Out, R](p: Pipeline[Out, R]): CIO[Option[Out]] =
+      runExec(p).flatMap {
+        case None          => CIO.value(None)
+        case Some(results) => TxSupport.collapseStrict(results, p.toOut).map(Some(_))
+      }
+
+    def execAttempt[Out, R](p: Pipeline[Out, R]): CIO[Option[R]] =
+      runExec(p).map(_.map(p.toResults))
+
+    private def runExec[Out, R](p: Pipeline[Out, R]): CIO[Option[Vector[Either[SageException, Any]]]] =
+      if (isReleased)
+        CIO.fail(TxSupport.scopeReleasedError)
+      else if (p.commands.isEmpty && !armed.get)
+        CIO.value(Some(Vector.empty))
+      else if (p.commands.exists(_.isBlocking))
+        CIO.fail(new IllegalArgumentException("a Transaction cannot carry blocking commands; run them individually on the client"))
+      else
+        CIO
+          .async[Vector[Frame]](complete => offload(submitExec(p, complete)))
+          .flatMap { frames =>
+            armed.set(false) // EXEC clears WATCH/MULTI state server-side whether it committed or aborted
+            refreshOnExecFault(frames)
+            TxSupport.interpretExec(p.commands, frames)
+          }
+
+    // validates the whole pipeline's slots against the pin *before* sending MULTI, so a cross-slot transaction is rejected with nothing on the wire
+    private def submitExec[Out, R](p: Pipeline[Out, R], complete: Try[Vector[Frame]] => Unit): Unit = {
+      lock.lock()
+      try
+        if (released) complete(Failure(TxSupport.scopeReleasedError))
+        else
+          pipelineSlot(p).flatMap(ensureConn) match {
+            case Left(error) => refreshOnFault(error); complete(Failure(error))
+            case Right(_)    => conn.submitRaw(Connection.multi +: p.commands :+ Connection.exec, faulting(complete))
+          }
+      finally lock.unlock()
+    }
+
+    private def withConn[A](command: Command[?], complete: Try[A] => Unit)(use: DedicatedConnection => Unit): Unit = {
+      lock.lock()
+      try
+        if (released) complete(Failure(TxSupport.scopeReleasedError))
+        else
+          commandSlot(command).flatMap(ensureConn) match {
+            case Left(error) => refreshOnFault(error); complete(Failure(error))
+            case Right(_)    => use(conn)
+          }
+      finally lock.unlock()
+    }
+
+    // lazily leases and pins the connection (called under `lock`; the blocking acquire is safe here — the finalizer never runs concurrently
+    // with a live block). With a slot: pin its owner on the first key, then require every later key to match; a keyless-acquired pin adopts
+    // the slot only if its node already owns it. Keyless before any key leases an arbitrary master.
+    private def ensureConn(slot: Option[Slot]): Either[Throwable, Unit] =
+      slot match {
+        case Some(s) if conn == null =>
+          nodeForSlotRefreshing(s) match {
+            case Some(node) => acquireOn(node).map(_ => pinnedSlot = Some(s))
+            case None       => Left(NotConnected())
+          }
+        case Some(s)                 =>
+          pinnedSlot match {
+            case Some(ps) if ps == s => Right(())
+            case Some(ps)            =>
+              Left(CrossSlot(s"transaction touches slot ${s.value} but is pinned to slot ${ps.value}; MULTI/EXEC requires a single slot"))
+            case None                =>
+              if (topologyRef.get().nodeForSlot(s).contains(pinnedNode)) { pinnedSlot = Some(s); Right(()) }
+              else Left(CrossSlot(s"transaction touches slot ${s.value} on a node other than its pinned one; MULTI/EXEC requires a single slot"))
+          }
+        case None if conn != null    => Right(())
+        case None                    =>
+          pickNode(topologyRef.get()) match {
+            case Some(node) => acquireOn(node)
+            case None       => Left(NotConnected())
+          }
+      }
+
+    private def nodeForSlotRefreshing(slot: Slot): Option[Node] =
+      topologyRef.get().nodeForSlot(slot).orElse { refresh(force = true); topologyRef.get().nodeForSlot(slot) }
+
+    private def acquireOn(node: Node): Either[Throwable, Unit] =
+      try {
+        val nc = getOrEstablish(node)
+        conn = nc.acquireForTransaction()
+        nodeClient = nc
+        pinnedNode = node
+        Right(())
+      } catch {
+        case error: SageException => Left(error)
+        case NonFatal(_)          => Left(ConnectionLost(mayHaveExecuted = false))
+      }
+
+    private def commandSlot(command: Command[?]): Either[Throwable, Option[Slot]] =
+      if (isMalformed(command))
+        Left(new IllegalArgumentException(s"${command.name}: declared key positions fall outside its arguments"))
+      else if (command.keyIndices.isEmpty)
+        Right(None)
+      else {
+        val slots = command.keyIndices.iterator.map(index => Slot.of(command.args(index))).toSet
+        if (slots.sizeIs > 1) Left(crossSlot(command.name, slots))
+        else Right(Some(slots.head))
+      }
+
+    private def pipelineSlot[Out, R](p: Pipeline[Out, R]): Either[Throwable, Option[Slot]] = {
+      var acc = Option.empty[Slot]
+      val it  = p.commands.iterator
+      while (it.hasNext)
+        commandSlot(it.next()) match {
+          case Left(error)       => return Left(error)
+          case Right(None)       => ()
+          case Right(Some(slot)) =>
+            acc match {
+              case None       => acc = Some(slot)
+              case Some(prev) =>
+                if (prev != slot) return Left(CrossSlot("transaction keys span multiple slots; MULTI/EXEC requires a single slot"))
+            }
+        }
+      Right(acc)
+    }
+
+    private def isReleased: Boolean = {
+      lock.lock();
+      try released
+      finally lock.unlock()
+    }
+
+    // run once by the lease finalizer: seal against further ops and release the pinned connection (recycle if clean, discard if armed or
+    // mid-command). A scope that never touched a key leased nothing, so there is nothing to release.
+    private[internal] def release(): Unit = {
+      lock.lock()
+      val (nc, c, reusable) =
+        try { released = true; (nodeClient, conn, conn != null && conn.isHealthy && conn.isQuiescent && !armed.get) }
+        finally lock.unlock()
+      if (nc != null) nc.releaseTransaction(c, reusable)
+    }
+  }
 
   // --- node registry (single-flight establish) -----------------------------------------------------------------------------------------
 
@@ -295,6 +596,11 @@ final private[client] class ClusterLive(
 }
 
 private[client] object ClusterLive {
+
+  // the disposition of a routed command's failure: re-route from scratch, refresh the topology but still fail this command, or fail in place
+  private enum Disposition {
+    case Reroute, RefreshThenTerminal, Terminal
+  }
 
   // one-shot single-flight cell: the establisher fills it, concurrent callers block on `get` and observe the same success or failure
   final private class Establish {

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
@@ -17,6 +17,15 @@ final private[client] class NodeClient(connection: MultiplexedConnection, pool: 
     else if (asking) connection.submitAsking(command, callback)
     else connection.submit(command, callback)
 
+  // a pipeline's per-node batch: one round-trip on this node's Multiplexed Connection. False when not connected (nothing submitted), so
+  // the caller re-routes each position rather than fabricating per-position errors. Blocking commands never reach here (rejected up front).
+  def submitAll(commands: Vector[Command[?]], callbacks: Vector[Try[Any] => Unit]): Boolean =
+    connection.submitAll(commands, callbacks)
+
+  def acquireForTransaction(): DedicatedConnection = pool.acquireForTransaction()
+
+  def releaseTransaction(connection: DedicatedConnection, reusable: Boolean): Unit = pool.releaseTransaction(connection, reusable)
+
   def isLive: Boolean = connection.isLive
 
   def close(): Unit = {

--- a/sage-client/shared/src/main/scala/sage/client/internal/TxSupport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/TxSupport.scala
@@ -1,0 +1,67 @@
+package sage.client.internal
+
+import scala.util.{Failure, Success, Try}
+
+import kyo.compat.*
+
+import sage.SageException
+import sage.SageException.{DecodeError, ProtocolError, TransactionDiscarded}
+import sage.commands.{Command, Reply}
+import sage.protocol.Frame
+
+/**
+  * The Pipeline/Transaction result-shaping shared by the standalone client and the cluster runtime, kept in one place so the
+  * per-position model and the MULTI/EXEC interpretation cannot drift between them.
+  */
+private[internal] object TxSupport {
+
+  // the strict-collapse step: fail with the first error, else hand the all-success values to the typed assembler
+  def collapseStrict[Out](results: Vector[Either[SageException, Any]], toOut: Vector[Any] => Out): CIO[Out] =
+    results.collectFirst { case Left(error) => error } match {
+      case Some(error) => CIO.fail(error)
+      case None        => CIO.value(toOut(results.collect { case Right(value) => value }))
+    }
+
+  // decoders return Either and never throw; a non-SageException here is a decoder bug surfaced as a decode failure rather than allowed
+  // to escape the per-position result model.
+  def toEither(result: Try[Any]): Either[SageException, Any] =
+    result match {
+      case Success(value)            => Right(value)
+      case Failure(e: SageException) => Left(e)
+      case Failure(other)            => Left(DecodeError("a decodable reply", s"decoder threw $other"))
+    }
+
+  // None = WATCH abort; Some = the per-position decoded results. A queueing-phase error fails the effect (nothing ran).
+  def interpretExec(commands: Vector[Command[?]], frames: Vector[Frame]): CIO[Option[Vector[Either[SageException, Any]]]] = {
+    val n          = commands.length
+    // frames: MULTI reply, then one queue reply per command, then the EXEC reply
+    val queueError = (0 to n).iterator.map(i => errorOf(frames(i))).collectFirst { case Some(message) => message }
+    queueError match {
+      case Some(message) => CIO.fail(TransactionDiscarded(message))
+      case None          =>
+        frames(n + 1) match {
+          case Frame.Null                              => CIO.value(None)
+          case Frame.Array(elems) if elems.length == n =>
+            CIO.value(Some(Vector.tabulate(n)(i => Reply.run(commands(i).asInstanceOf[Command[Any]], elems(i)))))
+          case Frame.Array(elems)                      =>
+            CIO.fail(ProtocolError(s"EXEC returned ${elems.length} results for $n queued commands"))
+          case other                                   =>
+            errorOf(other) match {
+              case Some(message) => CIO.fail(TransactionDiscarded(message))
+              case None          => CIO.fail(ProtocolError(s"unexpected EXEC reply: ${Frame.describe(other)}"))
+            }
+        }
+    }
+  }
+
+  def errorOf(frame: Frame): Option[String] =
+    frame match {
+      case Frame.SimpleError(message) => Some(message)
+      case Frame.BulkError(message)   => Some(message.asUtf8String)
+      case _                          => None
+    }
+
+  // a programmer error, deliberately outside the sealed hierarchy (like the blocking-command guard): a scope captured past its block
+  def scopeReleasedError: IllegalStateException =
+    new IllegalStateException("transaction scope used after its block returned")
+}

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -179,13 +179,13 @@ class ClusterClientSpec extends munit.FunSuite {
     slotsFrame(ranges.toVector*)
   }
 
-  private val keyA  = "{a}" // hashes to a slot owned by nodeA below
-  private val keyB  = "{b}" // hashes to a different slot, parked on nodeB by `splitOn`
+  private val keyA  = "{a}"
+  private val keyB  = "{b}"
   private val slotB = Slot.of(Bytes.utf8(keyB)).value
 
   test("a cross-slot pipeline splits per node and merges in submission order") {
     assert(Slot.of(Bytes.utf8(keyA)).value != slotB, "test keys must hash to different slots")
-    // each node answers a GET with its own host, so the merged order reveals which node served which position
+    // each node answers a GET with its own host, so the merged result reveals which node served which position
     val behaviour =
       (node: Node, text: String) => if (text.contains("CLUSTER")) Seq(splitOn(slotB)) else Seq(Frame.BulkString(Bytes.utf8(node.host)))
     val fixture   = new Fixture(behaviour, Vector(nodeA))

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -7,10 +7,11 @@ import scala.concurrent.duration.*
 import kyo.compat.*
 
 import sage.Bytes
-import sage.SageException.{CrossSlot, NotConnected}
+import sage.SageException.{CrossSlot, NotConnected, ServerError}
 import sage.client.internal.{ClusterLive, FakeTransport, MultiplexedConnection, Scheduler}
 import sage.cluster.{Node, Slot}
 import sage.commands.{Command, Connection, Pipeline, Strings}
+import sage.commands.Pipeline.pipeline
 import sage.protocol.Frame
 
 class ClusterClientSpec extends munit.FunSuite {
@@ -45,7 +46,9 @@ class ClusterClientSpec extends munit.FunSuite {
     */
   final private class Fixture(behaviour: (Node, String) => Seq[Frame], seeds: Vector[Node], unreachable: Set[Node] = Set.empty) {
 
-    private val transports = mutable.Map.empty[Node, FakeTransport]
+    // accumulate every transport per node (a node has both a Multiplexed and, once a transaction pins, a Dedicated connection) so a refresh
+    // issued on one is still observable even after the other is created
+    private val transports = mutable.Map.empty[Node, mutable.ArrayBuffer[FakeTransport]]
 
     private val factory: Node => MultiplexedConnection.TransportFactory = node =>
       (onFrame, onClosed) => {
@@ -55,7 +58,7 @@ class ClusterClientSpec extends munit.FunSuite {
           else behaviour(node, text)
         }
         val transport                    = new FakeTransport(onFrame, onClosed, respond)
-        transports(node) = transport
+        transports.getOrElseUpdate(node, mutable.ArrayBuffer.empty) += transport
         transport
       }
 
@@ -75,7 +78,8 @@ class ClusterClientSpec extends munit.FunSuite {
 
     live.bootstrapTopology()
 
-    def written(node: Node): Vector[String] = transports.get(node).toVector.flatMap(_.written.map(_.asUtf8String))
+    def written(node: Node): Vector[String] =
+      transports.getOrElse(node, mutable.ArrayBuffer.empty).toVector.flatMap(_.written.map(_.asUtf8String))
   }
 
   private def wholeClusterOn(node: Node): Frame = slotsFrame((node, 0, Slot.Count - 1))
@@ -166,19 +170,146 @@ class ClusterClientSpec extends munit.FunSuite {
     }
   }
 
-  test("pipelines and transactions are rejected in cluster mode") {
-    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.Null)
+  // nodeB owns only `slot`; nodeA owns the rest. A key hashing to `slot` routes to nodeB, any other key to nodeA.
+  private def splitOn(slot: Int): Frame = {
+    val ranges = mutable.ArrayBuffer.empty[(Node, Int, Int)]
+    if (slot > 0) ranges += ((nodeA, 0, slot - 1))
+    ranges += ((nodeB, slot, slot))
+    if (slot < Slot.Count - 1) ranges += ((nodeA, slot + 1, Slot.Count - 1))
+    slotsFrame(ranges.toVector*)
+  }
+
+  private val keyA  = "{a}" // hashes to a slot owned by nodeA below
+  private val keyB  = "{b}" // hashes to a different slot, parked on nodeB by `splitOn`
+  private val slotB = Slot.of(Bytes.utf8(keyB)).value
+
+  test("a cross-slot pipeline splits per node and merges in submission order") {
+    assert(Slot.of(Bytes.utf8(keyA)).value != slotB, "test keys must hash to different slots")
+    // each node answers a GET with its own host, so the merged order reveals which node served which position
+    val behaviour =
+      (node: Node, text: String) => if (text.contains("CLUSTER")) Seq(splitOn(slotB)) else Seq(Frame.BulkString(Bytes.utf8(node.host)))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
-    val pipelineFailed    = fixture.live.pipeline(Pipeline.sequence(Vector(Strings.get[String, String]("k")))).unsafeRun.failed
-    val transactionFailed = fixture.live.transaction(_ => CIO.value(())).unsafeRun.failed
-
-    for {
-      p <- pipelineFailed
-      t <- transactionFailed
-    } yield {
-      assert(p.isInstanceOf[UnsupportedOperationException], s"pipeline: $p")
-      assert(t.isInstanceOf[UnsupportedOperationException], s"transaction: $t")
+    fixture.live.pipelineAttempt((Strings.get[String, String](keyA), Strings.get[String, String](keyB)).pipeline).unsafeRun.map { result =>
+      assertEquals(result, (Right(Some(nodeA.host)), Right(Some(nodeB.host))))
+      assert(fixture.written(nodeA).exists(_.contains("GET")), "nodeA did not receive its GET")
+      assert(fixture.written(nodeB).exists(_.contains("GET")), "nodeB did not receive its GET")
     }
+  }
+
+  test("a per-node failure surfaces per-position without poisoning the other node's result") {
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(splitOn(slotB))
+      else if (node == nodeB) Seq(Frame.SimpleError("WRONGTYPE Operation against a key holding the wrong kind of value"))
+      else Seq(Frame.BulkString(Bytes.utf8("ok")))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.pipelineAttempt((Strings.get[String, String](keyA), Strings.get[String, String](keyB)).pipeline).unsafeRun.map {
+      case (first, second) =>
+        assertEquals(first, Right(Some("ok")))
+        assert(second.fold(_.isInstanceOf[ServerError], _ => false), s"second position should be a ServerError: $second")
+    }
+  }
+
+  test("a single-slot pipeline routes to one node and returns the typed tuple") {
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else Seq(Frame.BulkString(Bytes.utf8("v1")), Frame.BulkString(Bytes.utf8("v2")))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.pipeline((Strings.get[String, String]("{x}1"), Strings.get[String, String]("{x}2")).pipeline).unsafeRun.map { result =>
+      assertEquals(result, (Some("v1"), Some("v2")))
+    }
+  }
+
+  test("a cross-slot transaction is rejected with CrossSlot, with no MULTI sent") {
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(splitOn(slotB)) else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live
+      .transaction(tx => tx.watch(keyA).flatMap(_ => tx.run(Strings.get[String, String](keyB))))
+      .unsafeRun
+      .failed
+      .map { error =>
+        assert(error.isInstanceOf[CrossSlot], s"unexpected error: $error")
+        assert(!fixture.written(nodeB).exists(_.contains("MULTI")), "no MULTI should reach the other slot's node")
+      }
+  }
+
+  test("a keyless command keeps its submission-order position within a node's batch") {
+    // get, ping, get all hash/route to one node; the keyless ping must stay between the two gets on the wire, not be reordered to the end
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else Seq(Frame.BulkString(Bytes.utf8("v1")), Frame.SimpleString("PONG"), Frame.BulkString(Bytes.utf8("v2")))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live
+      .pipeline((Strings.get[String, String]("{a}1"), Connection.ping(None), Strings.get[String, String]("{a}2")).pipeline)
+      .unsafeRun
+      .map { result =>
+        assertEquals(result, (Some("v1"), "PONG", Some("v2")))
+        val batch = fixture.written(nodeA).find(_.contains("PING")).getOrElse(fail("no batch reached the node"))
+        assert(batch.indexOf("{a}1") < batch.indexOf("PING"), s"ping reordered before the first get: $batch")
+        assert(batch.indexOf("PING") < batch.indexOf("{a}2"), s"ping reordered after the second get: $batch")
+      }
+  }
+
+  test("an ownership fault during a transaction refreshes the topology so a retry can re-pin") {
+    val slot      = Slot.of(Bytes.utf8("{a}1")).value
+    // the pinned node answers the MULTI/EXEC batch with a MOVED while queuing: the tx fails, but a background refresh must still fire so a
+    // retry routes to the new owner instead of looping on the stale node
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (text.contains("MULTI"))
+        Seq(Frame.SimpleString("OK"), Frame.SimpleError(s"MOVED $slot b:6379"), Frame.SimpleError("EXECABORT Transaction discarded"))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live
+      .transaction(_.exec(Pipeline.sequence(Vector(Strings.get[String, String]("{a}1")))))
+      .unsafeRun
+      .failed
+      .map { _ =>
+        Thread.sleep(200) // the refresh is offloaded; give it a moment to issue its CLUSTER SLOTS
+        val clusterCalls = fixture.written(nodeA).count(_.contains("CLUSTER"))
+        assert(clusterCalls >= 2, s"a MOVED in EXEC should trigger a topology refresh; CLUSTER calls seen: $clusterCalls")
+      }
+  }
+
+  test("a transaction fault forces a refresh even inside the throttle window") {
+    val slot      = Slot.of(Bytes.utf8("{a}1")).value
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (text.contains("MULTI"))
+        Seq(Frame.SimpleString("OK"), Frame.SimpleError(s"MOVED $slot b:6379"), Frame.SimpleError("EXECABORT discarded"))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA)) // default minRefreshInterval (5s) far exceeds this test's duration
+
+    // two faults within the throttle window: a throttled refresh would run only once (CLUSTER stays at 2), a forced one runs on each
+    val tx = fixture.live.transaction(_.exec(Pipeline.sequence(Vector(Strings.get[String, String]("{a}1")))))
+    for {
+      _ <- tx.unsafeRun.failed
+      _  = Thread.sleep(150) // let the first forced refresh complete and stamp the throttle window
+      _ <- tx.unsafeRun.failed
+    } yield {
+      Thread.sleep(150)
+      val clusterCalls = fixture.written(nodeA).count(_.contains("CLUSTER"))
+      assert(clusterCalls >= 3, s"each tx fault must force a refresh despite the throttle; CLUSTER calls: $clusterCalls")
+    }
+  }
+
+  test("a single-slot transaction commits in cluster mode") {
+    val key       = "{a}1"
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (text.contains("MULTI"))
+        Seq(Frame.SimpleString("OK"), Frame.SimpleString("QUEUED"), Frame.Array(Vector(Frame.BulkString(Bytes.utf8("v")))))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live
+      .transaction(tx => tx.watch(key).flatMap(_ => tx.exec(Pipeline.sequence(Vector(Strings.get[String, String](key))))))
+      .unsafeRun
+      .map(result => assertEquals(result, Some(Vector(Some("v")))))
   }
 }


### PR DESCRIPTION
Closes #24.

Implements cluster-mode Pipelines and Transactions, which were previously rejected with `unsupported(...)`.

## Pipelines (split / merge)
- Split per node via the pure `ClusterTopology.split`; each node group is sent as **one `submitAll` batch** (single round-trip per node).
- Replies scatter back into an `AtomicReferenceArray` by original index — the merge **in submission order** (ADR-0021), no separate merge structure.
- A position a stale topology can't resolve (MOVED/ASK, unreachable node, `Unowned`) falls back to the existing per-command `dispatch`, reusing all the hardened redirect/refresh/failover logic. The countdown completes each position exactly once, never on a redirect.
- A per-command `CrossSlot` fails only its own position; blocking commands and malformed key indices are programmer errors that fail the whole effect up front.
- Keyless positions ride along on a node group's batch, kept in submission order.

## Transactions (lazy slot-pinning)
- The leased Dedicated Connection is acquired **lazily**, pinned to the slot of the first key touched (ADR-0027). Every later key must hash to that slot or fail `CrossSlot`; `exec` validates the whole pipeline's slots **before** sending `MULTI`.
- A transaction never follows a redirect (that would break `MULTI`/`EXEC` atomicity), but **forces** a background topology refresh on any ownership/connection fault — on the decoded-reply path *and* on EXEC error frames (a MOVED/READONLY arrives inside a `Success(Vector[Frame])`, not as a failure). Forcing bypasses the refresh throttle so the caller's retry re-pins to the new owner instead of looping on the stale node.

## Refactor
- Shared Pipeline/Transaction result shaping (strict collapse, per-position mapping, `MULTI`/`EXEC` interpretation) extracted into `TxSupport` so the standalone and cluster paths can't drift.
- `NodeClient` gains batch-submit and transaction-lease pass-throughs.

## Tests
- `ClusterClientSpec`: cross-slot split + submission-order merge, per-position failure isolation, single-slot pipeline, keyless ordering within a batch, cross-slot transaction rejection (no `MULTI` sent), ownership-fault refresh, throttle-bypass on tx faults, single-slot commit.
- `ClusterSuite`: real single-node-cluster pipeline + single-slot transaction.

All client unit tests green across the zio/kyo/ce/ox/future cells.