### PR TITLE
De-duplicate runtime internals: shared predicates and discard helper

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
@@ -80,7 +80,12 @@ final private[client] class ClientCache(maxBytes: Long) {
     val tracked = new Key(redisKey)
     lock.lock()
     try {
-      reverse.remove(tracked).foreach(_.foreach(ck => Option(entries.get(ck)).foreach(e => removeEntry(ck, e))))
+      reverse.remove(tracked).foreach { keys =>
+        keys.foreach { ck =>
+          val entry = entries.get(ck)
+          if (entry != null) removeEntry(ck, entry)
+        }
+      }
       pending.valuesIterator.foreach(inFlight => if (inFlight.keys.contains(tracked)) inFlight.dirty = true)
     } finally lock.unlock()
   }
@@ -115,13 +120,16 @@ final private[client] class ClientCache(maxBytes: Long) {
     while (bytesUsed > maxBytes && it.hasNext) {
       val evicted = it.next()
       it.remove()
-      bytesUsed -= evicted.getValue.sizeBytes
-      removeReverse(evicted.getKey, evicted.getValue)
+      dropAccounting(evicted.getKey, evicted.getValue)
     }
   }
 
   private def removeEntry(key: Key, entry: Entry): Unit = {
     entries.remove(key)
+    dropAccounting(key, entry)
+  }
+
+  private def dropAccounting(key: Key, entry: Entry): Unit = {
     bytesUsed -= entry.sizeBytes
     removeReverse(key, entry)
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -216,9 +216,6 @@ final private[client] class ClusterLive(
 
   private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
 
-  private def isMalformed(command: Command[?]): Boolean =
-    command.keyIndices.exists(index => index < 0 || index >= command.args.length)
-
   private def crossSlot(name: String, slots: Set[Slot]): CrossSlot =
     CrossSlot(s"$name: keys span ${slots.size} slots; a single command must touch exactly one")
 
@@ -237,7 +234,7 @@ final private[client] class ClusterLive(
     // blocking commands and malformed key indices are programmer errors: they fail the whole effect up front, never a single position
     else if (p.commands.exists(_.isBlocking))
       CIO.fail(new IllegalArgumentException("a Pipeline cannot carry blocking commands; run them individually on the client"))
-    else if (p.commands.exists(isMalformed))
+    else if (p.commands.exists(_.hasMalformedKeys))
       CIO.fail(new IllegalArgumentException("a Pipeline command declares key positions that fall outside its arguments"))
     else
       CIO.async(complete => offload(runPipeline(p, complete)))
@@ -459,7 +456,7 @@ final private[client] class ClusterLive(
       }
 
     private def commandSlot(command: Command[?]): Either[Throwable, Option[Slot]] =
-      if (isMalformed(command))
+      if (command.hasMalformedKeys)
         Left(malformedKeys(command.name))
       else if (command.keyIndices.isEmpty)
         Right(None)

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -99,8 +99,7 @@ final private[client] class DedicatedPool(
     if (reusable) release(connection)
     else
       locked {
-        live -= connection
-        scheduleClose(connection)
+        discardLocked(connection)
         available.signalAll()
       }
 
@@ -177,20 +176,15 @@ final private[client] class DedicatedPool(
     while (result == null && idle.nonEmpty) {
       val candidate = idle.removeLast()
       if (reusable(candidate)) result = candidate.connection
-      else {
-        live -= candidate.connection
-        scheduleClose(candidate.connection)
-      }
+      else discardLocked(candidate.connection)
     }
     result
   }
 
   private def release(connection: DedicatedConnection): Unit =
     locked {
-      if (closing || !connection.isHealthy || !isCurrent(connection.epoch)) {
-        live -= connection
-        scheduleClose(connection)
-      } else idle.append(DedicatedPool.Idle(connection, scheduler.nowMillis))
+      if (closing || !healthyAndCurrent(connection)) discardLocked(connection)
+      else idle.append(DedicatedPool.Idle(connection, scheduler.nowMillis))
       available.signalAll()
     }
 
@@ -210,11 +204,20 @@ final private[client] class DedicatedPool(
   }
 
   // a connection from an older generation outlived a reconnect (e.g. DNS failover) and now points at the old server
+  private def healthyAndCurrent(connection: DedicatedConnection): Boolean =
+    connection.isHealthy && isCurrent(connection.epoch)
+
   private def reusable(entry: DedicatedPool.Idle): Boolean =
-    entry.connection.isHealthy && isCurrent(entry.connection.epoch) && !expired(entry)
+    healthyAndCurrent(entry.connection) && !expired(entry)
 
   private def expired(entry: DedicatedPool.Idle): Boolean =
     config.idleTimeout.isFinite && scheduler.nowMillis - entry.idleSinceMillis >= config.idleTimeout.toMillis
+
+  // must hold the lock; callers that free an occupied slot signal waiters themselves
+  private def discardLocked(connection: DedicatedConnection): Unit = {
+    live -= connection
+    scheduleClose(connection)
+  }
 
   // closing a connection joins its I/O threads, so it must never run under the lock or on the scheduler's timer thread
   private def scheduleClose(connection: DedicatedConnection): Unit =

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -51,15 +51,18 @@ final private[client] class MultiplexedConnection private (
     finally lock.unlock()
   }
 
+  // the live connection, or null when not Live so callers fail fast rather than join a dead or reconnecting generation
+  private inline def liveConn(): Conn = locked(if (state == State.Live) current else null)
+
   def submit[A](command: Command[A], callback: Try[A] => Unit): Unit = {
-    val conn = locked(if (state == State.Live) current else null)
+    val conn = liveConn()
     if (conn == null) callback(Failure(NotConnected()))
     else conn.submit(command, callback)
   }
 
   // Captures one generation so the cache lookup and the fetch share a connection; a reconnect mid-flight fails the fetch as a normal loss.
   def cachedSubmit[A](command: Command[A], ttlMillis: Long, callback: Try[A] => Unit): Unit = {
-    val conn = locked(if (state == State.Live) current else null)
+    val conn = liveConn()
     if (conn == null) callback(Failure(NotConnected()))
     else conn.cachedSubmit(command, ttlMillis, callback)
   }
@@ -67,7 +70,7 @@ final private[client] class MultiplexedConnection private (
   // ASKING must immediately precede its command on the wire (it arms the target node for the next command on the connection). Writing the
   // pair as one batch keeps them adjacent and FIFO-matched even though every fiber shares this connection; the ASKING reply is discarded.
   def submitAsking[A](command: Command[A], callback: Try[A] => Unit): Unit = {
-    val conn = locked(if (state == State.Live) current else null)
+    val conn = liveConn()
     if (conn == null) callback(Failure(NotConnected()))
     else conn.submitAll(Vector(Connection.asking, command), Vector(_ => (), callback.asInstanceOf[Try[Any] => Unit]))
   }
@@ -75,7 +78,7 @@ final private[client] class MultiplexedConnection private (
   // Enqueues a whole pipeline onto a single generation, captured once, so a reconnect mid-batch can never split it across connections.
   // Returns false when not connected — nothing was submitted, so the caller fails fast rather than fabricating per-position errors.
   def submitAll(commands: Vector[Command[?]], callbacks: Vector[Try[Any] => Unit]): Boolean = {
-    val conn = locked(if (state == State.Live) current else null)
+    val conn = liveConn()
     if (conn == null) false
     else {
       conn.submitAll(commands, callbacks)
@@ -202,7 +205,7 @@ final private[client] class MultiplexedConnection private (
     }
 
   private def watchdogTick(): Unit = {
-    val conn = locked(if (state == State.Live) current else null)
+    val conn = liveConn()
     if (conn != null) conn.checkLiveness(scheduler.nowMillis, watchdog.pingInterval.toMillis, watchdog.pingTimeout.toMillis)
   }
 

--- a/sage-core/src/main/scala/sage/cluster/Topology.scala
+++ b/sage-core/src/main/scala/sage/cluster/Topology.scala
@@ -22,7 +22,7 @@ final class ClusterTopology private (val shards: Vector[Shard], owners: Array[No
   def nodeForSlot(slot: Slot): Option[Node] = Option(owners(slot.value))
 
   def route(command: Command[?]): Route =
-    if (command.keyIndices.exists(index => index < 0 || index >= command.args.length)) Route.Malformed
+    if (command.hasMalformedKeys) Route.Malformed
     else
       command.keyIndices.length match {
         case 0 => Route.Keyless

--- a/sage-core/src/main/scala/sage/commands/Command.scala
+++ b/sage-core/src/main/scala/sage/commands/Command.scala
@@ -39,6 +39,8 @@ final case class Command[+Out](
   // the key bytes the server tracks for this command, in arg order — the reverse-index keys a cache invalidation evicts by
   def keys: Vector[Bytes] = keyIndices.map(args)
 
+  def hasMalformedKeys: Boolean = keyIndices.exists(index => index < 0 || index >= args.length)
+
   def encode: Bytes = RespWriter.writeCommand(name, args)
 }
 


### PR DESCRIPTION
## What

Behavior-preserving de-duplication in the **impure/mutable runtime layer**, from a maintainability sweep of those files. No logic, lock-scope, or performance changes — just collapsing verbatim-repeated fragments behind named helpers so a future edit can't update one copy and miss another. Net **+13 lines** (the helpers and one de-nesting).

## Changes

- **`Command.hasMalformedKeys`** — the out-of-range key-index predicate (`keyIndices.exists(i => i < 0 || i >= args.length)`) was **byte-for-byte identical** in `ClusterTopology.route` and `ClusterLive.isMalformed`, and the two *must* agree for the up-front pipeline/transaction guard to match routing's `Malformed` classification. Now defined once on the pure `Command` and called from both — eliminates a real cross-module drift risk.
- **`MultiplexedConnection.liveConn()`** — `inline` helper for the five identical `locked(if Live current else null)` snapshots. Inline ⇒ identical bytecode and lock scope; centralizes the "a submit may only join a Live generation" rule.
- **`DedicatedPool.discardLocked()`** — the verbatim `live -= c; scheduleClose(c)` pair (three sites) behind one lock-held helper, with `signalAll` left explicit at the slot-freeing call sites. `healthyAndCurrent()` unifies the health+epoch gate that `release` and `reusable` expressed in opposite polarity.
- **`ClientCache.dropAccounting()`** — the `bytesUsed -=` / `removeReverse` pair shared by `removeEntry` and the eviction loop (removes a byte-counter/reverse-index drift risk); the dense triple-nested `invalidate` line is de-nested with an explicit null check (also drops a per-key `Option` allocation).

## Deliberately skipped

The lowest-value sentinel rewrites the sweep flagged (`RespParser` child-outcome, `SubscriptionConnection.Sink.next` null-vs-`None`) — they sit in the most concurrency-sensitive code for marginal gain, so churning them isn't worth the risk. The rest of the runtime layer is essential complexity and left untouched.

## Verification

Core + all four backends compile on Scala 3.3.7 and 3.8.3. **438 core** + **304 backend** unit tests pass (incl. `DedicatedPoolSpec`, `MultiplexedConnectionSpec`, `ClientCacheSpec`, `ClusterClientSpec`, `TopologySpec`). `scalafmtCheckAll` clean.
