### PR TITLE
Consolidate shard subscription placement into a single ledger

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,6 +47,10 @@ _Avoid_: pub/sub connection
 A connection carrying the Shard Channel subscriptions for the channels a single Node owns. A client holds one per owning Node, since a Shard Channel's `SSUBSCRIBE` must reach the Slot's owner; each is created on demand and released when its last subscription ends. On Slot migration or failover the affected subscriptions are re-homed to the new owner. Distinct from the Subscription Connection, which carries classic subscriptions; the two never share a connection.
 _Avoid_: per-node pub/sub connection, shard connection
 
+**Placement**:
+A single Shard Channel subscription's ledger of which Node currently carries which of its channels, and the one place that keeps that record in step with the wire. A plan groups a Node's channels so each group is one `SSUBSCRIBE` (one Slot, never `CROSSSLOT`). Applied two ways that differ only in failure handling: `place` is fail-fast for the initial subscribe (an attach failure propagates so the subscribe rolls back), `reconcile` is best-effort for re-homing (detach what left the plan, attach the rest, report whether to retry). `ClusterSubscriptions` owns one per sharded subscription and feeds it plans; classic subscriptions do not use it.
+_Avoid_: routing table, registry, placedAt
+
 **Shard Channel**:
 A pub/sub channel whose name hashes to a Slot (its Hash Tag, if present), so `SSUBSCRIBE`/`SPUBLISH` target that Slot's owning Node and messages stay within the Shard — unlike a classic channel, whose `PUBLISH` broadcasts across the whole cluster bus. There is no pattern form; a Shard Channel delivery surfaces to the subscriber as an ordinary Message (channel and payload).
 _Avoid_: sharded topic, shard topic

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
@@ -134,6 +134,12 @@ final private[client] class ClusterSubscriptions(
 
   // --- sharded (shard channels) ------------------------------------------------------------------------------------------------------------
 
+  // the per-node connections a placement attaches to: ensure under the manager lock (creating on demand), get without creating, both empty once closed
+  private val conns: Placement.Conns = new Placement.Conns {
+    def ensure(node: Node): Option[Placement.ShardConn] = locked(if (closed) None else Some(ensureShardConn(node)))
+    def get(node: Node): Option[Placement.ShardConn]    = locked(shardConns.get(node))
+  }
+
   def subscribeShard(channels: Vector[String]): RawSubscription = {
     val sink = new Sink(channels, Kind.Shard, bufferSize)
     val sub  = ShardSub(sink, channels)
@@ -147,23 +153,15 @@ final private[client] class ClusterSubscriptions(
     new RawSubscription(sink, () => closeShard(sub))
   }
 
-  // attach per (node, slot) group, recording each success in placedAt as it lands so a mid-way throw is rollback-able; an unowned Slot is
-  // left unplaced and retried, not silently dropped
+  // fail-fast initial placement: an attach failure rolls the whole subscribe back; an unowned Slot is left unplaced and retried, not dropped
   private def place(sub: ShardSub): Unit = {
     if (hasUnownedSlot(sub.channels)) refresh()
-    planFor(sub.channels).foreach { case (node, bySlot) =>
-      val conn = locked(if (closed) null else ensureShardConn(node))
-      if (conn != null)
-        bySlot.foreach { case (_, group) =>
-          conn.attach(sub.sink, group, Kind.Shard)
-          locked(sub.placedAt = sub.placedAt.updatedWith(node)(prev => Some(prev.getOrElse(Set.empty) ++ group)))
-        }
-    }
-    if (locked(sub.placedAt).valuesIterator.flatten.size < sub.channels.distinct.size) scheduleRetry()
+    sub.placement.place(planFor(sub.channels), conns)
+    if (!sub.placement.fullyPlaced) scheduleRetry()
   }
 
-  // pure: group channels by owning Node then Slot; an unowned Slot is dropped (the caller refreshes once per pass, not once per channel)
-  private def planFor(channels: Vector[String]): Map[Node, Map[Slot, Vector[String]]] = {
+  // pure: group channels by owning Node, then by Slot so each group becomes one SSUBSCRIBE; an unowned Slot is dropped (the caller refreshes once per pass)
+  private def planFor(channels: Vector[String]): Placement.Plan = {
     val topo   = topologyOf()
     val byNode = mutable.HashMap.empty[Node, mutable.HashMap[Slot, mutable.ArrayBuffer[String]]]
     channels.foreach { channel =>
@@ -172,7 +170,7 @@ final private[client] class ClusterSubscriptions(
         byNode.getOrElseUpdate(node, mutable.HashMap.empty).getOrElseUpdate(slot, mutable.ArrayBuffer.empty) += channel
       }
     }
-    byNode.iterator.map { case (node, slots) => node -> slots.iterator.map { case (s, cs) => s -> cs.toVector }.toMap }.toMap
+    byNode.iterator.map { case (node, slots) => node -> slots.valuesIterator.map(_.toVector).toVector }.toMap
   }
 
   private def hasUnownedSlot(channels: Vector[String]): Boolean = {
@@ -199,35 +197,13 @@ final private[client] class ClusterSubscriptions(
     if (go) offload { locked { reconcilePending = false }; reconcileShard() }
   }
 
-  // re-home each sub onto its channels' current owners: detach what moved, attach the rest, recording only what actually landed (a failed
-  // attach must not look subscribed). One refresh per pass; an incomplete pass retries so a transient failover failure converges.
+  // re-home each sub onto its channels' current owners. One refresh per pass; an incomplete pass retries so a transient failover failure converges.
   private def reconcileShard(): Unit = {
     val subs = locked(if (closed) Vector.empty else shardSubs.toVector)
     if (subs.nonEmpty) {
       if (subs.exists(sub => hasUnownedSlot(sub.channels))) refresh()
       var incomplete = false
-      subs.foreach { sub =>
-        val plan      = planFor(sub.channels)
-        val desired   = plan.map { case (node, bySlot) => node -> bySlot.valuesIterator.flatten.toSet }
-        val placedWas = locked(sub.placedAt)
-        // detach channels that left a node we still hold a live connection to
-        placedWas.foreach { case (node, had) =>
-          val gone = (had -- desired.getOrElse(node, Set.empty)).toVector
-          if (gone.nonEmpty) locked(shardConns.get(node)).foreach(_.detach(sub.sink, gone, Kind.Shard))
-        }
-        // attach to the current owners (idempotent), recording only what actually lands
-        val actual    = mutable.HashMap.empty[Node, Set[String]]
-        plan.foreach { case (node, bySlot) =>
-          val conn = locked(if (closed) null else ensureShardConn(node))
-          if (conn == null) incomplete = true
-          else
-            bySlot.foreach { case (_, group) =>
-              try { conn.attach(sub.sink, group, Kind.Shard); actual.update(node, actual.getOrElse(node, Set.empty) ++ group) }
-              catch { case NonFatal(_) => incomplete = true } // a transient establish failure: keep placedAt honest and retry below
-            }
-        }
-        locked(sub.placedAt = actual.toMap)
-      }
+      subs.foreach(sub => if (sub.placement.reconcile(planFor(sub.channels), conns)) incomplete = true)
       evictEmptyShardConns()
       if (incomplete) scheduleRetry()
     }
@@ -238,10 +214,8 @@ final private[client] class ClusterSubscriptions(
     if (!locked(closed)) scheduler.after(reconnect.initialDelay)(scheduleReconcile())
 
   private def closeShard(sub: ShardSub): Unit = {
-    val placed = locked { shardSubs -= sub; sub.placedAt }
-    placed.foreach { case (node, names) =>
-      locked(shardConns.get(node)).foreach(_.detach(sub.sink, names.toVector, Kind.Shard))
-    }
+    locked(shardSubs -= sub)
+    sub.placement.reconcile(Map.empty, conns) // detach every placement; the empty plan leaves the ledger empty
     sub.sink.terminate()
     evictEmptyShardConns()
   }
@@ -291,7 +265,6 @@ final private[client] class ClusterSubscriptions(
   final private case class ClassicSub(sink: Sink, names: Vector[String], kind: Kind)
 
   final private class ShardSub(val sink: Sink, val channels: Vector[String]) {
-    // where this sub is currently attached (guarded by the manager lock): node -> the channels subscribed on it
-    var placedAt: Map[Node, Set[String]] = Map.empty
+    val placement = new Placement(sink, channels)
   }
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Placement.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Placement.scala
@@ -1,0 +1,91 @@
+package sage.client.internal
+
+import java.util.concurrent.locks.ReentrantLock
+
+import scala.collection.mutable
+import scala.util.control.NonFatal
+
+import SubscriptionConnection.{Kind, Sink}
+
+import sage.cluster.Node
+
+/**
+  * The shard placement ledger for one subscription: it owns the record of which Node carries which of the subscription's Shard Channels and
+  * is the single place that keeps that record in step with the wire. A Node owning several slot ranges needs one `SSUBSCRIBE` per Slot (a
+  * batched cross-slot subscribe returns `CROSSSLOT`), so a plan groups a Node's channels into the groups that each become one `SSUBSCRIBE`.
+  *
+  * Two ways to apply a plan, differing only in their failure handling:
+  *   - [[place]] is fail-fast for the initial subscribe — an attach failure propagates so the caller can roll back — and records each group
+  *     as it lands, so a roll-back ([[reconcile]] to the empty plan) detaches exactly what was already placed.
+  *   - [[reconcile]] is best-effort for re-homing — it detaches channels that left the plan, attaches the rest, records only what actually
+  *     lands, and reports whether any attach failed so the caller can retry.
+  */
+final private[internal] class Placement(sink: Sink, requested: Vector[String]) {
+
+  private val lock                             = new ReentrantLock()
+  private var placedAt: Map[Node, Set[String]] = Map.empty
+
+  private inline def locked[A](inline body: A): A = {
+    lock.lock()
+    try body
+    finally lock.unlock()
+  }
+
+  def place(plan: Placement.Plan, conns: Placement.Conns): Unit =
+    plan.foreach { case (node, groups) =>
+      conns.ensure(node).foreach { conn =>
+        groups.foreach { group =>
+          conn.attach(sink, group, Kind.Shard)
+          locked { placedAt = placedAt.updatedWith(node)(prev => Some(prev.getOrElse(Set.empty) ++ group)) }
+        }
+      }
+    }
+
+  // true when some attach failed (an unowned Slot is dropped from the plan by the caller, not reported here); the caller retries until it converges
+  def reconcile(plan: Placement.Plan, conns: Placement.Conns): Boolean = {
+    val desired    = plan.view.mapValues(_.flatten.toSet).toMap
+    var incomplete = false
+    locked(placedAt).foreach { case (node, had) =>
+      val gone = (had -- desired.getOrElse(node, Set.empty)).toVector
+      if (gone.nonEmpty) conns.get(node).foreach(_.detach(sink, gone, Kind.Shard))
+    }
+    val actual     = mutable.HashMap.empty[Node, Set[String]]
+    plan.foreach { case (node, groups) =>
+      conns.ensure(node) match {
+        case None       => incomplete = true
+        case Some(conn) =>
+          groups.foreach { group =>
+            try { conn.attach(sink, group, Kind.Shard); actual.update(node, actual.getOrElse(node, Set.empty) ++ group) }
+            catch { case NonFatal(_) => incomplete = true }
+          }
+      }
+    }
+    locked { placedAt = actual.toMap }
+    incomplete
+  }
+
+  // every requested channel is placed on some owner; false means an unowned Slot or unreachable owner is still outstanding
+  def fullyPlaced: Boolean = locked(placedAt.valuesIterator.map(_.size).sum) >= requested.distinct.size
+}
+
+private[internal] object Placement {
+
+  // a Node's channels grouped so each inner Vector is one SSUBSCRIBE (one Slot), never spanning Slots
+  type Plan = Map[Node, Vector[Vector[String]]]
+
+  /**
+    * The Sharded Subscription Connections a placement attaches to, looked up under the manager's lock. `ensure` is empty once the manager is closed.
+    */
+  trait Conns {
+    def ensure(node: Node): Option[ShardConn]
+    def get(node: Node): Option[ShardConn]
+  }
+
+  /**
+    * What a placement needs of a connection: register/unregister a sink under names. [[SubscriptionConnection]] is the production adapter.
+    */
+  trait ShardConn {
+    def attach(sink: Sink, names: Vector[String], kind: Kind): Unit
+    def detach(sink: Sink, names: Vector[String], kind: Kind): Boolean
+  }
+}

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -36,7 +36,7 @@ final private[client] class SubscriptionConnection(
   isLive: () => Boolean,
   cluster: Boolean = false,
   onTerminated: () => Unit = () => ()
-) {
+) extends Placement.ShardConn {
   import SubscriptionConnection.*
 
   private val lock          = new ReentrantLock()

--- a/sage-client/shared/src/test/scala/sage/client/internal/PlacementSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/PlacementSpec.scala
@@ -1,0 +1,117 @@
+package sage.client.internal
+
+import scala.collection.mutable
+
+import SubscriptionConnection.{Kind, Sink}
+
+import sage.cluster.Node
+
+class PlacementSpec extends munit.FunSuite {
+
+  private val n1 = Node("h1", 1)
+  private val n2 = Node("h2", 2)
+
+  // a fake owner that records which names are currently subscribed; attach throws for any name in `failOn`
+  final private class FakeConn extends Placement.ShardConn {
+    val subscribed          = mutable.LinkedHashSet.empty[String]
+    var failOn: Set[String] = Set.empty
+
+    def attach(sink: Sink, names: Vector[String], kind: Kind): Unit    = {
+      if (names.exists(failOn)) throw new RuntimeException("attach refused")
+      subscribed ++= names
+    }
+    def detach(sink: Sink, names: Vector[String], kind: Kind): Boolean = {
+      subscribed --= names
+      subscribed.isEmpty
+    }
+  }
+
+  final private class FakePool(unavailable: Set[Node] = Set.empty) extends Placement.Conns {
+    val byNode                                          = mutable.HashMap.empty[Node, FakeConn]
+    def ensure(node: Node): Option[Placement.ShardConn] = if (unavailable(node)) None else Some(byNode.getOrElseUpdate(node, new FakeConn))
+    def get(node: Node): Option[Placement.ShardConn]    = byNode.get(node)
+  }
+
+  private def sink(names: String*): Sink = new Sink(names.toVector, Kind.Shard, 16)
+
+  private def groups(g: Vector[String]*): Vector[Vector[String]] = g.toVector
+
+  test("place attaches each group on its owner and reports full coverage") {
+    val pool      = new FakePool
+    val placement = new Placement(sink("a", "b"), Vector("a", "b"))
+
+    placement.place(Map(n1 -> groups(Vector("a"), Vector("b"))), pool)
+
+    assertEquals(pool.byNode(n1).subscribed.toSet, Set("a", "b"))
+    assert(placement.fullyPlaced, "every channel landed, so the placement is full")
+  }
+
+  test("place leaves an unowned channel unplaced — coverage is not full") {
+    val pool      = new FakePool(unavailable = Set(n2))
+    val placement = new Placement(sink("a", "b"), Vector("a", "b"))
+
+    placement.place(Map(n1 -> groups(Vector("a")), n2 -> groups(Vector("b"))), pool)
+
+    assertEquals(pool.byNode(n1).subscribed.toSet, Set("a"))
+    assert(!placement.fullyPlaced, "b's owner was unavailable, so coverage is incomplete")
+  }
+
+  test("place is fail-fast: an attach failure propagates, but what landed is recorded for roll-back") {
+    val pool      = new FakePool
+    val placement = new Placement(sink("a", "b"), Vector("a", "b"))
+    pool.byNode.getOrElseUpdate(n1, new FakeConn).failOn = Set("b")
+
+    intercept[RuntimeException](placement.place(Map(n1 -> groups(Vector("a"), Vector("b"))), pool))
+
+    assertEquals(pool.byNode(n1).subscribed.toSet, Set("a"))
+    // roll-back: reconcile to the empty plan detaches exactly what was placed
+    placement.reconcile(Map.empty, pool)
+    assert(pool.byNode(n1).subscribed.isEmpty, "the empty plan detaches the landed channel")
+  }
+
+  test("reconcile re-homes a channel to its new owner, leaving nothing on the old one") {
+    val pool      = new FakePool
+    val placement = new Placement(sink("a", "b"), Vector("a", "b"))
+
+    placement.reconcile(Map(n1 -> groups(Vector("a"), Vector("b"))), pool)
+    assertEquals(pool.byNode(n1).subscribed.toSet, Set("a", "b"))
+
+    // b migrates to n2
+    placement.reconcile(Map(n1 -> groups(Vector("a")), n2 -> groups(Vector("b"))), pool)
+
+    assertEquals(pool.byNode(n1).subscribed.toSet, Set("a"), "b is detached from its old owner — no stale subscription")
+    assertEquals(pool.byNode(n2).subscribed.toSet, Set("b"))
+  }
+
+  test("reconcile reports incomplete when an attach fails, then converges once the owner accepts") {
+    val pool      = new FakePool
+    val placement = new Placement(sink("a", "b"), Vector("a", "b"))
+    val owner     = pool.byNode.getOrElseUpdate(n1, new FakeConn)
+    owner.failOn = Set("b")
+
+    assert(placement.reconcile(Map(n1 -> groups(Vector("a"), Vector("b"))), pool), "b's attach failed, so the pass is incomplete")
+    assertEquals(owner.subscribed.toSet, Set("a"))
+    assert(!placement.fullyPlaced)
+
+    owner.failOn = Set.empty
+    assert(!placement.reconcile(Map(n1 -> groups(Vector("a"), Vector("b"))), pool), "retry now lands b — complete")
+    assertEquals(owner.subscribed.toSet, Set("a", "b"))
+    assert(placement.fullyPlaced)
+  }
+
+  test("a partial attach followed by a topology shift never duplicates a channel across owners") {
+    val pool      = new FakePool
+    val placement = new Placement(sink("a", "b"), Vector("a", "b"))
+    pool.byNode.getOrElseUpdate(n1, new FakeConn).failOn = Set("b")
+
+    // first pass: a lands on n1, b is refused
+    assert(placement.reconcile(Map(n1 -> groups(Vector("a"), Vector("b"))), pool))
+
+    // before the retry, b migrates to n2; a stays on n1
+    placement.reconcile(Map(n1 -> groups(Vector("a")), n2 -> groups(Vector("b"))), pool)
+
+    assertEquals(pool.byNode(n1).subscribed.toSet, Set("a"), "a is undisturbed on n1")
+    assertEquals(pool.byNode(n2).subscribed.toSet, Set("b"), "b lands on its new owner")
+    assert(placement.fullyPlaced)
+  }
+}


### PR DESCRIPTION
## What

Follow-up to #65. The desired→actual placement for sharded subscriptions was hand-written in three sites — `place`, `reconcileShard`, `closeShard` — each independently nudging a per-sub `placedAt` map that had to mirror each connection's sink registry. The invariant *"`placedAt` mirrors the wire"* had no single home, and there was no unit coverage for cluster placement (only end-to-end).

This extracts a `Placement` module that owns the ledger.

## Shape

- **`Placement`** owns one subscription's ledger behind its own lock, with two ways to apply a plan that differ only in failure handling:
  - `place` — fail-fast for the initial subscribe; commits incrementally so a rollback detaches exactly what landed.
  - `reconcile` — best-effort for re-homing; detaches what left the plan, attaches the rest, reports whether to retry.
- `closeShard` collapses into `reconcile` to the empty plan.
- The connection lookup sits behind a small `Conns` / `ShardConn` seam. Production adapter is `SubscriptionConnection`; tests use an in-memory fake pool.
- `planFor` drops `Slot` from its return type (`Map[Node, Vector[Vector[String]]]`), so `Placement` carries no topology knowledge — the per-group split that avoids `CROSSSLOT` is preserved.

## Behavior

Preserved exactly: fail-fast subscribe (rolls back on attach failure), best-effort reconcile (retries until it converges). Classic subscriptions are untouched. `placedAt` is gone from `ShardSub` — it lives only inside `Placement`.

## Tests

New `PlacementSpec` (6 tests) gives cluster placement its first unit coverage — including re-home leaving nothing stale on the old owner, incomplete-then-converge, and the partial-attach + topology-shift case that must not duplicate a channel across owners. All 111 client tests pass.