### PR TITLE
Fix: SORT_RO with BY/GET is not cacheable (stale-read bug)

### DIFF
--- a/sage-core/src/main/scala/sage/commands/Keys.scala
+++ b/sage-core/src/main/scala/sage/commands/Keys.scala
@@ -214,13 +214,14 @@ private[sage] object Keys {
     get: Vector[String] = Vector.empty,
     order: SortOrder = SortOrder.Asc,
     alpha: Boolean = false
-  )(using keyCodec: KeyCodec[K], valueCodec: ValueCodec[V]): Command[Vector[Option[V]]] =
-    Command.read(
-      "SORT_RO",
-      Command.FirstKey,
-      keyCodec.encode(key) +: sortOptionArgs(by, limit, get, order, alpha),
-      Decode.vector(Decode.optionalValue)
-    )
+  )(using keyCodec: KeyCodec[K], valueCodec: ValueCodec[V]): Command[Vector[Option[V]]] = {
+    val args   = keyCodec.encode(key) +: sortOptionArgs(by, limit, get, order, alpha)
+    val decode = Decode.vector(Decode.optionalValue)
+    // BY/GET patterns dereference keys beyond the source key, which the cache's reverse index (built from keyIndices) does
+    // not track, so an invalidation for one would not evict — only the bare form reads the source key alone and is cacheable
+    if (by.isEmpty && get.isEmpty) Command.read("SORT_RO", Command.FirstKey, args, decode)
+    else Command.readUncacheable("SORT_RO", Command.FirstKey, args, decode)
+  }
 
   def move[K](key: K, db: Int)(using keyCodec: KeyCodec[K]): Command[Boolean] =
     Command("MOVE", Command.FirstKey, Vector(keyCodec.encode(key), Bytes.utf8(db.toString)), Decode.flag)

--- a/sage-core/src/test/scala/sage/commands/CommandSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/CommandSpec.scala
@@ -21,6 +21,13 @@ class CommandSpec extends munit.FunSuite {
     assert(!Sets.sRandMember[String, String]("s").cacheable && Sets.sRandMember[String, String]("s").isReadOnly) // non-deterministic
   }
 
+  test("SORT_RO is cacheable only in its bare form; BY/GET dereference untracked keys") {
+    assert(Keys.sortRo[String, String]("k").cacheable)
+    assert(Keys.sortRo[String, String]("k", alpha = true, order = SortOrder.Desc).cacheable) // limit/order/alpha touch no extra keys
+    assert(!Keys.sortRo[String, String]("k", by = Some("w_*")).cacheable && Keys.sortRo[String, String]("k", by = Some("w_*")).isReadOnly)
+    assert(!Keys.sortRo[String, String]("k", get = Vector("d_*")).cacheable && Keys.sortRo[String, String]("k", get = Vector("d_*")).isReadOnly)
+  }
+
   test("PING encodes against the golden wire frame, with and without a message") {
     assertEquals(Connection.ping().encode.asUtf8String, "*1\r\n$4\r\nPING\r\n")
     assertEquals(Connection.ping(Some("hi")).encode.asUtf8String, "*2\r\n$4\r\nPING\r\n$2\r\nhi\r\n")


### PR DESCRIPTION
## Bug

`SORT_RO` is marked cacheable unconditionally ([`Keys.scala`](../blob/main/sage-core/src/main/scala/sage/commands/Keys.scala) `sortRo`), but the client-side cache indexes each entry by `command.keys` — derived from declared `keyIndices` (`Command.scala:40`, consumed at `MultiplexedConnection.scala` / `ClientCache.scala`). `SORT_RO` routes as `FirstKey`, so only the **source key** is in the reverse index.

With `BY <pattern>` or `GET <pattern>`, Redis dereferences **additional** keys. When one of those pattern-derived keys changes, the server's invalidation push names a key the local reverse index never recorded, so the cached `SORT_RO` result is **not evicted** — stale data is served until the TTL expires or the source key happens to be invalidated.

## Fix

Cache `SORT_RO` only in its **bare form** (no `BY`/`GET`). `limit`/`order`/`alpha` dereference no extra keys and remain cacheable. The optioned form stays read-only but becomes **uncacheable** — the same `read` vs `readUncacheable` distinction already used for `OBJECT REFCOUNT/FREQ/IDLETIME`.

This is conservative (a bare `BY nosort` or `GET #` reads only the source key but is now treated as uncacheable); the cost is at most a cache miss, never a stale read.

## Tests

New `CommandSpec` assertions: bare and `limit`/`order`/`alpha` forms are cacheable; `by`/`get` forms are read-only but not cacheable. Full core suite: **439 pass**.
