### PR TITLE
Drop redundant Command[?] -> Command[Any] casts

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -251,7 +251,7 @@ final private[client] class ClusterLive(
       if (remaining.decrementAndGet() == 0) complete(Success(Vector.tabulate(n)(results.get)))
     }
     def reroute(index: Int): Unit                                     =
-      offload(dispatch(p.commands(index).asInstanceOf[Command[Any]], cluster.maxRedirects, result => finish(index, TxSupport.toEither(result))))
+      offload(dispatch(p.commands(index), cluster.maxRedirects, result => finish(index, TxSupport.toEither(result))))
 
     val plan = topologyRef.get().split(p)
     plan.rejected.foreach {

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
@@ -72,8 +72,8 @@ final private[client] class DedicatedConnection private (
     bootstrap.foreach { command =>
       val latch   = new CountDownLatch(1)
       val outcome = new AtomicReference[Try[Any]]()
-      submit[Any](
-        command.asInstanceOf[Command[Any]],
+      submit(
+        command,
         result => {
           outcome.set(result)
           latch.countDown()

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -138,8 +138,8 @@ final private[client] class MultiplexedConnection private (
       bootstrap.foreach { command =>
         val latch   = new CountDownLatch(1)
         val outcome = new AtomicReference[Try[Any]]()
-        conn.submit[Any](
-          command.asInstanceOf[Command[Any]],
+        conn.submit(
+          command,
           result => {
             outcome.set(result)
             latch.countDown()
@@ -243,7 +243,7 @@ final private[client] class MultiplexedConnection private (
     // One Transport.Item, not N: the writer treats a queue element atomically, so concatenating the batch into a single payload is what
     // guarantees the pipeline is one socket write (one round-trip) rather than racing the writer between sends.
     def submitAll(commands: Vector[Command[?]], callbacks: Vector[Try[Any] => Unit]): Unit = {
-      val entries = Vector.tabulate(commands.length)(i => new Entry(commands(i).asInstanceOf[Command[Any]], callbacks(i)))
+      val entries = Vector.tabulate(commands.length)(i => new Entry(commands(i), callbacks(i)))
       transportRef.get().send(new Batch(entries))
     }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -180,7 +180,7 @@ final private[client] class SubscriptionConnection(
         conn.close()
         throw ConnectionLost(mayHaveExecuted = false)
       }
-      Reply.run(command.asInstanceOf[Command[Any]], box.get()) match {
+      Reply.run(command, box.get()) match {
         case Left(error) => conn.close(); throw error
         case Right(_)    => ()
       }

--- a/sage-client/shared/src/main/scala/sage/client/internal/TxSupport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/TxSupport.scala
@@ -42,7 +42,7 @@ private[internal] object TxSupport {
         frames(n + 1) match {
           case Frame.Null                              => CIO.value(None)
           case Frame.Array(elems) if elems.length == n =>
-            CIO.value(Some(Vector.tabulate(n)(i => Reply.run(commands(i).asInstanceOf[Command[Any]], elems(i)))))
+            CIO.value(Some(Vector.tabulate(n)(i => Reply.run(commands(i), elems(i)))))
           case Frame.Array(elems)                      =>
             CIO.fail(ProtocolError(s"EXEC returned ${elems.length} results for $n queued commands"))
           case other                                   =>


### PR DESCRIPTION
Reviewed every `asInstanceOf` in the runtime. Six of them cast a `Command[?]` to `Command[Any]`, but `Command[+Out]` is covariant — a `Command[?]` is already a subtype of `Command[Any]`, so those casts were no-ops. Removed them; inference binds the result type to the captured wildcard and the callback bodies only ever widen `Try[A]` to `Try[Any]`, which is always sound.

Removed in:
- `TxSupport` — `Reply.run(commands(i), elems(i))`
- `DedicatedConnection` / `MultiplexedConnection` — `submit(command, …)`
- `ClusterLive` — `dispatch(p.commands(index), …)`
- `MultiplexedConnection` — `new Entry(commands(i), callbacks(i))`
- `SubscriptionConnection` — `Reply.run(command, box.get())`

The remaining `asInstanceOf` usages are kept because they're genuinely necessary:
- **`MultiplexedConnection`** (2×) — contravariant `Try[A] => Unit` → `Try[Any] => Unit` casts feeding `submitAll`'s heterogeneous callback vector; covariance can't help in input position.
- **`Bytes`** — zero-copy view of the opaque `IArray[Byte]` as `Array[Byte]`.
- **`Pipeline`** — type-level tuple assembly (`Tuple.InverseMap`/`Tuple.Map`), with `Any` confined to the assemblers.
- **`Tls`** — `SSLSocketFactory.createSocket` is declared to return `Socket` but always returns `SSLSocket`.

All client backends (kyo/zio/future) compile; scalafmt clean.