### PR TITLE
Command family: streams

### DIFF
--- a/integration-tests/shared/src/test/scala/sage/integration/commands/Coverage.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/Coverage.scala
@@ -64,7 +64,12 @@ object Coverage {
     "SWAPDB"               -> "whole-database administration, out of scope",
     "QUIT"                 -> "deprecated: close the client instead of sending QUIT",
     "RESET"                -> "would reset state on the shared Multiplexed Connection across all fibers; not exposed",
-    "DISCARD"              -> "the transaction scope abandons by dropping its connection, not via DISCARD"
+    "DISCARD"              -> "the transaction scope abandons by dropping its connection, not via DISCARD",
+    "XGROUP"               -> "subcommand container; each XGROUP subcommand is its own Command name",
+    "XGROUP HELP"          -> "human-readable help text, not a runnable command",
+    "XINFO"                -> "subcommand container; each XINFO subcommand is its own Command name",
+    "XINFO HELP"           -> "human-readable help text, not a runnable command",
+    "XIDMPRECORD"          -> "internal: replayed during AOF loading, not for client use"
   )
 
   val todo: Set[String] = Set(
@@ -250,35 +255,6 @@ object Coverage {
     "TRIMSLOTS",
     "WAIT",
     "WAITAOF",
-    "XACK",
-    "XACKDEL",
-    "XADD",
-    "XAUTOCLAIM",
-    "XCFGSET",
-    "XCLAIM",
-    "XDEL",
-    "XDELEX",
-    "XGROUP",
-    "XGROUP CREATE",
-    "XGROUP CREATECONSUMER",
-    "XGROUP DELCONSUMER",
-    "XGROUP DESTROY",
-    "XGROUP HELP",
-    "XGROUP SETID",
-    "XIDMPRECORD",
-    "XINFO",
-    "XINFO CONSUMERS",
-    "XINFO GROUPS",
-    "XINFO HELP",
-    "XINFO STREAM",
-    "XLEN",
-    "XNACK",
-    "XPENDING",
-    "XRANGE",
-    "XREAD",
-    "XREADGROUP",
-    "XREVRANGE",
-    "XSETID",
-    "XTRIM"
+    "XCFGSET"
   )
 }

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/RedisStreamExtrasSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/RedisStreamExtrasSuite.scala
@@ -1,0 +1,58 @@
+package sage.integration.commands
+
+import kyo.compat.*
+
+import sage.commands.*
+import sage.integration.{Images, ServerSuite}
+
+/**
+  * XDELEX/XACKDEL (8.2) and XNACK (8.8) are Redis-only stream commands absent in Valkey, so they have no cross-server counterpart (ADR-0026).
+  */
+class RedisStreamExtrasSuite extends ServerSuite(Images.redis) {
+
+  test("XDELEX reports per-id deletion status") {
+    withClient { client =>
+      for {
+        _      <- client.xAdd("sx-delex", XAddId.Explicit(StreamId(1L, 0L)))(("f", "1"))
+        _      <- client.xAdd("sx-delex", XAddId.Explicit(StreamId(2L, 0L)))(("f", "2"))
+        status <- client.xDelEx("sx-delex")(StreamId(1L, 0L), StreamId(9L, 0L))
+        len    <- client.xLen("sx-delex")
+      } yield {
+        assertEquals(status, Vector(StreamEntryDeletion.Deleted, StreamEntryDeletion.NotFound))
+        assertEquals(len, 1L)
+      }
+    }
+  }
+
+  test("XACKDEL acknowledges and deletes in one step") {
+    withClient { client =>
+      for {
+        _      <- client.xAdd("sx-ackdel", XAddId.Explicit(StreamId(1L, 0L)))(("f", "1"))
+        _      <- client.xGroupCreate("sx-ackdel", "g", GroupStartId.At(StreamId(0L, 0L)))
+        _      <- client.xReadGroup[String, String, String]("g", "c1")(("sx-ackdel", GroupReadId.New))()
+        status <- client.xAckDel("sx-ackdel", "g")(StreamId(1L, 0L))
+        len    <- client.xLen("sx-ackdel")
+        pend   <- client.xPending("sx-ackdel", "g")
+      } yield {
+        assertEquals(status, Vector(StreamEntryDeletion.Deleted))
+        assertEquals(len, 0L)
+        assertEquals(pend.total, 0L)
+      }
+    }
+  }
+
+  test("XNACK releases a pending entry back to the group") {
+    withClient { client =>
+      for {
+        _        <- client.xAdd("sx-nack", XAddId.Explicit(StreamId(1L, 0L)))(("f", "1"))
+        _        <- client.xGroupCreate("sx-nack", "g", GroupStartId.At(StreamId(0L, 0L)))
+        _        <- client.xReadGroup[String, String, String]("g", "c1")(("sx-nack", GroupReadId.New))()
+        released <- client.xNack("sx-nack", "g", NackMode.Fail)(StreamId(1L, 0L))()
+        pend     <- client.xPending("sx-nack", "g")
+      } yield {
+        assertEquals(released, 1L)
+        assertEquals(pend.total, 1L)
+      }
+    }
+  }
+}

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/StreamsSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/StreamsSuite.scala
@@ -1,0 +1,141 @@
+package sage.integration.commands
+
+import scala.concurrent.duration.*
+
+import kyo.compat.*
+
+import sage.commands.*
+import sage.integration.{Images, ServerSuite}
+
+abstract class StreamsSuite(image: String) extends ServerSuite(image) {
+
+  test("XADD XLEN XRANGE and XREVRANGE round-trip entries, preserving field order") {
+    withClient { client =>
+      for {
+        id1 <- client.xAdd("s-range", XAddId.Explicit(StreamId(1L, 0L)))(("a", "1"), ("b", "2"))
+        id2 <- client.xAdd("s-range", XAddId.Explicit(StreamId(2L, 0L)))(("c", "3"))
+        len <- client.xLen("s-range")
+        all <- client.xRange[String, String, String]("s-range")
+        rev <- client.xRevRange[String, String, String]("s-range")
+        one <- client.xRange[String, String, String]("s-range", StreamRangeId.Exclusive(StreamId(1L, 0L)))
+      } yield {
+        assertEquals(id1, StreamId(1L, 0L))
+        assertEquals(id2, StreamId(2L, 0L))
+        assertEquals(len, 2L)
+        assertEquals(all, Vector(StreamEntry(StreamId(1L, 0L), Vector("a" -> "1", "b" -> "2")), StreamEntry(StreamId(2L, 0L), Vector("c" -> "3"))))
+        assertEquals(rev.map(_.id), Vector(StreamId(2L, 0L), StreamId(1L, 0L)))
+        assertEquals(one.map(_.id), Vector(StreamId(2L, 0L)))
+      }
+    }
+  }
+
+  test("XADD with * generates increasing ids, NOMKSTREAM declines a missing stream, and XDEL removes") {
+    withClient { client =>
+      for {
+        absent <- client.xAddNoMkStream("s-del-missing")(("f", "v"))
+        a      <- client.xAdd("s-del")(("f", "1"))
+        b      <- client.xAdd("s-del")(("f", "2"))
+        del    <- client.xDel("s-del")(a)
+        len    <- client.xLen("s-del")
+      } yield {
+        assertEquals(absent, None)
+        assert(b > a)
+        assertEquals(del, 1L)
+        assertEquals(len, 1L)
+      }
+    }
+  }
+
+  test("XTRIM MAXLEN caps the stream length") {
+    withClient { client =>
+      for {
+        _   <- client.xAdd("s-trim", XAddId.Explicit(StreamId(1L, 0L)))(("f", "1"))
+        _   <- client.xAdd("s-trim", XAddId.Explicit(StreamId(2L, 0L)))(("f", "2"))
+        _   <- client.xAdd("s-trim", XAddId.Explicit(StreamId(3L, 0L)))(("f", "3"))
+        cut <- client.xTrim("s-trim", Trimming.Exact(TrimThreshold.MaxLen(1L)))
+        len <- client.xLen("s-trim")
+      } yield {
+        assertEquals(cut, 2L)
+        assertEquals(len, 1L)
+      }
+    }
+  }
+
+  test("XINFO STREAM reports length and the last generated id") {
+    withClient { client =>
+      for {
+        _    <- client.xAdd("s-info", XAddId.Explicit(StreamId(1L, 0L)))(("f", "v"))
+        _    <- client.xAdd("s-info", XAddId.Explicit(StreamId(5L, 0L)))(("g", "w"))
+        info <- client.xInfoStream[String, String, String]("s-info")
+      } yield {
+        assertEquals(info.length, 2L)
+        assertEquals(info.lastGeneratedId, StreamId(5L, 0L))
+        assertEquals(info.firstEntry, Some(StreamEntry(StreamId(1L, 0L), Vector("f" -> "v"))))
+      }
+    }
+  }
+
+  test("a consumer group reads new entries, acknowledges them, and reports an empty PEL") {
+    withClient { client =>
+      for {
+        _       <- client.xAdd("s-grp", XAddId.Explicit(StreamId(1L, 0L)))(("f", "1"))
+        _       <- client.xAdd("s-grp", XAddId.Explicit(StreamId(2L, 0L)))(("f", "2"))
+        _       <- client.xGroupCreate("s-grp", "g", GroupStartId.At(StreamId(0L, 0L)))
+        read    <- client.xReadGroup[String, String, String]("g", "c1")(("s-grp", GroupReadId.New))(count = Some(10L))
+        pending <- client.xPending("s-grp", "g")
+        acked   <- client.xAck("s-grp", "g")(StreamId(1L, 0L), StreamId(2L, 0L))
+        drained <- client.xPending("s-grp", "g")
+        groups  <- client.xInfoGroups("s-grp")
+      } yield {
+        assertEquals(
+          read,
+          Vector("s-grp" -> Vector(StreamEntry(StreamId(1L, 0L), Vector("f" -> "1")), StreamEntry(StreamId(2L, 0L), Vector("f" -> "2"))))
+        )
+        assertEquals(pending.total, 2L)
+        assertEquals(acked, 2L)
+        assertEquals(drained.total, 0L)
+        assertEquals(groups.map(_.name), Vector("g"))
+      }
+    }
+  }
+
+  test("XCLAIM and XAUTOCLAIM transfer pending entries to another consumer") {
+    withClient { client =>
+      for {
+        _       <- client.xAdd("s-claim", XAddId.Explicit(StreamId(1L, 0L)))(("f", "1"))
+        _       <- client.xGroupCreate("s-claim", "g", GroupStartId.At(StreamId(0L, 0L)))
+        _       <- client.xReadGroup[String, String, String]("g", "c1")(("s-claim", GroupReadId.New))()
+        claimed <- client.xClaim[String, String, String]("s-claim", "g", "c2", Duration.Zero)(StreamId(1L, 0L))()
+        auto    <- client.xAutoClaim[String, String, String]("s-claim", "g", "c3", Duration.Zero)
+        owners  <- client.xPendingExtended("s-claim", "g")
+      } yield {
+        assertEquals(claimed, Vector(StreamEntry(StreamId(1L, 0L), Vector("f" -> "1"))))
+        assertEquals(auto.entries.map(_.id), Vector(StreamId(1L, 0L)))
+        assertEquals(owners.map(_.consumer), Vector("c3"))
+      }
+    }
+  }
+
+  test("XREAD with BLOCK does not stall ordinary commands on the multiplexed connection") {
+    withClient { client =>
+      for {
+        _   <- client.xAdd("s-block", XAddId.Explicit(StreamId(1L, 0L)))(("f", "0"))
+        out <- CIO.zip(
+                 client.xRead[String, String, String](("s-block", ReadId.After(StreamId(1L, 0L))))(block = Some(BlockTimeout.After(5.seconds))),
+                 for {
+                   pong <- client.ping()
+                   _    <- client.xAdd("s-block", XAddId.Explicit(StreamId(2L, 0L)))(("f", "1"))
+                 } yield pong
+               )
+      } yield {
+        val (read, pong) = out
+        assertEquals(pong, "PONG")
+        assertEquals(read, Vector("s-block" -> Vector(StreamEntry(StreamId(2L, 0L), Vector("f" -> "1")))))
+      }
+    }
+  }
+}
+
+class RedisStreamsSuite extends StreamsSuite(Images.redis)
+
+class ValkeyStreamsSuite extends StreamsSuite(Images.valkey)

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/StreamsSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/StreamsSuite.scala
@@ -116,6 +116,23 @@ abstract class StreamsSuite(image: String) extends ServerSuite(image) {
     }
   }
 
