### PR TITLE
Replica reads: shared ReadFrom policy, cluster READONLY + master-replica topology

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -134,6 +134,10 @@ _Avoid_: cluster map, slot map, layout
 A user-supplied address the cluster runtime contacts at startup to discover the Cluster Topology. Seeds bootstrap discovery only — once the topology is known, routing targets are Nodes the cluster reports, and a seed that is not itself a master is dropped. Any one seed answering is enough.
 _Avoid_: bootstrap node, contact point, seed node
 
+**Master-Replica**:
+A non-cluster deployment of one master Node and one or more replica Nodes, selected by `Topology.MasterReplica` and discovered from seed endpoints by asking each its role. Unlike a Cluster it has no slots, no redirects, and no cluster bus; unlike a Sentinel setup (out of scope) it has no external monitor. Reads route per the Read Policy and everything else goes to the master, exactly as in a cluster Shard — a Master-Replica is effectively a single Shard owning the whole keyspace. The same Client type serves it; only the topology selects the runtime.
+_Avoid_: master-slave, replica set, primary-replica, sentinel
+
 **Read Policy**:
 The `ReadFrom` setting governing which Node a read-only command may run on, the same setting for both cluster and master-replica deployments: `Master` (default — every command to the master), `MasterPreferred`, `Replica`, or `ReplicaPreferred`. Only read-only commands are eligible; writes and any command not marked read-only always go to the master, regardless of the policy. `Replica` fails when no replica is reachable; the `*Preferred` policies fall back to the master. Reads served by a replica may lag the master — staleness is the policy's accepted contract, not a fault. Uses "master", never "primary", matching the Node/Shard vocabulary.
 _Avoid_: read preference, routing policy, primary

