### PR TITLE
Centralize canonical double wire formatting

### DIFF
--- a/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
@@ -159,7 +159,7 @@ extension (client: SageClient) {
 
   /**
     * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
-    * entries forever. `handle` runs per entry; the entry is acknowledged only after `handle` returns, so a failure leaves it in the PEL for
+    * entries forever. `handle` runs per entry; the entry is acknowledged only after `handle` succeeds, so a failure leaves it in the PEL for
     * recovery. See ADR-0032.
     */
   def xConsume[K: KeyCodec, F: KeyCodec, V: ValueCodec](

--- a/sage-core/src/main/scala/sage/codec/Doubles.scala
+++ b/sage-core/src/main/scala/sage/codec/Doubles.scala
@@ -1,0 +1,37 @@
+package sage.codec
+
+/**
+  * The canonical RESP wire form for doubles: infinities and NaN are spelled `inf`/`-inf`/`nan` the way Redis writes and accepts
+  * them, never Java's `Infinity`/`NaN`. The single source of truth shared by the value codec, the score/range/coordinate
+  * encoders, and the bulk-string reply decoders. The RESP3 parser keeps its own wire-level grammar by design — it is not a codec.
+  */
+private[sage] object Doubles {
+
+  def format(value: Double): String =
+    if (value == Double.PositiveInfinity) "inf"
+    else if (value == Double.NegativeInfinity) "-inf"
+    else if (value.isNaN) "nan"
+    else value.toString
+
+  def parse(text: String): Option[Double] =
+    text match {
+      case "inf" | "+inf" => Some(Double.PositiveInfinity)
+      case "-inf"         => Some(Double.NegativeInfinity)
+      case "nan"          => Some(Double.NaN)
+      case other          => other.toDoubleOption
+    }
+
+  def formatFloat(value: Float): String =
+    if (value == Float.PositiveInfinity) "inf"
+    else if (value == Float.NegativeInfinity) "-inf"
+    else if (value.isNaN) "nan"
+    else value.toString
+
+  def parseFloat(text: String): Option[Float] =
+    text match {
+      case "inf" | "+inf" => Some(Float.PositiveInfinity)
+      case "-inf"         => Some(Float.NegativeInfinity)
+      case "nan"          => Some(Float.NaN)
+      case other          => other.toFloatOption
+    }
+}

--- a/sage-core/src/main/scala/sage/codec/ValueCodec.scala
+++ b/sage-core/src/main/scala/sage/codec/ValueCodec.scala
@@ -21,9 +21,11 @@ object ValueCodec {
 
   given long: ValueCodec[Long] = instance(Primitives.encodeNumber, Primitives.decodeNumber("Long", _.toLongOption))
 
-  given double: ValueCodec[Double] = instance(Primitives.encodeNumber, Primitives.decodeNumber("Double", _.toDoubleOption))
+  given double: ValueCodec[Double] =
+    instance(d => Bytes.utf8(Doubles.format(d)), Primitives.decodeNumber("Double", Doubles.parse))
 
-  given float: ValueCodec[Float] = instance(Primitives.encodeNumber, Primitives.decodeNumber("Float", _.toFloatOption))
+  given float: ValueCodec[Float] =
+    instance(f => Bytes.utf8(Doubles.formatFloat(f)), Primitives.decodeNumber("Float", Doubles.parseFloat))
 
   given boolean: ValueCodec[Boolean] = instance(Primitives.encodeBoolean, Primitives.decodeBoolean)
 

--- a/sage-core/src/main/scala/sage/commands/Decode.scala
+++ b/sage-core/src/main/scala/sage/commands/Decode.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration.FiniteDuration
 
 import sage.Bytes
 import sage.SageException.DecodeError
-import sage.codec.{KeyCodec, ValueCodec}
+import sage.codec.{Doubles, KeyCodec, ValueCodec}
 import sage.protocol.Frame
 
 private[commands] object Decode {
@@ -33,7 +33,7 @@ private[commands] object Decode {
   val double: Frame => Either[DecodeError, Double] = {
     case Frame.BulkString(bytes) =>
       val text = bytes.asUtf8String
-      text.toDoubleOption.toRight(DecodeError("double bulk string", s"bulk string '$text'"))
+      Doubles.parse(text).toRight(DecodeError("double bulk string", s"bulk string '$text'"))
     case other                   => Left(DecodeError("double bulk string", Frame.describe(other)))
   }
 
@@ -100,7 +100,7 @@ private[commands] object Decode {
     case Frame.Double(value)     => Right(value)
     case Frame.BulkString(bytes) =>
       val text = bytes.asUtf8String
-      text.toDoubleOption.toRight(DecodeError("double", s"bulk string '$text'"))
+      Doubles.parse(text).toRight(DecodeError("double", s"bulk string '$text'"))
     case other                   => Left(DecodeError("double", Frame.describe(other)))
   }
 
@@ -254,16 +254,10 @@ private[commands] object Decode {
 
   private def scoreText(frame: Frame): Either[DecodeError, Double] =
     frame match {
-      case Frame.BulkString(bytes) => parseScore(bytes.asUtf8String)
+      case Frame.BulkString(bytes) =>
+        val text = bytes.asUtf8String
+        Doubles.parse(text).toRight(DecodeError("double", s"bulk string '$text'"))
       case other                   => Left(DecodeError("score bulk string", Frame.describe(other)))
-    }
-
-  private def parseScore(text: String): Either[DecodeError, Double] =
-    text match {
-      case "inf" | "+inf" => Right(Double.PositiveInfinity)
-      case "-inf"         => Right(Double.NegativeInfinity)
-      case "nan"          => Right(Double.NaN)
-      case other          => other.toDoubleOption.toRight(DecodeError("double", s"bulk string '$other'"))
     }
 }
 

--- a/sage-core/src/main/scala/sage/commands/Geo.scala
+++ b/sage-core/src/main/scala/sage/commands/Geo.scala
@@ -2,7 +2,7 @@ package sage.commands
 
 import sage.Bytes
 import sage.SageException.DecodeError
-import sage.codec.{KeyCodec, ValueCodec}
+import sage.codec.{Doubles, KeyCodec, ValueCodec}
 import sage.protocol.Frame
 
 // longitude first, matching the wire order; named so the two same-typed coordinates cannot be silently swapped
@@ -167,8 +167,8 @@ private[sage] object Geo {
 
   private def shapeArgs(shape: GeoShape): Vector[Bytes] =
     shape match {
-      case GeoShape.ByRadius(radius, unit)     => Vector(ByRadius, Bytes.utf8(radius.toString), unitArg(unit))
-      case GeoShape.ByBox(width, height, unit) => Vector(ByBox, Bytes.utf8(width.toString), Bytes.utf8(height.toString), unitArg(unit))
+      case GeoShape.ByRadius(radius, unit)     => Vector(ByRadius, Bytes.utf8(Doubles.format(radius)), unitArg(unit))
+      case GeoShape.ByBox(width, height, unit) => Vector(ByBox, Bytes.utf8(Doubles.format(width)), Bytes.utf8(Doubles.format(height)), unitArg(unit))
     }
 
   private def sortArgs(sort: Option[GeoSort]): Vector[Bytes] =
@@ -193,7 +193,7 @@ private[sage] object Geo {
       case GeoUnit.Feet       => UnitFeet
     }
 
-  private def coordArg(value: Double): Bytes = Bytes.utf8(value.toString)
+  private def coordArg(value: Double): Bytes = Bytes.utf8(Doubles.format(value))
 
   private val coordinates: Frame => Either[DecodeError, GeoCoordinates] = {
     case Frame.Array(Vector(lon, lat)) =>

--- a/sage-core/src/main/scala/sage/commands/Hashes.scala
+++ b/sage-core/src/main/scala/sage/commands/Hashes.scala
@@ -6,7 +6,7 @@ import scala.concurrent.duration.{FiniteDuration, MILLISECONDS, SECONDS, TimeUni
 
 import sage.Bytes
 import sage.SageException.DecodeError
-import sage.codec.{KeyCodec, ValueCodec}
+import sage.codec.{Doubles, KeyCodec, ValueCodec}
 import sage.protocol.Frame
 
 /**
@@ -110,7 +110,12 @@ private[sage] object Hashes {
     Command("HINCRBY", Command.FirstKey, Vector(keyCodec.encode(key), fieldCodec.encode(field), Bytes.utf8(increment.toString)), Decode.long)
 
   def hIncrByFloat[K, F](key: K, field: F, increment: Double)(using keyCodec: KeyCodec[K], fieldCodec: KeyCodec[F]): Command[Double] =
-    Command("HINCRBYFLOAT", Command.FirstKey, Vector(keyCodec.encode(key), fieldCodec.encode(field), Bytes.utf8(increment.toString)), Decode.double)
+    Command(
+      "HINCRBYFLOAT",
+      Command.FirstKey,
+      Vector(keyCodec.encode(key), fieldCodec.encode(field), Bytes.utf8(Doubles.format(increment))),
+      Decode.double
+    )
 
   def hRandField[K, F](key: K)(using keyCodec: KeyCodec[K], fieldCodec: KeyCodec[F]): Command[Option[F]] =
     Command.readUncacheable("HRANDFIELD", Command.FirstKey, Vector(keyCodec.encode(key)), Decode.optionalKey[F])

--- a/sage-core/src/main/scala/sage/commands/SortedSets.scala
+++ b/sage-core/src/main/scala/sage/commands/SortedSets.scala
@@ -2,7 +2,7 @@ package sage.commands
 
 import sage.Bytes
 import sage.SageException.DecodeError
-import sage.codec.{KeyCodec, ValueCodec}
+import sage.codec.{Doubles, KeyCodec, ValueCodec}
 import sage.protocol.Frame
 
 /**
@@ -435,11 +435,7 @@ private[sage] object SortedSets {
 
   private def scoreArg(score: Double): Bytes = Bytes.utf8(formatScore(score))
 
-  private def formatScore(value: Double): String =
-    if (value == Double.PositiveInfinity) "inf"
-    else if (value == Double.NegativeInfinity) "-inf"
-    else if (value.isNaN) "nan"
-    else value.toString
+  private def formatScore(value: Double): String = Doubles.format(value)
 
   private def prefixed(prefix: Char, value: Bytes): Bytes = {
     val src = value.unsafeArray

--- a/sage-core/src/main/scala/sage/commands/Strings.scala
+++ b/sage-core/src/main/scala/sage/commands/Strings.scala
@@ -6,7 +6,7 @@ import scala.concurrent.duration.FiniteDuration
 
 import sage.Bytes
 import sage.SageException.DecodeError
-import sage.codec.{KeyCodec, ValueCodec}
+import sage.codec.{Doubles, KeyCodec, ValueCodec}
 import sage.protocol.Frame
 
 /**
@@ -130,7 +130,7 @@ private[sage] object Strings {
     Command("INCRBY", Command.FirstKey, Vector(keyCodec.encode(key), Bytes.utf8(increment.toString)), Decode.long)
 
   def incrByFloat[K](key: K, increment: Double)(using keyCodec: KeyCodec[K]): Command[Double] =
-    Command("INCRBYFLOAT", Command.FirstKey, Vector(keyCodec.encode(key), Bytes.utf8(increment.toString)), Decode.double)
+    Command("INCRBYFLOAT", Command.FirstKey, Vector(keyCodec.encode(key), Bytes.utf8(Doubles.format(increment))), Decode.double)
 
   def mGet[K, V](first: K, rest: K*)(using keyCodec: KeyCodec[K], valueCodec: ValueCodec[V]): Command[Vector[Option[V]]] = {
     val keys = (first +: rest.toVector).map(keyCodec.encode)
@@ -258,8 +258,8 @@ private[sage] object Strings {
     Command(
       "INCREX",
       Command.FirstKey,
-      Vector(keyCodec.encode(key), ByFloat, Bytes.utf8(increment.toString)) ++
-        incrExArgs(saturate, lowerBound.map(_.toString), upperBound.map(_.toString), expiry),
+      Vector(keyCodec.encode(key), ByFloat, Bytes.utf8(Doubles.format(increment))) ++
+        incrExArgs(saturate, lowerBound.map(Doubles.format), upperBound.map(Doubles.format), expiry),
       incrExResultDouble
     )
 


### PR DESCRIPTION
## What

Found during a consistency review of the codebase. The `inf`/`-inf`/`nan` canonical wire mapping for doubles was **triplicated** (`SortedSets.formatScore`, `RespParser`, `Decode.parseScore`) and **bypassed entirely** at a fourth set of sites, which produced two real inconsistencies — one of them a latent decode bug.

This PR introduces `sage.codec.Doubles` as the single source of truth (`format`/`parse` plus `Float` variants) and routes every codec-layer site through it.

## Bugs / inconsistencies fixed

**Encode divergence** — `Geo` (radius/box/coordinates), `Hashes.hIncrByFloat`, and `Strings.incrByFloat`/`increxByFloat` (increment and bounds) emitted Java's `"Infinity"`/`"NaN"`, which the server rejects, while `SortedSets.formatScore` alone emitted the canonical `inf`/`-inf`/`nan`. All now use `Doubles.format`.

**Latent decode bug** — `Decode.double`, `Decode.lenientDouble`, and `ValueCodec[Double]`/`[Float]` used bare `toDoubleOption`, which **cannot parse Redis's own `"inf"`/`"-inf"`/`"nan"` bulk-string replies** and failed them with a `DecodeError`. They now go through `Doubles.parse`. `Decode.scoreText` and `SortedSets.formatScore` delegate too, collapsing the triplication to one definition.

**Ox doc alignment** — `xConsume`'s doc said an entry is acknowledged after `handle` *returns*; the other three backends (and the actual PEL-recovery guarantee) say *succeeds*. Now consistent.

## Notes

- The RESP3 parser (`RespParser`) deliberately keeps its own wire-level grammar — per the domain model it is not a codec, so it's left untouched.
- For finite values the encoded bytes are byte-for-byte unchanged; this only affects the `inf`/`nan` edges plus dedup, so there is no regression surface for normal values.

## Testing

- `core` compiles on both Scala axes; all four client backends compile.
- `CodecSpec`, `SortedSetsSpec`, `StringsSpec`, `HashesSpec` pass (45 tests).