### PR TITLE
Listener SPI: observability events (#26)

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
+++ b/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
@@ -5,6 +5,8 @@ import javax.net.ssl.SSLContext
 
 import scala.concurrent.duration.*
 
+import sage.SageListener
+
 /**
   * Exponential reconnect backoff with full jitter (a random wait in `[0, base]`), spreading the reconnect storm across clients.
   */
@@ -115,5 +117,6 @@ final case class SageConfig(
   clientCache: CacheConfig = CacheConfig(),
   auth: Option[AuthConfig] = None,
   tls: Option[TlsConfig] = None,
-  topology: Topology = Topology.Standalone
+  topology: Topology = Topology.Standalone,
+  listeners: Vector[SageListener] = Vector.empty
 )

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -5,13 +5,13 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 import javax.net.ssl.SSLException
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
 import kyo.compat.*
 
-import sage.{Bytes, Message, PatternMessage, SageException}
+import sage.{Bytes, Message, Outcome, PatternMessage, SageEvent, SageException}
 import sage.SageException.{ConnectionLost, NotCacheable, NotConnected, ServerError, TimedOut, TlsError, UnsupportedServer}
 import sage.client.{AuthConfig, BackoffConfig, DedicatedPoolConfig, PubSubConfig, SageConfig, Topology, WatchdogConfig}
 import sage.cluster.Node
@@ -1074,7 +1074,8 @@ object Client {
         config.pubsub,
         config.auth,
         config.clientCache.maxBytes,
-        config.clientCache.enabled
+        config.clientCache.enabled,
+        Events(config.listeners)
       )
     }
 
@@ -1090,7 +1091,8 @@ object Client {
     pubsub: PubSubConfig = defaults.pubsub,
     auth: Option[AuthConfig] = None,
     cacheMaxBytes: Long = defaults.clientCache.maxBytes,
-    cachingEnabled: Boolean = defaults.clientCache.enabled
+    cachingEnabled: Boolean = defaults.clientCache.enabled,
+    events: Events = Events.disabled
   ): CIO[Client[CIO]] = {
     val bootstrap            = Vector(Connection.hello(auth.map(a => a.username -> a.password)))
     // only the Multiplexed Connection caches reads, so only it enables tracking; the dedicated pool and subscription connection keep the
@@ -1098,7 +1100,8 @@ object Client {
     val multiplexedBootstrap = if (cachingEnabled) bootstrap :+ Connection.clientTrackingOnOptin else bootstrap
     CIO
       .blocking(
-        MultiplexedConnection.connect(factory, scheduler, multiplexedBootstrap, reconnect, watchdog, connectTimeout, closeTimeout, cacheMaxBytes)
+        MultiplexedConnection
+          .connect(factory, scheduler, multiplexedBootstrap, reconnect, watchdog, connectTimeout, closeTimeout, cacheMaxBytes, None, events)
       )
       .map { connection =>
         val pool          = DedicatedPool.forConnection(factory, bootstrap, scheduler, connection, dedicatedPool, connectTimeout.toMillis)
@@ -1113,9 +1116,9 @@ object Client {
           pubsub.bufferSize,
           () => connection.isLive
         )
-        new Live(connection, pool, subscriptions, cachingEnabled)
+        new Live(connection, pool, subscriptions, cachingEnabled, events)
       }
-      .mapError(translateHandshake)
+      .mapError { error => events.close(); translateHandshake(error) }
   }
 
   // pre-6.0 Redis answers HELLO with an unknown-command error; newer servers reject an unsupported protocol version with NOPROTO. A
@@ -1134,13 +1137,14 @@ object Client {
     connection: MultiplexedConnection,
     pool: DedicatedPool,
     subscriptions: SubscriptionConnection,
-    cachingEnabled: Boolean
+    cachingEnabled: Boolean,
+    events: Events
   ) extends Client[CIO] {
 
     def run[A](command: Command[A]): CIO[A] =
       command.execution match {
-        case Execution.Ordinary => CIO.async(callback => connection.submit(command, callback))
-        case Execution.Blocking => CIO.async(callback => pool.use(command, callback))
+        case Execution.Ordinary => CIO.async(callback => connection.submit(command, Events.trackCommand(events, command, callback)))
+        case Execution.Blocking => CIO.async(callback => pool.use(command, Events.trackCommand(events, command, callback)))
       }
 
     def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =
@@ -1185,8 +1189,15 @@ object Client {
       else
         CIO.async { complete =>
           val collector = new TxSupport.IndexedCollector[Either[SageException, Any]](p.commands.length, complete)
-          val callbacks = Vector.tabulate(p.commands.length)(i => (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)))
-          if (!connection.submitAll(p.commands, callbacks)) complete(Failure(NotConnected()))
+          val callbacks = Vector.tabulate(p.commands.length)(i =>
+            Events.trackCommand[Any](events, p.commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)))
+          )
+          if (!connection.submitAll(p.commands, callbacks)) {
+            // not connected: still fail fast with one error, but report a failed completion per position (as a single disconnected run does)
+            if (events.enabled)
+              p.commands.foreach(c => events.emit(SageEvent.CommandCompleted(c.name, None, Duration.Zero, Outcome.Failed(NotConnected()))))
+            complete(Failure(NotConnected()))
+          }
         }
 
     def subscribeChannels[V: ValueCodec](channel: String, rest: String*): CIO[Subscription[CIO, Message[V]]] =