--- a/docs/adr/0038-shared-readfrom-policy-and-replica-read-routing.md
+++ b/docs/adr/0038-shared-readfrom-policy-and-replica-read-routing.md
@@ -1,0 +1,34 @@
+# Shared ReadFrom policy and replica read routing
+
+Read scaling routes read-only commands to replicas, governed by one `ReadFrom` policy that serves both the cluster `READONLY` mode and the master-replica topology. The policy lives at the **top level** of `SageConfig` (`readFrom: ReadFrom = Master`), not inside `ClusterConfig`, so a single setting covers both deployment shapes and the public surface stays consistent across the #40 freeze. The values are `Master | MasterPreferred | Replica | ReplicaPreferred`, defaulting to `Master` — today's behavior, every command to the master. The vocabulary is **master**, never *primary*, matching `Shard.master` and the Node/Shard glossary; an `Any` value was dropped as redundant with the `*Preferred` pair.
+
+## The eligibility gate
+
+The policy redirects only the read-only subset. A command is replica-eligible iff `command.isReadOnly && command.execution == Ordinary`; everything else goes to the master regardless of the policy:
+
+- **Writes and non-read-only reads** — always master.
+- **Blocking read-only commands** (`XREAD BLOCK`) — always master. Honoring the policy here would force a Dedicated Pool onto every replica for a rare case; instead a replica is a single auto-pipelined Multiplexed Connection and blocking reads stay on the writable node.
+- **`cached` reads** — always master. Client-side caching (ADR-0028) is anchored to the connection that registers tracking and receives invalidation pushes; serving a `cached` read from a replica would cache a possibly-stale value that the master's tracking stream could never invalidate. The two features compose by not overlapping. (In both cluster and master-replica mode `cached` currently runs *uncached* on the master — the local cache there is a follow-up, as in cluster today — but it stays master-pinned so the call is portable and never silently reads a stale replica.)
+- **Transactions / `WATCH` / `MULTI` / `EXEC`** — always master (Dedicated Pool, and they need the writable node anyway).
+
+The gate is `isReadOnly`, the looser property, not `cacheable` (the stricter, deterministic one). Non-deterministic read-only commands (`SRANDMEMBER`, `TTL`) therefore run on replicas under a replica policy and may observe slightly stale or time-varying state — the accepted contract of replica reads, not a fault.
+
+## Selection lives in the runtime
+
+Replica selection is inseparable from connection liveness (is this replica's socket up? established?) and from round-robin and fallback state — none of which the pure `ClusterTopology` snapshot can or should hold (ADR-0021). So `ClusterTopology.route` keeps returning the master and slot; the core gains only a pure replica-lookup helper, and `ReadFrom` never enters `sage-core`. The runtime consults the policy, picks a **live** replica by **round-robin per shard**, and applies fallback. Nearest/latency-based routing is deliberately out of scope (it needs per-node latency tracking).
+
+Fallback by policy: `MasterPreferred` → master, else a live replica; `ReplicaPreferred` → a live replica, else master; `Replica` is strict and **fails** when no replica is reachable, reusing `NotConnected` with a descriptive message rather than growing the sealed hierarchy. A `Standalone` topology has no replicas from sage's view, so config validation rejects `readFrom == Replica` there (a guaranteed-broken config) while letting the `*Preferred` policies degrade silently to the one node, so the same `readFrom` can be shared across environments.
+
+## Pipelines route all-or-nothing
+
+A Pipeline is split per node by slot, results reassembled in submission order. Letting individual commands within one pipeline pick master-vs-replica would split a single slot across two connections and create a read-your-own-write trap (a `SET k` then `GET k` in the same batch, the `GET` on a lagging replica). Instead the decision is per pipeline: if **every** command is replica-eligible, each shard's batch routes to a replica; if **any** command is not, the whole pipeline goes to the masters. This keeps the split model and reassembly untouched and never splits a slot across master and replica.
+
+## Considered Options
+
+- **`ReadFrom` inside `ClusterConfig`** — rejected: master-replica mode needs the same setting, and a cluster-local home would either duplicate it or be binary-incompatible to move after the #40 freeze.
+- **Policy in the pure core** (`route` returns the chosen replica) — rejected: the core would have to model connection liveness and load-balancing state it deliberately lacks.
+- **Per-command replica routing inside a pipeline** — rejected for the slot-splitting and read-your-write hazards above; all-or-nothing keeps the benefit for pure-read batches without them.
+
+## Consequences
+
+In cluster mode each replica is a single Multiplexed Connection (no Dedicated Pool, no Subscription Connection, no tracking), established lazily on the first read routed to it, with `READONLY` issued at connection setup (ADR-0039). In master-replica mode the same selection helper runs over the single shard. `Standalone` is unaffected at runtime (it has no replicas). The shared per-node-pool and replica-selection helpers are extracted so the cluster and master-replica runtimes do not duplicate them.

--- a/docs/adr/0039-master-replica-topology-and-event-driven-failover.md
+++ b/docs/adr/0039-master-replica-topology-and-event-driven-failover.md
@@ -1,0 +1,22 @@
+# Master-replica topology and event-driven failover
+
+`Topology.MasterReplica(seeds, config)` connects to a non-cluster deployment of one master and one or more replicas, for read scaling outside a cluster. It is discovery-only: at connect, sage asks a reachable seed its role (`ROLE`, or `INFO replication` for a single seed) and classifies the master and replicas from the supplied endpoints. The client type is unchanged (ADR-0007) — only the topology selects the runtime, as Standalone and Cluster do. Sentinel-managed discovery stays out of scope.
+
+There is no asserted-static `master + replicas` form. Its only advantage would be working when `ROLE`/`INFO` are blocked, but sage already mandates `HELLO` and `CLIENT SETINFO` (ADR-0037), so a node that answers those answers `ROLE` too; and an asserted master is a footgun across failover (writes to a demoted node until something refreshes). Listing your nodes as seeds covers the same use case while staying correct.
+
+A master-replica deployment is effectively a single Shard owning the whole keyspace, but it is served by a focused `MasterReplicaLive` runtime rather than a degenerate `ClusterLive`. The cluster runtime couples discovery (`CLUSTER SLOTS`) to a redirect state machine and carries slots, `CROSSSLOT`, all-masters fan-out, and sharded pub/sub — none of which apply here, and none of which inject cleanly. The genuinely shared parts — the per-node connection pool and the replica-selection helper (ADR-0038) — are extracted and used by both runtimes; the rest stays mode-specific.
+
+## Failover is event-driven, with no periodic poll
+
+Master-replica mode has none of cluster mode's failover machinery: no cluster bus, no `MOVED`/`ASK` redirects, no `CLUSTER SLOTS`. When a replica is promoted and the master demoted, the client learns of it from two events, both throttled by `minRefreshInterval`:
+
+1. **Reconnect** — a dropped master connection re-discovers roles, since a dropped master often *is* a failover. Combined with ADR-0014's reconnect-behind-a-stable-endpoint, this covers managed deployments where a primary DNS name or VIP repoints on failover: the connection reconnects to the same name, now the promoted node, and re-discovery confirms the roster.
+2. **`-READONLY` from the presumed master** — it was demoted in place without dropping the socket. Re-discover roles, and **fail the offending write** (refresh-then-terminal), so the caller's retry lands on the freshly-discovered master. This is the same disposition cluster mode already applies to a `READONLY` from a demoted master.
+
+There is deliberately **no background periodic `ROLE` poll**. A silent promotion with no traffic to the demoted node leaves the roster stale but harmlessly — the first write to hit `-READONLY` triggers the refresh — and cluster mode likewise refreshes on events, not a timer. `MasterReplicaConfig` leaves room to add an opt-in poll later if demand appears.
+
+This is more than the reference clients do: Lettuce's plain (non-sentinel, non-cluster) master-replica performs a one-time `ROLE` lookup and stays static, surfacing `-READONLY` to the caller and requiring the connection to be rebuilt outside the library on failover; redis4cats inherits that. sage's reconnect and `READONLY`-driven re-discovery turn a silent write outage into a self-healing retry, and the acceptance criteria require roles to refresh on reconnect regardless.
+
+## Consequences
+
+Replicas serve reads **without** `READONLY` — that command is cluster-only; the connection-setup `READONLY` of ADR-0038/ADR-0039 applies only to cluster replica connections. A new pure `Connection.readonly` builder is added to the core for the cluster path; no `READWRITE` is needed, since master connections never issue `READONLY`. A write that meets a demoted master fails fast (ADR-0006) rather than following a redirect the protocol does not provide. Read routing and the staleness contract are governed by the shared `ReadFrom` policy (ADR-0038).

--- a/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
+++ b/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
@@ -99,13 +99,35 @@ final case class ClusterConfig(
 )
 
 /**
+  * Master-replica tuning. `minRefreshInterval` throttles role re-discovery (`ROLE`/`INFO replication`) so a burst of `READONLY`s or
+  * reconnects triggers at most one discovery per window. There is no periodic poll: roles refresh only on reconnect and on a `READONLY`
+  * from the presumed master.
+  */
+final case class MasterReplicaConfig(
+  minRefreshInterval: FiniteDuration = 5.seconds
+)
+
+/**
+  * Which Node a read-only command may run on, the same setting for both cluster and master-replica deployments. Only read-only,
+  * non-blocking commands are eligible; writes, blocking reads, transactions, and `cached` reads always go to the master regardless of the
+  * policy. `Master` (the default) is today's behavior — every command to the master. `MasterPreferred` falls back to a replica only when the
+  * master is unreachable; `Replica` reads only from replicas and fails when none is reachable; `ReplicaPreferred` reads from a replica, else
+  * the master. Reads served by a replica may lag the master — that staleness is the policy's accepted contract.
+  */
+enum ReadFrom {
+  case Master, MasterPreferred, Replica, ReplicaPreferred
+}
+
+/**
   * Standalone connects to the one server at `endpoint`; cluster discovers its topology from `seeds` and routes every command to the owning
-  * node. The address lives here, inside the topology, so there is one place it can come from. The client type is the same either way — only
+  * node; master-replica discovers one master and its replicas from `seeds` (by asking each its `ROLE`) and routes reads per the Read Policy.
+  * The address lives here, inside the topology, so there is one place it can come from. The client type is the same in every case — only
   * this selects the runtime.
   */
 enum Topology {
   case Standalone(endpoint: Endpoint = Endpoint())
   case Cluster(seeds: Vector[Endpoint], config: ClusterConfig = ClusterConfig())
+  case MasterReplica(seeds: Vector[Endpoint], config: MasterReplicaConfig = MasterReplicaConfig())
 }
 
 /**
@@ -125,6 +147,7 @@ final case class SageConfig(
   auth: Option[AuthConfig] = None,
   tls: Option[TlsConfig] = None,
   topology: Topology = Topology.Standalone(),
+  readFrom: ReadFrom = ReadFrom.Master,
   database: Int = 0,
   clientName: Option[String] = None,
   listeners: Vector[SageListener] = Vector.empty

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -13,7 +13,7 @@ import kyo.compat.*
 
 import sage.{Bytes, Message, Outcome, PatternMessage, SageEvent, SageException}
 import sage.SageException.{ConnectionLost, NotCacheable, NotConnected, ServerError, TimedOut, TlsError, UnsupportedServer}
-import sage.client.{AuthConfig, BackoffConfig, BuildInfo, DedicatedPoolConfig, Endpoint, PubSubConfig, SageConfig, Topology, WatchdogConfig}
+import sage.client.{AuthConfig, BackoffConfig, BuildInfo, DedicatedPoolConfig, Endpoint, PubSubConfig, ReadFrom, SageConfig, Topology, WatchdogConfig}
 import sage.cluster.Node
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
@@ -1011,14 +1011,36 @@ object Client {
   private[internal] def notCacheable(command: Command[?]): NotCacheable =
     NotCacheable(s"${command.name} is not cacheable: cached requires a cacheable command with at least one key")
 
+  // a pipeline batched onto a single connection: scatter each reply into its submission-order slot, and on a disconnect report a failed
+  // completion per position (as a single disconnected run does) before failing the effect once. Shared by the standalone and master-replica
+  // runtimes; the cluster runtime splits per node instead.
+  private[internal] def submitBatchOnOne(
+    events: Events,
+    commands: Vector[Command[?]],
+    submitAll: (Vector[Command[?]], Vector[Try[Any] => Unit]) => Boolean,
+    complete: Try[Vector[Either[SageException, Any]]] => Unit
+  ): Unit = {
+    val collector = new TxSupport.IndexedCollector[Either[SageException, Any]](commands.length, complete)
+    val callbacks = Vector.tabulate(commands.length)(i =>
+      Events.trackCommand[Any](events, commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)))
+    )
+    if (!submitAll(commands, callbacks)) {
+      if (events.enabled)
+        commands.foreach(c => events.emit(SageEvent.CommandCompleted(c.name, None, Duration.Zero, Outcome.Failed(NotConnected()))))
+      complete(Failure(NotConnected()))
+    }
+  }
+
   def connect(config: SageConfig): CIO[Client[CIO]] =
     validate(config) match {
       case Some(problem) => CIO.fail(new IllegalArgumentException(problem))
       case None          =>
         config.topology match {
-          case Topology.Standalone(endpoint)          => connectStandalone(config, endpoint)
-          case Topology.Cluster(seeds, clusterConfig) =>
+          case Topology.Standalone(endpoint)                => connectStandalone(config, endpoint)
+          case Topology.Cluster(seeds, clusterConfig)       =>
             ClusterLive.connect(config, seeds.map(e => Node(e.host, e.port)), clusterConfig, Scheduler.real, translateHandshake)
+          case Topology.MasterReplica(seeds, masterReplica) =>
+            MasterReplicaLive.connect(config, seeds.map(e => Node(e.host, e.port)), masterReplica, Scheduler.real, translateHandshake)
         }
     }
 
@@ -1044,14 +1066,25 @@ object Client {
       positive(config.dedicatedPool.acquireTimeout, "dedicatedPool.acquireTimeout"),
       cond(config.pubsub.bufferSize >= 1, "pubsub.bufferSize must be >= 1")
     ) ++ watchdog ++ (config.topology match {
-      case Topology.Cluster(seeds, cluster) =>
+      case Topology.Cluster(seeds, cluster)             =>
         Vector(
           cond(seeds.nonEmpty, "cluster topology requires at least one seed"),
           cond(config.database == 0, "cluster topology has no SELECT; database must be 0"),
           cond(cluster.maxRedirects >= 0, "cluster.maxRedirects must be >= 0"),
           positive(cluster.minRefreshInterval, "cluster.minRefreshInterval")
         ) ++ seeds.map(s => port(s.port, s"seed ${s.host}:${s.port} port"))
-      case Topology.Standalone(endpoint)    => Vector(port(endpoint.port, s"endpoint ${endpoint.host}:${endpoint.port} port"))
+      case Topology.MasterReplica(seeds, masterReplica) =>
+        Vector(
+          cond(seeds.nonEmpty, "master-replica topology requires at least one seed"),
+          positive(masterReplica.minRefreshInterval, "masterReplica.minRefreshInterval")
+        ) ++ seeds.map(s => port(s.port, s"seed ${s.host}:${s.port} port"))
+      // a Standalone has no replicas, so the strict Replica policy could never serve a read; the *Preferred policies harmlessly degrade to
+      // the one node, so they stay valid (a readFrom can then be shared across environments)
+      case Topology.Standalone(endpoint)                =>
+        Vector(
+          port(endpoint.port, s"endpoint ${endpoint.host}:${endpoint.port} port"),
+          cond(config.readFrom != ReadFrom.Replica, "readFrom = Replica needs replicas; a Standalone topology has none")
+        )
     })
     checks.flatten.headOption
   }
@@ -1204,18 +1237,7 @@ object Client {
       else if (p.commands.exists(_.isBlocking))
         CIO.fail(new IllegalArgumentException("a Pipeline cannot carry blocking commands; run them individually on the client"))
       else
-        CIO.async { complete =>
-          val collector = new TxSupport.IndexedCollector[Either[SageException, Any]](p.commands.length, complete)
-          val callbacks = Vector.tabulate(p.commands.length)(i =>
-            Events.trackCommand[Any](events, p.commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)))
-          )
-          if (!connection.submitAll(p.commands, callbacks)) {
-            // not connected: still fail fast with one error, but report a failed completion per position (as a single disconnected run does)
-            if (events.enabled)
-              p.commands.foreach(c => events.emit(SageEvent.CommandCompleted(c.name, None, Duration.Zero, Outcome.Failed(NotConnected()))))
-            complete(Failure(NotConnected()))
-          }
-        }
+        CIO.async(complete => Client.submitBatchOnOne(events, p.commands, connection.submitAll, complete))
 
     def subscribeChannels[V: ValueCodec](channel: String, rest: String*): CIO[Subscription[CIO, Message[V]]] =
       CIO.blocking(channelMessages(subscriptions.subscribeChannels(channel +: rest.toVector)))
@@ -1262,7 +1284,7 @@ object Client {
       case Left(error)  => throw error
     }
 
-  final private class TxScope(val conn: DedicatedConnection) extends TransactionScope[CIO] {
+  final private[internal] class TxScope(val conn: DedicatedConnection) extends TransactionScope[CIO] {
 
     // tracks whether watched keys may still be armed on the connection; set as soon as WATCH is attempted, cleared by EXEC/UNWATCH
     val armed = new AtomicBoolean(false)
@@ -1280,7 +1302,7 @@ object Client {
     }
 
     // run once by the lease finalizer: seals the scope against further operations and reports whether the connection may be recycled
-    private[Client] def sealAndReusable(): Boolean = {
+    private[internal] def sealAndReusable(): Boolean = {
       lock.lock()
       try {
         released = true

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -63,6 +63,7 @@ final private[client] class ClusterLive(
   )
   // per-master round-robin cursor over its shard's replicas, so successive eligible reads spread across them
   private val replicaCursors = new java.util.concurrent.ConcurrentHashMap[Node, java.util.concurrent.atomic.AtomicInteger]()
+  private val keylessCursor  = new java.util.concurrent.atomic.AtomicInteger()
 
   private val subscriptions = new ClusterSubscriptions(
     nodeFactory,
@@ -172,7 +173,10 @@ final private[client] class ClusterLive(
             if (allowReplica && readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command))
               sendRead(command, node, slot, redirectsLeft, complete)
             else sendTo(node, command, asking = false, redirectsLeft, complete)
-          case Route.Keyless            => sendToAny(topology, command, redirectsLeft, complete)
+          case Route.Keyless            =>
+            if (allowReplica && readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command))
+              sendKeylessRead(topology, command, redirectsLeft, complete)
+            else sendToAny(topology, command, redirectsLeft, complete)
           case Route.Unowned(_)         => onUnowned(command, redirectsLeft, complete)
           case Route.CrossSlot(slots)   => complete(Failure(crossSlot(command.name, slots)))
           case Route.Malformed          =>
@@ -188,6 +192,21 @@ final private[client] class ClusterLive(
     val cursor   = replicaCursors.computeIfAbsent(master, _ => new java.util.concurrent.atomic.AtomicInteger())
     tryReadCandidates(command, ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement()), master, redirectsLeft, complete)
   }
+
+  // a keyless eligible read (KEYS, RANDOMKEY): round-robin over every replica, falling back per policy, so strict Replica never hits a master
+  private def sendKeylessRead[A](topology: ClusterTopology, command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit =
+    pickNode(topology) match {
+      case Some(master) =>
+        val replicas = topology.shards.iterator.flatMap(_.replicas).toVector.distinct
+        tryReadCandidates(
+          command,
+          ReadRouting.candidates(readFrom, master, replicas, keylessCursor.getAndIncrement()),
+          master,
+          redirectsLeft,
+          complete
+        )
+      case None         => complete(Failure(NotConnected()))
+    }
 
   private def tryReadCandidates[A](command: Command[A], candidates: Vector[Node], master: Node, redirectsLeft: Int, complete: Try[A] => Unit): Unit =
     candidates match {
@@ -221,11 +240,14 @@ final private[client] class ClusterLive(
     classify(error) match {
       case ClusterLive.Disposition.Reroute             =>
         error match {
-          // redirect from a replica: sync-refresh then re-dispatch so the retry re-applies the policy on the new owner, not the named master
-          case _: ServerError =>
-            if (redirectsLeft <= 0)
-              complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
-            else { refresh(force = true); offload(dispatch(command, redirectsLeft - 1, complete)) }
+          case e: ServerError =>
+            Redirect.parse(e.getMessage).get match {
+              // ASK is a one-shot handoff to the importing node (follow with ASKING); MOVED refreshes, then re-dispatch re-applies the policy
+              case ask if ask.kind == RedirectKind.Ask => onRedirect(node, ask, command, redirectsLeft, complete)
+              case _ if redirectsLeft <= 0             =>
+                complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
+              case _                                   => refresh(force = true); offload(dispatch(command, redirectsLeft - 1, complete))
+            }
           // connection loss: try the next candidate, else refresh and re-dispatch
           case _              =>
             if (rest.nonEmpty) tryReadCandidates(command, rest, master, redirectsLeft, complete) else onUnreachable(command, redirectsLeft, complete)

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -13,7 +13,7 @@ import kyo.compat.*
 
 import sage.{Message, PatternMessage, SageEvent, SageException}
 import sage.SageException.{ConnectionLost, CrossSlot, NotConnected, ServerError}
-import sage.client.{BackoffConfig, ClusterConfig, DedicatedPoolConfig, SageConfig, WatchdogConfig}
+import sage.client.{BackoffConfig, ClusterConfig, DedicatedPoolConfig, ReadFrom, SageConfig, WatchdogConfig}
 import sage.cluster.{ClusterTopology, Node, NodeGroup, Redirect, RedirectKind, Rejected, Route, Shard, Slot}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.{Cluster, Command, Connection, Pipeline}
@@ -42,10 +42,27 @@ final private[client] class ClusterLive(
   cluster: ClusterConfig,
   pubsubBufferSize: Int,
   seeds: Vector[Node],
+  readFrom: ReadFrom = ReadFrom.Master,
   events: Events = Events.disabled
 ) extends Client[CIO] {
 
   private val topologyRef = new AtomicReference[ClusterTopology](ClusterTopology.from(Vector.empty))
+
+  // replica connections are read-only (READONLY at setup, so a replica serves reads for its master's slots instead of answering MOVED) and
+  // carry no Dedicated Pool use — blocking reads stay on the master. A separate pool from the master registry, which drives redirects.
+  private val replicaPool    = new NodePool(
+    nodeFactory,
+    scheduler,
+    bootstrap :+ Connection.readonly,
+    reconnect,
+    watchdog,
+    connectTimeout,
+    closeTimeout,
+    dedicatedPool,
+    events
+  )
+  // per-master round-robin cursor over its shard's replicas, so successive eligible reads spread across them
+  private val replicaCursors = new java.util.concurrent.ConcurrentHashMap[Node, java.util.concurrent.atomic.AtomicInteger]()
 
   private val subscriptions = new ClusterSubscriptions(
     nodeFactory,
@@ -66,13 +83,7 @@ final private[client] class ClusterLive(
   // set once by close; routing and node establishment refuse afterwards, so close is terminal like the standalone client's
   @volatile private var closed = false
 
-  private val refreshLock   = new ReentrantLock()
-  private val refreshDone   = refreshLock.newCondition()
-  private var refreshing    = false
-  private val minRefreshMs  = cluster.minRefreshInterval.toMillis
-  // bootstrap's CLUSTER SLOTS does not consume the throttle window: seed so the first redirect/READONLY-driven refresh runs immediately,
-  // and only refreshes within minRefreshInterval of one another are throttled (Long.MinValue here would overflow the elapsed subtraction)
-  private var lastRefreshMs = scheduler.nowMillis - minRefreshMs
+  private val refreshThrottle = new RefreshThrottle(scheduler, cluster.minRefreshInterval.toMillis)
 
   private inline def lockedNodes[A](inline body: A): A = {
     nodesLock.lock()
@@ -102,9 +113,12 @@ final private[client] class ClusterLive(
     CIO.async[A](complete => offload(dispatch(command, cluster.maxRedirects, Events.trackCommand(events, command, complete))))
 
   // client-side caching in cluster mode (per-node tracking through redirects/failover) is a follow-up; for now a cached read runs without
-  // caching so the same call stays portable between standalone and cluster. The cacheability guard still applies, matching standalone.
+  // caching so the same call stays portable between standalone and cluster. The cacheability guard still applies, matching standalone. It
+  // always targets the master (allowReplica = false): caching is anchored to the master's tracking stream, so it never honors ReadFrom.
   def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =
-    if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command)) else run(command)
+    if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command))
+    else
+      CIO.async[A](complete => offload(dispatch(command, cluster.maxRedirects, Events.trackCommand(events, command, complete), allowReplica = false)))
 
   // a full SCAN must sweep every slot-owning master: SCAN cursors are node-local, so one arbitrary master would silently miss the rest. The
   // node order is fixed from the current snapshot when the walk begins (a reshard mid-scan can still miss or duplicate keys, as on any client).
@@ -147,20 +161,77 @@ final private[client] class ClusterLive(
 
   // --- routing -------------------------------------------------------------------------------------------------------------------------
 
-  private def dispatch[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit =
+  private def dispatch[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit, allowReplica: Boolean = true): Unit =
     if (closed) complete(Failure(NotConnected()))
     else {
       val topology = topologyRef.get()
       if (command.allMasters) sendToAllMasters(topology, command, complete)
       else
         topology.route(command) match {
-          case Route.ToNode(node, _)  => sendTo(node, command, asking = false, redirectsLeft, complete)
-          case Route.Keyless          => sendToAny(topology, command, redirectsLeft, complete)
-          case Route.Unowned(_)       => onUnowned(command, redirectsLeft, complete)
-          case Route.CrossSlot(slots) => complete(Failure(crossSlot(command.name, slots)))
-          case Route.Malformed        =>
+          case Route.ToNode(node, slot) =>
+            if (allowReplica && readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command))
+              sendRead(command, node, slot, redirectsLeft, complete)
+            else sendTo(node, command, asking = false, redirectsLeft, complete)
+          case Route.Keyless            => sendToAny(topology, command, redirectsLeft, complete)
+          case Route.Unowned(_)         => onUnowned(command, redirectsLeft, complete)
+          case Route.CrossSlot(slots)   => complete(Failure(crossSlot(command.name, slots)))
+          case Route.Malformed          =>
             complete(Failure(malformedKeys(command.name)))
         }
+    }
+
+  // an eligible read under a non-Master policy: walk the policy's ordered candidates (master vs this shard's replicas), submitting on the
+  // first that establishes live and falling through the rest on a connection loss. The master uses the redirect-driven master registry; a
+  // replica uses the read-only replica pool. Strict Replica with no live replica exhausts to NotConnected.
+  private def sendRead[A](command: Command[A], master: Node, slot: Slot, redirectsLeft: Int, complete: Try[A] => Unit): Unit = {
+    val replicas = topologyRef.get().shardForSlot(slot).map(_.replicas).getOrElse(Vector.empty)
+    val cursor   = replicaCursors.computeIfAbsent(master, _ => new java.util.concurrent.atomic.AtomicInteger())
+    tryReadCandidates(command, ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement()), master, redirectsLeft, complete)
+  }
+
+  private def tryReadCandidates[A](command: Command[A], candidates: Vector[Node], master: Node, redirectsLeft: Int, complete: Try[A] => Unit): Unit =
+    candidates match {
+      case node +: rest =>
+        val nc =
+          try if (node == master) getOrEstablish(node) else replicaPool.getOrEstablish(node)
+          catch { case NonFatal(_) => null }
+        if (nc == null || !nc.isLive) tryReadCandidates(command, rest, master, redirectsLeft, complete)
+        else
+          nc.submit[A](
+            command,
+            asking = false,
+            {
+              case Success(value) => Events.attributeNode(complete, node); complete(Success(value))
+              case Failure(error) => offload(onReadFailure(node, command, error, rest, master, redirectsLeft, complete))
+            }
+          )
+      // strict Replica, all candidates unreachable: refresh so the next read sees the new roster
+      case _            => triggerRefresh(); complete(Failure(NotConnected()))
+    }
+
+  private def onReadFailure[A](
+    node: Node,
+    command: Command[A],
+    error: Throwable,
+    rest: Vector[Node],
+    master: Node,
+    redirectsLeft: Int,
+    complete: Try[A] => Unit
+  ): Unit =
+    classify(error) match {
+      case ClusterLive.Disposition.Reroute             =>
+        error match {
+          // redirect from a replica: sync-refresh then re-dispatch so the retry re-applies the policy on the new owner, not the named master
+          case _: ServerError =>
+            if (redirectsLeft <= 0)
+              complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
+            else { refresh(force = true); offload(dispatch(command, redirectsLeft - 1, complete)) }
+          // connection loss: try the next candidate, else refresh and re-dispatch
+          case _              =>
+            if (rest.nonEmpty) tryReadCandidates(command, rest, master, redirectsLeft, complete) else onUnreachable(command, redirectsLeft, complete)
+        }
+      case ClusterLive.Disposition.RefreshThenTerminal => triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error))
+      case ClusterLive.Disposition.Terminal            => Events.attributeNode(complete, node); complete(Failure(error))
     }
 
   // a broadcast command (SCRIPT LOAD, FUNCTION LOAD, …) runs on every slot-owning master, since a cluster replicates no script/function
@@ -266,9 +337,15 @@ final private[client] class ClusterLive(
     refresh(force = false)
     val topology = topologyRef.get()
     topology.route(command) match {
-      case Route.ToNode(node, _) => sendTo(node, command, asking = false, redirectsLeft, complete)
-      // still unowned after refresh: send to an arbitrary master and trust the server's reply (a MOVED to follow, or CLUSTERDOWN)
-      case _                     => sendToAny(topology, command, redirectsLeft, complete)
+      // re-apply the read policy: an eligible read must still go to a replica once the slot resolves, not be pinned to its master
+      case Route.ToNode(node, slot)                                                  =>
+        if (readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command)) sendRead(command, node, slot, redirectsLeft, complete)
+        else sendTo(node, command, asking = false, redirectsLeft, complete)
+      // strict Replica must not fall back to a master: refresh and retry (bounded), never sendToAny
+      case _ if readFrom == ReadFrom.Replica && ReadRouting.replicaEligible(command) =>
+        onUnreachable(command, redirectsLeft, complete)
+      // still unowned after refresh: any master, trusting its reply (a MOVED to follow, or CLUSTERDOWN)
+      case _                                                                         => sendToAny(topology, command, redirectsLeft, complete)
     }
   }
 
@@ -321,7 +398,10 @@ final private[client] class ClusterLive(
     // layer attributes onto it (set in sendBatch for the batch path, or by dispatch->sendTo for a rerouted position)
     val emits                     =
       Vector.tabulate(n)(i => Events.trackCommand[Any](events, p.commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result))))
-    def reroute(index: Int): Unit = offload(dispatch(p.commands(index), cluster.maxRedirects, emits(index)))
+    // all-or-nothing: a fully replica-eligible pipeline batches on replicas, else on masters; reroutes honor the same choice so a slot is
+    // never split across master and replica
+    val useReplica                = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
+    def reroute(index: Int): Unit = offload(dispatch(p.commands(index), cluster.maxRedirects, emits(index), allowReplica = useReplica))
 
     val plan = topologyRef.get().split(p)
     // a malformed command is a programmer error: split is the single source of that classification (the standalone client has no slots and
@@ -339,8 +419,23 @@ final private[client] class ClusterLive(
     if (plan.perNode.isEmpty) plan.keyless.foreach(reroute)
     plan.perNode.zipWithIndex.foreach { case (NodeGroup(node, positions), groupIndex) =>
       // sorted: keep each node's batch in submission order even when keyless positions are folded into the first group
-      sendBatch(node, if (groupIndex == 0) (positions ++ plan.keyless).sorted else positions, p, emits, reroute)
+      sendBatch(node, if (groupIndex == 0) (positions ++ plan.keyless).sorted else positions, p, emits, reroute, useReplica)
     }
+  }
+
+  // first live read candidate for a shard under the policy, with the node it landed on (for attribution); (master, null) when none
+  private def readConn(master: Node): (Node, NodeClient) = {
+    val replicas = topologyRef.get().shards.collectFirst { case s if s.master == master => s.replicas }.getOrElse(Vector.empty)
+    val cursor   = replicaCursors.computeIfAbsent(master, _ => new java.util.concurrent.atomic.AtomicInteger())
+    val it       = ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement()).iterator
+    while (it.hasNext) {
+      val node = it.next()
+      val nc   =
+        try if (node == master) getOrEstablish(node) else replicaPool.getOrEstablish(node)
+        catch { case NonFatal(_) => null }
+      if (nc != null && nc.isLive) return (node, nc)
+    }
+    (master, null)
   }
 
   private def sendBatch[Out, R](
@@ -348,9 +443,19 @@ final private[client] class ClusterLive(
     indices: Vector[Int],
     p: Pipeline[Out, R],
     emits: Vector[Try[Any] => Unit],
-    reroute: Int => Unit
+    reroute: Int => Unit,
+    useReplica: Boolean
   ): Unit = {
-    def settle(index: Int, result: Try[Any]): Unit = { Events.attributeNode(emits(index), node); emits(index)(result) }
+    // the node the batch lands on (a replica when useReplica), so completions attribute the serving node
+    val (target, nc)                               =
+      if (useReplica) readConn(node)
+      else
+        (
+          node,
+          try getOrEstablish(node)
+          catch { case NonFatal(_) => null }
+        )
+    def settle(index: Int, result: Try[Any]): Unit = { Events.attributeNode(emits(index), target); emits(index)(result) }
     val callbacks: Vector[Try[Any] => Unit]        = indices.map { index => (result: Try[Any]) =>
       result match {
         case Success(_)     => settle(index, result)
@@ -362,9 +467,6 @@ final private[client] class ClusterLive(
           }
       }
     }
-    val nc                                         =
-      try getOrEstablish(node)
-      catch { case NonFatal(_) => null }
     // node unreachable, or not connected when the batch reached it: nothing was sent, so re-route every position individually
     if (nc == null || !nc.submitAll(indices.map(p.commands), callbacks)) indices.foreach(reroute)
   }
@@ -626,23 +728,8 @@ final private[client] class ClusterLive(
 
   private def triggerRefresh(): Unit = offload(refresh(force = false))
 
-  private def refresh(force: Boolean): Unit = {
-    refreshLock.lock()
-    val iRefresh =
-      try
-        if (refreshing) { while (refreshing) refreshDone.awaitUninterruptibly(); false }
-        else if (!force && scheduler.nowMillis - lastRefreshMs < minRefreshMs) false
-        else { refreshing = true; true }
-      finally refreshLock.unlock()
-
-    if (iRefresh)
-      try querySlots(refreshCandidates()).foreach { case (from, shards) => adopt(from, shards) }
-      finally {
-        refreshLock.lock()
-        try { refreshing = false; lastRefreshMs = scheduler.nowMillis; refreshDone.signalAll() }
-        finally refreshLock.unlock()
-      }
-  }
+  private def refresh(force: Boolean): Unit =
+    refreshThrottle(force)(querySlots(refreshCandidates()).foreach { case (from, shards) => adopt(from, shards) })
 
   private def refreshCandidates(): Vector[Node] = {
     val (live, others) = lockedNodes(established.toVector).partition(_._2.isLive)
@@ -671,9 +758,9 @@ final private[client] class ClusterLive(
   // installs a fresh topology and prunes bundles for masters it no longer lists, so a vanished node's reconnect loop cannot leak. An empty
   // announce-IP from CLUSTER SLOTS means "the node I queried", so substitute `from` the same way redirects do
   private def adopt(from: Node, shards: Vector[Shard]): Unit = {
-    val resolved    = shards.map(shard => shard.copy(master = resolve(shard.master, from), replicas = shard.replicas.map(resolve(_, from))))
-    val previous    = if (events.enabled) slotOwningMasters(topologyRef.get()).toSet else Set.empty[Node]
-    val newTopology = ClusterTopology.from(resolved)
+    val resolved     = shards.map(shard => shard.copy(master = resolve(shard.master, from), replicas = shard.replicas.map(resolve(_, from))))
+    val previous     = if (events.enabled) slotOwningMasters(topologyRef.get()).toSet else Set.empty[Node]
+    val newTopology  = ClusterTopology.from(resolved)
     topologyRef.set(newTopology)
     // skip the empty -> populated bootstrap transition: discovering the topology at connect is not a change. A real failover/reshard
     // always replaces a non-empty master set, so `previous.nonEmpty` only suppresses the startup event.
@@ -681,12 +768,16 @@ final private[client] class ClusterLive(
       val current = slotOwningMasters(newTopology)
       if (current.toSet != previous) events.emit(SageEvent.TopologyChanged(current))
     }
-    val masters     = resolved.map(_.master).toSet
-    val gone        = lockedNodes {
+    val masters      = resolved.map(_.master).toSet
+    val gone         = lockedNodes {
       val absent = established.keysIterator.filterNot(masters.contains).toVector
       absent.flatMap(node => established.remove(node))
     }
     gone.foreach(nc => offload(nc.close()))
+    // prune replica connections (and their round-robin cursors) for replicas the new topology no longer lists, mirroring the master prune
+    val replicaNodes = resolved.iterator.flatMap(_.replicas).toSet
+    replicaPool.retain(replicaNodes.contains)
+    replicaCursors.keySet.removeIf(node => !masters.contains(node))
     // re-home Shard Channel subscriptions onto the new slot owners; a classic subscription follows the cluster bus, so it only re-homes when
     // its pinned master's socket actually drops (handled by the connection's onTerminated), not on every topology change
     subscriptions.onTopologyChanged()
@@ -695,6 +786,7 @@ final private[client] class ClusterLive(
   private def closeAll(): Unit = {
     val all = lockedNodes { closed = true; val snapshot = established.values.toVector; established.clear(); snapshot }
     subscriptions.close()
+    replicaPool.close()
     all.foreach(_.close())
     events.close()
   }
@@ -751,6 +843,7 @@ private[client] object ClusterLive {
         cluster,
         config.pubsub.bufferSize,
         seeds,
+        config.readFrom,
         events
       )
       // discovery's handshake/TLS failures are translated here (a NOPROTO/SSL surfaces like a standalone connect) rather than via mapError,

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -242,8 +242,11 @@ final private[client] class ClusterLive(
         error match {
           case e: ServerError =>
             Redirect.parse(e.getMessage).get match {
-              // ASK is a one-shot handoff to the importing node (follow with ASKING); MOVED refreshes, then re-dispatch re-applies the policy
-              case ask if ask.kind == RedirectKind.Ask => onRedirect(node, ask, command, redirectsLeft, complete)
+              // ASK hands off to the importing master: *Preferred may follow it with ASKING, but strict Replica must not touch a master, so
+              // it fails (the migrating key is not on any replica); MOVED refreshes, then re-dispatch re-applies the policy
+              case ask if ask.kind == RedirectKind.Ask =>
+                if (readFrom == ReadFrom.Replica) complete(Failure(NotConnected()))
+                else onRedirect(node, ask, command, redirectsLeft, complete)
               case _ if redirectsLeft <= 0             =>
                 complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
               case _                                   => refresh(force = true); offload(dispatch(command, redirectsLeft - 1, complete))

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -1,0 +1,370 @@
+package sage.client.internal
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.locks.ReentrantLock
+
+import scala.concurrent.duration.*
+import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
+
+import kyo.compat.*
+
+import sage.{Message, PatternMessage, SageException}
+import sage.SageException.{ConnectionLost, NotConnected, ServerError, TimedOut}
+import sage.client.{ReadFrom, SageConfig}
+import sage.cluster.Node
+import sage.codec.ValueCodec
+import sage.commands.{Command, Pipeline, Role, Server}
+
+/**
+  * The master-replica runtime: a non-cluster deployment of one master and its replicas, discovered from seeds by asking each its `ROLE`.
+  * Writes, blocking reads, transactions, and `cached` reads go to the master; ordinary read-only commands route to replicas per the
+  * [[ReadFrom]] policy (round-robin, with the policy's fallback). The same `Client` type as standalone and cluster; only the topology selects
+  * it.
+  *
+  * Roles refresh only on events — a reconnect-driven command loss or a `READONLY` from the presumed master — throttled by
+  * `minRefreshInterval`, never on a timer. A write that meets a demoted master fails fast (kicking off a re-discovery) so the caller's retry
+  * lands on the freshly-discovered master, mirroring the cluster runtime's `READONLY` disposition.
+  */
+final private[client] class MasterReplicaLive(
+  nodeFactory: Node => MultiplexedConnection.TransportFactory,
+  scheduler: Scheduler,
+  bootstrap: Vector[Command[?]],
+  config: SageConfig,
+  seeds: Vector[Node],
+  minRefreshInterval: FiniteDuration,
+  events: Events = Events.disabled
+) extends Client[CIO] {
+
+  private val readFrom = config.readFrom
+
+  private val masterPool  = pool()
+  private val replicaPool = pool() // non-cluster replicas serve reads without READONLY, so the same plain bootstrap as the master
+
+  private def pool(): NodePool =
+    new NodePool(
+      nodeFactory,
+      scheduler,
+      bootstrap,
+      config.reconnect,
+      config.watchdog,
+      config.connectTimeout,
+      config.closeTimeout,
+      config.dedicatedPool,
+      events
+    )
+
+  private val masterNodeRef    = new AtomicReference[Node](null)
+  private val replicasRef      = new AtomicReference[Vector[Node]](Vector.empty)
+  private val cursor           = new AtomicInteger()
+  @volatile private var closed = false
+
+  // lazily created on the first subscription, pinned to the master discovered then; classic pub/sub re-homing across a master failover is a
+  // follow-up (the connection re-issues its subscriptions on reconnect to the same address, which a stable endpoint repoints)
+  private val subLock                                         = new ReentrantLock()
+  @volatile private var subscriptions: SubscriptionConnection = null
+
+  private val refreshThrottle = new RefreshThrottle(scheduler, minRefreshInterval.toMillis)
+
+  private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
+
+  // --- discovery -----------------------------------------------------------------------------------------------------------------------
+
+  // contacts seeds (and currently-known nodes) until one answers ROLE, resolving the master and its replicas; throws the last failure if
+  // none answers, so the first connect surfaces a handshake/TLS error like a standalone connect would
+  private[client] def bootstrapRoles(): Unit = {
+    var lastError: Throwable = NotConnected()
+    val candidates           = seeds.iterator
+    var done                 = false
+    while (!done && candidates.hasNext) {
+      val seed = candidates.next()
+      try
+        resolveFrom(seed) match {
+          case Some((master, replicas)) => masterNodeRef.set(master); replicasRef.set(replicas); done = true
+          case None                     => ()
+        }
+      catch { case NonFatal(error) => lastError = error }
+    }
+    if (!done) { closeAll(); throw lastError }
+  }
+
+  // probes a node's ROLE; a master answers with its replica list, a replica points at its master (followed once), a sentinel is skipped
+  private def resolveFrom(node: Node): Option[(Node, Vector[Node])] =
+    probeRole(node).flatMap {
+      case Role.Master(_, replicas)       => Some(node -> replicas.map(r => Node(r.host, r.port)))
+      case Role.Replica(host, port, _, _) =>
+        val master = Node(host, port)
+        probeRole(master).collect { case Role.Master(_, replicas) => master -> replicas.map(r => Node(r.host, r.port)) }
+      case _: Role.Sentinel               => None
+    }
+
+  // a throwaway connection (must not leave a pooled one behind): a connect/handshake failure propagates so bootstrapRoles surfaces it like a
+  // standalone connect; a node that handshakes but doesn't answer ROLE yields None
+  private def probeRole(node: Node): Option[Role] = {
+    val nc = NodeClient.connect(
+      nodeFactory(node),
+      scheduler,
+      bootstrap,
+      config.reconnect,
+      config.watchdog,
+      config.connectTimeout,
+      config.closeTimeout,
+      config.dedicatedPool,
+      Some(node),
+      events
+    )
+    try {
+      val latch   = new CountDownLatch(1)
+      val outcome = new AtomicReference[Try[Role]]()
+      nc.submit[Role](Server.role, asking = false, result => { outcome.set(result); latch.countDown() })
+      if (!latch.await(config.connectTimeout.toMillis, TimeUnit.MILLISECONDS)) None
+      else outcome.get() match { case Success(role) => Some(role); case Failure(_) => None }
+    } finally nc.close()
+  }
+
+  private def triggerRefresh(): Unit = offload(refreshThrottle(force = false)(rediscover()))
+
+  // adopt the new master/replicas and prune pools for nodes that vanished
+  private def rediscover(): Unit = {
+    val candidates = (Option(masterNodeRef.get()).toVector ++ replicasRef.get() ++ seeds).distinct
+    candidates.iterator
+      .flatMap(n =>
+        try resolveFrom(n)
+        catch { case NonFatal(_) => None }
+      )
+      .nextOption()
+      .foreach { case (master, replicas) =>
+        masterNodeRef.set(master)
+        replicasRef.set(replicas)
+        replicaPool.retain(replicas.toSet.contains)
+        masterPool.retain(_ == master)
+      }
+  }
+
+  // --- routing -------------------------------------------------------------------------------------------------------------------------
+
+  def run[A](command: Command[A]): CIO[A] =
+    CIO.async[A] { complete =>
+      val tracked = Events.trackCommand(events, command, complete)
+      offload(if (readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command)) sendRead(command, tracked) else sendMaster(command, tracked))
+    }
+
+  // cached reads always go to the master (caching is anchored to its tracking stream); cluster-style, the cache itself is a follow-up, so
+  // the read runs uncached but stays on the master so the call is portable
+  def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =
+    if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command))
+    else CIO.async[A](complete => offload(sendMaster(command, Events.trackCommand(events, command, complete))))
+
+  private def sendMaster[A](command: Command[A], complete: Try[A] => Unit): Unit = {
+    if (closed) { complete(Failure(NotConnected())); return }
+    val node = masterNodeRef.get()
+    val nc   =
+      try masterPool.getOrEstablish(node)
+      catch { case NonFatal(_) => null }
+    if (nc == null) { triggerRefresh(); complete(Failure(NotConnected())) }
+    else
+      nc.submit[A](
+        command,
+        asking = false,
+        {
+          case s @ Success(_) => Events.attributeNode(complete, node); complete(s)
+          case f @ Failure(e) => if (isOwnershipFault(e)) triggerRefresh(); Events.attributeNode(complete, node); complete(f)
+        }
+      )
+  }
+
+  private def sendRead[A](command: Command[A], complete: Try[A] => Unit): Unit = {
+    if (closed) { complete(Failure(NotConnected())); return }
+    val master     = masterNodeRef.get()
+    val candidates = ReadRouting.candidates(readFrom, master, replicasRef.get(), cursor.getAndIncrement())
+    tryRead(command, candidates, master, complete)
+  }
+
+  private def tryRead[A](command: Command[A], candidates: Vector[Node], master: Node, complete: Try[A] => Unit): Unit =
+    candidates match {
+      case node +: rest =>
+        val isMaster = node == master
+        val nc       =
+          try if (isMaster) masterPool.getOrEstablish(node) else replicaPool.getOrEstablish(node)
+          catch { case NonFatal(_) => null }
+        if (nc == null || !nc.isLive) tryRead(command, rest, master, complete)
+        else
+          nc.submit[A](
+            command,
+            asking = false,
+            {
+              case s @ Success(_) => Events.attributeNode(complete, node); complete(s)
+              case Failure(error) => offload(onReadFault(node, isMaster, error, command, rest, master, complete))
+            }
+          )
+      case _            => complete(Failure(NotConnected())) // strict Replica with no live replica, or whole set unreachable
+    }
+
+  private def onReadFault[A](
+    node: Node,
+    isMaster: Boolean,
+    error: Throwable,
+    command: Command[A],
+    rest: Vector[Node],
+    master: Node,
+    complete: Try[A] => Unit
+  ): Unit = {
+    if (isMaster && isOwnershipFault(error)) triggerRefresh()
+    if (isConnLoss(error)) {
+      if (rest.nonEmpty) tryRead(command, rest, master, complete)
+      else { triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error)) }
+    } else { Events.attributeNode(complete, node); complete(Failure(error)) } // data error: terminal in place
+  }
+
+  private def isOwnershipFault(error: Throwable): Boolean = error match {
+    case e: ServerError    => e.code == "READONLY"
+    case NotConnected()    => true
+    case ConnectionLost(_) => true
+    case _                 => false
+  }
+
+  private def isConnLoss(error: Throwable): Boolean = error match {
+    case NotConnected()    => true
+    case ConnectionLost(_) => true
+    case _                 => false
+  }
+
+  // --- pipelines -----------------------------------------------------------------------------------------------------------------------
+
+  def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out]      = submitPipeline(p).flatMap(TxSupport.collapseStrict(_, p.toOut))
+  def pipelineAttempt[Out, R](p: Pipeline[Out, R]): CIO[R] = submitPipeline(p).map(p.toResults)
+
+  private def submitPipeline[Out, R](p: Pipeline[Out, R]): CIO[Vector[Either[SageException, Any]]] =
+    if (p.commands.isEmpty) CIO.value(Vector.empty)
+    else if (p.commands.exists(_.isBlocking))
+      CIO.fail(new IllegalArgumentException("a Pipeline cannot carry blocking commands; run them individually on the client"))
+    else
+      CIO.async { complete =>
+        offload {
+          // all-or-nothing: a fully replica-eligible pipeline batches on a replica, else on the master
+          val useReplica = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
+          val nc         = if (useReplica) readConn() else masterConn()
+          // submitBatchOnOne either way, so a not-connected pipeline still reports a failed completion per position
+          val submit     = if (nc == null) (_: Vector[Command[?]], _: Vector[Try[Any] => Unit]) => false else nc.submitAll
+          Client.submitBatchOnOne(events, p.commands, submit, complete)
+        }
+      }
+
+  private def masterConn(): NodeClient =
+    try masterPool.getOrEstablish(masterNodeRef.get())
+    catch { case NonFatal(_) => null }
+
+  // the first live read candidate under the policy, master or replica (used for a replica-eligible pipeline batch); null when none
+  private def readConn(): NodeClient = {
+    val master            = masterNodeRef.get()
+    val it                = ReadRouting.candidates(readFrom, master, replicasRef.get(), cursor.getAndIncrement()).iterator
+    var found: NodeClient = null
+    while (found == null && it.hasNext) {
+      val node = it.next()
+      val nc   =
+        try if (node == master) masterPool.getOrEstablish(node) else replicaPool.getOrEstablish(node)
+        catch { case NonFatal(_) => null }
+      if (nc != null && nc.isLive) found = nc
+    }
+    found
+  }
+
+  // --- transactions (always on the master) ---------------------------------------------------------------------------------------------
+
+  def transaction[A](body: TransactionScope[CIO] => CIO[A]): CIO[A] =
+    CIO.acquireReleaseWith(acquireScope)(releaseScope)(lease => body(lease.scope))
+
+  private def acquireScope: CIO[MasterReplicaLive.TxLease] =
+    CIO.blocking {
+      val nc =
+        try masterPool.getOrEstablish(masterNodeRef.get())
+        catch { case e: NotConnected => throw e; case NonFatal(_) => throw ConnectionLost(mayHaveExecuted = false) }
+      try new MasterReplicaLive.TxLease(new Client.TxScope(nc.acquireForTransaction()), nc)
+      catch {
+        case e: NotConnected => throw e
+        case e: TimedOut     => throw e
+        case NonFatal(_)     => throw ConnectionLost(mayHaveExecuted = false)
+      }
+    }
+
+  private def releaseScope(lease: MasterReplicaLive.TxLease): CIO[Unit] =
+    CIO.blocking(lease.nc.releaseTransaction(lease.scope.conn, lease.scope.sealAndReusable()))
+
+  // --- pub/sub (on the master) ---------------------------------------------------------------------------------------------------------
+
+  private def subs(): SubscriptionConnection = {
+    var s = subscriptions
+    if (s == null) {
+      subLock.lock()
+      try {
+        if (subscriptions == null) {
+          val master = masterNodeRef.get()
+          subscriptions = new SubscriptionConnection(
+            nodeFactory(master),
+            bootstrap,
+            scheduler,
+            config.reconnect,
+            config.watchdog,
+            config.connectTimeout.toMillis,
+            config.pubsub.bufferSize,
+            () => masterPool.existingLive(masterNodeRef.get()).isDefined
+          )
+        }
+        s = subscriptions
+      } finally subLock.unlock()
+    }
+    s
+  }
+
+  def subscribeChannels[V: ValueCodec](channel: String, rest: String*): CIO[Subscription[CIO, Message[V]]] =
+    CIO.blocking(Client.channelMessages(subs().subscribeChannels(channel +: rest.toVector)))
+
+  def subscribePatterns[V: ValueCodec](pattern: String, rest: String*): CIO[Subscription[CIO, PatternMessage[V]]] =
+    CIO.blocking(Client.patternMessages(subs().subscribePatterns(pattern +: rest.toVector)))
+
+  // a non-cluster server has no slots, so a Shard Channel rides the one Subscription Connection, exactly as standalone treats it
+  def subscribeShardChannels[V: ValueCodec](channel: String, rest: String*): CIO[Subscription[CIO, Message[V]]] =
+    CIO.blocking(Client.channelMessages(subs().subscribeShard(channel +: rest.toVector)))
+
+  // --- scan / lifecycle ----------------------------------------------------------------------------------------------------------------
+
+  def scanTargets: CIO[Vector[ScanTarget]]                      = CIO.value(Vector(ScanTarget.any))
+  def runOn[A](target: ScanTarget, command: Command[A]): CIO[A] = run(command)
+
+  def close: CIO[Unit] = CIO.blocking(closeAll())
+
+  private def closeAll(): Unit = {
+    closed = true
+    val s = subscriptions
+    if (s != null) s.close()
+    masterPool.close()
+    replicaPool.close()
+    events.close()
+  }
+}
+
+private[client] object MasterReplicaLive {
+
+  final private[client] class TxLease(val scope: Client.TxScope, val nc: NodeClient)
+
+  def connect(
+    config: SageConfig,
+    seeds: Vector[Node],
+    masterReplica: sage.client.MasterReplicaConfig,
+    scheduler: Scheduler,
+    translate: Throwable => Throwable
+  ): CIO[Client[CIO]] =
+    CIO.blocking[Client[CIO]] {
+      val bootstrap                                               = Client.bootstrapCommands(config.auth, config.database, config.clientName)
+      val factory: Node => MultiplexedConnection.TransportFactory = node => {
+        val upgrade = Tls.buildUpgrade(config.tls, node.host, node.port)
+        (onFrame, onClosed) => SocketTransport.connect(node.host, node.port, config.connectTimeout, upgrade, onFrame, onClosed)
+      }
+      val events                                                  = Events(config.listeners)
+      val live                                                    =
+        new MasterReplicaLive(factory, scheduler, bootstrap, config, seeds, masterReplica.minRefreshInterval, events)
+      try { live.bootstrapRoles(); live }
+      catch { case NonFatal(error) => events.close(); throw translate(error) }
+    }
+}

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -1,0 +1,125 @@
+package sage.client.internal
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.locks.ReentrantLock
+
+import scala.collection.mutable
+import scala.concurrent.duration.FiniteDuration
+
+import sage.SageException.NotConnected
+import sage.client.{BackoffConfig, DedicatedPoolConfig, WatchdogConfig}
+import sage.cluster.Node
+import sage.commands.Command
+
+/**
+  * A registry of [[NodeClient]] bundles keyed by [[Node]], with single-flight establishment: concurrent callers for the same node block on
+  * one in-flight connect and observe the same success or failure, and a connect that completes after [[close]] is discarded rather than
+  * published. Shared by the cluster runtime (for its replica connections) and the master-replica runtime (for both roles); the cluster
+  * runtime keeps its own master registry, since that one drives the redirect/refresh state machine.
+  *
+  * The `bootstrap` is fixed per pool, so a replica pool can append `READONLY` while a master pool stays read-write.
+  */
+final private[client] class NodePool(
+  nodeFactory: Node => MultiplexedConnection.TransportFactory,
+  scheduler: Scheduler,
+  bootstrap: Vector[Command[?]],
+  reconnect: BackoffConfig,
+  watchdog: WatchdogConfig,
+  connectTimeout: FiniteDuration,
+  closeTimeout: FiniteDuration,
+  dedicatedPool: DedicatedPoolConfig,
+  events: Events = Events.disabled
+) {
+
+  private val lock             = new ReentrantLock()
+  private val established      = mutable.HashMap.empty[Node, NodeClient]
+  private val pendingEstablish = mutable.HashMap.empty[Node, NodePool.Establish]
+  @volatile private var closed = false
+
+  private inline def locked[A](inline body: A): A = {
+    lock.lock()
+    try body
+    finally lock.unlock()
+  }
+
+  // a live bundle for the node if one is already established, without attempting a connect
+  def existingLive(node: Node): Option[NodeClient] = locked(established.get(node)).filter(_.isLive)
+
+  // connects and runs the bootstrap synchronously (single-flight); throws NotConnected if closed or the connect fails
+  def getOrEstablish(node: Node): NodeClient = {
+    var existing: NodeClient       = null
+    var waitOn: NodePool.Establish = null
+    var mine: NodePool.Establish   = null
+    locked {
+      if (closed) throw NotConnected()
+      established.get(node) match {
+        case Some(nc) => existing = nc
+        case None     =>
+          pendingEstablish.get(node) match {
+            case Some(p) => waitOn = p
+            case None    => mine = new NodePool.Establish; pendingEstablish.put(node, mine)
+          }
+      }
+    }
+    if (existing != null) existing
+    else if (waitOn != null) waitOn.get()
+    else
+      try {
+        val nc    = NodeClient.connect(
+          nodeFactory(node),
+          scheduler,
+          bootstrap,
+          reconnect,
+          watchdog,
+          connectTimeout,
+          closeTimeout,
+          dedicatedPool,
+          Some(node),
+          events
+        )
+        val stale = locked { pendingEstablish.remove(node); if (closed) true else { established.put(node, nc); false } }
+        if (stale) { nc.close(); throw NotConnected() }
+        mine.succeed(nc)
+        nc
+      } catch {
+        case error: Throwable =>
+          locked(pendingEstablish.remove(node))
+          mine.fail(error)
+          throw error
+      }
+  }
+
+  // drops and closes every bundle whose node `keep` rejects, so a vanished node's reconnect loop cannot leak; closes are offloaded
+  def retain(keep: Node => Boolean): Unit = {
+    val gone = locked {
+      val absent = established.keysIterator.filterNot(keep).toVector
+      absent.flatMap(node => established.remove(node))
+    }
+    gone.foreach(nc => scheduler.after(scala.concurrent.duration.Duration.Zero)(nc.close()))
+  }
+
+  def close(): Unit = {
+    val all = locked { closed = true; val snap = established.values.toVector; established.clear(); snap }
+    all.foreach(_.close())
+  }
+}
+
+private[client] object NodePool {
+
+  // one-shot single-flight cell: the establisher fills it, concurrent callers block on `get` and observe the same success or failure
+  final private class Establish {
+    private val latch                                           = new CountDownLatch(1)
+    @volatile private var result: Either[Throwable, NodeClient] = null
+
+    def succeed(nc: NodeClient): Unit = { result = Right(nc); latch.countDown() }
+    def fail(error: Throwable): Unit  = { result = Left(error); latch.countDown() }
+
+    def get(): NodeClient = {
+      latch.await()
+      result match {
+        case Right(nc)   => nc
+        case Left(error) => throw error
+      }
+    }
+  }
+}

