### PR TITLE
Remove unused qualified-private symbols

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
@@ -100,17 +100,6 @@ final private[client] class ClientCache(maxBytes: Long) {
     } finally lock.unlock()
   }
 
-  private[internal] def size: Int       = {
-    lock.lock();
-    try entries.size
-    finally lock.unlock()
-  }
-  private[internal] def usedBytes: Long = {
-    lock.lock();
-    try bytesUsed
-    finally lock.unlock()
-  }
-
   private def insert(key: Key, entry: Entry): Unit = {
     val previous = entries.put(key, entry)
     if (previous != null) bytesUsed -= previous.sizeBytes

--- a/sage-core/src/main/scala/sage/commands/Decode.scala
+++ b/sage-core/src/main/scala/sage/commands/Decode.scala
@@ -19,11 +19,6 @@ private[commands] object Decode {
     case other                => Left(DecodeError("integer", Frame.describe(other)))
   }
 
-  val int: Frame => Either[DecodeError, Int] = {
-    case Frame.Integer(value) => Right(value.toInt)
-    case other                => Left(DecodeError("integer", Frame.describe(other)))
-  }
-
   val flag: Frame => Either[DecodeError, Boolean] = {
     case Frame.Integer(0) => Right(false)
     case Frame.Integer(1) => Right(true)


### PR DESCRIPTION
Removes three dead symbols found during a dead-code sweep. Each had zero references anywhere in the repo (production, all four runtime adapters, and tests).

- `Decode.int` — integer decoding goes through `Decode.long`/`Decode.flag`; nothing referenced `Decode.int`.
- `ClientCache.size` and `ClientCache.usedBytes` — never called; the cache's LRU test asserts eviction via `acquire` returning `Fetch`, not through these accessors.

All three are *qualified*-private (`private[...]`), which is why they slipped past the build's `-Wunused:privates` + `-Xfatal-warnings` (that check doesn't flag qualified-private members).

`sbt scalafmtAll` clean; `core` and `clientCe` compile with fatal warnings enabled.