+  test("XINFO STREAM FULL decodes the group PEL after a consumer has read but not acked") {
+    withClient { client =>
+      for {
+        _    <- client.xAdd("s-full", XAddId.Explicit(StreamId(1L, 0L)))(("f", "1"))
+        _    <- client.xGroupCreate("s-full", "g", GroupStartId.At(StreamId(0L, 0L)))
+        _    <- client.xReadGroup[String, String, String]("g", "c1")(("s-full", GroupReadId.New))()
+        full <- client.xInfoStreamFull[String, String, String]("s-full")
+      } yield {
+        assertEquals(full.length, 1L)
+        assertEquals(full.groups.map(_.name), Vector("g"))
+        assertEquals(full.groups.head.pending.map(_.id), Vector(StreamId(1L, 0L)))
+        assertEquals(full.groups.head.pending.head.consumer, Some("c1"))
+        assertEquals(full.groups.head.consumers.head.pending.map(_.id), Vector(StreamId(1L, 0L)))
+      }
+    }
+  }
+
   test("XREAD with BLOCK does not stall ordinary commands on the multiplexed connection") {
     withClient { client =>
       for {

--- a/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
+++ b/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
@@ -2,7 +2,7 @@ package sage.integration
 
 import zio.*
 
-import sage.commands.Commands
+import sage.commands.{BlockTimeout, Commands, GroupStartId, StreamId, XAddId}
 import sage.commands.Pipeline.pipeline
 import sage.zio.*
 
@@ -146,6 +146,54 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
             _      <- ZIO.foreachParDiscard(1 to 50)(i => client.zAdd("zscan")((s"m$i", i.toDouble)))
             pairs  <- client.zScanAll[String, String]("zscan", count = Some(10L)).runCollect
           } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
+        }
+
+      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    }
+  }
+
+  test("xRangeAll pages every entry as a native ZStream") {
+    withContainers { server =>
+      val program: Task[Unit] =
+        ZIO.scoped {
+          for {
+            client  <- SageClient.scoped(configOf(server))
+            _       <- ZIO.foreachDiscard(1 to 50)(i => client.xAdd("xrangeall", XAddId.Explicit(StreamId(i.toLong, 0L)))(("f", s"v$i")))
+            entries <- client.xRangeAll[String, String, String]("xrangeall", batch = 10L).runCollect
+          } yield assertEquals(entries.map(_.id).toList, (1 to 50).map(i => StreamId(i.toLong, 0L)).toList)
+        }
+
+      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    }
+  }
+
+  test("xConsume tails a group and auto-acks each entry after the handler succeeds") {
+    withContainers { server =>
+      val program: Task[Unit] =
+        ZIO.scoped {
+          for {
+            client <- SageClient.scoped(configOf(server))
+            _      <- ZIO.foreachDiscard(1 to 3)(i => client.xAdd("xconsume", XAddId.Explicit(StreamId(i.toLong, 0L)))(("f", s"v$i")))
+            _      <- client.xGroupCreate("xconsume", "g", GroupStartId.At(StreamId(0L, 0L)))
+            seen   <- Ref.make(Vector.empty[String])
+            fiber  <- client
+                        .xConsume[String, String, String](
+                          "g",
+                          "c",
+                          "xconsume",
+                          block = BlockTimeout.After(scala.concurrent.duration.FiniteDuration(200L, java.util.concurrent.TimeUnit.MILLISECONDS))
+                        ) { entry =>
+                          seen.update(_ :+ entry.fields.head._2)
+                        }
+                        .fork
+            _      <- seen.get.repeatUntil(_.size >= 3).timeoutFail(new RuntimeException("xConsume did not deliver"))(zio.Duration.fromSeconds(10))
+            _      <- fiber.interrupt
+            got    <- seen.get
+            pend   <- client.xPending("xconsume", "g")
+          } yield {
+            assertEquals(got.sorted, Vector("v1", "v2", "v3"))
+            assertEquals(pend.total, 0L)
+          }
         }
 
       Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())

--- a/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
+++ b/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
@@ -1,5 +1,7 @@
 package sage.ce
 
+import java.util.concurrent.TimeUnit
+
 import scala.concurrent.duration.FiniteDuration
 
 import cats.effect.{IO, Resource}
@@ -9,7 +11,7 @@ import sage.{Message, PatternMessage}
 import sage.client.SageConfig
 import sage.client.internal.{Client, Subscription, TransactionScope}
 import sage.codec.{KeyCodec, ValueCodec}
-import sage.commands.{Command, Hashes, Keys, Pipeline, RedisType, ScanCursor, ScanPage, Sets, SortedSets}
+import sage.commands.*
 
 /**
   * The cats-effect-native surface: the same client, with every method returning `IO`.
@@ -68,6 +70,66 @@ extension (client: SageClient) {
       .lower
 
   /**
+    * Lazily pages an entire stream by range, batching `XRANGE` and advancing past the last id each page. Stops when a page comes back empty.
+    */
+  def xRangeAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    key: K,
+    start: StreamRangeId = StreamRangeId.Min,
+    end: StreamRangeId = StreamRangeId.Max,
+    batch: Long = 100L
+  ): fs2.Stream[IO, StreamEntry[F, V]] =
+    CStream
+      .unfold[Option[StreamRangeId], Vector[StreamEntry[F, V]]](Some(start)) {
+        case None       => CIO.value(None)
+        case Some(from) =>
+          CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))).map { entries =>
+            if (entries.isEmpty) None
+            else Some((entries, if (entries.length < batch) None else Some(StreamRangeId.Exclusive(entries.last.id))))
+          }
+      }
+      .flatMap(items => CStream.init(items))
+      .lower
+
+  /**
+    * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
+    * entries forever. `handle` runs per entry; the entry is acknowledged only after `handle` succeeds, so a failure leaves it in the PEL for
+    * recovery. See ADR-0032.
+    */
+  def xConsume[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    group: String,
+    consumer: String,
+    key: K,
+    count: Option[Long] = None,
+    block: BlockTimeout = SageClient.defaultPoll
+  )(handle: StreamEntry[F, V] => IO[Unit]): IO[Unit] =
+    consumeStream[K, F, V](group, consumer, key, count, block)
+      .evalMap(entry => handle(entry) >> client.run(Streams.xAck(key, group)(entry.id)).void)
+      .compile
+      .drain
+
+  private def consumeStream[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    group: String,
+    consumer: String,
+    key: K,
+    count: Option[Long],
+    block: BlockTimeout
+  ): fs2.Stream[IO, StreamEntry[F, V]] =
+    CStream
+      .unfold[Either[StreamId, Unit], Vector[StreamEntry[F, V]]](Left(StreamId.Zero)) {
+        case Left(after) =>
+          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map { result =>
+            val entries = result.flatMap(_._2)
+            if (entries.isEmpty) Some((Vector.empty, Right(()))) else Some((entries, Left(entries.last.id)))
+          }
+        case Right(_)    =>
+          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block)))).map { result =>
+            Some((result.flatMap(_._2), Right(())))
+          }
+      }
+      .flatMap(items => CStream.init(items))
+      .lower
+
+  /**
     * Subscribes to one or more channels; closing the stream's scope unsubscribes. Survives reconnects via auto-resubscribe, dropping
     * messages published during the reconnect gap.
     */
@@ -94,6 +156,9 @@ extension (client: SageClient) {
 }
 
 object SageClient {
+
+  // bounded poll so xConsume's blocking read returns periodically, keeping cancellation responsive
+  private[ce] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, TimeUnit.SECONDS))
 
   def connect(config: SageConfig): IO[SageClient] =
     Client.connect(config).lower.map(new Lowered(_))

--- a/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
+++ b/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
@@ -10,7 +10,7 @@ import sage.{Message, PatternMessage}
 import sage.client.SageConfig
 import sage.client.internal.{Client, Subscription, TransactionScope}
 import sage.codec.{KeyCodec, ValueCodec}
-import sage.commands.{Command, Hashes, Keys, Pipeline, RedisType, ScanCursor, ScanPage, Sets, SortedSets}
+import sage.commands.*
 
 /**
   * The Kyo-native surface: the same client, with every method returning a Kyo pending computation.
@@ -77,6 +77,64 @@ extension (client: SageClient) {
       .lower
 
   /**
+    * Lazily pages an entire stream by range, batching `XRANGE` and advancing past the last id each page. Stops when a page comes back empty.
+    */
+  def xRangeAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    key: K,
+    start: StreamRangeId = StreamRangeId.Min,
+    end: StreamRangeId = StreamRangeId.Max,
+    batch: Long = 100L
+  )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[Throwable] & Async] =
+    CStream
+      .unfold[Option[StreamRangeId], Vector[StreamEntry[F, V]]](Some(start)) {
+        case None       => CIO.value(None)
+        case Some(from) =>
+          CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))).map { entries =>
+            if (entries.isEmpty) None
+            else Some((entries, if (entries.length < batch) None else Some(StreamRangeId.Exclusive(entries.last.id))))
+          }
+      }
+      .flatMap(items => CStream.init(items))
+      .lower
+
+  /**
+    * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
+    * entries forever. `handle` runs per entry; the entry is acknowledged only after `handle` succeeds, so a failure leaves it in the PEL for
+    * recovery. See ADR-0032.
+    */
+  def xConsume[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    group: String,
+    consumer: String,
+    key: K,
+    count: Option[Long] = None,
+    block: BlockTimeout = SageClient.defaultPoll
+  )(handle: StreamEntry[F, V] => KyoEff[Unit])(using Tag[F], Tag[V], Frame): KyoEff[Unit] =
+    consumeStream[K, F, V](group, consumer, key, count, block)
+      .foreach(entry => handle(entry).flatMap(_ => client.run(Streams.xAck(key, group)(entry.id)).map(_ => ())))
+
+  private def consumeStream[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    group: String,
+    consumer: String,
+    key: K,
+    count: Option[Long],
+    block: BlockTimeout
+  )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[Throwable] & Async] =
+    CStream
+      .unfold[Either[StreamId, Unit], Vector[StreamEntry[F, V]]](Left(StreamId.Zero)) {
+        case Left(after) =>
+          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map { result =>
+            val entries = result.flatMap(_._2)
+            if (entries.isEmpty) Some((Vector.empty, Right(()))) else Some((entries, Left(entries.last.id)))
+          }
+        case Right(_)    =>
+          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block)))).map { result =>
+            Some((result.flatMap(_._2), Right(())))
+          }
+      }
+      .flatMap(items => CStream.init(items))
+      .lower
+
+  /**
     * Subscribes to one or more channels; closing the enclosing `Scope` unsubscribes. Survives reconnects via auto-resubscribe, dropping
     * messages published during the reconnect gap.
     */
@@ -109,6 +167,9 @@ extension (client: SageClient) {
 }
 
 object SageClient {
+
+  // bounded poll so xConsume's blocking read returns periodically, keeping cancellation responsive
+  private[kyo] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, java.util.concurrent.TimeUnit.SECONDS))
 
   def connect(config: SageConfig): SageClient < (Abort[Throwable] & Async) =
     Client.connect(config).lower.map(new Lowered(_))

--- a/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
@@ -1,5 +1,7 @@
 package sage.ox
 
+import java.util.concurrent.TimeUnit
+
 import scala.concurrent.duration.FiniteDuration
 
 import _root_.ox.{useInScope, Ox}
@@ -10,7 +12,7 @@ import sage.{Message, PatternMessage}
 import sage.client.SageConfig
 import sage.client.internal.{Client, Subscription, TransactionScope}
 import sage.codec.{KeyCodec, ValueCodec}
-import sage.commands.{Command, Hashes, Keys, Pipeline, RedisType, ScanCursor, ScanPage, Sets, SortedSets}
+import sage.commands.*
 
 /**
   * The Ox-native surface: direct style, every method usable inside an Ox scope.
@@ -69,6 +71,67 @@ extension (client: SageClient) {
       .lower
 
   /**
+    * Lazily pages an entire stream by range, batching `XRANGE` and advancing past the last id each page. Stops when a page comes back empty.
+    */
+  def xRangeAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    key: K,
+    start: StreamRangeId = StreamRangeId.Min,
+    end: StreamRangeId = StreamRangeId.Max,
+    batch: Long = 100L
+  ): Ox ?=> Flow[StreamEntry[F, V]] =
+    CStream
+      .unfold[Option[StreamRangeId], Vector[StreamEntry[F, V]]](Some(start)) {
+        case None       => CIO.value(None)
+        case Some(from) =>
+          CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))).map { entries =>
+            if (entries.isEmpty) None
+            else Some((entries, if (entries.length < batch) None else Some(StreamRangeId.Exclusive(entries.last.id))))
+          }
+      }
+      .flatMap(items => CStream.init(items))
+      .lower
+
+  /**
+    * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
+    * entries forever. `handle` runs per entry; the entry is acknowledged only after `handle` returns, so a failure leaves it in the PEL for
+    * recovery. See ADR-0032.
+    */
+  def xConsume[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    group: String,
+    consumer: String,
+    key: K,
+    count: Option[Long] = None,
+    block: BlockTimeout = SageClient.defaultPoll
+  )(handle: StreamEntry[F, V] => (Ox ?=> Unit)): Ox ?=> Unit =
+    consumeStream[K, F, V](group, consumer, key, count, block).runForeach { entry =>
+      handle(entry)
+      client.run(Streams.xAck(key, group)(entry.id))
+      ()
+    }
+
+  private def consumeStream[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    group: String,
+    consumer: String,
+    key: K,
+    count: Option[Long],
+    block: BlockTimeout
+  ): Ox ?=> Flow[StreamEntry[F, V]] =
+    CStream
+      .unfold[Either[StreamId, Unit], Vector[StreamEntry[F, V]]](Left(StreamId.Zero)) {
+        case Left(after) =>
+          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map { result =>
+            val entries = result.flatMap(_._2)
+            if (entries.isEmpty) Some((Vector.empty, Right(()))) else Some((entries, Left(entries.last.id)))
+          }
+        case Right(_)    =>
+          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block)))).map { result =>
+            Some((result.flatMap(_._2), Right(())))
+          }
+      }
+      .flatMap(items => CStream.init(items))
+      .lower
+
+  /**
     * Subscribes to one or more channels; ending the flow unsubscribes. Survives reconnects via auto-resubscribe, dropping messages
     * published during the reconnect gap.
     */
