### PR TITLE
Share the pipeline result collector and fold cluster malformed-key handling into split

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -1,7 +1,7 @@
 package sage.client.internal
 
 import java.time.Instant
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReferenceArray}
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 import javax.net.ssl.SSLException
 
@@ -842,13 +842,8 @@ object Client {
         CIO.fail(new IllegalArgumentException("a Pipeline cannot carry blocking commands; run them individually on the client"))
       else
         CIO.async { complete =>
-          val n         = p.commands.length
-          val slots     = new AtomicReferenceArray[Either[SageException, Any]](n)
-          val remaining = new AtomicInteger(n)
-          val callbacks = Vector.tabulate(n) { i => (result: Try[Any]) =>
-            slots.set(i, TxSupport.toEither(result))
-            if (remaining.decrementAndGet() == 0) complete(Success(Vector.tabulate(n)(slots.get)))
-          }
+          val collector = new TxSupport.IndexedCollector[Either[SageException, Any]](p.commands.length, complete)
+          val callbacks = Vector.tabulate(p.commands.length)(i => (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)))
           if (!connection.submitAll(p.commands, callbacks)) complete(Failure(NotConnected()))
         }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -1,7 +1,7 @@
 package sage.client.internal
 
 import java.util.concurrent.{CountDownLatch, TimeUnit}
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference, AtomicReferenceArray}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.collection.mutable
@@ -245,11 +245,10 @@ final private[client] class ClusterLive(
   private def submitPipeline[Out, R](p: Pipeline[Out, R]): CIO[Vector[Either[SageException, Any]]] =
     if (p.commands.isEmpty)
       CIO.value(Vector.empty)
-    // blocking commands and malformed key indices are programmer errors: they fail the whole effect up front, never a single position
+    // a blocking command is a programmer error: it fails the whole effect up front, never a single position. Malformed keys are the same
+    // kind of error but classified by split, so runPipeline fails on them (the single source, shared with single-command dispatch).
     else if (p.commands.exists(_.isBlocking))
       CIO.fail(new IllegalArgumentException("a Pipeline cannot carry blocking commands; run them individually on the client"))
-    else if (p.commands.exists(_.hasMalformedKeys))
-      CIO.fail(new IllegalArgumentException("a Pipeline command declares key positions that fall outside its arguments"))
     else
       CIO.async(complete => offload(runPipeline(p, complete)))
 
@@ -258,22 +257,22 @@ final private[client] class ClusterLive(
   // back to per-command dispatch. The countdown completes the effect once every position has landed terminally — once, never on a redirect.
   private def runPipeline[Out, R](p: Pipeline[Out, R], complete: Try[Vector[Either[SageException, Any]]] => Unit): Unit = {
     val n                                                             = p.commands.length
-    val results                                                       = new AtomicReferenceArray[Either[SageException, Any]](n)
-    val remaining                                                     = new AtomicInteger(n)
-    def finish(index: Int, outcome: Either[SageException, Any]): Unit = {
-      results.set(index, outcome)
-      if (remaining.decrementAndGet() == 0) complete(Success(Vector.tabulate(n)(results.get)))
-    }
+    val collector                                                     = new TxSupport.IndexedCollector[Either[SageException, Any]](n, complete)
+    def finish(index: Int, outcome: Either[SageException, Any]): Unit = collector.set(index, outcome)
     def reroute(index: Int): Unit                                     =
       offload(dispatch(p.commands(index), cluster.maxRedirects, result => finish(index, TxSupport.toEither(result))))
 
     val plan = topologyRef.get().split(p)
+    // a malformed command is a programmer error: split is the single source of that classification (the standalone client has no slots and
+    // doesn't check), so fail the whole effect before anything reaches the wire, never as a per-position result
+    plan.rejected.iterator.collectFirst { case (index, Rejected.Malformed) => index } match {
+      case Some(index) => complete(Failure(malformedKeys(p.commands(index).name))); return
+      case None        => ()
+    }
     plan.rejected.foreach {
       case (index, Rejected.CrossSlot(slots)) => finish(index, Left(crossSlot(p.commands(index).name, slots)))
       case (index, Rejected.Unowned(_))       => reroute(index) // dispatch refreshes then re-routes
-      // a programmer error: fail the whole effect, like single-command dispatch and the up-front guard, never a per-position result
-      case (index, Rejected.Malformed)        =>
-        complete(Failure(malformedKeys(p.commands(index).name)))
+      case (_, Rejected.Malformed)            => ()             // unreachable: the guard above returned
     }
     // keyless positions ride along on the first node group's batch; with no keyed group, dispatch routes each to any node
     if (plan.perNode.isEmpty) plan.keyless.foreach(reroute)

--- a/sage-client/shared/src/main/scala/sage/client/internal/TxSupport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/TxSupport.scala
@@ -1,5 +1,7 @@
 package sage.client.internal
 
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReferenceArray}
+
 import scala.util.{Failure, Success, Try}
 
 import kyo.compat.*
@@ -64,4 +66,20 @@ private[internal] object TxSupport {
   // a programmer error, deliberately outside the sealed hierarchy (like the blocking-command guard): a scope captured past its block
   def scopeReleasedError: IllegalStateException =
     new IllegalStateException("transaction scope used after its block returned")
+
+  /**
+    * N positions filled by independent callbacks, completing the single supplied callback once every position has landed. Each position is
+    * set exactly once (one reply per command, or one terminal re-route outcome), so the countdown reaching zero fires the completion once —
+    * no done-guard is needed. This is the collect-all shape shared by the standalone and cluster pipelines; the connection's fail-fast
+    * RawBatch deliberately keeps its own.
+    */
+  final class IndexedCollector[A](n: Int, complete: Try[Vector[A]] => Unit) {
+    private val slots     = new AtomicReferenceArray[A](n)
+    private val remaining = new AtomicInteger(n)
+
+    def set(index: Int, value: A): Unit = {
+      slots.set(index, value)
+      if (remaining.decrementAndGet() == 0) complete(Success(Vector.tabulate(n)(slots.get)))
+    }
+  }
 }


### PR DESCRIPTION
Two small simplifications to the client's pipeline plumbing, from a review pass. No behavior change except a more informative error message for malformed-key pipelines in cluster mode.

## Share the indexed result collector

The "N callbacks fill indexed slots, complete the single callback once every slot has landed" pattern was hand-rolled in both `Client.submitPipeline` and `ClusterLive.runPipeline` (`AtomicReferenceArray` + `AtomicInteger` + a tabulate-on-zero). Extracted it into `TxSupport.IndexedCollector[A]`, alongside the other shared result-shaping, and used it from both sites.

`DedicatedConnection.RawBatch` is deliberately left alone — it's *fail-fast* (completes on the first failure via a done-CAS) and carries raw `Frame`s rather than `Either`s, so folding it in would conflate two different completion semantics.

## Fold cluster malformed-key handling into `split`

`ClusterLive.submitPipeline` rejected `hasMalformedKeys` up front, and `runPipeline` *also* handled `Rejected.Malformed` from `split` — but since `split` derives that from the same `hasMalformedKeys`, the up-front guard meant the `runPipeline` branch was unreachable.

`split` is now the single source of that classification: the redundant up-front scan is gone, and `runPipeline` fails the whole effect on `Rejected.Malformed` *before anything reaches the wire* (a pre-scan with an early `return`, kept out of a lambda so it stays a legal local return under `-Xfatal-warnings`). The error now names the offending command, matching single-command dispatch. The blocking-command guard stays up front since `split` doesn't classify blocking.

## Verification

- `clientZio/compile` clean
- `clientZio/test` green (111 passed, incl. `ClusterClientSpec` and `TransactionSpec`)
- `scalafmtAll` applied