### PR TITLE
Collapse per-Backend client lowering into one shared adapter

### DIFF
--- a/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
+++ b/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
@@ -9,7 +9,7 @@ import kyo.compat.*
 
 import sage.{Message, PatternMessage}
 import sage.client.SageConfig
-import sage.client.internal.{Client, ScanStep, ScanTarget, Subscription, TransactionScope}
+import sage.client.internal.{Client, LoweredClient, ScanStep, ScanTarget, Subscription}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
 
@@ -187,47 +187,8 @@ object SageClient {
   def resource(config: SageConfig): Resource[IO, SageClient] =
     Resource.make(connect(config))(_.close.voidError)
 
-  final private class Lowered(underlying: Client[CIO]) extends Client[IO] {
-
-    def run[A](command: Command[A]): IO[A] = underlying.run(command).lower
-
-    def cached[A](command: Command[A], ttl: FiniteDuration): IO[A] = underlying.cached(command, ttl).lower
-
-    def pipeline[Out, R](p: Pipeline[Out, R]): IO[Out] = underlying.pipeline(p).lower
-
-    def pipelineAttempt[Out, R](p: Pipeline[Out, R]): IO[R] = underlying.pipelineAttempt(p).lower
-
-    def transaction[A](body: TransactionScope[IO] => IO[A]): IO[A] =
-      underlying.transaction[A](scope => CIO.lift(body(lower(scope)))).lower
-
-    def subscribeChannels[V: ValueCodec](channel: String, rest: String*): IO[Subscription[IO, Message[V]]] =
-      underlying.subscribeChannels[V](channel, rest*).map(lower).lower
-
-    def subscribePatterns[V: ValueCodec](pattern: String, rest: String*): IO[Subscription[IO, PatternMessage[V]]] =
-      underlying.subscribePatterns[V](pattern, rest*).map(lower).lower
-
-    def subscribeShardChannels[V: ValueCodec](channel: String, rest: String*): IO[Subscription[IO, Message[V]]] =
-      underlying.subscribeShardChannels[V](channel, rest*).map(lower).lower
-
-    def scanTargets: IO[Vector[ScanTarget]] = underlying.scanTargets.lower
-
-    def runOn[A](target: ScanTarget, command: Command[A]): IO[A] = underlying.runOn(target, command).lower
-
-    private def lower(scope: TransactionScope[CIO]): TransactionScope[IO] =
-      new TransactionScope[IO] {
-        def watch[K: KeyCodec](key: K, rest: K*): IO[Unit]          = scope.watch(key, rest*).lower
-        def run[A](command: Command[A]): IO[A]                      = scope.run(command).lower
-        def exec[Out, R](p: Pipeline[Out, R]): IO[Option[Out]]      = scope.exec(p).lower
-        def execAttempt[Out, R](p: Pipeline[Out, R]): IO[Option[R]] = scope.execAttempt(p).lower
-        def discard: IO[Unit]                                       = scope.discard.lower
-      }
-
-    private def lower[A](sub: Subscription[CIO, A]): Subscription[IO, A] =
-      new Subscription[IO, A] {
-        def next: IO[Option[A]] = sub.next.lower
-        def close: IO[Unit]     = sub.close.lower
-      }
-
-    def close: IO[Unit] = underlying.close.lower
+  final private class Lowered(underlying: Client[CIO]) extends LoweredClient[IO](underlying) {
+    protected def lower[A](c: CIO[A]): IO[A] = c.lower
+    protected def lift[A](fa: IO[A]): CIO[A] = CIO.lift(fa)
   }
 }

--- a/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
+++ b/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
@@ -8,7 +8,7 @@ import _root_.kyo.compat.*
 
 import sage.{Message, PatternMessage}
 import sage.client.SageConfig
-import sage.client.internal.{Client, ScanStep, ScanTarget, Subscription, TransactionScope}
+import sage.client.internal.{Client, LoweredClient, ScanStep, ScanTarget, Subscription}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
 
@@ -198,49 +198,8 @@ object SageClient {
   def scoped(config: SageConfig): SageClient < (Scope & Abort[Throwable] & Async) =
     Scope.acquireRelease(connect(config))(client => Abort.run(client.close))
 
-  final private class Lowered(underlying: Client[CIO]) extends Client[[A] =>> A < (Abort[Throwable] & Async)] {
-
-    def run[A](command: Command[A]): A < (Abort[Throwable] & Async) = underlying.run(command).lower
-
-    def cached[A](command: Command[A], ttl: FiniteDuration): A < (Abort[Throwable] & Async) = underlying.cached(command, ttl).lower
-
-    def pipeline[Out, R](p: Pipeline[Out, R]): Out < (Abort[Throwable] & Async) = underlying.pipeline(p).lower
-
-    def pipelineAttempt[Out, R](p: Pipeline[Out, R]): R < (Abort[Throwable] & Async) = underlying.pipelineAttempt(p).lower
-
-    def transaction[A](
-      body: TransactionScope[[X] =>> X < (Abort[Throwable] & Async)] => A < (Abort[Throwable] & Async)
-    ): A < (Abort[Throwable] & Async) =
-      underlying.transaction[A](scope => CIO.lift(body(lower(scope)))).lower
-
-    def subscribeChannels[V: ValueCodec](channel: String, rest: String*): Subscription[KyoEff, Message[V]] < (Abort[Throwable] & Async) =
-      underlying.subscribeChannels[V](channel, rest*).lower.map(lower)
-
-    def subscribePatterns[V: ValueCodec](pattern: String, rest: String*): Subscription[KyoEff, PatternMessage[V]] < (Abort[Throwable] & Async) =
-      underlying.subscribePatterns[V](pattern, rest*).lower.map(lower)
-
-    def subscribeShardChannels[V: ValueCodec](channel: String, rest: String*): Subscription[KyoEff, Message[V]] < (Abort[Throwable] & Async) =
-      underlying.subscribeShardChannels[V](channel, rest*).lower.map(lower)
-
-    def scanTargets: Vector[ScanTarget] < (Abort[Throwable] & Async) = underlying.scanTargets.lower
-
-    def runOn[A](target: ScanTarget, command: Command[A]): A < (Abort[Throwable] & Async) = underlying.runOn(target, command).lower
-
-    private def lower(scope: TransactionScope[CIO]): TransactionScope[[X] =>> X < (Abort[Throwable] & Async)] =
-      new TransactionScope[[X] =>> X < (Abort[Throwable] & Async)] {
-        def watch[K: KeyCodec](key: K, rest: K*): Unit < (Abort[Throwable] & Async)          = scope.watch(key, rest*).lower
-        def run[A](command: Command[A]): A < (Abort[Throwable] & Async)                      = scope.run(command).lower
-        def exec[Out, R](p: Pipeline[Out, R]): Option[Out] < (Abort[Throwable] & Async)      = scope.exec(p).lower
-        def execAttempt[Out, R](p: Pipeline[Out, R]): Option[R] < (Abort[Throwable] & Async) = scope.execAttempt(p).lower
-        def discard: Unit < (Abort[Throwable] & Async)                                       = scope.discard.lower
-      }
-
-    private def lower[A](sub: Subscription[CIO, A]): Subscription[KyoEff, A] =
-      new Subscription[KyoEff, A] {
-        def next: Option[A] < (Abort[Throwable] & Async) = sub.next.lower
-        def close: Unit < (Abort[Throwable] & Async)     = sub.close.lower
-      }
-
-    def close: Unit < (Abort[Throwable] & Async) = underlying.close.lower
+  final private class Lowered(underlying: Client[CIO]) extends LoweredClient[[A] =>> A < (Abort[Throwable] & Async)](underlying) {
+    protected def lower[A](c: CIO[A]): A < (Abort[Throwable] & Async) = c.lower
+    protected def lift[A](fa: A < (Abort[Throwable] & Async)): CIO[A] = CIO.lift(fa)
   }
 }

--- a/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
@@ -10,7 +10,7 @@ import kyo.compat.*
 
 import sage.{Message, PatternMessage}
 import sage.client.SageConfig
-import sage.client.internal.{Client, ScanStep, ScanTarget, Subscription, TransactionScope}
+import sage.client.internal.{Client, LoweredClient, ScanStep, ScanTarget, Subscription}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
 
@@ -200,47 +200,8 @@ object SageClient {
       catch { case _: Throwable => () }
     }
 
-  final private class Lowered(underlying: Client[CIO]) extends Client[[A] =>> Ox ?=> A] {
-
-    def run[A](command: Command[A]): Ox ?=> A = underlying.run(command).lower
-
-    def cached[A](command: Command[A], ttl: FiniteDuration): Ox ?=> A = underlying.cached(command, ttl).lower
-
-    def pipeline[Out, R](p: Pipeline[Out, R]): Ox ?=> Out = underlying.pipeline(p).lower
-
-    def pipelineAttempt[Out, R](p: Pipeline[Out, R]): Ox ?=> R = underlying.pipelineAttempt(p).lower
-
-    def transaction[A](body: TransactionScope[[X] =>> Ox ?=> X] => (Ox ?=> A)): Ox ?=> A =
-      underlying.transaction[A](scope => CIO.lift(body(lower(scope)))).lower
-
-    def subscribeChannels[V: ValueCodec](channel: String, rest: String*): Ox ?=> Subscription[[X] =>> Ox ?=> X, Message[V]] =
-      lower(underlying.subscribeChannels[V](channel, rest*).lower)
-
-    def subscribePatterns[V: ValueCodec](pattern: String, rest: String*): Ox ?=> Subscription[[X] =>> Ox ?=> X, PatternMessage[V]] =
-      lower(underlying.subscribePatterns[V](pattern, rest*).lower)
-
-    def subscribeShardChannels[V: ValueCodec](channel: String, rest: String*): Ox ?=> Subscription[[X] =>> Ox ?=> X, Message[V]] =
-      lower(underlying.subscribeShardChannels[V](channel, rest*).lower)
-
-    def scanTargets: Ox ?=> Vector[ScanTarget] = underlying.scanTargets.lower
-
-    def runOn[A](target: ScanTarget, command: Command[A]): Ox ?=> A = underlying.runOn(target, command).lower
-
-    private def lower(scope: TransactionScope[CIO]): TransactionScope[[X] =>> Ox ?=> X] =
-      new TransactionScope[[X] =>> Ox ?=> X] {
-        def watch[K: KeyCodec](key: K, rest: K*): Ox ?=> Unit          = scope.watch(key, rest*).lower
-        def run[A](command: Command[A]): Ox ?=> A                      = scope.run(command).lower
-        def exec[Out, R](p: Pipeline[Out, R]): Ox ?=> Option[Out]      = scope.exec(p).lower
-        def execAttempt[Out, R](p: Pipeline[Out, R]): Ox ?=> Option[R] = scope.execAttempt(p).lower
-        def discard: Ox ?=> Unit                                       = scope.discard.lower
-      }
-
-    private def lower[A](sub: Subscription[CIO, A]): Subscription[[X] =>> Ox ?=> X, A] =
-      new Subscription[[X] =>> Ox ?=> X, A] {
-        def next: Ox ?=> Option[A] = sub.next.lower
-        def close: Ox ?=> Unit     = sub.close.lower
-      }
-
-    def close: Ox ?=> Unit = underlying.close.lower
+  final private class Lowered(underlying: Client[CIO]) extends LoweredClient[[X] =>> Ox ?=> X](underlying) {
+    protected def lower[A](c: CIO[A]): Ox ?=> A = c.lower
+    protected def lift[A](fa: Ox ?=> A): CIO[A] = CIO.lift(fa)
   }
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/LoweredClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LoweredClient.scala
@@ -1,0 +1,63 @@
+package sage.client.internal
+
+import scala.concurrent.duration.FiniteDuration
+
+import kyo.compat.*
+
+import sage.{Message, PatternMessage}
+import sage.codec.{KeyCodec, ValueCodec}
+import sage.commands.{Command, Pipeline}
+
+/**
+  * Lowers the runtime's [[Client]] from the kyo-compat carrier `CIO` to a Backend's native effect `F`, written once for every Backend. A
+  * Backend supplies only the two natural transformations [[lower]] (`CIO ~> F`) and [[lift]] (`F ~> CIO`); the whole client surface is
+  * expressed in terms of them. The native streaming sugar (`scanAll`, `subscribe`, …) stays per Backend, since it returns that ecosystem's
+  * own stream type.
+  */
+abstract class LoweredClient[F[_]](underlying: Client[CIO]) extends Client[F] {
+
+  protected def lower[A](c: CIO[A]): F[A]
+
+  protected def lift[A](fa: F[A]): CIO[A]
+
+  final def run[A](command: Command[A]): F[A] = lower(underlying.run(command))
+
+  final def cached[A](command: Command[A], ttl: FiniteDuration): F[A] = lower(underlying.cached(command, ttl))
+
+  final def pipeline[Out, R](p: Pipeline[Out, R]): F[Out] = lower(underlying.pipeline(p))
+
+  final def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R] = lower(underlying.pipelineAttempt(p))
+
+  final def transaction[A](body: TransactionScope[F] => F[A]): F[A] =
+    lower(underlying.transaction[A](scope => lift(body(lowerScope(scope)))))
+
+  final def subscribeChannels[V: ValueCodec](channel: String, rest: String*): F[Subscription[F, Message[V]]] =
+    lower(underlying.subscribeChannels[V](channel, rest*).map(lowerSub))
+
+  final def subscribePatterns[V: ValueCodec](pattern: String, rest: String*): F[Subscription[F, PatternMessage[V]]] =
+    lower(underlying.subscribePatterns[V](pattern, rest*).map(lowerSub))
+
+  final def subscribeShardChannels[V: ValueCodec](channel: String, rest: String*): F[Subscription[F, Message[V]]] =
+    lower(underlying.subscribeShardChannels[V](channel, rest*).map(lowerSub))
+
+  final private[sage] def scanTargets: F[Vector[ScanTarget]] = lower(underlying.scanTargets)
+
+  final private[sage] def runOn[A](target: ScanTarget, command: Command[A]): F[A] = lower(underlying.runOn(target, command))
+
+  final def close: F[Unit] = lower(underlying.close)
+
+  private def lowerScope(scope: TransactionScope[CIO]): TransactionScope[F] =
+    new TransactionScope[F] {
+      def watch[K: KeyCodec](key: K, rest: K*): F[Unit]          = lower(scope.watch(key, rest*))
+      def run[A](command: Command[A]): F[A]                      = lower(scope.run(command))
+      def exec[Out, R](p: Pipeline[Out, R]): F[Option[Out]]      = lower(scope.exec(p))
+      def execAttempt[Out, R](p: Pipeline[Out, R]): F[Option[R]] = lower(scope.execAttempt(p))
+      def discard: F[Unit]                                       = lower(scope.discard)
+    }
+
+  private def lowerSub[A](sub: Subscription[CIO, A]): Subscription[F, A] =
+    new Subscription[F, A] {
+      def next: F[Option[A]] = lower(sub.next)
+      def close: F[Unit]     = lower(sub.close)
+    }
+}

--- a/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
+++ b/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
@@ -10,7 +10,7 @@ import zio.stream.ZStream
 
 import sage.{Message, PatternMessage}
 import sage.client.SageConfig
-import sage.client.internal.{Client, ScanStep, ScanTarget, Subscription, TransactionScope}
+import sage.client.internal.{Client, LoweredClient, ScanStep, ScanTarget, Subscription}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
 
@@ -201,47 +201,8 @@ object SageClient {
   def layer(config: SageConfig): ZLayer[Any, Throwable, SageClient] =
     ZLayer.scoped(scoped(config))
 
-  final private class Lowered(underlying: Client[CIO]) extends Client[Task] {
-
-    def run[A](command: Command[A]): Task[A] = underlying.run(command).lower
-
-    def cached[A](command: Command[A], ttl: FiniteDuration): Task[A] = underlying.cached(command, ttl).lower
-
-    def pipeline[Out, R](p: Pipeline[Out, R]): Task[Out] = underlying.pipeline(p).lower
-
-    def pipelineAttempt[Out, R](p: Pipeline[Out, R]): Task[R] = underlying.pipelineAttempt(p).lower
-
-    def transaction[A](body: TransactionScope[Task] => Task[A]): Task[A] =
-      underlying.transaction[A](scope => CIO.lift(body(lower(scope)))).lower
-
-    def subscribeChannels[V: ValueCodec](channel: String, rest: String*): Task[Subscription[Task, Message[V]]] =
-      underlying.subscribeChannels[V](channel, rest*).map(lower).lower
-
-    def subscribePatterns[V: ValueCodec](pattern: String, rest: String*): Task[Subscription[Task, PatternMessage[V]]] =
-      underlying.subscribePatterns[V](pattern, rest*).map(lower).lower
-
-    def subscribeShardChannels[V: ValueCodec](channel: String, rest: String*): Task[Subscription[Task, Message[V]]] =
-      underlying.subscribeShardChannels[V](channel, rest*).map(lower).lower
-
-    def scanTargets: Task[Vector[ScanTarget]] = underlying.scanTargets.lower
-
-    def runOn[A](target: ScanTarget, command: Command[A]): Task[A] = underlying.runOn(target, command).lower
-
-    private def lower(scope: TransactionScope[CIO]): TransactionScope[Task] =
-      new TransactionScope[Task] {
-        def watch[K: KeyCodec](key: K, rest: K*): Task[Unit]          = scope.watch(key, rest*).lower
-        def run[A](command: Command[A]): Task[A]                      = scope.run(command).lower
-        def exec[Out, R](p: Pipeline[Out, R]): Task[Option[Out]]      = scope.exec(p).lower
-        def execAttempt[Out, R](p: Pipeline[Out, R]): Task[Option[R]] = scope.execAttempt(p).lower
-        def discard: Task[Unit]                                       = scope.discard.lower
-      }
-
-    private def lower[A](sub: Subscription[CIO, A]): Subscription[Task, A] =
-      new Subscription[Task, A] {
-        def next: Task[Option[A]] = sub.next.lower
-        def close: Task[Unit]     = sub.close.lower
-      }
-
-    def close: Task[Unit] = underlying.close.lower
+  final private class Lowered(underlying: Client[CIO]) extends LoweredClient[Task](underlying) {
+    protected def lower[A](c: CIO[A]): Task[A] = c.lower
+    protected def lift[A](fa: Task[A]): CIO[A] = CIO.lift(fa)
   }
 }


### PR DESCRIPTION
## What

Each Backend (`zio`/`ce`/`kyo`/`ox`) redeclared the same ~13-method `Lowered` class, every method just delegating to the `CIO` carrier via `.lower`. The interface was as wide as the implementation — a shallow adapter repeated four times.

This introduces a generic `LoweredClient[F]` in the shared (compat-cross-compiled) runtime that expresses the whole `Client[F]` surface — `run`, `cached`, `pipeline`, `transaction`, the three `subscribe*`, `scanTargets`, `runOn`, `close`, plus the `TransactionScope`/`Subscription` lowerings — in terms of the two things that genuinely vary per Backend:

```scala
protected def lower[A](c: CIO[A]): F[A]   // CIO ~> F
protected def lift[A](fa: F[A]): CIO[A]   // F ~> CIO
```

Each Backend's `Lowered` collapses to those two one-liners, e.g. cats-effect:

```scala
final private class Lowered(underlying: Client[CIO]) extends LoweredClient[IO](underlying) {
  protected def lower[A](c: CIO[A]): IO[A] = c.lower
  protected def lift[A](fa: IO[A]): CIO[A] = CIO.lift(fa)
}
```

Net **−174 / +16** across the four Backends, plus one ~62-line shared module. The now-unused `TransactionScope` import was dropped from each Backend (the LTS cells compile under `-Xfatal-warnings`).

## Out of scope

The native streaming `extension` blocks (`scanAll`/`subscribe`/`xConsume`/…) stay per-Backend — they return each ecosystem's own stream type (`ZStream`/`fs2.Stream`/kyo `Stream`/`Flow`) and use native combinators, so they can't be unified the same way. The four `CStream.unfold(…).lower` bodies are near-identical and could be lifted in a follow-up.

## Verification

- All four cells compile clean, including kyo on Scala Next 3.8.3.
- `testUnit` green: core + all four Backend cells (the zio cell's `ConnectSpec`/`TransactionSpec`/`ClusterClientSpec` drive transactions, subscriptions, and cluster routing through the new adapter), the Future anchor, and integration compile.
- `scalafmtAll` applied.