--- a/sage-client/shared/src/main/scala/sage/client/internal/ReadRouting.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ReadRouting.scala
@@ -1,0 +1,30 @@
+package sage.client.internal
+
+import sage.client.ReadFrom
+import sage.cluster.Node
+import sage.commands.Command
+
+/**
+  * The shared read-routing policy, used by both the cluster and master-replica runtimes. It decides nothing about connection liveness — it
+  * only turns a [[ReadFrom]] policy plus a master and its replicas into the ordered list of candidate Nodes to try; the runtime walks that
+  * list, skipping nodes it cannot establish, and falls back exactly as the order dictates.
+  */
+private[client] object ReadRouting {
+
+  // an ordinary (non-blocking) read; writes, blocking reads, cursor-bound scans (whose cursor is node-local), and `cached` reads (gated
+  // separately) never reach here
+  def replicaEligible(command: Command[?]): Boolean = command.isReadOnly && !command.isBlocking && !command.cursorBound
+
+  // the ordered candidates for an eligible read, round-robin-rotated by `rr` across the replicas; an empty result means strict Replica fails
+  def candidates(readFrom: ReadFrom, master: Node, replicas: Vector[Node], rr: Int): Vector[Node] = {
+    val rotated =
+      if (replicas.isEmpty) Vector.empty
+      else { val k = ((rr % replicas.length) + replicas.length) % replicas.length; replicas.drop(k) ++ replicas.take(k) }
+    readFrom match {
+      case ReadFrom.Master           => Vector(master)
+      case ReadFrom.MasterPreferred  => master +: rotated
+      case ReadFrom.Replica          => rotated
+      case ReadFrom.ReplicaPreferred => rotated :+ master
+    }
+  }
+}