@@ -103,6 +166,9 @@ extension (client: SageClient) {
 }
 
 object SageClient {
+
+  // bounded poll so xConsume's blocking read returns periodically, keeping cancellation responsive
+  private[ox] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, TimeUnit.SECONDS))
 
   def connect(config: SageConfig): Ox ?=> SageClient = new Lowered(Client.connect(config).lower)
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -628,6 +628,143 @@ trait CommandRunner[F[_]] {
   final def pfCount[K: KeyCodec](first: K, rest: K*): F[Long] = run(HyperLogLog.pfCount(first, rest*))
 
   final def pfMerge[K: KeyCodec](destination: K, sources: K*): F[Unit] = run(HyperLogLog.pfMerge(destination, sources*))
+
+  final def xAdd[K: KeyCodec, F0: KeyCodec, V: ValueCodec](
+    key: K,
+    id: XAddId = XAddId.Auto,
+    trim: Option[Trimming] = None,
+    policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef
+  )(first: (F0, V), rest: (F0, V)*): F[StreamId] = run(Streams.xAdd(key, id, trim, policy)(first, rest*))
+
+  final def xAddNoMkStream[K: KeyCodec, F0: KeyCodec, V: ValueCodec](
+    key: K,
+    id: XAddId = XAddId.Auto,
+    trim: Option[Trimming] = None,
+    policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef
+  )(first: (F0, V), rest: (F0, V)*): F[Option[StreamId]] = run(Streams.xAddNoMkStream(key, id, trim, policy)(first, rest*))
+
+  final def xLen[K: KeyCodec](key: K): F[Long] = run(Streams.xLen(key))
+
+  final def xDel[K: KeyCodec](key: K)(first: StreamId, rest: StreamId*): F[Long] = run(Streams.xDel(key)(first, rest*))
+
+  final def xTrim[K: KeyCodec](key: K, trim: Trimming, policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef): F[Long] =
+    run(Streams.xTrim(key, trim, policy))
+
+  final def xSetId[K: KeyCodec](key: K, id: GroupStartId, entriesAdded: Option[Long] = None, maxDeletedId: Option[StreamId] = None): F[Unit] =
+    run(Streams.xSetId(key, id, entriesAdded, maxDeletedId))
+
+  final def xRange[K: KeyCodec, F0: KeyCodec, V: ValueCodec](
+    key: K,
+    start: StreamRangeId = StreamRangeId.Min,
+    end: StreamRangeId = StreamRangeId.Max,
+    count: Option[Long] = None
+  ): F[Vector[StreamEntry[F0, V]]] = run(Streams.xRange(key, start, end, count))
+
+  final def xRevRange[K: KeyCodec, F0: KeyCodec, V: ValueCodec](
+    key: K,
+    end: StreamRangeId = StreamRangeId.Max,
+    start: StreamRangeId = StreamRangeId.Min,
+    count: Option[Long] = None
+  ): F[Vector[StreamEntry[F0, V]]] = run(Streams.xRevRange(key, end, start, count))
+
+  final def xRead[K: KeyCodec, F0: KeyCodec, V: ValueCodec](first: (K, ReadId), rest: (K, ReadId)*)(
+    count: Option[Long] = None,
+    block: Option[BlockTimeout] = None
+  ): F[Vector[(K, Vector[StreamEntry[F0, V]])]] = run(Streams.xRead(first, rest*)(count, block))
+
+  final def xReadGroup[K: KeyCodec, F0: KeyCodec, V: ValueCodec](group: String, consumer: String)(first: (K, GroupReadId), rest: (K, GroupReadId)*)(
+    count: Option[Long] = None,
+    block: Option[BlockTimeout] = None,
+    noAck: Boolean = false
+  ): F[Vector[(K, Vector[StreamEntry[F0, V]])]] = run(Streams.xReadGroup(group, consumer)(first, rest*)(count, block, noAck))
+
+  final def xAck[K: KeyCodec](key: K, group: String)(first: StreamId, rest: StreamId*): F[Long] = run(Streams.xAck(key, group)(first, rest*))
+
+  final def xGroupCreate[K: KeyCodec](
+    key: K,
+    group: String,
+    id: GroupStartId = GroupStartId.Last,
+    mkStream: Boolean = false,
+    entriesRead: Option[Long] = None
+  ): F[Unit] = run(Streams.xGroupCreate(key, group, id, mkStream, entriesRead))
+
+  final def xGroupSetId[K: KeyCodec](key: K, group: String, id: GroupStartId = GroupStartId.Last, entriesRead: Option[Long] = None): F[Unit] =
+    run(Streams.xGroupSetId(key, group, id, entriesRead))
+
+  final def xGroupDestroy[K: KeyCodec](key: K, group: String): F[Boolean] = run(Streams.xGroupDestroy(key, group))
+
+  final def xGroupCreateConsumer[K: KeyCodec](key: K, group: String, consumer: String): F[Boolean] =
+    run(Streams.xGroupCreateConsumer(key, group, consumer))
+
+  final def xGroupDelConsumer[K: KeyCodec](key: K, group: String, consumer: String): F[Long] =
+    run(Streams.xGroupDelConsumer(key, group, consumer))
+
+  final def xClaim[K: KeyCodec, F0: KeyCodec, V: ValueCodec](key: K, group: String, consumer: String, minIdle: FiniteDuration)(
+    first: StreamId,
+    rest: StreamId*
+  )(idle: Option[ClaimIdle] = None, retryCount: Option[Long] = None, force: Boolean = false): F[Vector[StreamEntry[F0, V]]] =
+    run(Streams.xClaim(key, group, consumer, minIdle)(first, rest*)(idle, retryCount, force))
+
+  final def xClaimJustId[K: KeyCodec](key: K, group: String, consumer: String, minIdle: FiniteDuration)(first: StreamId, rest: StreamId*)(
+    idle: Option[ClaimIdle] = None,
+    retryCount: Option[Long] = None,
+    force: Boolean = false
+  ): F[Vector[StreamId]] = run(Streams.xClaimJustId(key, group, consumer, minIdle)(first, rest*)(idle, retryCount, force))
+
+  final def xAutoClaim[K: KeyCodec, F0: KeyCodec, V: ValueCodec](
+    key: K,
+    group: String,
+    consumer: String,
+    minIdle: FiniteDuration,
+    start: StreamId = StreamId.Zero,
+    count: Option[Long] = None
+  ): F[XAutoClaimResult[F0, V]] = run(Streams.xAutoClaim(key, group, consumer, minIdle, start, count))
+
+  final def xAutoClaimJustId[K: KeyCodec](
+    key: K,
+    group: String,
+    consumer: String,
+    minIdle: FiniteDuration,
+    start: StreamId = StreamId.Zero,
+    count: Option[Long] = None
+  ): F[XAutoClaimJustIdResult] = run(Streams.xAutoClaimJustId(key, group, consumer, minIdle, start, count))
+
+  final def xPending[K: KeyCodec](key: K, group: String): F[PendingSummary] = run(Streams.xPending(key, group))
+
+  final def xPendingExtended[K: KeyCodec](
+    key: K,
+    group: String,
+    start: StreamRangeId = StreamRangeId.Min,
+    end: StreamRangeId = StreamRangeId.Max,
+    count: Long = 10L,
+    consumer: Option[String] = None,
+    idle: Option[FiniteDuration] = None
+  ): F[Vector[PendingEntry]] = run(Streams.xPendingExtended(key, group, start, end, count, consumer, idle))
+
+  final def xInfoStream[K: KeyCodec, F0: KeyCodec, V: ValueCodec](key: K): F[StreamInfo[F0, V]] = run(StreamInfo.xInfoStream(key))
+
+  final def xInfoStreamFull[K: KeyCodec, F0: KeyCodec, V: ValueCodec](key: K, count: Option[Long] = None): F[StreamInfoFull[F0, V]] =
+    run(StreamInfo.xInfoStreamFull(key, count))
+
+  final def xInfoGroups[K: KeyCodec](key: K): F[Vector[GroupInfo]] = run(StreamInfo.xInfoGroups(key))
+
+  final def xInfoConsumers[K: KeyCodec](key: K, group: String): F[Vector[ConsumerInfo]] = run(StreamInfo.xInfoConsumers(key, group))
+
+  final def xDelEx[K: KeyCodec](key: K, policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef)(
+    first: StreamId,
+    rest: StreamId*
+  ): F[Vector[StreamEntryDeletion]] =
+    run(Streams.xDelEx(key, policy)(first, rest*))
+
+  final def xAckDel[K: KeyCodec](key: K, group: String, policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef)(
+    first: StreamId,
+    rest: StreamId*
+  ): F[Vector[StreamEntryDeletion]] = run(Streams.xAckDel(key, group, policy)(first, rest*))
+
+  final def xNack[K: KeyCodec](key: K, group: String, mode: NackMode)(first: StreamId, rest: StreamId*)(
+    retryCount: Option[Long] = None,
+    force: Boolean = false
+  ): F[Long] = run(Streams.xNack(key, group, mode)(first, rest*)(retryCount, force))
 }
 
 /**

--- a/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
+++ b/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
@@ -1,5 +1,7 @@
 package sage.zio
 
+import java.util.concurrent.TimeUnit
+
 import scala.concurrent.duration.FiniteDuration
 
 import kyo.compat.*
@@ -10,7 +12,7 @@ import sage.{Message, PatternMessage}
 import sage.client.SageConfig
 import sage.client.internal.{Client, Subscription, TransactionScope}
 import sage.codec.{KeyCodec, ValueCodec}
-import sage.commands.{Command, Hashes, Keys, Pipeline, RedisType, ScanCursor, ScanPage, Sets, SortedSets}
+import sage.commands.*
 
 /**
   * The ZIO-native surface: the same client, with every method returning `Task`.
@@ -75,6 +77,65 @@ extension (client: SageClient) {
       .lower
 
   /**
+    * Lazily pages an entire stream by range, batching `XRANGE` and advancing past the last id each page. Stops when a page comes back empty.
+    */
+  def xRangeAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    key: K,
+    start: StreamRangeId = StreamRangeId.Min,
+    end: StreamRangeId = StreamRangeId.Max,
+    batch: Long = 100L
+  ): ZStream[Any, Throwable, StreamEntry[F, V]] =
+    CStream
+      .unfold[Option[StreamRangeId], Vector[StreamEntry[F, V]]](Some(start)) {
+        case None       => CIO.value(None)
+        case Some(from) =>
+          CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))).map { entries =>
+            if (entries.isEmpty) None
+            else Some((entries, if (entries.length < batch) None else Some(StreamRangeId.Exclusive(entries.last.id))))
+          }
+      }
+      .flatMap(items => CStream.init(items))
+      .lower
+
+  /**
+    * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
+    * entries forever. `handle` runs per entry; the entry is acknowledged only after `handle` succeeds, so a failure leaves it in the PEL for
+    * recovery. See ADR-0032.
+    */
+  def xConsume[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    group: String,
+    consumer: String,
+    key: K,
+    count: Option[Long] = None,
+    block: BlockTimeout = SageClient.defaultPoll
+  )(handle: StreamEntry[F, V] => Task[Unit]): Task[Unit] =
+    consumeStream[K, F, V](group, consumer, key, count, block)
+      .mapZIO(entry => handle(entry) *> client.run(Streams.xAck(key, group)(entry.id)).unit)
+      .runDrain
+
+  private def consumeStream[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    group: String,
+    consumer: String,
+    key: K,
+    count: Option[Long],
+    block: BlockTimeout
+  ): ZStream[Any, Throwable, StreamEntry[F, V]] =
+    CStream
+      .unfold[Either[StreamId, Unit], Vector[StreamEntry[F, V]]](Left(StreamId.Zero)) {
+        case Left(after) =>
+          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map { result =>
+            val entries = result.flatMap(_._2)
+            if (entries.isEmpty) Some((Vector.empty, Right(()))) else Some((entries, Left(entries.last.id)))
+          }
+        case Right(_)    =>
+          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block)))).map { result =>
+            Some((result.flatMap(_._2), Right(())))
+          }
+      }
+      .flatMap(items => CStream.init(items))
+      .lower
+
+  /**
     * Subscribes to one or more channels; closing the stream's scope unsubscribes. Survives reconnects via auto-resubscribe, dropping
     * messages published during the reconnect gap.
     */
@@ -106,6 +167,9 @@ extension (client: SageClient) {
 }
 
 object SageClient {
+
+  // bounded poll so xConsume's blocking read returns periodically, keeping cancellation responsive
+  private[zio] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, TimeUnit.SECONDS))
 
   def connect(config: SageConfig): Task[SageClient] =
     Client.connect(config).lower.map(new Lowered(_))