@@ -1199,7 +1210,7 @@ object Client {
     def subscribeShardChannels[V: ValueCodec](channel: String, rest: String*): CIO[Subscription[CIO, Message[V]]] =
       CIO.blocking(channelMessages(subscriptions.subscribeShard(channel +: rest.toVector)))
 
-    def close: CIO[Unit] = CIO.blocking { subscriptions.close(); pool.close(); connection.close() }
+    def close: CIO[Unit] = CIO.blocking { subscriptions.close(); pool.close(); connection.close(); events.close() }
   }
 
   // wrap a raw subscription as the effect-typed seam each backend lowers into its native stream; a channel/shard delivery is a Message

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -11,7 +11,7 @@ import scala.util.control.NonFatal
 
 import kyo.compat.*
 
-import sage.{Message, PatternMessage, SageException}
+import sage.{Message, PatternMessage, SageEvent, SageException}
 import sage.SageException.{ConnectionLost, CrossSlot, NotConnected, ServerError}
 import sage.client.{BackoffConfig, ClusterConfig, DedicatedPoolConfig, SageConfig, WatchdogConfig}
 import sage.cluster.{ClusterTopology, Node, NodeGroup, Redirect, RedirectKind, Rejected, Route, Shard, Slot}
@@ -41,7 +41,8 @@ final private[client] class ClusterLive(
   dedicatedPool: DedicatedPoolConfig,
   cluster: ClusterConfig,
   pubsubBufferSize: Int,
-  seeds: Vector[Node]
+  seeds: Vector[Node],
+  events: Events = Events.disabled
 ) extends Client[CIO] {
 
   private val topologyRef = new AtomicReference[ClusterTopology](ClusterTopology.from(Vector.empty))
@@ -98,7 +99,7 @@ final private[client] class ClusterLive(
   }
 
   def run[A](command: Command[A]): CIO[A] =
-    CIO.async[A](complete => offload(dispatch(command, cluster.maxRedirects, complete)))
+    CIO.async[A](complete => offload(dispatch(command, cluster.maxRedirects, Events.trackCommand(events, command, complete))))
 
   // client-side caching in cluster mode (per-node tracking through redirects/failover) is a follow-up; for now a cached read runs without
   // caching so the same call stays portable between standalone and cluster. The cacheability guard still applies, matching standalone.
@@ -120,7 +121,8 @@ final private[client] class ClusterLive(
   // rather than rerouting to an arbitrary master (which would resume a node-local cursor on the wrong keyspace)
   def runOn[A](target: ScanTarget, command: Command[A]): CIO[A] =
     target.node match {
-      case Some(node) => CIO.async[A](complete => offload(sendTo(node, command, asking = false, redirectsLeft = 0, complete)))
+      case Some(node) =>
+        CIO.async[A](complete => offload(sendTo(node, command, asking = false, redirectsLeft = 0, Events.trackCommand(events, command, complete))))
       case None       => run(command)
     }
 
@@ -205,7 +207,7 @@ final private[client] class ClusterLive(
         command,
         asking,
         {
-          case Success(value) => complete(Success(value))
+          case Success(value) => Events.attributeNode(complete, node); complete(Success(value))
           case Failure(error) => offload(onFailure(node, command, error, redirectsLeft, complete))
         }
       )
@@ -219,8 +221,9 @@ final private[client] class ClusterLive(
           case ServerError(message) => onRedirect(node, Redirect.parse(message).get, command, redirectsLeft, complete)
           case _                    => onUnreachable(command, redirectsLeft, complete)
         }
-      case ClusterLive.Disposition.RefreshThenTerminal => triggerRefresh(); complete(Failure(error))
-      case ClusterLive.Disposition.Terminal            => complete(Failure(error))
+      case ClusterLive.Disposition.RefreshThenTerminal =>
+        triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error))
+      case ClusterLive.Disposition.Terminal            => Events.attributeNode(complete, node); complete(Failure(error))
     }
 
   // The single failure taxonomy a routed command can meet, shared by single-command [[onFailure]] and a Pipeline batch's per-position
@@ -312,11 +315,13 @@ final private[client] class ClusterLive(
   // A per-command CrossSlot fails only its own slot; a position a stale topology can't resolve (redirect, unreachable node, Unowned) falls
   // back to per-command dispatch. The countdown completes the effect once every position has landed terminally — once, never on a redirect.
   private def runPipeline[Out, R](p: Pipeline[Out, R], complete: Try[Vector[Either[SageException, Any]]] => Unit): Unit = {
-    val n                                                             = p.commands.length
-    val collector                                                     = new TxSupport.IndexedCollector[Either[SageException, Any]](n, complete)
-    def finish(index: Int, outcome: Either[SageException, Any]): Unit = collector.set(index, outcome)
-    def reroute(index: Int): Unit                                     =
-      offload(dispatch(p.commands(index), cluster.maxRedirects, result => finish(index, TxSupport.toEither(result))))
+    val n                         = p.commands.length
+    val collector                 = new TxSupport.IndexedCollector[Either[SageException, Any]](n, complete)
+    // one tracking callback per position: the terminal completion for that command, emitting CommandCompleted with the node the routing
+    // layer attributes onto it (set in sendBatch for the batch path, or by dispatch->sendTo for a rerouted position)
+    val emits                     =
+      Vector.tabulate(n)(i => Events.trackCommand[Any](events, p.commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result))))
+    def reroute(index: Int): Unit = offload(dispatch(p.commands(index), cluster.maxRedirects, emits(index)))
 
     val plan = topologyRef.get().split(p)
     // a malformed command is a programmer error: split is the single source of that classification (the standalone client has no slots and