--- a/sage-client/shared/src/main/scala/sage/client/internal/RefreshThrottle.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/RefreshThrottle.scala
@@ -1,0 +1,34 @@
+package sage.client.internal
+
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+  * Single-flight, throttled discovery: collapses concurrent refreshes onto one in-flight run (others block until it finishes) and skips a
+  * run that lands within `minRefreshMs` of the last, unless `force`. Shared by the cluster and master-replica runtimes, which differ only in
+  * what `work` does. `lastRefresh` starts a full window in the past, so the first triggered refresh always runs.
+  */
+final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: Long) {
+
+  private val lock          = new ReentrantLock()
+  private val done          = lock.newCondition()
+  private var refreshing    = false
+  private var lastRefreshMs = scheduler.nowMillis - minRefreshMs
+
+  def apply(force: Boolean)(work: => Unit): Unit = {
+    lock.lock()
+    val mine =
+      try
+        if (refreshing) { while (refreshing) done.awaitUninterruptibly(); false }
+        else if (!force && scheduler.nowMillis - lastRefreshMs < minRefreshMs) false
+        else { refreshing = true; true }
+      finally lock.unlock()
+
+    if (mine)
+      try work
+      finally {
+        lock.lock()
+        try { refreshing = false; lastRefreshMs = scheduler.nowMillis; done.signalAll() }
+        finally lock.unlock()
+      }
+  }
+}