--- a/sage-core/src/main/scala/sage/commands/BlockTimeout.scala
+++ b/sage-core/src/main/scala/sage/commands/BlockTimeout.scala
@@ -18,6 +18,7 @@ object BlockTimeout {
 
   // sub-second timeouts use the decimal-seconds wire form, rounding up so the wait is never shorter than asked. `After` floors at one
   // millisecond: a zero or negative duration must never emit "0", which is the wire's "block forever" — only `Forever` may mean infinite.
+  // This is the SECONDS form used by `BLPOP`/`BLMOVE`/`BZPOPMIN`; the stream blocking reads take milliseconds — see [[millisWire]].
   private[commands] def wire(timeout: BlockTimeout): Bytes =
     timeout match {
       case Forever         => Zero
@@ -27,6 +28,13 @@ object BlockTimeout {
           if (millis % 1000L == 0L) (millis / 1000L).toString
           else java.math.BigDecimal.valueOf(millis, 3).stripTrailingZeros.toPlainString
         Bytes.utf8(text)
+    }
+
+  // the millisecond form `XREAD`/`XREADGROUP` `BLOCK` requires (the SECONDS [[wire]] form would silently shorten the wait 1000x)
+  private[commands] def millisWire(timeout: BlockTimeout): Bytes =
+    timeout match {
+      case Forever         => Zero
+      case After(duration) => Bytes.utf8(Math.max(1L, Math.ceilDiv(duration.toNanos, 1000000L)).toString)
     }
 
   private val Zero = Bytes.utf8("0")

--- a/sage-core/src/main/scala/sage/commands/Commands.scala
+++ b/sage-core/src/main/scala/sage/commands/Commands.scala
@@ -11,5 +11,7 @@ object Commands {
   export Pubsub.{publish, pubsubChannels, pubsubNumPat, pubsubNumSub}
   export Sets.*
   export SortedSets.*
+  export StreamInfo.*
+  export Streams.*
   export Strings.*
 }

--- a/sage-core/src/main/scala/sage/commands/StreamInfo.scala
+++ b/sage-core/src/main/scala/sage/commands/StreamInfo.scala
@@ -43,9 +43,10 @@ final case class GroupInfo(
 final case class ConsumerInfo(name: String, pending: Long, idle: FiniteDuration, inactive: Option[FiniteDuration])
 
 /**
-  * A row of a full PEL listing: the entry id, the instant it was last delivered, and how many times it has been delivered.
+  * A row of a full PEL listing: the entry id, the instant it was last delivered, and how many times it has been delivered. `consumer` is
+  * the owning consumer at the group level (empty string for an `XNACK`-released entry) and `None` at the consumer level, where it is implied.
   */
-final case class FullPendingEntry(id: StreamId, lastDelivered: Instant, deliveryCount: Long)
+final case class FullPendingEntry(id: StreamId, consumer: Option[String], lastDelivered: Instant, deliveryCount: Long)
 
 /**
   * A consumer inside `XINFO STREAM ... FULL`, with its own slice of the PEL.
@@ -175,7 +176,7 @@ private[sage] object StreamInfo {
           pelCount  <- f.optional("pel-count", Decode.long)
           read      <- f.optional("entries-read", Decode.long)
           lag       <- f.optional("lag", Decode.long)
-          pending   <- f.optionalVector("pending", fullPendingReply)
+          pending   <- f.optionalVector("pending", groupPendingReply)
           consumers <- f.optionalVector("consumers", fullConsumerReply)
         } yield FullGroupInfo(name, lastId, pelCount, read, lag, pending, consumers)
       }
@@ -188,19 +189,31 @@ private[sage] object StreamInfo {
           seen    <- f.optional("seen-time", millisInstant)
           active  <- f.optional("active-time", millisInstant)
           pel     <- f.optional("pel-count", Decode.long)
-          pending <- f.optionalVector("pending", fullPendingReply)
+          pending <- f.optionalVector("pending", consumerPendingReply)
         } yield FullConsumerInfo(name, seen, active, pel, pending)
       }
 
-  // a FULL PEL row is the flat array [id, delivery-time-ms, delivery-count]
-  private val fullPendingReply: Frame => Either[DecodeError, FullPendingEntry] = {
+  // a group-level FULL PEL row carries its owning consumer: [id, consumer, delivery-time-ms, delivery-count]
+  private val groupPendingReply: Frame => Either[DecodeError, FullPendingEntry] = {
+    case Frame.Array(Vector(idFrame, consumerFrame, deliveredFrame, countFrame)) =>
+      for {
+        id        <- Streams.streamId(idFrame)
+        consumer  <- Decode.utf8String(consumerFrame)
+        delivered <- millisInstant(deliveredFrame)
+        count     <- Decode.long(countFrame)
+      } yield FullPendingEntry(id, Some(consumer), delivered, count)
+    case other                                                                   => Left(DecodeError("group pending [id, consumer, delivery-time, delivery-count]", Frame.describe(other)))
+  }
+
+  // a consumer-level FULL PEL row omits the (implied) consumer: [id, delivery-time-ms, delivery-count]
+  private val consumerPendingReply: Frame => Either[DecodeError, FullPendingEntry] = {
     case Frame.Array(Vector(idFrame, deliveredFrame, countFrame)) =>
       for {
         id        <- Streams.streamId(idFrame)
         delivered <- millisInstant(deliveredFrame)
         count     <- Decode.long(countFrame)
-      } yield FullPendingEntry(id, delivered, count)
-    case other                                                    => Left(DecodeError("full pending [id, delivery-time, delivery-count]", Frame.describe(other)))
+      } yield FullPendingEntry(id, None, delivered, count)
+    case other                                                    => Left(DecodeError("consumer pending [id, delivery-time, delivery-count]", Frame.describe(other)))
   }
 
   private val millisDuration: Frame => Either[DecodeError, FiniteDuration] =

--- a/sage-core/src/main/scala/sage/commands/StreamInfo.scala
+++ b/sage-core/src/main/scala/sage/commands/StreamInfo.scala
@@ -1,0 +1,266 @@
+package sage.commands
+
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.FiniteDuration
+
+import sage.SageException.DecodeError
+import sage.codec.{KeyCodec, ValueCodec}
+import sage.protocol.Frame
+
+/**
+  * `XINFO STREAM`: the summary view. Version-specific fields (7.0+) are `Option`, decoded leniently on presence per ADR-0024.
+  */
+final case class StreamInfo[F, V](
+  length: Long,
+  radixTreeKeys: Long,
+  radixTreeNodes: Long,
+  lastGeneratedId: StreamId,
+  maxDeletedEntryId: Option[StreamId],
+  entriesAdded: Option[Long],
+  recordedFirstEntryId: Option[StreamId],
+  groups: Long,
+  firstEntry: Option[StreamEntry[F, V]],
+  lastEntry: Option[StreamEntry[F, V]]
+)
+
+/**
+  * One row of `XINFO GROUPS`. `entriesRead`/`lag` exist from 7.0 (and `lag` may be null even then), so both are `Option`.
+  */
+final case class GroupInfo(
+  name: String,
+  consumers: Long,
+  pending: Long,
+  lastDeliveredId: StreamId,
+  entriesRead: Option[Long],
+  lag: Option[Long]
+)
+
+/**
+  * One row of `XINFO CONSUMERS`. `inactive` exists from 7.2.
+  */
+final case class ConsumerInfo(name: String, pending: Long, idle: FiniteDuration, inactive: Option[FiniteDuration])
+
+/**
+  * A row of a full PEL listing: the entry id, the instant it was last delivered, and how many times it has been delivered.
+  */
+final case class FullPendingEntry(id: StreamId, lastDelivered: Instant, deliveryCount: Long)
+
+/**
+  * A consumer inside `XINFO STREAM ... FULL`, with its own slice of the PEL.
+  */
+final case class FullConsumerInfo(
+  name: String,
+  seenTime: Option[Instant],
+  activeTime: Option[Instant],
+  pelCount: Option[Long],
+  pending: Vector[FullPendingEntry]
+)
+
+/**
+  * A group inside `XINFO STREAM ... FULL`, with the group-level PEL and its consumers.
+  */
+final case class FullGroupInfo(
+  name: String,
+  lastDeliveredId: StreamId,
+  pelCount: Option[Long],
+  entriesRead: Option[Long],
+  lag: Option[Long],
+  pending: Vector[FullPendingEntry],
+  consumers: Vector[FullConsumerInfo]
+)
+
+/**
+  * `XINFO STREAM ... FULL`: the deep view, inlining every entry, group, PEL and consumer. Decoded leniently on presence (ADR-0024).
+  */
+final case class StreamInfoFull[F, V](
+  length: Long,
+  radixTreeKeys: Long,
+  radixTreeNodes: Long,
+  lastGeneratedId: StreamId,
+  maxDeletedEntryId: Option[StreamId],
+  entriesAdded: Option[Long],
+  recordedFirstEntryId: Option[StreamId],
+  entries: Vector[StreamEntry[F, V]],
+  groups: Vector[FullGroupInfo]
+)
+
+private[sage] object StreamInfo {
+
+  def xInfoStream[K, F, V](key: K)(using keyCodec: KeyCodec[K], fieldCodec: KeyCodec[F], valueCodec: ValueCodec[V]): Command[StreamInfo[F, V]] =
+    Command.readUncacheable("XINFO STREAM", Command.FirstKey, Vector(keyCodec.encode(key)), streamReply[F, V])
+
+  def xInfoStreamFull[K, F, V](key: K, count: Option[Long] = None)(
+    using keyCodec: KeyCodec[K],
+    fieldCodec: KeyCodec[F],
+    valueCodec: ValueCodec[V]
+  ): Command[StreamInfoFull[F, V]] =
+    Command.readUncacheable(
+      "XINFO STREAM",
+      Command.FirstKey,
+      Vector(keyCodec.encode(key), Full) ++ count.toVector.flatMap(n => Vector(CountWord, sage.Bytes.utf8(n.toString))),
+      streamFullReply[F, V]
+    )
+
+  def xInfoGroups[K](key: K)(using keyCodec: KeyCodec[K]): Command[Vector[GroupInfo]] =
+    Command.readUncacheable("XINFO GROUPS", Command.FirstKey, Vector(keyCodec.encode(key)), Decode.vector(groupReply))
+
+  def xInfoConsumers[K](key: K, group: String)(using keyCodec: KeyCodec[K]): Command[Vector[ConsumerInfo]] =
+    Command.readUncacheable("XINFO CONSUMERS", Command.FirstKey, Vector(keyCodec.encode(key), sage.Bytes.utf8(group)), Decode.vector(consumerReply))
+
+  private def streamReply[F, V](using KeyCodec[F], ValueCodec[V]): Frame => Either[DecodeError, StreamInfo[F, V]] =
+    frame =>
+      Fields.of(frame).flatMap { f =>
+        for {
+          length   <- f.required("length", Decode.long)
+          rtKeys   <- f.requiredOr("radix-tree-keys", Decode.long, 0L)
+          rtNodes  <- f.requiredOr("radix-tree-nodes", Decode.long, 0L)
+          lastId   <- f.required("last-generated-id", Streams.streamId)
+          maxDel   <- f.optional("max-deleted-entry-id", Streams.streamId)
+          added    <- f.optional("entries-added", Decode.long)
+          firstRec <- f.optional("recorded-first-entry-id", Streams.streamId)
+          groups   <- f.requiredOr("groups", Decode.long, 0L)
+          firstE   <- f.optional("first-entry", Streams.streamEntry[F, V])
+          lastE    <- f.optional("last-entry", Streams.streamEntry[F, V])
+        } yield StreamInfo(length, rtKeys, rtNodes, lastId, maxDel, added, firstRec, groups, firstE, lastE)
+      }
+
+  private def streamFullReply[F, V](using KeyCodec[F], ValueCodec[V]): Frame => Either[DecodeError, StreamInfoFull[F, V]] =
+    frame =>
+      Fields.of(frame).flatMap { f =>
+        for {
+          length   <- f.required("length", Decode.long)
+          rtKeys   <- f.requiredOr("radix-tree-keys", Decode.long, 0L)
+          rtNodes  <- f.requiredOr("radix-tree-nodes", Decode.long, 0L)
+          lastId   <- f.required("last-generated-id", Streams.streamId)
+          maxDel   <- f.optional("max-deleted-entry-id", Streams.streamId)
+          added    <- f.optional("entries-added", Decode.long)
+          firstRec <- f.optional("recorded-first-entry-id", Streams.streamId)
+          entries  <- f.optionalVector("entries", Streams.streamEntry[F, V])
+          groups   <- f.optionalVector("groups", fullGroupReply)
+        } yield StreamInfoFull(length, rtKeys, rtNodes, lastId, maxDel, added, firstRec, entries, groups)
+      }
+
+  private val groupReply: Frame => Either[DecodeError, GroupInfo] =
+    frame =>
+      Fields.of(frame).flatMap { f =>
+        for {
+          name      <- f.required("name", Decode.utf8String)
+          consumers <- f.requiredOr("consumers", Decode.long, 0L)
+          pending   <- f.requiredOr("pending", Decode.long, 0L)
+          lastId    <- f.required("last-delivered-id", Streams.streamId)
+          read      <- f.optional("entries-read", Decode.long)
+          lag       <- f.optional("lag", Decode.long)
+        } yield GroupInfo(name, consumers, pending, lastId, read, lag)
+      }
+
+  private val consumerReply: Frame => Either[DecodeError, ConsumerInfo] =
+    frame =>
+      Fields.of(frame).flatMap { f =>
+        for {
+          name     <- f.required("name", Decode.utf8String)
+          pending  <- f.requiredOr("pending", Decode.long, 0L)
+          idle     <- f.required("idle", millisDuration)
+          inactive <- f.optional("inactive", millisDuration)
+        } yield ConsumerInfo(name, pending, idle, inactive)
+      }
+
+  private val fullGroupReply: Frame => Either[DecodeError, FullGroupInfo] =
+    frame =>
+      Fields.of(frame).flatMap { f =>
+        for {
+          name      <- f.required("name", Decode.utf8String)
+          lastId    <- f.required("last-delivered-id", Streams.streamId)
+          pelCount  <- f.optional("pel-count", Decode.long)
+          read      <- f.optional("entries-read", Decode.long)
+          lag       <- f.optional("lag", Decode.long)
+          pending   <- f.optionalVector("pending", fullPendingReply)
+          consumers <- f.optionalVector("consumers", fullConsumerReply)
+        } yield FullGroupInfo(name, lastId, pelCount, read, lag, pending, consumers)
+      }
+
+  private val fullConsumerReply: Frame => Either[DecodeError, FullConsumerInfo] =
+    frame =>
+      Fields.of(frame).flatMap { f =>
+        for {
+          name    <- f.required("name", Decode.utf8String)
+          seen    <- f.optional("seen-time", millisInstant)
+          active  <- f.optional("active-time", millisInstant)
+          pel     <- f.optional("pel-count", Decode.long)
+          pending <- f.optionalVector("pending", fullPendingReply)
+        } yield FullConsumerInfo(name, seen, active, pel, pending)
+      }
+
+  // a FULL PEL row is the flat array [id, delivery-time-ms, delivery-count]
+  private val fullPendingReply: Frame => Either[DecodeError, FullPendingEntry] = {
+    case Frame.Array(Vector(idFrame, deliveredFrame, countFrame)) =>
+      for {
+        id        <- Streams.streamId(idFrame)
+        delivered <- millisInstant(deliveredFrame)
+        count     <- Decode.long(countFrame)
+      } yield FullPendingEntry(id, delivered, count)
+    case other                                                    => Left(DecodeError("full pending [id, delivery-time, delivery-count]", Frame.describe(other)))
+  }
+
+  private val millisDuration: Frame => Either[DecodeError, FiniteDuration] =
+    frame => Decode.long(frame).map(ms => FiniteDuration(ms, TimeUnit.MILLISECONDS))
+
+  private val millisInstant: Frame => Either[DecodeError, Instant] =
+    frame => Decode.long(frame).map(Instant.ofEpochMilli)
+
+  /**
+    * A lenient view over an introspection reply map: read fields by known name, ignore the rest (ADR-0024).
+    */
+  final private class Fields private (table: Map[String, Frame]) {
+
+    def required[A](name: String, decode: Frame => Either[DecodeError, A]): Either[DecodeError, A] =
+      table.get(name).toRight(DecodeError(s"field '$name'", "absent")).flatMap(decode)
+
+    // a field that is core to the reply but whose absence on some server we tolerate with a default rather than failing the whole decode
+    def requiredOr[A](name: String, decode: Frame => Either[DecodeError, A], fallback: A): Either[DecodeError, A] =
+      table.get(name) match {
+        case None | Some(Frame.Null) => Right(fallback)
+        case Some(frame)             => decode(frame)
+      }
+
+    def optional[A](name: String, decode: Frame => Either[DecodeError, A]): Either[DecodeError, Option[A]] =
+      table.get(name) match {
+        case None | Some(Frame.Null) => Right(None)
+        case Some(frame)             => decode(frame).map(Some(_))
+      }
+
+    def optionalVector[A](name: String, element: Frame => Either[DecodeError, A]): Either[DecodeError, Vector[A]] =
+      table.get(name) match {
+        case None | Some(Frame.Null) => Right(Vector.empty)
+        case Some(frame)             => Decode.vector(element)(frame)
+      }
+  }
+
+  private object Fields {
+
+    def of(frame: Frame): Either[DecodeError, Fields] =
+      frame match {
+        case Frame.Map(entries) => build(entries)
+        case Frame.Array(elements) if elements.length % 2 == 0 => build(elements.grouped(2).map(p => p(0) -> p(1)).toVector)
+        case other => Left(DecodeError("introspection map", Frame.describe(other)))
+      }
+
+    private def build(entries: Vector[(Frame, Frame)]): Either[DecodeError, Fields] = {
+      val builder = Map.newBuilder[String, Frame]
+      val it      = entries.iterator
+      while (it.hasNext) {
+        val (keyFrame, valueFrame) = it.next()
+        keyFrame match {
+          case Frame.BulkString(bytes)  => builder += bytes.asUtf8String -> valueFrame
+          case Frame.SimpleString(name) => builder += name               -> valueFrame
+          case other                    => return Left(DecodeError("field name", Frame.describe(other)))
+        }
+      }
+      Right(new Fields(builder.result()))
+    }
+  }
+
+  private val Full      = sage.Bytes.utf8("FULL")
+  private val CountWord = sage.Bytes.utf8("COUNT")
+}

--- a/sage-core/src/main/scala/sage/commands/Streams.scala
+++ b/sage-core/src/main/scala/sage/commands/Streams.scala
@@ -149,7 +149,7 @@ private[sage] object Streams {
     first: (F, V),
     rest: (F, V)*
   )(using keyCodec: KeyCodec[K], fieldCodec: KeyCodec[F], valueCodec: ValueCodec[V]): Command[StreamId] =
-    Command("XADD", Command.FirstKey, addArgs(key, noMkStream = false, id, trim, policy, first +: rest.toVector), streamIdReply)
+    Command("XADD", Command.FirstKey, addArgs(key, noMkStream = false, id, trim, policy, first +: rest.toVector), streamId)
 
   // returns None when NOMKSTREAM was set and the stream did not exist
   def xAddNoMkStream[K, F, V](
@@ -158,7 +158,7 @@ private[sage] object Streams {
     trim: Option[Trimming] = None,
     policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef
   )(first: (F, V), rest: (F, V)*)(using keyCodec: KeyCodec[K], fieldCodec: KeyCodec[F], valueCodec: ValueCodec[V]): Command[Option[StreamId]] =
-    Command("XADD", Command.FirstKey, addArgs(key, noMkStream = true, id, trim, policy, first +: rest.toVector), optionalStreamIdReply)
+    Command("XADD", Command.FirstKey, addArgs(key, noMkStream = true, id, trim, policy, first +: rest.toVector), optionalStreamId)
 
   def xLen[K](key: K)(using keyCodec: KeyCodec[K]): Command[Long] =
     Command.read("XLEN", Command.FirstKey, Vector(keyCodec.encode(key)), Decode.long)
@@ -167,7 +167,7 @@ private[sage] object Streams {
     Command("XDEL", Command.FirstKey, keyCodec.encode(key) +: (first +: rest.toVector).map(_.wire), Decode.long)
 
   def xTrim[K](key: K, trim: Trimming, policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef)(using keyCodec: KeyCodec[K]): Command[Long] =
-    Command("XTRIM", Command.FirstKey, (keyCodec.encode(key) +: policyArgs(policy)) ++ trimArgs(trim), Decode.long)
+    Command("XTRIM", Command.FirstKey, (keyCodec.encode(key) +: trimArgs(trim)) ++ policyArgs(policy), Decode.long)
 
   def xSetId[K](key: K, id: GroupStartId, entriesAdded: Option[Long] = None, maxDeletedId: Option[StreamId] = None)(
     using keyCodec: KeyCodec[K]
@@ -291,7 +291,7 @@ private[sage] object Streams {
       "XCLAIM",
       Command.FirstKey,
       claimArgs(key, group, consumer, minIdle, first +: rest.toVector, idle, retryCount, force, justId = true),
-      Decode.vector(streamIdElement)
+      Decode.vector(streamId)
     )
 
   def xAutoClaim[K, F, V](
@@ -517,8 +517,6 @@ private[sage] object Streams {
     case other                   => Left(DecodeError("stream id", Frame.describe(other)))
   }
 
-  private val streamIdElement: Frame => Either[DecodeError, StreamId] = streamId
-
   private def parseId(text: String): Either[DecodeError, StreamId] = {
     val dash = text.indexOf('-')
     if (dash < 0) text.toLongOption.map(ms => StreamId(ms, 0L)).toRight(DecodeError("stream id 'ms-seq'", s"'$text'"))
@@ -529,9 +527,7 @@ private[sage] object Streams {
       }
   }
 
-  private val streamIdReply: Frame => Either[DecodeError, StreamId] = streamId
-
-  private val optionalStreamIdReply: Frame => Either[DecodeError, Option[StreamId]] = {
+  private val optionalStreamId: Frame => Either[DecodeError, Option[StreamId]] = {
     case Frame.Null => Right(None)
     case other      => streamId(other).map(Some(_))
   }
@@ -579,7 +575,7 @@ private[sage] object Streams {
       for {
         cursor  <- streamId(cursorFrame)
         entries <- Decode.vector(streamEntry[F, V])(entriesFrame)
-        deleted <- Decode.vector(streamIdElement)(deletedFrame)
+        deleted <- Decode.vector(streamId)(deletedFrame)
       } yield XAutoClaimResult(cursor, entries, deleted)
     // pre-7.0 omits the deleted-ids element
     case Frame.Array(Vector(cursorFrame, entriesFrame))               =>
@@ -594,13 +590,13 @@ private[sage] object Streams {
     case Frame.Array(Vector(cursorFrame, claimedFrame, deletedFrame)) =>
       for {
         cursor  <- streamId(cursorFrame)
-        claimed <- Decode.vector(streamIdElement)(claimedFrame)
-        deleted <- Decode.vector(streamIdElement)(deletedFrame)
+        claimed <- Decode.vector(streamId)(claimedFrame)
+        deleted <- Decode.vector(streamId)(deletedFrame)
       } yield XAutoClaimJustIdResult(cursor, claimed, deleted)
     case Frame.Array(Vector(cursorFrame, claimedFrame))               =>
       for {
         cursor  <- streamId(cursorFrame)
-        claimed <- Decode.vector(streamIdElement)(claimedFrame)
+        claimed <- Decode.vector(streamId)(claimedFrame)
       } yield XAutoClaimJustIdResult(cursor, claimed, Vector.empty)
     case other                                                        => Left(DecodeError("xautoclaim justid [cursor, ids, deleted]", Frame.describe(other)))
   }
@@ -617,8 +613,8 @@ private[sage] object Streams {
     case Frame.Array(Vector(totalFrame, minFrame, maxFrame, consumersFrame)) =>
       for {
         total     <- Decode.long(totalFrame)
-        min       <- optionalId(minFrame)
-        max       <- optionalId(maxFrame)
+        min       <- optionalStreamId(minFrame)
+        max       <- optionalStreamId(maxFrame)
         consumers <- consumersFrame match {
                        case Frame.Null        => Right(Vector.empty[(String, Long)])
                        case Frame.Array(rows) => collect(rows)(consumerCount)
@@ -647,11 +643,6 @@ private[sage] object Streams {
         deliveries <- Decode.long(deliveriesFrame)
       } yield PendingEntry(id, consumer, FiniteDuration(idle, java.util.concurrent.TimeUnit.MILLISECONDS), deliveries)
     case other                                                                   => Left(DecodeError("xpending entry [id, consumer, idle, count]", Frame.describe(other)))
-  }
-
-  private val optionalId: Frame => Either[DecodeError, Option[StreamId]] = {
-    case Frame.Null => Right(None)
-    case other      => streamId(other).map(Some(_))
   }
 
   // XPENDING per-consumer counts come back as bulk-string integers

--- a/sage-core/src/main/scala/sage/commands/Streams.scala
+++ b/sage-core/src/main/scala/sage/commands/Streams.scala
@@ -1,0 +1,722 @@
+package sage.commands
+
+import java.time.Instant
+
+import scala.concurrent.duration.FiniteDuration
+
+import sage.Bytes
+import sage.SageException.DecodeError
+import sage.codec.{KeyCodec, ValueCodec}
+import sage.protocol.Frame
+
+/**
+  * A concrete Stream Entry ID: a millisecond timestamp and a per-millisecond sequence. The one type used for replies and for explicit
+  * values; each command position that also admits a special token (`*`, `-`/`+`, `$`, `>`, `(`) carries its own sealed type listing only
+  * the tokens legal there, so an illegal form at a position cannot be written. See ADR-0031.
+  */
+final case class StreamId(ms: Long, seq: Long) extends Ordered[StreamId] {
+  def compare(that: StreamId): Int  = {
+    val c = java.lang.Long.compareUnsigned(ms, that.ms); if (c != 0) c else java.lang.Long.compareUnsigned(seq, that.seq)
+  }
+  private[commands] def wire: Bytes = Bytes.utf8(s"$ms-$seq")
+}
+
+object StreamId {
+  val Zero: StreamId = StreamId(0L, 0L)
+}
+
+/**
+  * The id position of `XADD`: an explicit id, full auto (`*`), or auto-sequence within a chosen millisecond (`<ms>-*`).
+  */
+enum XAddId {
+  case Auto
+  case AutoSeq(ms: Long)
+  case Explicit(id: StreamId)
+}
+
+/**
+  * A bound for `XRANGE`/`XREVRANGE`/`XPENDING`: the open extremes `-`/`+`, or an inclusive/exclusive id (`(` prefix).
+  */
+enum StreamRangeId {
+  case Min
+  case Max
+  case Inclusive(id: StreamId)
+  case Exclusive(id: StreamId)
+}
+
+/**
+  * The per-stream id of `XREAD`: only-new (`$`), the single last entry (`+`, 7.4+), or all entries after an explicit id.
+  */
+enum ReadId {
+  case New
+  case LastEntry
+  case After(id: StreamId)
+}
+
+/**
+  * The per-stream id of `XREADGROUP`: new-for-group (`>`), or this consumer's pending history after an explicit id.
+  */
+enum GroupReadId {
+  case New
+  case After(id: StreamId)
+}
+
+/**
+  * The id of `XGROUP CREATE`/`XSETID`: the stream's last id (`$`) or an explicit id (`StreamId.Zero` is the beginning).
+  */
+enum GroupStartId {
+  case Last
+  case At(id: StreamId)
+}
+
+/**
+  * One record in a Stream: an id and an ordered, duplicate-permitting list of field/value pairs (a `Vector`, never a `Map`).
+  */
+final case class StreamEntry[F, V](id: StreamId, fields: Vector[(F, V)])
+
+/**
+  * A trim threshold, shared by `XADD` and `XTRIM`: cap the length (`MAXLEN`) or evict ids below a floor (`MINID`).
+  */
+enum TrimThreshold {
+  case MaxLen(count: Long)
+  case MinId(id: StreamId)
+}
+
+/**
+  * How a Stream is trimmed, shared by `XADD` and `XTRIM` (the [[ListSide]] domain-primitive exception). `Approximate` (`~`) is the only
+  * form that admits `LIMIT`, so a `LIMIT` without `~` — which the raw command rejects — cannot be expressed.
+  */
+enum Trimming {
+  case Exact(threshold: TrimThreshold)
+  case Approximate(threshold: TrimThreshold, limit: Option[Long] = None)
+}
+
+/**
+  * How entry deletion interacts with consumer-group references, shared by `XADD`/`XTRIM`/`XDELEX`/`XACKDEL` (8.2+). `KeepRef` is the
+  * historical default: delete the entry but leave dangling references in every group's PEL.
+  */
+enum StreamDeletionPolicy {
+  case KeepRef, DelRef, Acked
+}
+
+/**
+  * How `XNACK` (8.8+) adjusts an entry's delivery counter when releasing it back to the group.
+  */
+enum NackMode {
+  case Silent, Fail, Fatal
+}
+
+/**
+  * The per-id outcome of `XDELEX`/`XACKDEL`: the id was absent (`-1`), deleted (`1`), or kept because references remain (`2`).
+  */
+enum StreamEntryDeletion {
+  case NotFound, Deleted, Retained
+}
+
+/**
+  * How `XCLAIM` overrides an entry's idle time: a relative duration (`IDLE`) or an absolute instant (`TIME`).
+  */
+enum ClaimIdle {
+  case Idle(duration: FiniteDuration)
+  case At(timestamp: Instant)
+}
+
+/**
+  * `XAUTOCLAIM`: the next scan cursor, the claimed entries, and the ids that were dropped because they no longer exist (7.0+).
+  */
+final case class XAutoClaimResult[F, V](cursor: StreamId, entries: Vector[StreamEntry[F, V]], deleted: Vector[StreamId])
+
+/**
+  * `XAUTOCLAIM JUSTID`: the next cursor, the claimed ids, and the dropped ids (7.0+).
+  */
+final case class XAutoClaimJustIdResult(cursor: StreamId, claimed: Vector[StreamId], deleted: Vector[StreamId])
+
+/**
+  * `XPENDING` summary: total pending, the id range, and the per-consumer counts. All empty when nothing is pending.
+  */
+final case class PendingSummary(total: Long, min: Option[StreamId], max: Option[StreamId], consumers: Vector[(String, Long)])
+
+/**
+  * One row of `XPENDING` extended: the entry, its owning consumer, how long it has been idle, and how many times it was delivered.
+  */
+final case class PendingEntry(id: StreamId, consumer: String, idle: FiniteDuration, deliveryCount: Long)
+
+private[sage] object Streams {
+
+  // --- writes -------------------------------------------------------------
+
+  def xAdd[K, F, V](key: K, id: XAddId = XAddId.Auto, trim: Option[Trimming] = None, policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef)(
+    first: (F, V),
+    rest: (F, V)*
+  )(using keyCodec: KeyCodec[K], fieldCodec: KeyCodec[F], valueCodec: ValueCodec[V]): Command[StreamId] =
+    Command("XADD", Command.FirstKey, addArgs(key, noMkStream = false, id, trim, policy, first +: rest.toVector), streamIdReply)
+
+  // returns None when NOMKSTREAM was set and the stream did not exist
+  def xAddNoMkStream[K, F, V](
+    key: K,
+    id: XAddId = XAddId.Auto,
+    trim: Option[Trimming] = None,
+    policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef
+  )(first: (F, V), rest: (F, V)*)(using keyCodec: KeyCodec[K], fieldCodec: KeyCodec[F], valueCodec: ValueCodec[V]): Command[Option[StreamId]] =
+    Command("XADD", Command.FirstKey, addArgs(key, noMkStream = true, id, trim, policy, first +: rest.toVector), optionalStreamIdReply)
+
+  def xLen[K](key: K)(using keyCodec: KeyCodec[K]): Command[Long] =
+    Command.read("XLEN", Command.FirstKey, Vector(keyCodec.encode(key)), Decode.long)
+
+  def xDel[K](key: K)(first: StreamId, rest: StreamId*)(using keyCodec: KeyCodec[K]): Command[Long] =
+    Command("XDEL", Command.FirstKey, keyCodec.encode(key) +: (first +: rest.toVector).map(_.wire), Decode.long)
+
+  def xTrim[K](key: K, trim: Trimming, policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef)(using keyCodec: KeyCodec[K]): Command[Long] =
+    Command("XTRIM", Command.FirstKey, (keyCodec.encode(key) +: policyArgs(policy)) ++ trimArgs(trim), Decode.long)
+
+  def xSetId[K](key: K, id: GroupStartId, entriesAdded: Option[Long] = None, maxDeletedId: Option[StreamId] = None)(
+    using keyCodec: KeyCodec[K]
+  ): Command[Unit] =
+    Command(
+      "XSETID",
+      Command.FirstKey,
+      (Vector(keyCodec.encode(key), groupStartWire(id)) ++ entriesAdded.toVector.flatMap(n => Vector(EntriesAdded, Bytes.utf8(n.toString)))) ++
+        maxDeletedId.toVector.flatMap(d => Vector(MaxDeletedId, d.wire)),
+      Decode.ok
+    )
+
+  // --- range reads --------------------------------------------------------
+
+  def xRange[K, F, V](key: K, start: StreamRangeId = StreamRangeId.Min, end: StreamRangeId = StreamRangeId.Max, count: Option[Long] = None)(
+    using keyCodec: KeyCodec[K],
+    fieldCodec: KeyCodec[F],
+    valueCodec: ValueCodec[V]
+  ): Command[Vector[StreamEntry[F, V]]] =
+    rangeCommand("XRANGE", key, start, end, count)
+
+  def xRevRange[K, F, V](key: K, end: StreamRangeId = StreamRangeId.Max, start: StreamRangeId = StreamRangeId.Min, count: Option[Long] = None)(
+    using keyCodec: KeyCodec[K],
+    fieldCodec: KeyCodec[F],
+    valueCodec: ValueCodec[V]
+  ): Command[Vector[StreamEntry[F, V]]] =
+    rangeCommand("XREVRANGE", key, end, start, count)
+
+  private def rangeCommand[K, F, V](name: String, key: K, a: StreamRangeId, b: StreamRangeId, count: Option[Long])(
+    using keyCodec: KeyCodec[K],
+    fieldCodec: KeyCodec[F],
+    valueCodec: ValueCodec[V]
+  ): Command[Vector[StreamEntry[F, V]]] =
+    Command.read(
+      name,
+      Command.FirstKey,
+      Vector(keyCodec.encode(key), rangeWire(a), rangeWire(b)) ++ count.toVector.flatMap(n => Vector(Count, Bytes.utf8(n.toString))),
+      Decode.vector(streamEntry[F, V])
+    )
+
+  // --- multi-stream reads -------------------------------------------------
+
+  def xRead[K, F, V](first: (K, ReadId), rest: (K, ReadId)*)(count: Option[Long] = None, block: Option[BlockTimeout] = None)(
+    using keyCodec: KeyCodec[K],
+    fieldCodec: KeyCodec[F],
+    valueCodec: ValueCodec[V]
+  ): Command[Vector[(K, Vector[StreamEntry[F, V]])]] = {
+    val leading      = countArg(count) ++ blockArg(block)
+    val (args, keys) = streamsArgs(first +: rest.toVector, leading, readWire)
+    Command("XREAD", keys, args, readReply[K, F, V], execution = blockExecution(block), isReadOnly = true)
+  }
+
+  def xReadGroup[K, F, V](group: String, consumer: String)(first: (K, GroupReadId), rest: (K, GroupReadId)*)(
+    count: Option[Long] = None,
+    block: Option[BlockTimeout] = None,
+    noAck: Boolean = false
+  )(using keyCodec: KeyCodec[K], fieldCodec: KeyCodec[F], valueCodec: ValueCodec[V]): Command[Vector[(K, Vector[StreamEntry[F, V]])]] = {
+    val leading      =
+      Vector(Group, Bytes.utf8(group), Bytes.utf8(consumer)) ++ countArg(count) ++ blockArg(block) ++ (if (noAck) Vector(NoAck) else Vector.empty)
+    val (args, keys) = streamsArgs(first +: rest.toVector, leading, groupReadWire)
+    Command("XREADGROUP", keys, args, readReply[K, F, V], execution = blockExecution(block))
+  }
+
+  // --- consumer groups ----------------------------------------------------
+
+  def xAck[K](key: K, group: String)(first: StreamId, rest: StreamId*)(using keyCodec: KeyCodec[K]): Command[Long] =
+    Command("XACK", Command.FirstKey, Vector(keyCodec.encode(key), Bytes.utf8(group)) ++ (first +: rest.toVector).map(_.wire), Decode.long)
+
+  def xGroupCreate[K](key: K, group: String, id: GroupStartId = GroupStartId.Last, mkStream: Boolean = false, entriesRead: Option[Long] = None)(
+    using keyCodec: KeyCodec[K]
+  ): Command[Unit] =
+    Command(
+      "XGROUP CREATE",
+      Command.FirstKey,
+      (Vector(keyCodec.encode(key), Bytes.utf8(group), groupStartWire(id)) ++ (if (mkStream) Vector(MkStream) else Vector.empty)) ++
+        entriesRead.toVector.flatMap(n => Vector(EntriesRead, Bytes.utf8(n.toString))),
+      Decode.ok
+    )
+
+  def xGroupSetId[K](key: K, group: String, id: GroupStartId = GroupStartId.Last, entriesRead: Option[Long] = None)(
+    using keyCodec: KeyCodec[K]
+  ): Command[Unit] =
+    Command(
+      "XGROUP SETID",
+      Command.FirstKey,
+      Vector(keyCodec.encode(key), Bytes.utf8(group), groupStartWire(id)) ++ entriesRead.toVector.flatMap(n =>
+        Vector(EntriesRead, Bytes.utf8(n.toString))
+      ),
+      Decode.ok
+    )
+
+  def xGroupDestroy[K](key: K, group: String)(using keyCodec: KeyCodec[K]): Command[Boolean] =
+    Command("XGROUP DESTROY", Command.FirstKey, Vector(keyCodec.encode(key), Bytes.utf8(group)), Decode.flag)
+
+  def xGroupCreateConsumer[K](key: K, group: String, consumer: String)(using keyCodec: KeyCodec[K]): Command[Boolean] =
+    Command("XGROUP CREATECONSUMER", Command.FirstKey, Vector(keyCodec.encode(key), Bytes.utf8(group), Bytes.utf8(consumer)), Decode.flag)
+
+  def xGroupDelConsumer[K](key: K, group: String, consumer: String)(using keyCodec: KeyCodec[K]): Command[Long] =
+    Command("XGROUP DELCONSUMER", Command.FirstKey, Vector(keyCodec.encode(key), Bytes.utf8(group), Bytes.utf8(consumer)), Decode.long)
+
+  // --- claiming -----------------------------------------------------------
+
+  def xClaim[K, F, V](key: K, group: String, consumer: String, minIdle: FiniteDuration)(first: StreamId, rest: StreamId*)(
+    idle: Option[ClaimIdle] = None,
+    retryCount: Option[Long] = None,
+    force: Boolean = false
+  )(using keyCodec: KeyCodec[K], fieldCodec: KeyCodec[F], valueCodec: ValueCodec[V]): Command[Vector[StreamEntry[F, V]]] =
+    Command(
+      "XCLAIM",
+      Command.FirstKey,
+      claimArgs(key, group, consumer, minIdle, first +: rest.toVector, idle, retryCount, force, justId = false),
+      Decode.vector(streamEntry[F, V])
+    )
+
+  def xClaimJustId[K](key: K, group: String, consumer: String, minIdle: FiniteDuration)(first: StreamId, rest: StreamId*)(
+    idle: Option[ClaimIdle] = None,
+    retryCount: Option[Long] = None,
+    force: Boolean = false
+  )(using keyCodec: KeyCodec[K]): Command[Vector[StreamId]] =
+    Command(
+      "XCLAIM",
+      Command.FirstKey,
+      claimArgs(key, group, consumer, minIdle, first +: rest.toVector, idle, retryCount, force, justId = true),
+      Decode.vector(streamIdElement)
+    )
+
+  def xAutoClaim[K, F, V](
+    key: K,
+    group: String,
+    consumer: String,
+    minIdle: FiniteDuration,
+    start: StreamId = StreamId.Zero,
+    count: Option[Long] = None
+  )(
+    using keyCodec: KeyCodec[K],
+    fieldCodec: KeyCodec[F],
+    valueCodec: ValueCodec[V]
+  ): Command[XAutoClaimResult[F, V]] =
+    Command("XAUTOCLAIM", Command.FirstKey, autoClaimArgs(key, group, consumer, minIdle, start, count, justId = false), autoClaimReply[F, V])
+
+  def xAutoClaimJustId[K](
+    key: K,
+    group: String,
+    consumer: String,
+    minIdle: FiniteDuration,
+    start: StreamId = StreamId.Zero,
+    count: Option[Long] = None
+  )(
+    using keyCodec: KeyCodec[K]
+  ): Command[XAutoClaimJustIdResult] =
+    Command("XAUTOCLAIM", Command.FirstKey, autoClaimArgs(key, group, consumer, minIdle, start, count, justId = true), autoClaimJustIdReply)
+
+  // --- pending ------------------------------------------------------------
+
+  def xPending[K](key: K, group: String)(using keyCodec: KeyCodec[K]): Command[PendingSummary] =
+    Command.readUncacheable("XPENDING", Command.FirstKey, Vector(keyCodec.encode(key), Bytes.utf8(group)), pendingSummaryReply)
+
+  def xPendingExtended[K](
+    key: K,
+    group: String,
+    start: StreamRangeId = StreamRangeId.Min,
+    end: StreamRangeId = StreamRangeId.Max,
+    count: Long = 10L,
+    consumer: Option[String] = None,
+    idle: Option[FiniteDuration] = None
+  )(using keyCodec: KeyCodec[K]): Command[Vector[PendingEntry]] =
+    Command.readUncacheable(
+      "XPENDING",
+      Command.FirstKey,
+      (Vector(keyCodec.encode(key), Bytes.utf8(group)) ++ idle.toVector.flatMap(d => Vector(Idle, Bytes.utf8(TimeArgs.millis(d).toString)))) ++
+        Vector(rangeWire(start), rangeWire(end), Bytes.utf8(count.toString)) ++ consumer.toVector.map(Bytes.utf8),
+      Decode.vector(pendingEntryElement)
+    )
+
+  // --- Redis-only 8.2+/8.8+ (ADR-0026) ------------------------------------
+
+  def xDelEx[K](key: K, policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef)(first: StreamId, rest: StreamId*)(
+    using keyCodec: KeyCodec[K]
+  ): Command[Vector[StreamEntryDeletion]] = {
+    val ids = first +: rest.toVector
+    Command(
+      "XDELEX",
+      Command.FirstKey,
+      (keyCodec.encode(key) +: policyArgs(policy)) ++ (Ids +: Bytes.utf8(ids.size.toString) +: ids.map(_.wire)),
+      Decode.vector(deletionElement)
+    )
+  }
+
+  def xAckDel[K](key: K, group: String, policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef)(first: StreamId, rest: StreamId*)(
+    using keyCodec: KeyCodec[K]
+  ): Command[Vector[StreamEntryDeletion]] = {
+    val ids = first +: rest.toVector
+    Command(
+      "XACKDEL",
+      Command.FirstKey,
+      (Vector(keyCodec.encode(key), Bytes.utf8(group)) ++ policyArgs(policy)) ++ (Ids +: Bytes.utf8(ids.size.toString) +: ids.map(_.wire)),
+      Decode.vector(deletionElement)
+    )
+  }
+
+  def xNack[K](key: K, group: String, mode: NackMode)(first: StreamId, rest: StreamId*)(
+    retryCount: Option[Long] = None,
+    force: Boolean = false
+  )(using keyCodec: KeyCodec[K]): Command[Long] = {
+    val ids = first +: rest.toVector
+    Command(
+      "XNACK",
+      Command.FirstKey,
+      (Vector(keyCodec.encode(key), Bytes.utf8(group), nackModeWire(mode), Ids, Bytes.utf8(ids.size.toString)) ++ ids.map(_.wire)) ++
+        retryCount.toVector.flatMap(n => Vector(RetryCount, Bytes.utf8(n.toString))) ++ (if (force) Vector(Force) else Vector.empty),
+      Decode.long
+    )
+  }
+
+  // --- arg builders -------------------------------------------------------
+
+  private def addArgs[K, F, V](key: K, noMkStream: Boolean, id: XAddId, trim: Option[Trimming], policy: StreamDeletionPolicy, fields: Vector[(F, V)])(
+    using keyCodec: KeyCodec[K],
+    fieldCodec: KeyCodec[F],
+    valueCodec: ValueCodec[V]
+  ): Vector[Bytes] =
+    (keyCodec.encode(key) +: (if (noMkStream) Vector(NoMkStream) else Vector.empty)) ++
+      policyArgs(policy) ++ trim.toVector.flatMap(trimArgs) ++ (xAddIdWire(id) +: fields.flatMap { case (f, v) =>
+        Vector(fieldCodec.encode(f), valueCodec.encode(v))
+      })
+
+  private def claimArgs[K](
+    key: K,
+    group: String,
+    consumer: String,
+    minIdle: FiniteDuration,
+    ids: Vector[StreamId],
+    idle: Option[ClaimIdle],
+    retryCount: Option[Long],
+    force: Boolean,
+    justId: Boolean
+  )(using keyCodec: KeyCodec[K]): Vector[Bytes] =
+    (Vector(keyCodec.encode(key), Bytes.utf8(group), Bytes.utf8(consumer), Bytes.utf8(TimeArgs.millis(minIdle).toString)) ++ ids.map(_.wire)) ++
+      idleArgs(idle) ++ retryCount.toVector.flatMap(n => Vector(RetryCount, Bytes.utf8(n.toString))) ++
+      (if (force) Vector(Force) else Vector.empty) ++ (if (justId) Vector(JustId) else Vector.empty)
+
+  private def autoClaimArgs[K](
+    key: K,
+    group: String,
+    consumer: String,
+    minIdle: FiniteDuration,
+    start: StreamId,
+    count: Option[Long],
+    justId: Boolean
+  )(
+    using keyCodec: KeyCodec[K]
+  ): Vector[Bytes] =
+    Vector(keyCodec.encode(key), Bytes.utf8(group), Bytes.utf8(consumer), Bytes.utf8(TimeArgs.millis(minIdle).toString), start.wire) ++
+      count.toVector.flatMap(n => Vector(Count, Bytes.utf8(n.toString))) ++ (if (justId) Vector(JustId) else Vector.empty)
+
+  private def idleArgs(idle: Option[ClaimIdle]): Vector[Bytes] =
+    idle.toVector.flatMap {
+      case ClaimIdle.Idle(duration) => Vector(Idle, Bytes.utf8(TimeArgs.millis(duration).toString))
+      case ClaimIdle.At(timestamp)  => Vector(Time, Bytes.utf8(TimeArgs.millis(timestamp).toString))
+    }
+
+  private def trimArgs(trim: Trimming): Vector[Bytes] =
+    trim match {
+      case Trimming.Exact(threshold)              => thresholdKeyword(threshold) +: Vector(Eq, thresholdValue(threshold))
+      case Trimming.Approximate(threshold, limit) =>
+        (thresholdKeyword(threshold) +: Vector(Tilde, thresholdValue(threshold))) ++ limit.toVector.flatMap(n =>
+          Vector(LimitWord, Bytes.utf8(n.toString))
+        )
+    }
+
+  private def thresholdKeyword(threshold: TrimThreshold): Bytes = threshold match {
+    case _: TrimThreshold.MaxLen => MaxLenWord; case _: TrimThreshold.MinId => MinIdWord
+  }
+  private def thresholdValue(threshold: TrimThreshold): Bytes   = threshold match {
+    case TrimThreshold.MaxLen(c) => Bytes.utf8(c.toString); case TrimThreshold.MinId(id) => id.wire
+  }
+
+  private def policyArgs(policy: StreamDeletionPolicy): Vector[Bytes] =
+    policy match {
+      case StreamDeletionPolicy.KeepRef => Vector.empty
+      case StreamDeletionPolicy.DelRef  => Vector(DelRef)
+      case StreamDeletionPolicy.Acked   => Vector(Acked)
+    }
+
+  private def streamsArgs[K, I](keysAndIds: Vector[(K, I)], leading: Vector[Bytes], idWire: I => Bytes)(
+    using keyCodec: KeyCodec[K]
+  ): (Vector[Bytes], Vector[Int]) = {
+    val keys       = keysAndIds.map { case (key, _) => keyCodec.encode(key) }
+    val ids        = keysAndIds.map { case (_, id) => idWire(id) }
+    val keyStart   = leading.length + 1 // after the leading options and the STREAMS keyword
+    val keyIndices = Vector.tabulate(keys.length)(keyStart + _)
+    ((leading :+ StreamsWord) ++ keys ++ ids, keyIndices)
+  }
+
+  private def countArg(count: Option[Long]): Vector[Bytes]           = count.toVector.flatMap(n => Vector(Count, Bytes.utf8(n.toString)))
+  private def blockArg(block: Option[BlockTimeout]): Vector[Bytes]   = block.toVector.flatMap(b => Vector(Block, BlockTimeout.millisWire(b)))
+  private def blockExecution(block: Option[BlockTimeout]): Execution = if (block.isDefined) Execution.Blocking else Execution.Ordinary
+
+  // --- token wire forms ---------------------------------------------------
+
+  private def xAddIdWire(id: XAddId): Bytes =
+    id match {
+      case XAddId.Auto          => Star
+      case XAddId.AutoSeq(ms)   => Bytes.utf8(s"$ms-*")
+      case XAddId.Explicit(sid) => sid.wire
+    }
+
+  private def rangeWire(id: StreamRangeId): Bytes =
+    id match {
+      case StreamRangeId.Min            => Dash
+      case StreamRangeId.Max            => Plus
+      case StreamRangeId.Inclusive(sid) => sid.wire
+      case StreamRangeId.Exclusive(sid) => Bytes.utf8(s"(${sid.ms}-${sid.seq}")
+    }
+
+  private def readWire(id: ReadId): Bytes =
+    id match {
+      case ReadId.New        => Dollar
+      case ReadId.LastEntry  => Plus
+      case ReadId.After(sid) => sid.wire
+    }
+
+  private def groupReadWire(id: GroupReadId): Bytes =
+    id match {
+      case GroupReadId.New        => Gt
+      case GroupReadId.After(sid) => sid.wire
+    }
+
+  private def groupStartWire(id: GroupStartId): Bytes =
+    id match {
+      case GroupStartId.Last    => Dollar
+      case GroupStartId.At(sid) => sid.wire
+    }
+
+  private def nackModeWire(mode: NackMode): Bytes =
+    mode match {
+      case NackMode.Silent => Silent
+      case NackMode.Fail   => Fail
+      case NackMode.Fatal  => Fatal
+    }
+
+  // --- decoders -----------------------------------------------------------
+
+  private[commands] val streamId: Frame => Either[DecodeError, StreamId] = {
+    case Frame.BulkString(raw)   => parseId(raw.asUtf8String)
+    case Frame.SimpleString(raw) => parseId(raw)
+    case other                   => Left(DecodeError("stream id", Frame.describe(other)))
+  }
+
+  private val streamIdElement: Frame => Either[DecodeError, StreamId] = streamId
+
+  private def parseId(text: String): Either[DecodeError, StreamId] = {
+    val dash = text.indexOf('-')
+    if (dash < 0) text.toLongOption.map(ms => StreamId(ms, 0L)).toRight(DecodeError("stream id 'ms-seq'", s"'$text'"))
+    else
+      (text.substring(0, dash).toLongOption, text.substring(dash + 1).toLongOption) match {
+        case (Some(ms), Some(seq)) => Right(StreamId(ms, seq))
+        case _                     => Left(DecodeError("stream id 'ms-seq'", s"'$text'"))
+      }
+  }
+
+  private val streamIdReply: Frame => Either[DecodeError, StreamId] = streamId
+
+  private val optionalStreamIdReply: Frame => Either[DecodeError, Option[StreamId]] = {
+    case Frame.Null => Right(None)
+    case other      => streamId(other).map(Some(_))
+  }
+
+  // an entry is `[id, [field, value, …]]`; a tombstone (claimed entry whose data was deleted) is `[id, nil]`
+  private[commands] def streamEntry[F, V](using KeyCodec[F], ValueCodec[V]): Frame => Either[DecodeError, StreamEntry[F, V]] = {
+    case Frame.Array(Vector(idFrame, fieldsFrame)) =>
+      for {
+        id     <- streamId(idFrame)
+        fields <- fieldsFrame match {
+                    case Frame.Null => Right(Vector.empty[(F, V)])
+                    case other      => Decode.flatPairs[F, V](other)
+                  }
+      } yield StreamEntry(id, fields)
+    case other                                     => Left(DecodeError("stream entry [id, fields]", Frame.describe(other)))
+  }
+
+  // XREAD/XREADGROUP reply: RESP3 map of stream-name -> entries (RESP2 array of [name, entries] pairs); null when nothing is ready
+  private def readReply[K, F, V](
+    using KeyCodec[K],
+    KeyCodec[F],
+    ValueCodec[V]
+  ): Frame => Either[DecodeError, Vector[(K, Vector[StreamEntry[F, V]])]] = {
+    val entries                                                                                          = Decode.vector(streamEntry[F, V])
+    def pair(nameFrame: Frame, entriesFrame: Frame): Either[DecodeError, (K, Vector[StreamEntry[F, V]])] =
+      for {
+        name    <- Decode.key[K](nameFrame)
+        decoded <- entries(entriesFrame)
+      } yield name -> decoded
+    frame =>
+      frame match {
+        case Frame.Null        => Right(Vector.empty)
+        case Frame.Map(rows)   => collectPairs(rows) { case (n, e) => pair(n, e) }
+        case Frame.Array(rows) =>
+          collect(rows) {
+            case Frame.Array(Vector(n, e)) => pair(n, e)
+            case other                     => Left(DecodeError("stream [name, entries] pair", Frame.describe(other)))
+          }
+        case other             => Left(DecodeError("stream read map or null", Frame.describe(other)))
+      }
+  }
+
+  private def autoClaimReply[F, V](using KeyCodec[F], ValueCodec[V]): Frame => Either[DecodeError, XAutoClaimResult[F, V]] = {
+    case Frame.Array(Vector(cursorFrame, entriesFrame, deletedFrame)) =>
+      for {
+        cursor  <- streamId(cursorFrame)
+        entries <- Decode.vector(streamEntry[F, V])(entriesFrame)
+        deleted <- Decode.vector(streamIdElement)(deletedFrame)
+      } yield XAutoClaimResult(cursor, entries, deleted)
+    // pre-7.0 omits the deleted-ids element
+    case Frame.Array(Vector(cursorFrame, entriesFrame))               =>
+      for {
+        cursor  <- streamId(cursorFrame)
+        entries <- Decode.vector(streamEntry[F, V])(entriesFrame)
+      } yield XAutoClaimResult(cursor, entries, Vector.empty)
+    case other                                                        => Left(DecodeError("xautoclaim [cursor, entries, deleted]", Frame.describe(other)))
+  }
+
+  private val autoClaimJustIdReply: Frame => Either[DecodeError, XAutoClaimJustIdResult] = {
+    case Frame.Array(Vector(cursorFrame, claimedFrame, deletedFrame)) =>
+      for {
+        cursor  <- streamId(cursorFrame)
+        claimed <- Decode.vector(streamIdElement)(claimedFrame)
+        deleted <- Decode.vector(streamIdElement)(deletedFrame)
+      } yield XAutoClaimJustIdResult(cursor, claimed, deleted)
+    case Frame.Array(Vector(cursorFrame, claimedFrame))               =>
+      for {
+        cursor  <- streamId(cursorFrame)
+        claimed <- Decode.vector(streamIdElement)(claimedFrame)
+      } yield XAutoClaimJustIdResult(cursor, claimed, Vector.empty)
+    case other                                                        => Left(DecodeError("xautoclaim justid [cursor, ids, deleted]", Frame.describe(other)))
+  }
+
+  private val deletionElement: Frame => Either[DecodeError, StreamEntryDeletion] = {
+    case Frame.Integer(-1L) => Right(StreamEntryDeletion.NotFound)
+    case Frame.Integer(1L)  => Right(StreamEntryDeletion.Deleted)
+    case Frame.Integer(2L)  => Right(StreamEntryDeletion.Retained)
+    case other              => Left(DecodeError("deletion status -1/1/2", Frame.describe(other)))
+  }
+
+  // XPENDING summary: [total, min-id, max-id, [[consumer, count], …]]; an empty group replies [0, nil, nil, nil]
+  private val pendingSummaryReply: Frame => Either[DecodeError, PendingSummary] = {
+    case Frame.Array(Vector(totalFrame, minFrame, maxFrame, consumersFrame)) =>
+      for {
+        total     <- Decode.long(totalFrame)
+        min       <- optionalId(minFrame)
+        max       <- optionalId(maxFrame)
+        consumers <- consumersFrame match {
+                       case Frame.Null        => Right(Vector.empty[(String, Long)])
+                       case Frame.Array(rows) => collect(rows)(consumerCount)
+                       case other             => Left(DecodeError("consumer counts array or null", Frame.describe(other)))
+                     }
+      } yield PendingSummary(total, min, max, consumers)
+    case other                                                               => Left(DecodeError("xpending summary", Frame.describe(other)))
+  }
+
+  private val consumerCount: Frame => Either[DecodeError, (String, Long)] = {
+    case Frame.Array(Vector(nameFrame, countFrame)) =>
+      for {
+        name  <- Decode.utf8String(nameFrame)
+        count <- countText(countFrame)
+      } yield name -> count
+    case other                                      => Left(DecodeError("[consumer, count] pair", Frame.describe(other)))
+  }
+
+  // XPENDING extended row: [id, consumer, idle-ms, delivery-count]
+  private val pendingEntryElement: Frame => Either[DecodeError, PendingEntry] = {
+    case Frame.Array(Vector(idFrame, consumerFrame, idleFrame, deliveriesFrame)) =>
+      for {
+        id         <- streamId(idFrame)
+        consumer   <- Decode.utf8String(consumerFrame)
+        idle       <- Decode.long(idleFrame)
+        deliveries <- Decode.long(deliveriesFrame)
+      } yield PendingEntry(id, consumer, FiniteDuration(idle, java.util.concurrent.TimeUnit.MILLISECONDS), deliveries)
+    case other                                                                   => Left(DecodeError("xpending entry [id, consumer, idle, count]", Frame.describe(other)))
+  }
+
+  private val optionalId: Frame => Either[DecodeError, Option[StreamId]] = {
+    case Frame.Null => Right(None)
+    case other      => streamId(other).map(Some(_))
+  }
+
+  // XPENDING per-consumer counts come back as bulk-string integers
+  private def countText(frame: Frame): Either[DecodeError, Long] =
+    frame match {
+      case Frame.Integer(value)    => Right(value)
+      case Frame.BulkString(bytes) => bytes.asUtf8String.toLongOption.toRight(DecodeError("integer", s"bulk string '${bytes.asUtf8String}'"))
+      case other                   => Left(DecodeError("integer", Frame.describe(other)))
+    }
+
+  private def collect[A](frames: Vector[Frame])(f: Frame => Either[DecodeError, A]): Either[DecodeError, Vector[A]] = {
+    val builder = Vector.newBuilder[A]
+    builder.sizeHint(frames.length)
+    val it      = frames.iterator
+    while (it.hasNext)
+      f(it.next()) match {
+        case Right(value) => builder += value
+        case Left(error)  => return Left(error)
+      }
+    Right(builder.result())
+  }
+
+  private def collectPairs[A](pairs: Vector[(Frame, Frame)])(f: (Frame, Frame) => Either[DecodeError, A]): Either[DecodeError, Vector[A]] = {
+    val builder = Vector.newBuilder[A]
+    builder.sizeHint(pairs.length)
+    val it      = pairs.iterator
+    while (it.hasNext) {
+      val (a, b) = it.next()
+      f(a, b) match {
+        case Right(value) => builder += value
+        case Left(error)  => return Left(error)
+      }
+    }
+    Right(builder.result())
+  }
+
+  private val Star         = Bytes.utf8("*")
+  private val Dash         = Bytes.utf8("-")
+  private val Plus         = Bytes.utf8("+")
+  private val Dollar       = Bytes.utf8("$")
+  private val Gt           = Bytes.utf8(">")
+  private val NoMkStream   = Bytes.utf8("NOMKSTREAM")
+  private val MaxLenWord   = Bytes.utf8("MAXLEN")
+  private val MinIdWord    = Bytes.utf8("MINID")
+  private val Eq           = Bytes.utf8("=")
+  private val Tilde        = Bytes.utf8("~")
+  private val LimitWord    = Bytes.utf8("LIMIT")
+  private val Count        = Bytes.utf8("COUNT")
+  private val Block        = Bytes.utf8("BLOCK")
+  private val StreamsWord  = Bytes.utf8("STREAMS")
+  private val Group        = Bytes.utf8("GROUP")
+  private val NoAck        = Bytes.utf8("NOACK")
+  private val MkStream     = Bytes.utf8("MKSTREAM")
+  private val EntriesRead  = Bytes.utf8("ENTRIESREAD")
+  private val EntriesAdded = Bytes.utf8("ENTRIESADDED")
+  private val MaxDeletedId = Bytes.utf8("MAXDELETEDID")
+  private val Idle         = Bytes.utf8("IDLE")
+  private val Time         = Bytes.utf8("TIME")
+  private val RetryCount   = Bytes.utf8("RETRYCOUNT")
+  private val Force        = Bytes.utf8("FORCE")
+  private val JustId       = Bytes.utf8("JUSTID")
+  private val Ids          = Bytes.utf8("IDS")
+  private val DelRef       = Bytes.utf8("DELREF")
+  private val Acked        = Bytes.utf8("ACKED")
+  private val Silent       = Bytes.utf8("SILENT")
+  private val Fail         = Bytes.utf8("FAIL")
+  private val Fatal        = Bytes.utf8("FATAL")
+}

--- a/sage-core/src/test/scala/sage/commands/CommandSamples.scala
+++ b/sage-core/src/test/scala/sage/commands/CommandSamples.scala
@@ -416,6 +416,10 @@ object CommandSamples {
     Sample(Streams.xDel("k")(StreamId(1L, 0L), StreamId(2L, 3L)), Vector("XDEL", "k", "1-0", "2-3")),
     Sample(Streams.xTrim("k", Trimming.Exact(TrimThreshold.MaxLen(5L))), Vector("XTRIM", "k", "MAXLEN", "=", "5")),
     Sample(Streams.xTrim("k", Trimming.Approximate(TrimThreshold.MinId(StreamId(7L, 0L)))), Vector("XTRIM", "k", "MINID", "~", "7-0")),
+    Sample(
+      Streams.xTrim("k", Trimming.Approximate(TrimThreshold.MaxLen(1000L), Some(100L)), StreamDeletionPolicy.DelRef),
+      Vector("XTRIM", "k", "MAXLEN", "~", "1000", "LIMIT", "100", "DELREF")
+    ),
     Sample(Streams.xSetId("k", GroupStartId.At(StreamId(5L, 0L))), Vector("XSETID", "k", "5-0")),
     Sample(Streams.xRange[String, String, String]("k"), Vector("XRANGE", "k", "-", "+")),
     Sample(

--- a/sage-core/src/test/scala/sage/commands/CommandSamples.scala
+++ b/sage-core/src/test/scala/sage/commands/CommandSamples.scala
@@ -397,6 +397,102 @@ object CommandSamples {
     Sample(HyperLogLog.pfAdd[String, String]("k"), Vector("PFADD", "k")),
     Sample(HyperLogLog.pfCount("a", "b"), Vector("PFCOUNT", "a", "b")),
     Sample(HyperLogLog.pfMerge("dst", "a", "b"), Vector("PFMERGE", "dst", "a", "b")),
-    Sample(HyperLogLog.pfMerge[String]("dst"), Vector("PFMERGE", "dst"))
+    Sample(HyperLogLog.pfMerge[String]("dst"), Vector("PFMERGE", "dst")),
+    Sample(Streams.xAdd("k")(("f", "v")), Vector("XADD", "k", "*", "f", "v")),
+    Sample(
+      Streams.xAdd(
+        "k",
+        XAddId.Explicit(StreamId(5L, 0L)),
+        Some(Trimming.Approximate(TrimThreshold.MaxLen(1000L), Some(100L))),
+        StreamDeletionPolicy.DelRef
+      )(
+        ("f", "v")
+      ),
+      Vector("XADD", "k", "DELREF", "MAXLEN", "~", "1000", "LIMIT", "100", "5-0", "f", "v")
+    ),
+    Sample(Streams.xAdd("k", XAddId.AutoSeq(5L))(("f", "v")), Vector("XADD", "k", "5-*", "f", "v")),
+    Sample(Streams.xAddNoMkStream("k")(("f", "v")), Vector("XADD", "k", "NOMKSTREAM", "*", "f", "v")),
+    Sample(Streams.xLen("k"), Vector("XLEN", "k")),
+    Sample(Streams.xDel("k")(StreamId(1L, 0L), StreamId(2L, 3L)), Vector("XDEL", "k", "1-0", "2-3")),
+    Sample(Streams.xTrim("k", Trimming.Exact(TrimThreshold.MaxLen(5L))), Vector("XTRIM", "k", "MAXLEN", "=", "5")),
+    Sample(Streams.xTrim("k", Trimming.Approximate(TrimThreshold.MinId(StreamId(7L, 0L)))), Vector("XTRIM", "k", "MINID", "~", "7-0")),
+    Sample(Streams.xSetId("k", GroupStartId.At(StreamId(5L, 0L))), Vector("XSETID", "k", "5-0")),
+    Sample(Streams.xRange[String, String, String]("k"), Vector("XRANGE", "k", "-", "+")),
+    Sample(
+      Streams.xRange[String, String, String]("k", StreamRangeId.Inclusive(StreamId(1L, 0L)), StreamRangeId.Exclusive(StreamId(9L, 0L)), Some(10L)),
+      Vector("XRANGE", "k", "1-0", "(9-0", "COUNT", "10")
+    ),
+    Sample(Streams.xRevRange[String, String, String]("k"), Vector("XREVRANGE", "k", "+", "-")),
+    Sample(Streams.xRead[String, String, String](("k", ReadId.New))(), Vector("XREAD", "STREAMS", "k", "$")),
+    Sample(
+      Streams.xRead[String, String, String](("k", ReadId.After(StreamId(0L, 0L))))(count = Some(5L), block = Some(BlockTimeout.After(1.second))),
+      Vector("XREAD", "COUNT", "5", "BLOCK", "1000", "STREAMS", "k", "0-0")
+    ),
+    Sample(
+      Streams.xReadGroup[String, String, String]("g", "c")(("k", GroupReadId.New))(),
+      Vector("XREADGROUP", "GROUP", "g", "c", "STREAMS", "k", ">")
+    ),
+    Sample(
+      Streams.xReadGroup[String, String, String]("g", "c")(("k", GroupReadId.New))(
+        count = Some(5L),
+        block = Some(BlockTimeout.After(1.second)),
+        noAck = true
+      ),
+      Vector("XREADGROUP", "GROUP", "g", "c", "COUNT", "5", "BLOCK", "1000", "NOACK", "STREAMS", "k", ">")
+    ),
+    Sample(Streams.xAck("k", "g")(StreamId(1L, 0L)), Vector("XACK", "k", "g", "1-0")),
+    Sample(Streams.xGroupCreate("k", "g"), Vector("XGROUP", "CREATE", "k", "g", "$")),
+    Sample(
+      Streams.xGroupCreate("k", "g", GroupStartId.At(StreamId(0L, 0L)), mkStream = true, entriesRead = Some(7L)),
+      Vector("XGROUP", "CREATE", "k", "g", "0-0", "MKSTREAM", "ENTRIESREAD", "7")
+    ),
+    Sample(Streams.xGroupSetId("k", "g"), Vector("XGROUP", "SETID", "k", "g", "$")),
+    Sample(Streams.xGroupDestroy("k", "g"), Vector("XGROUP", "DESTROY", "k", "g")),
+    Sample(Streams.xGroupCreateConsumer("k", "g", "c"), Vector("XGROUP", "CREATECONSUMER", "k", "g", "c")),
+    Sample(Streams.xGroupDelConsumer("k", "g", "c"), Vector("XGROUP", "DELCONSUMER", "k", "g", "c")),
+    Sample(Streams.xClaim[String, String, String]("k", "g", "c", 5.seconds)(StreamId(1L, 0L))(), Vector("XCLAIM", "k", "g", "c", "5000", "1-0")),
+    Sample(
+      Streams.xClaim[String, String, String]("k", "g", "c", 5.seconds)(StreamId(1L, 0L))(
+        idle = Some(ClaimIdle.Idle(2.seconds)),
+        retryCount = Some(3L),
+        force = true
+      ),
+      Vector("XCLAIM", "k", "g", "c", "5000", "1-0", "IDLE", "2000", "RETRYCOUNT", "3", "FORCE")
+    ),
+    Sample(Streams.xClaimJustId("k", "g", "c", 5.seconds)(StreamId(1L, 0L))(), Vector("XCLAIM", "k", "g", "c", "5000", "1-0", "JUSTID")),
+    Sample(Streams.xAutoClaim[String, String, String]("k", "g", "c", 5.seconds), Vector("XAUTOCLAIM", "k", "g", "c", "5000", "0-0")),
+    Sample(
+      Streams.xAutoClaimJustId("k", "g", "c", 5.seconds, StreamId(0L, 0L), Some(50L)),
+      Vector("XAUTOCLAIM", "k", "g", "c", "5000", "0-0", "COUNT", "50", "JUSTID")
+    ),
+    Sample(Streams.xPending("k", "g"), Vector("XPENDING", "k", "g")),
+    Sample(Streams.xPendingExtended("k", "g"), Vector("XPENDING", "k", "g", "-", "+", "10")),
+    Sample(
+      Streams.xPendingExtended(
+        "k",
+        "g",
+        StreamRangeId.Inclusive(StreamId(1L, 0L)),
+        StreamRangeId.Exclusive(StreamId(9L, 0L)),
+        5L,
+        Some("c"),
+        Some(1.second)
+      ),
+      Vector("XPENDING", "k", "g", "IDLE", "1000", "1-0", "(9-0", "5", "c")
+    ),
+    Sample(StreamInfo.xInfoStream[String, String, String]("k"), Vector("XINFO", "STREAM", "k")),
+    Sample(StreamInfo.xInfoStreamFull[String, String, String]("k", Some(10L)), Vector("XINFO", "STREAM", "k", "FULL", "COUNT", "10")),
+    Sample(StreamInfo.xInfoGroups("k"), Vector("XINFO", "GROUPS", "k")),
+    Sample(StreamInfo.xInfoConsumers("k", "g"), Vector("XINFO", "CONSUMERS", "k", "g")),
+    Sample(Streams.xDelEx("k")(StreamId(1L, 0L)), Vector("XDELEX", "k", "IDS", "1", "1-0")),
+    Sample(
+      Streams.xDelEx("k", StreamDeletionPolicy.Acked)(StreamId(1L, 0L), StreamId(2L, 0L)),
+      Vector("XDELEX", "k", "ACKED", "IDS", "2", "1-0", "2-0")
+    ),
+    Sample(Streams.xAckDel("k", "g")(StreamId(1L, 0L)), Vector("XACKDEL", "k", "g", "IDS", "1", "1-0")),
+    Sample(Streams.xNack("k", "g", NackMode.Fail)(StreamId(1L, 0L))(), Vector("XNACK", "k", "g", "FAIL", "IDS", "1", "1-0")),
+    Sample(
+      Streams.xNack("k", "g", NackMode.Fatal)(StreamId(1L, 0L))(retryCount = Some(2L), force = true),
+      Vector("XNACK", "k", "g", "FATAL", "IDS", "1", "1-0", "RETRYCOUNT", "2", "FORCE")
+    )
   )
 }

--- a/sage-core/src/test/scala/sage/commands/StreamsSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/StreamsSpec.scala
@@ -1,0 +1,158 @@
+package sage.commands
+
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.FiniteDuration
+
+import sage.Bytes
+import sage.protocol.Frame
+
+class StreamsSpec extends munit.FunSuite {
+
+  private def bulk(value: String): Frame                = Frame.BulkString(Bytes.utf8(value))
+  private def entry(id: String, fields: String*): Frame = Frame.Array(Vector(bulk(id), Frame.Array(fields.toVector.map(bulk))))
+
+  test("XADD decodes the generated id; NOMKSTREAM decodes null as None") {
+    assertEquals(Reply.run(Streams.xAdd("k")(("f", "v")), bulk("1526919030474-55")), Right(StreamId(1526919030474L, 55L)))
+    assertEquals(Reply.run(Streams.xAddNoMkStream("k")(("f", "v")), Frame.Null), Right(None))
+    assertEquals(Reply.run(Streams.xAddNoMkStream("k")(("f", "v")), bulk("5-0")), Right(Some(StreamId(5L, 0L))))
+  }
+
+  test("XRANGE decodes entries, preserving field order and a missing-stream null as empty? (present array)") {
+    val reply = Frame.Array(Vector(entry("1-0", "a", "1", "b", "2"), entry("2-0", "c", "3")))
+    assertEquals(
+      Reply.run(Streams.xRange[String, String, String]("k"), reply),
+      Right(Vector(StreamEntry(StreamId(1L, 0L), Vector("a" -> "1", "b" -> "2")), StreamEntry(StreamId(2L, 0L), Vector("c" -> "3"))))
+    )
+  }
+
+  test("XREAD decodes a RESP3 map of stream -> entries, and null/timeout as an empty vector") {
+    val reply = Frame.Map(Vector(bulk("s1") -> Frame.Array(Vector(entry("1-0", "f", "v")))))
+    assertEquals(
+      Reply.run(Streams.xRead[String, String, String](("s1", ReadId.New))(), reply),
+      Right(Vector("s1" -> Vector(StreamEntry(StreamId(1L, 0L), Vector("f" -> "v")))))
+    )
+    assertEquals(Reply.run(Streams.xRead[String, String, String](("s1", ReadId.New))(), Frame.Null), Right(Vector.empty))
+  }
+
+  test("XREAD also accepts the RESP2 array-of-pairs shape") {
+    val reply = Frame.Array(Vector(Frame.Array(Vector(bulk("s1"), Frame.Array(Vector(entry("1-0", "f", "v")))))))
+    assertEquals(
+      Reply.run(Streams.xRead[String, String, String](("s1", ReadId.New))(), reply),
+      Right(Vector("s1" -> Vector(StreamEntry(StreamId(1L, 0L), Vector("f" -> "v")))))
+    )
+  }
+
+  test("XAUTOCLAIM decodes the cursor/entries/deleted triple and the pre-7.0 two-element form") {
+    val three = Frame.Array(Vector(bulk("5-0"), Frame.Array(Vector(entry("1-0", "f", "v"))), Frame.Array(Vector(bulk("2-0")))))
+    assertEquals(
+      Reply.run(Streams.xAutoClaim[String, String, String]("k", "g", "c", FiniteDuration(1, TimeUnit.SECONDS)), three),
+      Right(XAutoClaimResult(StreamId(5L, 0L), Vector(StreamEntry(StreamId(1L, 0L), Vector("f" -> "v"))), Vector(StreamId(2L, 0L))))
+    )
+    val two   = Frame.Array(Vector(bulk("0-0"), Frame.Array(Vector(entry("1-0", "f", "v")))))
+    assertEquals(
+      Reply.run(Streams.xAutoClaim[String, String, String]("k", "g", "c", FiniteDuration(1, TimeUnit.SECONDS)), two),
+      Right(XAutoClaimResult(StreamId(0L, 0L), Vector(StreamEntry(StreamId(1L, 0L), Vector("f" -> "v"))), Vector.empty))
+    )
+  }
+
+  test("XAUTOCLAIM tolerates a tombstone entry [id, nil] as an entry with no fields") {
+    val reply = Frame.Array(Vector(bulk("0-0"), Frame.Array(Vector(Frame.Array(Vector(bulk("1-0"), Frame.Null)))), Frame.Array(Vector.empty)))
+    assertEquals(
+      Reply.run(Streams.xAutoClaim[String, String, String]("k", "g", "c", FiniteDuration(1, TimeUnit.SECONDS)), reply),
+      Right(XAutoClaimResult(StreamId(0L, 0L), Vector(StreamEntry(StreamId(1L, 0L), Vector.empty)), Vector.empty))
+    )
+  }
+
+  test("XPENDING summary decodes the populated form and the empty group") {
+    val populated = Frame.Array(
+      Vector(
+        Frame.Integer(2L),
+        bulk("1-0"),
+        bulk("9-0"),
+        Frame.Array(Vector(Frame.Array(Vector(bulk("c1"), bulk("1"))), Frame.Array(Vector(bulk("c2"), bulk("1")))))
+      )
+    )
+    assertEquals(
+      Reply.run(Streams.xPending("k", "g"), populated),
+      Right(PendingSummary(2L, Some(StreamId(1L, 0L)), Some(StreamId(9L, 0L)), Vector("c1" -> 1L, "c2" -> 1L)))
+    )
+    val empty     = Frame.Array(Vector(Frame.Integer(0L), Frame.Null, Frame.Null, Frame.Null))
+    assertEquals(Reply.run(Streams.xPending("k", "g"), empty), Right(PendingSummary(0L, None, None, Vector.empty)))
+  }
+
+  test("XPENDING extended decodes a row with its idle time and delivery count") {
+    val reply = Frame.Array(Vector(Frame.Array(Vector(bulk("1-0"), bulk("c1"), Frame.Integer(5000L), Frame.Integer(3L)))))
+    assertEquals(
+      Reply.run(Streams.xPendingExtended("k", "g"), reply),
+      Right(Vector(PendingEntry(StreamId(1L, 0L), "c1", FiniteDuration(5000L, TimeUnit.MILLISECONDS), 3L)))
+    )
+  }
+
+  test("XDELEX decodes the per-id deletion status") {
+    val reply = Frame.Array(Vector(Frame.Integer(1L), Frame.Integer(-1L), Frame.Integer(2L)))
+    assertEquals(
+      Reply.run(Streams.xDelEx("k")(StreamId(1L, 0L), StreamId(2L, 0L), StreamId(3L, 0L)), reply),
+      Right(Vector(StreamEntryDeletion.Deleted, StreamEntryDeletion.NotFound, StreamEntryDeletion.Retained))
+    )
+  }
+
+  test("XINFO STREAM decodes leniently: 7.0 fields present, and absent as None") {
+    val withNew = Frame.Map(
+      Vector(
+        bulk("length")                  -> Frame.Integer(2L),
+        bulk("radix-tree-keys")         -> Frame.Integer(1L),
+        bulk("radix-tree-nodes")        -> Frame.Integer(2L),
+        bulk("last-generated-id")       -> bulk("5-0"),
+        bulk("max-deleted-entry-id")    -> bulk("3-0"),
+        bulk("entries-added")           -> Frame.Integer(7L),
+        bulk("recorded-first-entry-id") -> bulk("1-0"),
+        bulk("groups")                  -> Frame.Integer(1L),
+        bulk("first-entry")             -> entry("1-0", "f", "v"),
+        bulk("last-entry")              -> entry("5-0", "g", "w")
+      )
+    )
+    val info    = Reply.run(StreamInfo.xInfoStream[String, String, String]("k"), withNew).toOption.get
+    assertEquals(info.length, 2L)
+    assertEquals(info.entriesAdded, Some(7L))
+    assertEquals(info.maxDeletedEntryId, Some(StreamId(3L, 0L)))
+    assertEquals(info.firstEntry, Some(StreamEntry(StreamId(1L, 0L), Vector("f" -> "v"))))
+
+    val legacy = Frame.Map(
+      Vector(
+        bulk("length")            -> Frame.Integer(0L),
+        bulk("radix-tree-keys")   -> Frame.Integer(0L),
+        bulk("radix-tree-nodes")  -> Frame.Integer(1L),
+        bulk("last-generated-id") -> bulk("0-0"),
+        bulk("groups")            -> Frame.Integer(0L),
+        bulk("first-entry")       -> Frame.Null,
+        bulk("last-entry")        -> Frame.Null
+      )
+    )
+    val old    = Reply.run(StreamInfo.xInfoStream[String, String, String]("k"), legacy).toOption.get
+    assertEquals(old.entriesAdded, None)
+    assertEquals(old.maxDeletedEntryId, None)
+    assertEquals(old.firstEntry, None)
+  }
+
+  test("XINFO GROUPS decodes entries-read/lag as optional, tolerating a null lag") {
+    val reply = Frame.Array(
+      Vector(
+        Frame.Map(
+          Vector(
+            bulk("name")              -> bulk("g1"),
+            bulk("consumers")         -> Frame.Integer(2L),
+            bulk("pending")           -> Frame.Integer(3L),
+            bulk("last-delivered-id") -> bulk("5-0"),
+            bulk("entries-read")      -> Frame.Integer(5L),
+            bulk("lag")               -> Frame.Null
+          )
+        )
+      )
+    )
+    assertEquals(
+      Reply.run(StreamInfo.xInfoGroups("k"), reply),
+      Right(Vector(GroupInfo("g1", 2L, 3L, StreamId(5L, 0L), Some(5L), None)))
+    )
+  }
+}

--- a/sage-core/src/test/scala/sage/commands/StreamsSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/StreamsSpec.scala
@@ -155,4 +155,34 @@ class StreamsSpec extends munit.FunSuite {
       Right(Vector(GroupInfo("g1", 2L, 3L, StreamId(5L, 0L), Some(5L), None)))
     )
   }
+
+  test("XINFO STREAM FULL decodes the 4-element group PEL row and the 3-element consumer PEL row") {
+    val groupPel    = Frame.Array(Vector(Frame.Array(Vector(bulk("1-0"), bulk("c1"), Frame.Integer(1000L), Frame.Integer(2L)))))
+    val consumerPel = Frame.Array(Vector(Frame.Array(Vector(bulk("1-0"), Frame.Integer(1000L), Frame.Integer(2L)))))
+    val consumer    = Frame.Map(Vector(bulk("name") -> bulk("c1"), bulk("pel-count") -> Frame.Integer(1L), bulk("pending") -> consumerPel))
+    val group       = Frame.Map(
+      Vector(
+        bulk("name")              -> bulk("g1"),
+        bulk("last-delivered-id") -> bulk("1-0"),
+        bulk("pel-count")         -> Frame.Integer(1L),
+        bulk("pending")           -> groupPel,
+        bulk("consumers")         -> Frame.Array(Vector(consumer))
+      )
+    )
+    val reply       = Frame.Map(
+      Vector(
+        bulk("length")            -> Frame.Integer(1L),
+        bulk("radix-tree-keys")   -> Frame.Integer(1L),
+        bulk("radix-tree-nodes")  -> Frame.Integer(2L),
+        bulk("last-generated-id") -> bulk("1-0"),
+        bulk("entries")           -> Frame.Array(Vector(entry("1-0", "f", "v"))),
+        bulk("groups")            -> Frame.Array(Vector(group))
+      )
+    )
+    val full        = Reply.run(StreamInfo.xInfoStreamFull[String, String, String]("k"), reply).toOption.get
+    assertEquals(full.entries.map(_.id), Vector(StreamId(1L, 0L)))
+    val g           = full.groups.head
+    assertEquals(g.pending, Vector(FullPendingEntry(StreamId(1L, 0L), Some("c1"), java.time.Instant.ofEpochMilli(1000L), 2L)))
+    assertEquals(g.consumers.head.pending, Vector(FullPendingEntry(StreamId(1L, 0L), None, java.time.Instant.ofEpochMilli(1000L), 2L)))
+  }
 }


### PR DESCRIPTION
Closes #14.

Implements the full stream command family following the established family pattern (ADR-0011), plus per-backend stream sugar. Design was locked in a prior grilling session; ADR-0031 (per-position Stream Entry ID types) and ADR-0032 (consumer tailing stream semantics) already landed on `main`.

## Core — `sage.commands.Streams` / `StreamInfo`

- **Per-position Stream Entry ID types** — `XAddId`, `StreamRangeId`, `ReadId`, `GroupReadId`, `GroupStartId` over the concrete `StreamId(ms, seq)`, so an illegal token at a position (e.g. `>` to `XADD`, `(` to `XREAD`) can't be written. See ADR-0031.
- **`StreamEntry[F, V]`** with an ordered `Vector` body (never a `Map` — preserves field order/duplicates). Group/consumer names are plain `String`.
- Shared domain primitives: `Trimming` (`Exact`/`Approximate(limit)` over `MaxLen`/`MinId`), `StreamDeletionPolicy` (`KeepRef`/`DelRef`/`Acked`), `NackMode`.
- Builders: `xAdd` (+ `xAddNoMkStream` split per ADR-0011), `xLen`, `xDel`, `xRange`/`xRevRange`, `xTrim`, `xSetId`, `xAck`, `xRead`/`xReadGroup` (a `block: Option[BlockTimeout]` flips `Execution.Blocking` so blocking reads route through the Dedicated pool), the `XGROUP` subcommands, `xClaim`/`xClaimJustId`, `xAutoClaim`/`xAutoClaimJustId`, `xPending`/`xPendingExtended`, and all four `XINFO` views (`xInfoStream`/`xInfoStreamFull`/`xInfoGroups`/`xInfoConsumers`) with **lenient field-presence decoding** (ADR-0024).
- **Redis-only** `xDelEx`/`xAckDel` (8.2) and `xNack` (8.8) via single-server suites (ADR-0026); `KEEPREF`/`DELREF`/`ACKED` also on `xAdd`/`xTrim`.
- `BlockTimeout.millisWire` — stream `BLOCK` is **milliseconds**, not the seconds form `BLPOP`/`BZPOPMIN` use (would otherwise shorten the wait 1000×).

## Client sugar

- Per-command methods on `CommandRunner` (delegating to `run`).
- Per-backend (zio/ce/ox/kyo) `xRangeAll` (lazy `XRANGE` pagination via the exclusive-`(` cursor, mirroring `scanAll`) and `xConsume` (handler-based consumer that **auto-acks only after the handler succeeds** — at-least-once — and drains its own PEL on startup before tailing; ADR-0032).

## Tests

- `StreamsSpec` (decoder unit tests) and `CommandSamples` wire goldens (312 samples pass).
- Cross-server `StreamsSuite` (Redis + Valkey) incl. **the blocking-`XREAD`-doesn't-stall-ordinary-commands** acceptance case; Redis-only `RedisStreamExtrasSuite`; zio smoke coverage of `xRangeAll`/`xConsume`.
- **Coverage spec partition is exact** against `redis:8.8.0` and `valkey:9.1.0` (redis 187 implemented / 169 todo / 63 skipped). `XGROUP`/`XINFO` containers + `HELP` and the internal `XIDMPRECORD` are `skipped`; `XCFGSET` stays `todo`.

All four backends and test cells compile; `core/test` (523) and the stream integration suites are green.