@@ -326,7 +331,7 @@ final private[client] class ClusterLive(
       case None        => ()
     }
     plan.rejected.foreach {
-      case (index, Rejected.CrossSlot(slots)) => finish(index, Left(crossSlot(p.commands(index).name, slots)))
+      case (index, Rejected.CrossSlot(slots)) => emits(index)(Failure(crossSlot(p.commands(index).name, slots)))
       case (index, Rejected.Unowned(_))       => reroute(index) // dispatch refreshes then re-routes
       case (_, Rejected.Malformed)            => ()             // unreachable: the guard above returned
     }
@@ -334,7 +339,7 @@ final private[client] class ClusterLive(
     if (plan.perNode.isEmpty) plan.keyless.foreach(reroute)
     plan.perNode.zipWithIndex.foreach { case (NodeGroup(node, positions), groupIndex) =>
       // sorted: keep each node's batch in submission order even when keyless positions are folded into the first group
-      sendBatch(node, if (groupIndex == 0) (positions ++ plan.keyless).sorted else positions, p, finish, reroute)
+      sendBatch(node, if (groupIndex == 0) (positions ++ plan.keyless).sorted else positions, p, emits, reroute)
     }
   }
 
@@ -342,21 +347,22 @@ final private[client] class ClusterLive(
     node: Node,
     indices: Vector[Int],
     p: Pipeline[Out, R],
-    finish: (Int, Either[SageException, Any]) => Unit,
+    emits: Vector[Try[Any] => Unit],
     reroute: Int => Unit
   ): Unit = {
-    val callbacks: Vector[Try[Any] => Unit] = indices.map { index => (result: Try[Any]) =>
+    def settle(index: Int, result: Try[Any]): Unit = { Events.attributeNode(emits(index), node); emits(index)(result) }
+    val callbacks: Vector[Try[Any] => Unit]        = indices.map { index => (result: Try[Any]) =>
       result match {
-        case Success(value) => finish(index, Right(value))
+        case Success(_)     => settle(index, result)
         case Failure(error) =>
           classify(error) match {
             case ClusterLive.Disposition.Reroute             => reroute(index)
-            case ClusterLive.Disposition.RefreshThenTerminal => triggerRefresh(); finish(index, TxSupport.toEither(result))
-            case ClusterLive.Disposition.Terminal            => finish(index, TxSupport.toEither(result))
+            case ClusterLive.Disposition.RefreshThenTerminal => triggerRefresh(); settle(index, result)
+            case ClusterLive.Disposition.Terminal            => settle(index, result)
           }
       }
     }
-    val nc                                  =
+    val nc                                         =
       try getOrEstablish(node)
       catch { case NonFatal(_) => null }
     // node unreachable, or not connected when the batch reached it: nothing was sent, so re-route every position individually
@@ -590,7 +596,19 @@ final private[client] class ClusterLive(
     else if (waitOn != null) waitOn.get()
     else
       try {
-        val nc    = NodeClient.connect(nodeFactory(node), scheduler, bootstrap, reconnect, watchdog, connectTimeout, closeTimeout, dedicatedPool)
+        val nc    =
+          NodeClient.connect(
+            nodeFactory(node),
+            scheduler,
+            bootstrap,
+            reconnect,
+            watchdog,
+            connectTimeout,
+            closeTimeout,
+            dedicatedPool,
+            Some(node),
+            events
+          )
         // re-check under the lock: a close that landed during the blocking connect must not re-publish this bundle into a closed client
         val stale = lockedNodes { pendingEstablish.remove(node); if (closed) true else { established.put(node, nc); false } }
         if (stale) { nc.close(); throw NotConnected() }
@@ -653,10 +671,18 @@ final private[client] class ClusterLive(
   // installs a fresh topology and prunes bundles for masters it no longer lists, so a vanished node's reconnect loop cannot leak. An empty
   // announce-IP from CLUSTER SLOTS means "the node I queried", so substitute `from` the same way redirects do
   private def adopt(from: Node, shards: Vector[Shard]): Unit = {
-    val resolved = shards.map(shard => shard.copy(master = resolve(shard.master, from), replicas = shard.replicas.map(resolve(_, from))))
-    topologyRef.set(ClusterTopology.from(resolved))
-    val masters  = resolved.map(_.master).toSet
-    val gone     = lockedNodes {
+    val resolved    = shards.map(shard => shard.copy(master = resolve(shard.master, from), replicas = shard.replicas.map(resolve(_, from))))
+    val previous    = if (events.enabled) slotOwningMasters(topologyRef.get()).toSet else Set.empty[Node]
+    val newTopology = ClusterTopology.from(resolved)
+    topologyRef.set(newTopology)
+    // skip the empty -> populated bootstrap transition: discovering the topology at connect is not a change. A real failover/reshard
+    // always replaces a non-empty master set, so `previous.nonEmpty` only suppresses the startup event.
+    if (events.enabled && previous.nonEmpty) {
+      val current = slotOwningMasters(newTopology)
+      if (current.toSet != previous) events.emit(SageEvent.TopologyChanged(current))
+    }
+    val masters     = resolved.map(_.master).toSet
+    val gone        = lockedNodes {
       val absent = established.keysIterator.filterNot(masters.contains).toVector
       absent.flatMap(node => established.remove(node))
     }
@@ -670,6 +696,7 @@ final private[client] class ClusterLive(
     val all = lockedNodes { closed = true; val snapshot = established.values.toVector; established.clear(); snapshot }
     subscriptions.close()
     all.foreach(_.close())
+    events.close()
   }
 }
 
@@ -710,6 +737,7 @@ private[client] object ClusterLive {
         val upgrade = Tls.buildUpgrade(config.tls, node.host, node.port)
         (onFrame, onClosed) => SocketTransport.connect(node.host, node.port, config.connectTimeout, upgrade, onFrame, onClosed)
       }
+      val events                                                  = Events(config.listeners)
       val live                                                    = new ClusterLive(
         factory,
         scheduler,
@@ -721,11 +749,12 @@ private[client] object ClusterLive {
         config.dedicatedPool,
         cluster,
         config.pubsub.bufferSize,
-        seeds
+        seeds,
+        events
       )
       // discovery's handshake/TLS failures are translated here (a NOPROTO/SSL surfaces like a standalone connect) rather than via mapError,
       // which the per-backend CIO alias does not reconcile through `Client`'s invariant type parameter
       try { live.bootstrapTopology(); live }
-      catch { case NonFatal(error) => throw translate(error) }
+      catch { case NonFatal(error) => events.close(); throw translate(error) }
     }
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
@@ -1,0 +1,103 @@
+package sage.client.internal
+
+import java.util.concurrent.ArrayBlockingQueue
+
+import scala.concurrent.duration.{FiniteDuration, NANOSECONDS}
+import scala.util.Try
+import scala.util.control.NonFatal
+
+import sage.{Outcome, SageEvent, SageListener}
+import sage.cluster.Node
+import sage.commands.Command
+
+/**
+  * The event-delivery seam. [[emit]] is called from the runtime's hot paths (the reply thread, routing offloads) and must never block: it
+  * does a single non-blocking enqueue. A slow or throwing listener can therefore neither stall command execution nor corrupt it. When no
+  * listener is registered the whole thing is a no-op ([[Events.disabled]]) and no thread runs.
+  */
+private[client] trait Events {
+  def enabled: Boolean
+  def emit(event: SageEvent): Unit
+  def close(): Unit
+}
+
+private[client] object Events {
+
+  // a healthy listener never fills this; one that does is misbehaving, and dropping (drop-newest) is the only relief that never blocks the
+  // producer. Deliberately not a config knob — promotable backward-compatibly if a real need appears.
+  final private val QueueDepth = 1024
+
+  val disabled: Events = new Events {
+    def enabled: Boolean             = false
+    def emit(event: SageEvent): Unit = ()
+    def close(): Unit                = ()
+  }
+
+  def apply(listeners: Vector[SageListener]): Events =
+    if (listeners.isEmpty) disabled else new Dispatcher(listeners)
+
+  /**
+    * One bounded queue drained by a single daemon thread that fans each event to every listener, each call guarded so a throwing listener
+    * cannot kill the loop or affect its peers. A full queue drops the newest event silently.
+    */
+  final private class Dispatcher(listeners: Vector[SageListener]) extends Events {
+
+    private val queue             = new ArrayBlockingQueue[SageEvent](QueueDepth)
+    @volatile private var running = true
+
+    private val worker = {
+      val t = new Thread(() => drain(), "sage-listener")
+      t.setDaemon(true)
+      t.start()
+      t
+    }
+
+    def enabled: Boolean             = true
+    def emit(event: SageEvent): Unit = { val _ = queue.offer(event) }
+    def close(): Unit                = { running = false; worker.interrupt() }
+
+    private def drain(): Unit = {
+      try while (running) dispatch(queue.take())
+      catch { case _: InterruptedException => () }
+      // best-effort: deliver what is already queued before exiting
+      var event = queue.poll()
+      while (event != null) { dispatch(event); event = queue.poll() }
+    }
+
+    private def dispatch(event: SageEvent): Unit = {
+      var i = 0
+      while (i < listeners.length) {
+        try listeners(i).onEvent(event)
+        catch { case NonFatal(_) => () }
+        i += 1
+      }
+    }
+  }
+
+  /**
+    * Wraps a command's terminal reply callback so it emits a [[SageEvent.CommandCompleted]] when the command settles, timing from the wrap.
+    * The node is left unset until the routing layer attributes it via [[attributeNode]] (standalone never does, so it stays `None`). Returns
+    * the callback unchanged when events are disabled, so a client without listeners pays nothing.
+    */
+  def trackCommand[A](events: Events, command: Command[?], callback: Try[A] => Unit): Try[A] => Unit =
+    if (!events.enabled) callback else new CommandEmit[A](command.name, System.nanoTime(), events, callback)
+
+  // set on the tracking callback by the routing layer at the node-known terminal site, just before it completes; a no-op for any other callback
+  def attributeNode(callback: AnyRef, node: Node): Unit =
+    callback match {
+      case emit: CommandEmit[?] => emit.at(node)
+      case _                    => ()
+    }
+
+  final private class CommandEmit[A](command: String, startNanos: Long, events: Events, callback: Try[A] => Unit) extends (Try[A] => Unit) {
+
+    @volatile private var node: Option[Node] = None
+
+    def at(n: Node): Unit = node = Some(n)
+
+    def apply(result: Try[A]): Unit = {
+      events.emit(SageEvent.CommandCompleted(command, node, FiniteDuration(System.nanoTime() - startNanos, NANOSECONDS), Outcome.of(result)))
+      callback(result)
+    }
+  }
+}

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -8,10 +8,10 @@ import scala.concurrent.duration.*
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
-import sage.Bytes
-import sage.SageException
+import sage.{Bytes, Outcome, SageEvent, SageException}
 import sage.SageException.{ConnectionLost, NotConnected}
 import sage.client.{BackoffConfig, WatchdogConfig}
+import sage.cluster.Node
 import sage.commands.{Command, Connection, Invalidation, Reply}
 import sage.protocol.Frame
 
@@ -32,7 +32,9 @@ final private[client] class MultiplexedConnection private (
   watchdog: WatchdogConfig,
   connectTimeout: FiniteDuration,
   closeTimeout: FiniteDuration,
-  cacheMaxBytes: Long
+  cacheMaxBytes: Long,
+  node: Option[Node],
+  events: Events
 ) {
   import MultiplexedConnection.{Generation, State}
 
@@ -122,11 +124,14 @@ final private[client] class MultiplexedConnection private (
 
   private def connectInitial(): Unit = {
     val conn = establish() // the first connect propagates a handshake failure; only reconnects retry
+    // emit under the lock so the enqueue is ordered with the state transition: a socket dropping immediately after cannot deliver
+    // Disconnected before this Connected (the same lock serializes both)
     locked {
       current = conn
       state = State.Live
       generation = generation.next
       startWatchdog()
+      events.emit(SageEvent.Connection.Connected(node))
     }
   }
 
@@ -175,6 +180,7 @@ final private[client] class MultiplexedConnection private (
             current = conn
             state = State.Live
             generation = generation.next
+            events.emit(SageEvent.Connection.Connected(node))
             true
           } else false
         }
@@ -185,14 +191,18 @@ final private[client] class MultiplexedConnection private (
   }
 
   // Connections that never became `current` (a failed establish) are ignored here; their caller handles them.
-  private def onConnTerminated(conn: Conn): Unit = locked {
-    if (conn eq current)
-      state match {
-        case State.Live | State.Reconnecting => state = State.Reconnecting; scheduleReconnect(0)
-        case State.Draining                  => state = State.Closed; stopWatchdog()
-        case State.Closed                    => ()
-      }
-  }
+  private def onConnTerminated(conn: Conn): Unit =
+    // Disconnected fires only on the Live edge (a fresh loss, not a failed reconnect attempt), under the lock so it is ordered after the
+    // Connected of the connection it ends
+    locked {
+      if (conn eq current)
+        state match {
+          case State.Live         => state = State.Reconnecting; scheduleReconnect(0); events.emit(SageEvent.Connection.Disconnected(node))
+          case State.Reconnecting => scheduleReconnect(0)
+          case State.Draining     => state = State.Closed; stopWatchdog()
+          case State.Closed       => ()
+        }
+    }
 
   private def startWatchdog(): Unit =
     if (watchdog.enabled && watchdogHandle == null)
@@ -258,13 +268,28 @@ final private[client] class MultiplexedConnection private (
         case Failure(error) => callback(Failure(error))
       }
       cache.acquire(commandBytes, keys, scheduler.nowMillis, waiter) match {
-        case ClientCache.Hit(frame) => deliver(frame)
-        case ClientCache.Wait       => ()
+        // a Hit serves locally; a Wait coalesces onto an in-flight fetch — both avoid a server round trip, so both are reported as a hit
+        case ClientCache.Hit(frame) => events.emit(SageEvent.Cache.Hit(command.name)); deliver(frame)
+        case ClientCache.Wait       => events.emit(SageEvent.Cache.Hit(command.name))
         case ClientCache.Fetch      =>
+          events.emit(SageEvent.Cache.Miss(command.name))
+          val started                     = System.nanoTime()
           val raw                         = Command[Frame](command.name, command.keyIndices, command.args, frame => Right(frame))
-          val onReply: Try[Frame] => Unit = {
-            case Success(frame) => cache.store(commandBytes, keys, frame, scheduler.nowMillis, ttlMillis)
-            case Failure(error) => cache.fail(commandBytes, error)
+          val onReply: Try[Frame] => Unit = { result =>
+            result match {
+              case Success(frame) => cache.store(commandBytes, keys, frame, scheduler.nowMillis, ttlMillis)
+              case Failure(error) => cache.fail(commandBytes, error)
+            }
+            // a miss touched the server, so unlike a hit it also produces a CommandCompleted; the outcome reflects the decoded reply
+            if (events.enabled)
+              events.emit(
+                SageEvent.CommandCompleted(
+                  command.name,
+                  node,
+                  FiniteDuration(System.nanoTime() - started, NANOSECONDS),
+                  Outcome.of(result.flatMap(decodeFrame(command, _)))
+                )
+              )
           }
           submitAll(Vector(Connection.clientCachingYes, raw), Vector(_ => (), onReply.asInstanceOf[Try[Any] => Unit]))
       }
@@ -381,10 +406,12 @@ private[client] object MultiplexedConnection {
     watchdog: WatchdogConfig,
     connectTimeout: FiniteDuration,
     closeTimeout: FiniteDuration,
-    cacheMaxBytes: Long = 0L
+    cacheMaxBytes: Long = 0L,
+    node: Option[Node] = None,
+    events: Events = Events.disabled
   ): MultiplexedConnection = {
     val connection =
-      new MultiplexedConnection(factory, scheduler, bootstrap, backoff, watchdog, connectTimeout, closeTimeout, cacheMaxBytes)
+      new MultiplexedConnection(factory, scheduler, bootstrap, backoff, watchdog, connectTimeout, closeTimeout, cacheMaxBytes, node, events)
     connection.connectInitial()
     connection
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
@@ -4,6 +4,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
 import sage.client.{BackoffConfig, DedicatedPoolConfig, WatchdogConfig}
+import sage.cluster.Node
 import sage.commands.Command
 
 /**
@@ -48,9 +49,12 @@ private[client] object NodeClient {
     watchdog: WatchdogConfig,
     connectTimeout: FiniteDuration,
     closeTimeout: FiniteDuration,
-    dedicatedPool: DedicatedPoolConfig
+    dedicatedPool: DedicatedPoolConfig,
+    node: Option[Node] = None,
+    events: Events = Events.disabled
   ): NodeClient = {
-    val connection = MultiplexedConnection.connect(factory, scheduler, bootstrap, reconnect, watchdog, connectTimeout, closeTimeout)
+    val connection =
+      MultiplexedConnection.connect(factory, scheduler, bootstrap, reconnect, watchdog, connectTimeout, closeTimeout, 0L, node, events)
     val pool       = DedicatedPool.forConnection(factory, bootstrap, scheduler, connection, dedicatedPool, connectTimeout.toMillis)
     new NodeClient(connection, pool)
   }

--- a/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
@@ -1,0 +1,171 @@
+package sage.client.internal
+
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
+
+import scala.collection.mutable
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+import scala.util.{Failure, Success}
+
+import sage.{Bytes, SageEvent, SageListener}
+import sage.client.{BackoffConfig, WatchdogConfig}
+import sage.cluster.Node
+import sage.commands.{Connection, Strings}
+import sage.protocol.Frame
+
+class EventsSpec extends munit.FunSuite {
+
+  private val fixedBackoff = BackoffConfig(initialDelay = 1.milli, maxDelay = 1.milli, multiplier = 1.0)
+  private val noWatchdog   = WatchdogConfig(enabled = false)
+
+  // a synchronous sink, so wiring assertions are deterministic; the real Dispatcher's async behavior is exercised separately
+  final private class Recording extends Events {
+    private val buf                  = mutable.ArrayBuffer.empty[SageEvent]
+    def enabled: Boolean             = true
+    def emit(event: SageEvent): Unit = synchronized { val _ = buf += event }
+    def close(): Unit                = ()
+    def events: Vector[SageEvent]    = synchronized(buf.toVector)
+  }
+
+  final private class Capturing(latch: CountDownLatch) extends SageListener {
+    val received                        = new ConcurrentLinkedQueue[SageEvent]()
+    def onEvent(event: SageEvent): Unit = { received.add(event); latch.countDown() }
+  }
+
+  private def connect(
+    node: Option[Node],
+    events: Events,
+    respond: Bytes => Seq[Frame] = _ => Nil
+  ): (MultiplexedConnection, mutable.ArrayBuffer[FakeTransport]) = {
+    val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
+      val transport = new FakeTransport(onFrame, onClosed, respond)
+      transports += transport
+      transport
+    }
+    val connection                                      =
+      MultiplexedConnection
+        .connect(factory, new ManualScheduler, Vector.empty, fixedBackoff, noWatchdog, 1.second, Duration.Zero, 1L << 20, node, events)
+    (connection, transports)
+  }
+
+  // --- the dispatcher --------------------------------------------------------------------------------------------------------------------
+
+  test("no listeners yields the disabled, no-op sink") {
+    assert(!Events(Vector.empty).enabled)
+    assert(Events(Vector.empty) eq Events.disabled)
+  }
+
+  test("delivers each event to every registered listener") {
+    val latch = new CountDownLatch(2)
+    val a     = new Capturing(latch)
+    val b     = new Capturing(latch)
+    val bus   = Events(Vector(a, b))
+    try {
+      bus.emit(SageEvent.TopologyChanged(Vector(Node("h", 1))))
+      assert(latch.await(2, TimeUnit.SECONDS))
+      assertEquals(a.received.asScala.toVector, Vector(SageEvent.TopologyChanged(Vector(Node("h", 1)))))
+      assertEquals(b.received.asScala.toVector, Vector(SageEvent.TopologyChanged(Vector(Node("h", 1)))))
+    } finally bus.close()
+  }
+
+  test("a throwing listener does not stop delivery to its peers") {
+    val latch    = new CountDownLatch(1)
+    val throwing = new SageListener { def onEvent(event: SageEvent): Unit = throw new RuntimeException("boom") }
+    val healthy  = new Capturing(latch)
+    val bus      = Events(Vector(throwing, healthy))
+    try {
+      bus.emit(SageEvent.Cache.Hit("GET"))
+      assert(latch.await(2, TimeUnit.SECONDS))
+      assertEquals(healthy.received.peek(), SageEvent.Cache.Hit("GET"))
+    } finally bus.close()
+  }
+
+  test("a full queue drops events rather than blocking the producer") {
+    val release  = new CountDownLatch(1)
+    val seen     = new java.util.concurrent.atomic.AtomicInteger(0)
+    // blocks on the first event so the queue fills behind it
+    val blocking = new SageListener {
+      def onEvent(event: SageEvent): Unit = { seen.incrementAndGet(); release.await() }
+    }
+    val bus      = Events(Vector(blocking))
+    try {
+      val started = System.nanoTime()
+      var i       = 0
+      while (i < 5000) { bus.emit(SageEvent.Cache.Miss("GET")); i += 1 }
+      val elapsed = (System.nanoTime() - started).nanos
+      assert(elapsed < 2.seconds, s"emit blocked: took $elapsed for 5000 events")
+    } finally {
+      release.countDown()
+      bus.close()
+    }
+    assert(seen.get() <= 1100, s"expected drops, retained ${seen.get()}")
+  }
+
+  // --- command completion ----------------------------------------------------------------------------------------------------------------
+
+  test("trackCommand emits a completion with name and outcome, and is transparent when disabled") {
+    val rec                                = new Recording
+    var settled                            = Option.empty[String]
+    val tracked                            = Events.trackCommand[String](rec, Connection.ping(None), r => settled = r.toOption)
+    tracked(Success("PONG"))
+    assertEquals(settled, Some("PONG"))
+    rec.events match {
+      case Vector(SageEvent.CommandCompleted("PING", None, _, sage.Outcome.Succeeded)) => ()
+      case other                                                                       => fail(s"unexpected: $other")
+    }
+    val cb: scala.util.Try[String] => Unit = _ => ()
+    val plain                              = Events.trackCommand[String](Events.disabled, Connection.ping(None), cb)
+    assert(plain eq cb) // disabled wraps nothing, so a listener-less client pays nothing
+  }
+
+  test("attributeNode tags the completion with the node the routing layer resolved") {
+    val rec     = new Recording
+    val tracked = Events.trackCommand[Long](rec, Strings.incr[String]("k"), _ => ())
+    Events.attributeNode(tracked, Node("redis", 7000))
+    tracked(Failure(sage.SageException.NotConnected()))
+    rec.events match {
+      case Vector(SageEvent.CommandCompleted("INCR", Some(Node("redis", 7000)), _, sage.Outcome.Failed(_))) => ()
+      case other                                                                                            => fail(s"unexpected: $other")
+    }
+  }
+
+  // --- connection lifecycle --------------------------------------------------------------------------------------------------------------
+
+  test("emits Connected on connect and Disconnected on unexpected loss, tagged with the node") {
+    val node            = Some(Node("shard-a", 6379))
+    val rec             = new Recording
+    val (_, transports) = connect(node, rec)
+    transports.head.close()
+    assertEquals(
+      rec.events,
+      Vector(SageEvent.Connection.Connected(node), SageEvent.Connection.Disconnected(node))
+    )
+  }
+
+  // --- cache -----------------------------------------------------------------------------------------------------------------------------
+
+  test("a cached read misses then hits") {
+    var writes          = 0
+    val rec             = new Recording
+    val (connection, _) = connect(
+      None,
+      rec,
+      respond = _ => {
+        writes += 1
+        // the first write is the [CLIENT CACHING YES, GET] batch: reply OK to the marker, the value to the read
+        if (writes == 1) Seq(Frame.SimpleString("OK"), Frame.BulkString(Bytes.utf8("v"))) else Nil
+      }
+    )
+    val get             = Strings.get[String, String]("k")
+    connection.cachedSubmit(get, 60000L, (_: scala.util.Try[Option[String]]) => ())
+    connection.cachedSubmit(get, 60000L, (_: scala.util.Try[Option[String]]) => ())
+    val evs             = rec.events
+    assertEquals(evs.collect { case c: SageEvent.Cache => c }, Vector(SageEvent.Cache.Miss("GET"), SageEvent.Cache.Hit("GET")))
+    // the miss touched the server, so it also produces one CommandCompleted; the hit produces none
+    assertEquals(
+      evs.collect { case c: SageEvent.CommandCompleted => (c.name, c.node, c.outcome) },
+      Vector(("GET", None, sage.Outcome.Succeeded))
+    )
+  }
+}

--- a/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
@@ -1,12 +1,15 @@
 package sage.client
 
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
+
 import scala.concurrent.ExecutionContext
+import scala.jdk.CollectionConverters.*
 
 import kyo.compat.*
 
-import sage.Bytes
-import sage.SageException.UnsupportedServer
-import sage.client.internal.{Client, FakeTransport, MultiplexedConnection}
+import sage.{Bytes, Outcome, SageEvent, SageListener}
+import sage.SageException.{NotConnected, UnsupportedServer}
+import sage.client.internal.{Client, Events, FakeTransport, ManualScheduler, MultiplexedConnection}
 import sage.commands.{Command, Execution, Pipeline}
 import sage.protocol.Frame
 
@@ -73,6 +76,36 @@ class ConnectSpec extends munit.FunSuite {
       assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
       assertEquals(transport().written.count(_.asUtf8String.contains("BLPOP")), 0)
     }
+  }
+
+  test("a pipeline that fails fast while disconnected reports a failed completion per position") {
+    val (factory, transport) = scripted(helloThenPong)
+    val scheduler            = new ManualScheduler // so the post-drop reconnect stays pending and the connection stays not-live
+    val completions          = new ConcurrentLinkedQueue[SageEvent.CommandCompleted]()
+    val latch                = new CountDownLatch(2)
+    val listener             = new SageListener {
+      def onEvent(event: SageEvent): Unit = event match {
+        case c: SageEvent.CommandCompleted => completions.add(c); latch.countDown()
+        case _                             => ()
+      }
+    }
+    val get                  = Command("GET", Command.NoKeys, Vector.empty, (_: Frame) => Right(0L))
+    val twoGets              = Pipeline.sequence(Vector(get, get))
+    Client
+      .connectWith(factory, scheduler, events = Events(Vector(listener)))
+      .flatMap { client =>
+        transport().close() // drop the live socket; reconnect is scheduled on the manual scheduler and never runs
+        client.pipeline(twoGets)
+      }
+      .unsafeRun
+      .failed
+      .map { error =>
+        assert(error.isInstanceOf[NotConnected], s"unexpected error: $error")
+        assert(latch.await(2, TimeUnit.SECONDS), "expected a failed completion per pipeline position")
+        val seen = completions.asScala.toVector
+        assertEquals(seen.map(_.name), Vector("GET", "GET"))
+        assert(seen.forall(_.outcome.isInstanceOf[Outcome.Failed]), s"expected all failed, got ${seen.map(_.outcome)}")
+      }
   }
 
   test("an empty pipeline succeeds without a round-trip") {

--- a/sage-core/src/main/scala/sage/SageEvent.scala
+++ b/sage-core/src/main/scala/sage/SageEvent.scala
@@ -1,0 +1,74 @@
+package sage
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.{Failure, Success, Try}
+
+import sage.cluster.Node
+
+/**
+  * A runtime observability signal reported to a [[SageListener]]: a command completion, a connection lifecycle transition, a cache hit or
+  * miss, or a topology change. A sealed hierarchy so listeners match exhaustively. An Event carries no command arguments or payloads, so
+  * secrets (`HELLO`/`AUTH` credentials, user values) never reach a listener. Distinct from a `Message` (a pub/sub delivery) and a
+  * `StreamEntry` (a record in a Stream) — those are never Events.
+  */
+sealed trait SageEvent
+
+object SageEvent {
+
+  /**
+    * One logical user command settled: its name, the node that produced the final result (`None` on standalone, or for an all-masters
+    * command), the client-observed duration (from acceptance to settlement, folding in any cluster redirects/retries), and its outcome. A
+    * cached read that hits the local cache yields only a [[Cache.Hit]] and no `CommandCompleted` — it touched no server; a cached miss yields
+    * a [[Cache.Miss]] and, when its server fetch settles, a `CommandCompleted`.
+    */
+  final case class CommandCompleted(name: String, node: Option[Node], duration: FiniteDuration, outcome: Outcome) extends SageEvent
+
+  /**
+    * The Multiplexed Connection's lifecycle. `Connected` fires on the initial connect and on every successful reconnect; `Disconnected`
+    * fires when a live connection is lost unexpectedly and the runtime begins reconnecting. Graceful close and individual reconnect attempts
+    * are not reported. `node` is `Some` in cluster (the master this connection serves) and `None` on standalone.
+    */
+  sealed trait Connection extends SageEvent {
+    def node: Option[Node]
+  }
+
+  object Connection {
+    final case class Connected(node: Option[Node])    extends Connection
+    final case class Disconnected(node: Option[Node]) extends Connection
+  }
+
+  /**
+    * A client-side caching outcome for a `cached` read, by command name. `Hit` is a read served without a server round trip — either from a
+    * stored entry or by coalescing onto an in-flight fetch; `Miss` is a read that issued the server fetch.
+    */
+  sealed trait Cache extends SageEvent {
+    def command: String
+  }
+
+  object Cache {
+    final case class Hit(command: String)  extends Cache
+    final case class Miss(command: String) extends Cache
+  }
+
+  /**
+    * The cluster's slot-owning master set changed (failover, or scaling a shard in or out). Reported only when that set actually differs,
+    * not on every topology refresh; a reshard that moves slots between the same masters does not fire it.
+    */
+  final case class TopologyChanged(masters: Vector[Node]) extends SageEvent
+}
+
+/**
+  * A command's terminal result, stripped of its value: it either succeeded or failed with the error the caller saw.
+  */
+sealed trait Outcome
+
+object Outcome {
+  case object Succeeded                     extends Outcome
+  final case class Failed(error: Throwable) extends Outcome
+
+  def of(result: Try[?]): Outcome =
+    result match {
+      case Success(_) => Succeeded
+      case Failure(e) => Failed(e)
+    }
+}

--- a/sage-core/src/main/scala/sage/SageListener.scala
+++ b/sage-core/src/main/scala/sage/SageListener.scala
@@ -1,0 +1,11 @@
+package sage
+
+/**
+  * A user-supplied observer of runtime [[SageEvent]]s, registered in configuration. The callback is synchronous and `Unit`-returning so the
+  * SPI is effect-agnostic and lives in the Core, letting an integration module bind to it without depending on any Backend. sage invokes it
+  * off the command path, so a slow or throwing listener can never block or break command execution: a slow one only delays event delivery (and
+  * sheds events once the dispatch queue fills), a throwing one is swallowed.
+  */
+trait SageListener {
+  def onEvent(event: SageEvent): Unit
+}


### PR DESCRIPTION
Implements #26.

## What

A zero-dependency observability SPI. A user supplies a `SageListener` in `SageConfig`; sage reports a sealed `SageEvent` hierarchy:

- **`CommandCompleted`** — name, node (`Some` in cluster, `None` standalone / all-masters), client-observed duration (nanos, redirects folded in), outcome (`Succeeded`/`Failed`). Emitted for `run`, cluster `runOn` (SCAN pages), pipeline positions, and cached **misses** (a hit touches no server, so it yields only `Cache.Hit`).
- **`Connection.Connected` / `Disconnected`** — the Multiplexed Connection's lifecycle (initial + reconnect; unexpected loss). Nothing on graceful close or per failed attempt.
- **`Cache.Hit` / `Miss`** — by command name; a coalesced wait counts as a hit.
- **`TopologyChanged`** — the new slot-owning master set, only when it actually changes (not on refresh, not on the bootstrap empty→populated transition).

The SPI (`SageListener`, `SageEvent`, `Outcome`) lives in `sage-core` and is a synchronous `Unit` callback, so it is effect-agnostic across all backends and a future integration module binds to it without depending on any backend.

## Delivery contract

Events are delivered off the command path by a single bounded daemon dispatcher (queue depth 1024). The hot path only does a non-blocking enqueue; under overload the dispatcher drops newest, and a throwing listener is swallowed — so a slow or throwing listener can neither block nor break command execution. With no listener registered the sink is a no-op and no thread starts. Rationale recorded in ADR 0035; the `SageListener`/`SageEvent` glossary terms are in `CONTEXT.md` (both already on `main`).

No telemetry library is added to any artifact.

## Tests

`EventsSpec` (shared): dispatcher fan-out, throwing-listener isolation, drop-under-overload (producer never blocks), `trackCommand`/`attributeNode`, Connected/Disconnected ordering, cache miss→hit + miss-completion. `ConnectSpec`: a disconnected pipeline reports a failed completion per position. All cells green (core+zio 120, ce+ox 83; future/kyo compile).

## Scoped out (documented)

Transaction-internal commands emit no `CommandCompleted`; cache events are standalone-only (cluster `cached` runs uncached); connection events cover the Multiplexed Connection only.