--- a/sage-client/shared/src/test/scala/sage/client/internal/ReadRoutingSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ReadRoutingSpec.scala
@@ -1,0 +1,58 @@
+package sage.client.internal
+
+import sage.client.ReadFrom
+import sage.cluster.Node
+import sage.commands.{Command, Execution}
+
+class ReadRoutingSpec extends munit.FunSuite {
+
+  private val m  = Node("master", 6379)
+  private val r1 = Node("replica1", 6379)
+  private val r2 = Node("replica2", 6379)
+
+  test("Master routes to the master only") {
+    assertEquals(ReadRouting.candidates(ReadFrom.Master, m, Vector(r1, r2), 0), Vector(m))
+  }
+
+  test("MasterPreferred tries the master first, then replicas") {
+    assertEquals(ReadRouting.candidates(ReadFrom.MasterPreferred, m, Vector(r1, r2), 0), Vector(m, r1, r2))
+  }
+
+  test("ReplicaPreferred tries replicas first, then the master") {
+    assertEquals(ReadRouting.candidates(ReadFrom.ReplicaPreferred, m, Vector(r1, r2), 0), Vector(r1, r2, m))
+  }
+
+  test("Replica lists replicas only, round-robin-rotated by the cursor") {
+    assertEquals(ReadRouting.candidates(ReadFrom.Replica, m, Vector(r1, r2), 0), Vector(r1, r2))
+    assertEquals(ReadRouting.candidates(ReadFrom.Replica, m, Vector(r1, r2), 1), Vector(r2, r1))
+    assertEquals(ReadRouting.candidates(ReadFrom.Replica, m, Vector(r1, r2), 2), Vector(r1, r2))
+  }
+
+  test("Replica with no replicas is empty, so the strict policy fails") {
+    assertEquals(ReadRouting.candidates(ReadFrom.Replica, m, Vector.empty, 0), Vector.empty)
+  }
+
+  test("ReplicaPreferred with no replicas falls back to the master") {
+    assertEquals(ReadRouting.candidates(ReadFrom.ReplicaPreferred, m, Vector.empty, 0), Vector(m))
+  }
+
+  test("a negative cursor still rotates within bounds") {
+    assertEquals(ReadRouting.candidates(ReadFrom.Replica, m, Vector(r1, r2), -1), Vector(r2, r1))
+  }
+
+  private def cmd(
+    name: String,
+    execution: Execution = Execution.Ordinary,
+    isReadOnly: Boolean = false,
+    cursorBound: Boolean = false
+  ): Command[Unit] =
+    Command(name, Command.NoKeys, Vector.empty, _ => Right(()), execution, isReadOnly = isReadOnly, cursorBound = cursorBound)
+
+  test("eligibility: ordinary read-only is eligible; writes, blocking reads, and cursor-bound scans are not") {
+    assert(ReadRouting.replicaEligible(cmd("GET", isReadOnly = true)))
+    assert(!ReadRouting.replicaEligible(cmd("SET")))
+    assert(!ReadRouting.replicaEligible(cmd("XREAD", Execution.Blocking, isReadOnly = true)))
+    // a SCAN cursor is only valid on its issuing node, so it must never round-robin across replicas
+    assert(!ReadRouting.replicaEligible(cmd("HSCAN", isReadOnly = true, cursorBound = true)))
+  }
+}

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -47,7 +47,12 @@ class ClusterClientSpec extends munit.FunSuite {
     * A cluster of fake per-node transports. `behaviour` scripts each node's reply to a written command (HELLO and CLUSTER SLOTS are
     * answered here); `written(node)` exposes what reached that node so routing can be asserted.
     */
