### PR TITLE
Streams sugar: xAutoClaimAll and xTail iteration helpers

### DIFF
--- a/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
+++ b/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
@@ -112,6 +112,50 @@ extension (client: SageClient) {
       .lower
 
   /**
+    * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Entries
+    * dropped because they no longer exist are skipped (the server reports them per-call as deleted; they are not surfaced here).
+    */
+  def xAutoClaimAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    key: K,
+    group: String,
+    consumer: String,
+    minIdle: FiniteDuration,
+    start: StreamId = StreamId.Zero,
+    count: Option[Long] = None
+  ): fs2.Stream[IO, StreamEntry[F, V]] =
+    CStream
+      .unfold[Option[StreamId], Vector[StreamEntry[F, V]]](Some(start)) {
+        case None       => CIO.value(None)
+        case Some(from) =>
+          CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))).map { result =>
+            Some((result.entries, if (result.cursor == StreamId.Zero) None else Some(result.cursor)))
+          }
+      }
+      .flatMap(items => CStream.init(items))
+      .lower
+
+  /**
+    * Follows a stream without a consumer group: replays every entry after `from`, then blocks for new entries forever, advancing past the
+    * last id each round. Blocking on an explicit id (never `$`) leaves no gap for entries arriving mid-loop. No acknowledgement, unlike
+    * [[xConsume]]. `from` defaults to the start; pass a later id to tail from there.
+    */
+  def xTail[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    key: K,
+    from: StreamId = StreamId.Zero,
+    count: Option[Long] = None,
+    block: BlockTimeout = SageClient.defaultPoll
+  ): fs2.Stream[IO, StreamEntry[F, V]] =
+    CStream
+      .unfold[StreamId, Vector[StreamEntry[F, V]]](from) { last =>
+        CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map { result =>
+          val entries = result.flatMap(_._2)
+          Some((entries, if (entries.isEmpty) last else entries.last.id))
+        }
+      }
+      .flatMap(items => CStream.init(items))
+      .lower
+
+  /**
     * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
     * entries forever. `handle` runs per entry; the entry is acknowledged only after `handle` succeeds, so a failure leaves it in the PEL for
     * recovery. See ADR-0032.

--- a/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
+++ b/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
@@ -112,8 +112,9 @@ extension (client: SageClient) {
       .lower
 
   /**
-    * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Entries
-    * dropped because they no longer exist are skipped (the server reports them per-call as deleted; they are not surfaced here).
+    * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Tombstone
+    * entries — claimed ids whose data was already deleted, which the decoder surfaces with no fields — are skipped, so every emitted entry
+    * carries data.
     */
   def xAutoClaimAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
     key: K,
@@ -128,7 +129,7 @@ extension (client: SageClient) {
         case None       => CIO.value(None)
         case Some(from) =>
           CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))).map { result =>
-            Some((result.entries, if (result.cursor == StreamId.Zero) None else Some(result.cursor)))
+            Some((result.entries.filter(_.fields.nonEmpty), if (result.cursor == StreamId.Zero) None else Some(result.cursor)))
           }
       }
       .flatMap(items => CStream.init(items))

--- a/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
+++ b/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
@@ -119,6 +119,50 @@ extension (client: SageClient) {
       .lower
 
   /**
+    * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Entries
+    * dropped because they no longer exist are skipped (the server reports them per-call as deleted; they are not surfaced here).
+    */
+  def xAutoClaimAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    key: K,
+    group: String,
+    consumer: String,
+    minIdle: FiniteDuration,
+    start: StreamId = StreamId.Zero,
+    count: Option[Long] = None
+  )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[Throwable] & Async] =
+    CStream
+      .unfold[Option[StreamId], Vector[StreamEntry[F, V]]](Some(start)) {
+        case None       => CIO.value(None)
+        case Some(from) =>
+          CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))).map { result =>
+            Some((result.entries, if (result.cursor == StreamId.Zero) None else Some(result.cursor)))
+          }
+      }
+      .flatMap(items => CStream.init(items))
+      .lower
+
+  /**
+    * Follows a stream without a consumer group: replays every entry after `from`, then blocks for new entries forever, advancing past the
+    * last id each round. Blocking on an explicit id (never `$`) leaves no gap for entries arriving mid-loop. No acknowledgement, unlike
+    * [[xConsume]]. `from` defaults to the start; pass a later id to tail from there.
+    */
+  def xTail[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    key: K,
+    from: StreamId = StreamId.Zero,
+    count: Option[Long] = None,
+    block: BlockTimeout = SageClient.defaultPoll
+  )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[Throwable] & Async] =
+    CStream
+      .unfold[StreamId, Vector[StreamEntry[F, V]]](from) { last =>
+        CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map { result =>
+          val entries = result.flatMap(_._2)
+          Some((entries, if (entries.isEmpty) last else entries.last.id))
+        }
+      }
+      .flatMap(items => CStream.init(items))
+      .lower
+
+  /**
     * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
     * entries forever. `handle` runs per entry; the entry is acknowledged only after `handle` succeeds, so a failure leaves it in the PEL for
     * recovery. See ADR-0032.

--- a/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
+++ b/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
@@ -119,8 +119,9 @@ extension (client: SageClient) {
       .lower
 
   /**
-    * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Entries
-    * dropped because they no longer exist are skipped (the server reports them per-call as deleted; they are not surfaced here).
+    * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Tombstone
+    * entries — claimed ids whose data was already deleted, which the decoder surfaces with no fields — are skipped, so every emitted entry
+    * carries data.
     */
   def xAutoClaimAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
     key: K,