-  final private class Fixture(behaviour: (Node, String) => Seq[Frame], seeds: Vector[Node], unreachable: Set[Node] = Set.empty) {
+  final private class Fixture(
+    behaviour: (Node, String) => Seq[Frame],
+    seeds: Vector[Node],
+    unreachable: Set[Node] = Set.empty,
+    readFrom: ReadFrom = ReadFrom.Master
+  ) {
 
     // accumulate every transport per node (a node has both a Multiplexed and, once a transaction pins, a Dedicated connection) so a refresh
     // issued on one is still observable even after the other is created
@@ -81,7 +86,8 @@ class ClusterClientSpec extends munit.FunSuite {
         DedicatedPoolConfig(),
         ClusterConfig(),
         1024,
-        seeds
+        seeds,
+        readFrom
       )
 
     live.bootstrapTopology()
@@ -122,6 +128,38 @@ class ClusterClientSpec extends munit.FunSuite {
       assertEquals(result, Some(owner.host))
       assert(fixture.written(owner).exists(_.contains("GET")), "owner did not receive GET")
       assert(!fixture.written(other).exists(_.contains("GET")), "non-owner received GET")
+    }
+  }
+
+  test("under a Replica policy an eligible read routes to the shard's replica, which gets READONLY at setup") {
+    val nodeR                   = Node("r", 6379)
+    // CLUSTER SLOTS lists nodeR as nodeA's replica for the whole keyspace
+    def slotsWithReplica: Frame =
+      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+    val behaviour               = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsWithReplica)
+      else if (text.contains("READONLY")) Seq(Frame.SimpleString("OK"))
+      else Seq(Frame.BulkString(Bytes.utf8(if (node == nodeR) "from-replica" else "from-master")))
+    val fixture                 = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.Replica)
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
+      assertEquals(result, Some("from-replica"))
+      assert(fixture.written(nodeR).exists(_.contains("READONLY")), "replica connection did not issue READONLY at setup")
+      assert(fixture.written(nodeR).exists(_.contains("GET")), "replica did not receive the read")
+      assert(!fixture.written(nodeA).exists(_.contains("GET")), "master received a read it should not have")
+    }
+  }
+
+  test("under a Replica policy a write still goes to the master") {
+    val nodeR     = Node("r", 6379)
+    def slots     =
+      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(slots) else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.Replica)
+
+    fixture.live.run(Strings.set[String, String]("foo", "bar")).unsafeRun.map { _ =>
+      assert(fixture.written(nodeA).exists(_.contains("SET")), "master did not receive the write")
+      assert(!fixture.written(nodeR).exists(_.contains("SET")), "replica received a write")
     }
   }
 