@@ -135,7 +136,7 @@ extension (client: SageClient) {
         case None       => CIO.value(None)
         case Some(from) =>
           CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))).map { result =>
-            Some((result.entries, if (result.cursor == StreamId.Zero) None else Some(result.cursor)))
+            Some((result.entries.filter(_.fields.nonEmpty), if (result.cursor == StreamId.Zero) None else Some(result.cursor)))
           }
       }
       .flatMap(items => CStream.init(items))

--- a/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
@@ -113,6 +113,50 @@ extension (client: SageClient) {
       .lower
 
   /**
+    * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Entries
+    * dropped because they no longer exist are skipped (the server reports them per-call as deleted; they are not surfaced here).
+    */
+  def xAutoClaimAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    key: K,
+    group: String,
+    consumer: String,
+    minIdle: FiniteDuration,
+    start: StreamId = StreamId.Zero,
+    count: Option[Long] = None
+  ): Ox ?=> Flow[StreamEntry[F, V]] =
+    CStream
+      .unfold[Option[StreamId], Vector[StreamEntry[F, V]]](Some(start)) {
+        case None       => CIO.value(None)
+        case Some(from) =>
+          CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))).map { result =>
+            Some((result.entries, if (result.cursor == StreamId.Zero) None else Some(result.cursor)))
+          }
+      }
+      .flatMap(items => CStream.init(items))
+      .lower
+
+  /**
+    * Follows a stream without a consumer group: replays every entry after `from`, then blocks for new entries forever, advancing past the
+    * last id each round. Blocking on an explicit id (never `$`) leaves no gap for entries arriving mid-loop. No acknowledgement, unlike
+    * [[xConsume]]. `from` defaults to the start; pass a later id to tail from there.
+    */
+  def xTail[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    key: K,
+    from: StreamId = StreamId.Zero,
+    count: Option[Long] = None,
+    block: BlockTimeout = SageClient.defaultPoll
+  ): Ox ?=> Flow[StreamEntry[F, V]] =
+    CStream
+      .unfold[StreamId, Vector[StreamEntry[F, V]]](from) { last =>
+        CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map { result =>
+          val entries = result.flatMap(_._2)
+          Some((entries, if (entries.isEmpty) last else entries.last.id))
+        }
+      }
+      .flatMap(items => CStream.init(items))
+      .lower
+
+  /**
     * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
     * entries forever. `handle` runs per entry; the entry is acknowledged only after `handle` returns, so a failure leaves it in the PEL for
     * recovery. See ADR-0032.

--- a/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
@@ -113,8 +113,9 @@ extension (client: SageClient) {
       .lower
 
   /**
-    * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Entries
-    * dropped because they no longer exist are skipped (the server reports them per-call as deleted; they are not surfaced here).
+    * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Tombstone
+    * entries — claimed ids whose data was already deleted, which the decoder surfaces with no fields — are skipped, so every emitted entry
+    * carries data.
     */
   def xAutoClaimAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
     key: K,
@@ -129,7 +130,7 @@ extension (client: SageClient) {
         case None       => CIO.value(None)
         case Some(from) =>
           CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))).map { result =>
-            Some((result.entries, if (result.cursor == StreamId.Zero) None else Some(result.cursor)))
+            Some((result.entries.filter(_.fields.nonEmpty), if (result.cursor == StreamId.Zero) None else Some(result.cursor)))
           }
       }
       .flatMap(items => CStream.init(items))

--- a/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
+++ b/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
@@ -119,6 +119,50 @@ extension (client: SageClient) {
       .lower
 
   /**
+    * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Entries
+    * dropped because they no longer exist are skipped (the server reports them per-call as deleted; they are not surfaced here).
+    */
+  def xAutoClaimAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    key: K,
+    group: String,
+    consumer: String,
+    minIdle: FiniteDuration,
+    start: StreamId = StreamId.Zero,
+    count: Option[Long] = None
+  ): ZStream[Any, Throwable, StreamEntry[F, V]] =
+    CStream
+      .unfold[Option[StreamId], Vector[StreamEntry[F, V]]](Some(start)) {
+        case None       => CIO.value(None)
+        case Some(from) =>
+          CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))).map { result =>
+            Some((result.entries, if (result.cursor == StreamId.Zero) None else Some(result.cursor)))
+          }
+      }
+      .flatMap(items => CStream.init(items))
+      .lower
+
+  /**
+    * Follows a stream without a consumer group: replays every entry after `from`, then blocks for new entries forever, advancing past the
+    * last id each round. Blocking on an explicit id (never `$`) leaves no gap for entries arriving mid-loop. No acknowledgement, unlike
+    * [[xConsume]]. `from` defaults to the start; pass a later id to tail from there.
+    */
+  def xTail[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+    key: K,
+    from: StreamId = StreamId.Zero,
+    count: Option[Long] = None,
+    block: BlockTimeout = SageClient.defaultPoll
+  ): ZStream[Any, Throwable, StreamEntry[F, V]] =
+    CStream
+      .unfold[StreamId, Vector[StreamEntry[F, V]]](from) { last =>
+        CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map { result =>
+          val entries = result.flatMap(_._2)
+          Some((entries, if (entries.isEmpty) last else entries.last.id))
+        }
+      }
+      .flatMap(items => CStream.init(items))
+      .lower
+
+  /**
     * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
     * entries forever. `handle` runs per entry; the entry is acknowledged only after `handle` succeeds, so a failure leaves it in the PEL for
     * recovery. See ADR-0032.

--- a/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
+++ b/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
@@ -119,8 +119,9 @@ extension (client: SageClient) {
       .lower
 
   /**
-    * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Entries
-    * dropped because they no longer exist are skipped (the server reports them per-call as deleted; they are not surfaced here).
+    * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Tombstone
+    * entries — claimed ids whose data was already deleted, which the decoder surfaces with no fields — are skipped, so every emitted entry
+    * carries data.
     */
   def xAutoClaimAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
     key: K,
@@ -135,7 +136,7 @@ extension (client: SageClient) {
         case None       => CIO.value(None)
         case Some(from) =>
           CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))).map { result =>
-            Some((result.entries, if (result.cursor == StreamId.Zero) None else Some(result.cursor)))
+            Some((result.entries.filter(_.fields.nonEmpty), if (result.cursor == StreamId.Zero) None else Some(result.cursor)))
           }
       }
       .flatMap(items => CStream.init(items))


### PR DESCRIPTION
Follows the same precedent as the SCAN family (`scanAll`/`hScanAll`/…) and `xRangeAll`/`xConsume`: wrap the awkward cursor/iteration commands into native streams so library users don't hand-roll the loops. Two helpers added as `SageClient` extension methods across all four backends (zio/ce/ox/kyo).

## `xAutoClaimAll`
The streams analog of `scanAll`. `XAUTOCLAIM` is cursor-driven exactly like `SCAN`, but users previously had to loop manually. This iterates from `start` (default `StreamId.Zero`), emits the claimed entries each page, advances the cursor, and terminates when the cursor wraps back to `0-0`.

```scala
client.xAutoClaimAll[K, F, V](key, group, consumer, minIdle, start = StreamId.Zero, count = None): Stream[StreamEntry[F, V]]
```

Entries the server reports as dropped (no longer exist) are skipped rather than surfaced.

## `xTail`
Follows a stream *without* a consumer group — the counterpart to the group-based `xConsume`. Replays everything after `from`, then blocks for new entries forever. No acknowledgement.

```scala
client.xTail[K, F, V](key, from = StreamId.Zero, count = None, block = defaultPoll): Stream[StreamEntry[F, V]]
```

Design note: it blocks on `ReadId.After(lastId)`, never `$`. `$` resolves to the stream's current last id at block time, so an entry arriving between a drain and the next blocking call would be skipped — blocking on the explicit last-seen id is gap-free. On a block timeout it re-blocks from the same id.

## Notes
- Each backend returns its native stream type (`ZStream` / `fs2.Stream` / `Flow` / kyo `Stream`); kyo carries the same `(using Tag[F], Tag[V])` bounds as `xRangeAll`.
- Formatted with `scalafmtAll`; all four client backends compile clean.
- Deliberately left out blocking-pop streams (BLPOP-as-queue) for now, given the dedicated-connection-pinning trade-off.