--- a/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
@@ -3,6 +3,7 @@ package sage.client
 import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.*
 import scala.jdk.CollectionConverters.*
 
 import kyo.compat.*
@@ -61,6 +62,31 @@ class ConnectSpec extends munit.FunSuite {
     Client.connectWith(factory).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[UnsupportedServer], s"unexpected error: $error")
     }
+  }
+
+  test("readFrom = Replica on a Standalone topology is rejected before connecting") {
+    Client.connect(SageConfig(readFrom = ReadFrom.Replica)).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+    }
+  }
+
+  test("a MasterReplica topology with no seeds is rejected") {
+    Client.connect(SageConfig(topology = Topology.MasterReplica(Vector.empty))).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+    }
+  }
+
+  test("readFrom = ReplicaPreferred on a Standalone topology passes validation (degrades to the one node)") {
+    // it may connect (a local server) or fail to connect (none) — either way it must not be rejected by validation
+    Client
+      .connect(SageConfig(readFrom = ReadFrom.ReplicaPreferred, connectTimeout = 100.millis))
+      .flatMap(_.close)
+      .unsafeRun
+      .map(_ => assert(true))
+      .recover {
+        case _: IllegalArgumentException => fail("ReplicaPreferred on Standalone should pass validation")
+        case _                           => assert(true) // a connect failure (no server) is fine; only validation matters here
+      }
   }
 
   test("the ZIO artifact lowers to a native ZIO") {

--- a/sage-core/src/main/scala/sage/cluster/Topology.scala
+++ b/sage-core/src/main/scala/sage/cluster/Topology.scala
@@ -17,9 +17,13 @@ final case class Shard(master: Node, replicas: Vector[Node], slots: Vector[SlotR
   * A pure snapshot of which masters own which slots. Routing and splitting are total classifications over it — they never raise, choose a
   * connection, or decide a retry.
   */
-final class ClusterTopology private (val shards: Vector[Shard], owners: Array[Node]) {
+final class ClusterTopology private (val shards: Vector[Shard], owners: Array[Node], shardOwners: Array[Shard]) {
 
   def nodeForSlot(slot: Slot): Option[Node] = Option(owners(slot.value))
+
+  // the Shard owning a slot, exposing its replicas — the runtime's input for replica routing (the core only locates them; selecting a live
+  // one and applying the read policy is the runtime's job, since it alone knows connection liveness)
+  def shardForSlot(slot: Slot): Option[Shard] = Option(shardOwners(slot.value))
 
   def route(command: Command[?]): Route =
     if (command.hasMalformedKeys) Route.Malformed
@@ -70,16 +74,18 @@ object ClusterTopology {
     * authority, the core only represents what it is given.
     */
   def from(shards: Vector[Shard]): ClusterTopology = {
-    val owners = new Array[Node](Slot.Count)
+    val owners      = new Array[Node](Slot.Count)
+    val shardOwners = new Array[Shard](Slot.Count)
     shards.foreach { shard =>
       shard.slots.foreach { range =>
         var slot = range.start.value
         while (slot <= range.end.value) {
           owners(slot) = shard.master
+          shardOwners(slot) = shard
           slot += 1
         }
       }
     }
-    new ClusterTopology(shards, owners)
+    new ClusterTopology(shards, owners, shardOwners)
   }
 }

--- a/sage-core/src/main/scala/sage/commands/Command.scala
+++ b/sage-core/src/main/scala/sage/commands/Command.scala
@@ -25,6 +25,10 @@ enum Execution {
   * `allMasters` marks a keyless command whose effect is per-node and not replicated across shards, so a cluster must run it on every
   * slot-owning master rather than one (`SCRIPT LOAD`, `FUNCTION LOAD` and their `FLUSH`/`DELETE`/`RESTORE` mutations, and `FLUSHALL`/
   * `FLUSHDB`). Inert on a standalone server.
+  *
+  * `cursorBound` marks a command whose reply carries a continuation cursor valid only on the node that issued it (`SCAN`/`HSCAN`/`SSCAN`/
+  * `ZSCAN`). Such a read is excluded from replica round-robin routing: iterating its pages across different replicas would feed a cursor to
+  * a node that never minted it, skipping or duplicating entries.
   */
 final case class Command[+Out](
   name: String,
@@ -34,11 +38,12 @@ final case class Command[+Out](
   execution: Execution = Execution.Ordinary,
   isReadOnly: Boolean = false,
   cacheable: Boolean = false,
-  allMasters: Boolean = false
+  allMasters: Boolean = false,
+  cursorBound: Boolean = false
 ) {
 
   def map[B](f: Out => B): Command[B] =
-    Command(name, keyIndices, args, frame => decode(frame).map(f), execution, isReadOnly, cacheable, allMasters)
+    Command(name, keyIndices, args, frame => decode(frame).map(f), execution, isReadOnly, cacheable, allMasters, cursorBound)
 
   def isBlocking: Boolean = execution == Execution.Blocking
 
@@ -64,6 +69,17 @@ object Command {
     args: Vector[Bytes],
     decode: Frame => Either[DecodeError, Out]
   ): Command[Out] = Command(name, keyIndices, args, decode, Execution.Ordinary, isReadOnly = true, cacheable = true)
+
+  /**
+    * A read-only command whose reply carries a node-local continuation cursor (`SCAN` and its `H`/`S`/`Z` variants): read-only but pinned to
+    * its issuing node, so replica routing must not round-robin its pages. Not cacheable — a cursor page is not a pure function of key state.
+    */
+  def readCursor[Out](
+    name: String,
+    keyIndices: Vector[Int],
+    args: Vector[Bytes],
+    decode: Frame => Either[DecodeError, Out]
+  ): Command[Out] = Command(name, keyIndices, args, decode, Execution.Ordinary, isReadOnly = true, cacheable = false, cursorBound = true)
 
   /**
     * A read-only command that must not be cached: its result varies with time or is non-deterministic, so no invalidation would evict it.

--- a/sage-core/src/main/scala/sage/commands/Connection.scala
+++ b/sage-core/src/main/scala/sage/commands/Connection.scala
@@ -17,6 +17,10 @@ private[sage] object Connection {
   // prefixes a single command redirected by `ASK`, telling the target node to serve the key it is importing for this one command
   val asking: Command[Unit] = Command("ASKING", keyIndices = Command.NoKeys, args = Vector.empty, decode = Decode.ok)
 
+  // puts a cluster replica connection into read-only mode so it serves reads for slots its master owns instead of answering MOVED. Issued
+  // once at connection setup on replica connections only (re-issued on reconnect); a master connection never sends it, staying read-write.
+  val readonly: Command[Unit] = Command("READONLY", keyIndices = Command.NoKeys, args = Vector.empty, decode = Decode.ok)
+
   // enables RESP3 server-assisted client-side caching in opt-in mode on this connection: no key is tracked until a CLIENT CACHING YES
   // precedes the read, and invalidation pushes arrive on this same connection. Run once per connection at bootstrap.
   val clientTrackingOnOptin: Command[Unit] =

--- a/sage-core/src/main/scala/sage/commands/Hashes.scala
+++ b/sage-core/src/main/scala/sage/commands/Hashes.scala
@@ -139,7 +139,7 @@ private[sage] object Hashes {
     fieldCodec: KeyCodec[F],
     valueCodec: ValueCodec[V]
   ): Command[ScanPage[(F, V)]] =
-    Command.read(
+    Command.readCursor(
       "HSCAN",
       Command.FirstKey,
       Vector(keyCodec.encode(key), ScanCursor.bytes(cursor)) ++ ScanArgs.options(pattern, count),
@@ -150,7 +150,7 @@ private[sage] object Hashes {
     using keyCodec: KeyCodec[K],
     fieldCodec: KeyCodec[F]
   ): Command[ScanPage[F]] =
-    Command.read(
+    Command.readCursor(
       "HSCAN",
       Command.FirstKey,
       (Vector(keyCodec.encode(key), ScanCursor.bytes(cursor)) ++ ScanArgs.options(pattern, count)) :+ NoValues,

--- a/sage-core/src/main/scala/sage/commands/Keys.scala
+++ b/sage-core/src/main/scala/sage/commands/Keys.scala
@@ -179,7 +179,7 @@ private[sage] object Keys {
     count: Option[Long] = None,
     ofType: Option[RedisType] = None
   )(using keyCodec: KeyCodec[K]): Command[ScanPage[K]] =
-    Command.read(
+    Command.readCursor(
       "SCAN",
       Command.NoKeys,
       ScanCursor.bytes(cursor) +:

--- a/sage-core/src/main/scala/sage/commands/Sets.scala
+++ b/sage-core/src/main/scala/sage/commands/Sets.scala
@@ -84,7 +84,7 @@ private[sage] object Sets {
     using keyCodec: KeyCodec[K],
     valueCodec: ValueCodec[V]
   ): Command[ScanPage[V]] =
-    Command.read(
+    Command.readCursor(
       "SSCAN",
       Command.FirstKey,
       Vector(keyCodec.encode(key), ScanCursor.bytes(cursor)) ++ ScanArgs.options(pattern, count),

--- a/sage-core/src/main/scala/sage/commands/SortedSets.scala
+++ b/sage-core/src/main/scala/sage/commands/SortedSets.scala
@@ -308,7 +308,7 @@ private[sage] object SortedSets {
     using keyCodec: KeyCodec[K],
     valueCodec: ValueCodec[V]
   ): Command[ScanPage[(V, Double)]] =
-    Command.read(
+    Command.readCursor(
       "ZSCAN",
       Command.FirstKey,
       Vector(keyCodec.encode(key), ScanCursor.bytes(cursor)) ++ ScanArgs.options(pattern, count),

--- a/sage-core/src/test/scala/sage/cluster/TopologySpec.scala
+++ b/sage-core/src/test/scala/sage/cluster/TopologySpec.scala
@@ -31,6 +31,14 @@ class TopologySpec extends munit.FunSuite {
     assertEquals(topo.nodeForSlot(Slot.unsafe(15)), Some(b))
   }
 
+  test("shardForSlot exposes the owning shard's replicas, None for an uncovered slot") {
+    val r1    = Node("r1", 6379)
+    val shard = Shard(a, Vector(r1), Vector(SlotRange(Slot.unsafe(0), Slot.unsafe(100))))
+    val topo  = ClusterTopology.from(Vector(shard))
+    assertEquals(topo.shardForSlot(Slot.unsafe(50)).map(_.replicas), Some(Vector(r1)))
+    assertEquals(topo.shardForSlot(Slot.unsafe(200)), None)
+  }
+
   test("a single-slot command routes to its owner") {
     assertEquals(whole.route(keyed("foo")), Route.ToNode(a, Slot.of(Bytes.utf8("foo"))))
   }

--- a/sage-core/src/test/scala/sage/commands/CommandSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/CommandSpec.scala
@@ -21,6 +21,18 @@ class CommandSpec extends munit.FunSuite {
     assert(!Sets.sRandMember[String, String]("s").cacheable && Sets.sRandMember[String, String]("s").isReadOnly) // non-deterministic
   }
 
+  test("SCAN-family commands are cursor-bound (node-local cursor) and not cacheable, so replica routing never round-robins them") {
+    val scans = Vector(
+      Keys.scan[String](ScanCursor.start),
+      Hashes.hScan[String, String, String]("h", ScanCursor.start),
+      Hashes.hScanNoValues[String, String]("h", ScanCursor.start),
+      Sets.sScan[String, String]("s", ScanCursor.start),
+      SortedSets.zScan[String, String]("z", ScanCursor.start)
+    )
+    scans.foreach(c => assert(c.cursorBound && c.isReadOnly && !c.cacheable, s"${c.name} should be a cursor-bound, non-cacheable read"))
+    assert(!Strings.get[String, String]("foo").cursorBound) // an ordinary read is not cursor-bound
+  }
+
   test("SORT_RO is cacheable only in its bare form; BY/GET dereference untracked keys") {
     assert(Keys.sortRo[String, String]("k").cacheable)
     assert(Keys.sortRo[String, String]("k", alpha = true, order = SortOrder.Desc).cacheable) // limit/order/alpha touch no extra keys


### PR DESCRIPTION
Closes #80. Read-scaling by routing read-only commands to replicas, for both deployment shapes.

## Surface (gates #40)
- `SageConfig.readFrom: ReadFrom = Master` — top-level, shared by cluster and master-replica. Values `Master | MasterPreferred | Replica | ReplicaPreferred`.
- `Topology.MasterReplica(seeds, MasterReplicaConfig(minRefreshInterval))` — discovery-only.

## Eligibility gate
A command routes to a replica only if `isReadOnly && !isBlocking && !cursorBound`. Writes, blocking reads (`XREAD BLOCK`), `cached` reads, transactions/`WATCH`, and SCAN-family commands always go to the master. `cached` is master-pinned (caching is anchored to the master's tracking stream). Default `Master` is fully backward-compatible.

## Cluster mode
- Per-replica **Multiplexed Connection** with `READONLY` issued at connection setup (new core `Connection.readonly`), established lazily; no dedicated pool / subscription on replicas.
- Round-robin per shard across live replicas; `*Preferred` falls back, strict `Replica` fails `NotConnected` (and refreshes to learn a new roster).
- Pipelines are **all-or-nothing**: a fully replica-eligible pipeline batches on replicas, otherwise all on masters; a slot is never split.
- Redirect and unowned paths **re-apply the policy** — a strict `Replica` read never leaks onto a master.

## Master-replica mode
- Focused `MasterReplicaLive`: `ROLE` discovery from seeds, reads to replicas per policy, everything else to the master.
- **Event-driven** role re-discovery on reconnect and on a `-READONLY` from the presumed master (throttled, no periodic poll); a write to a demoted master fails fast so the retry lands on the freshly-discovered master.

## Shared / core
- Extracted `NodePool` (single-flight node registry), `ReadRouting` (candidate policy), `RefreshThrottle` (single-flight throttled refresh), and `Client.submitBatchOnOne` (single-connection pipeline submit) — used across runtimes to avoid duplication.
- Core: `ClusterTopology.shardForSlot` (pure replica lookup; routing stays master-centric) and a `Command.cursorBound` flag so node-local SCAN cursors are never round-robined across replicas.

## Docs
- ADR-0038 (shared ReadFrom policy & replica read routing), ADR-0039 (master-replica topology & event-driven failover).
- `CONTEXT.md` gains **Read Policy** and **Master-Replica** glossary terms.

## Tests
Pure `ReadRoutingSpec` (policy ordering, eligibility, cursor-bound exclusion), `CommandSpec` (SCAN-family are cursor-bound/non-cacheable), `TopologySpec` (`shardForSlot`), `ConnectSpec` (validation), and `ClusterClientSpec` (replica read hits the READONLY replica; writes stay on the master). Full core + client unit suites green across backends.

Not included: a two-container master-replica integration test (multi-node integration is deferred in this repo, as the cluster suite is single-node by design); the routing is covered by the fake-transport unit tests.