### PR TITLE
Fix topology-refresh and redirect edge cases in client runtimes

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -486,7 +486,21 @@ final private[client] class ClusterLive(
         case Success(_)     => settle(index, result)
         case Failure(error) =>
           classify(error) match {
-            case ClusterLive.Disposition.Reroute             => reroute(index)
+            case ClusterLive.Disposition.Reroute             =>
+              error match {
+                // ASK keeps the slot's owner, so re-routing by topology bounces off the exporting node again and burns a redirect; follow it
+                // straight to the importing node with ASKING (as single-command dispatch does). MOVED and connection loss re-route normally.
+                case e: ServerError =>
+                  val redirect = Redirect.parse(e.getMessage).get // classify only reroutes a ServerError that parses as a redirect
+                  redirect.kind match {
+                    // strict Replica must not follow ASK onto the importing master (mirrors the single-read path at onReadFailure)
+                    case RedirectKind.Ask if useReplica && readFrom == ReadFrom.Replica => settle(index, Failure(NotConnected()))
+                    case RedirectKind.Ask                                               =>
+                      onRedirect(target, redirect, p.commands(index), cluster.maxRedirects, emits(index))
+                    case RedirectKind.Moved                                             => reroute(index)
+                  }
+                case _              => reroute(index)
+              }
             case ClusterLive.Disposition.RefreshThenTerminal => triggerRefresh(); settle(index, result)
             case ClusterLive.Disposition.Terminal            => settle(index, result)
           }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -23,9 +23,9 @@ import sage.commands.{Command, Pipeline, Role, Server}
   * [[ReadFrom]] policy (round-robin, with the policy's fallback). The same `Client` type as standalone and cluster; only the topology selects
   * it.
   *
-  * Roles refresh only on events — a reconnect-driven command loss or a `READONLY` from the presumed master — throttled by
-  * `minRefreshInterval`, never on a timer. A write that meets a demoted master fails fast (kicking off a re-discovery) so the caller's retry
-  * lands on the freshly-discovered master, mirroring the cluster runtime's `READONLY` disposition.
+  * Roles refresh only on events — a reconnect-driven command loss, a `READONLY` from the presumed master, or a read that can reach no
+  * candidate — throttled by `minRefreshInterval`, never on a timer. A write that meets a demoted master fails fast (kicking off a
+  * re-discovery) so the caller's retry lands on the freshly-discovered master, mirroring the cluster runtime's `READONLY` disposition.
   */
 final private[client] class MasterReplicaLive(
   nodeFactory: Node => MultiplexedConnection.TransportFactory,
@@ -198,7 +198,8 @@ final private[client] class MasterReplicaLive(
               case Failure(error) => offload(onReadFault(node, isMaster, error, command, rest, master, complete))
             }
           )
-      case _            => complete(Failure(NotConnected())) // strict Replica with no live replica, or whole set unreachable
+      // nothing reached the wire, so no fault event fires: re-discover here or a strict-Replica read stays stuck on a stale replica set
+      case _            => triggerRefresh(); complete(Failure(NotConnected()))
     }
 
   private def onReadFault[A](
@@ -245,6 +246,8 @@ final private[client] class MasterReplicaLive(
           // all-or-nothing: a fully replica-eligible pipeline batches on a replica, else on the master
           val useReplica = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
           val nc         = if (useReplica) readConn() else masterConn()
+          // no reachable node fires no wire fault, so re-discover here or a stale replica set / down master strands the pipeline forever
+          if (nc == null) triggerRefresh()
           // submitBatchOnOne either way, so a not-connected pipeline still reports a failed completion per position
           val submit     = if (nc == null) (_: Vector[Command[?]], _: Vector[Try[Any] => Unit]) => false else nc.submitAll
           Client.submitBatchOnOne(events, p.commands, submit, complete)

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -318,16 +318,17 @@ final private[client] class MultiplexedConnection private (
 
     // Out-of-band frames never consume a pending entry. A READONLY reply fails its command, then poisons the connection: an in-place
     // failover demotes the old master without dropping the socket, so it looks healthy but rejects writes.
-    private def onFrame(frame: Frame): Unit = {
-      lastReplyAtMillis = scheduler.nowMillis
+    private def onFrame(frame: Frame): Unit =
       frame match {
         case Frame.Push(elements) =>
+          // not touching lastReplyAtMillis: a push proves only the read path, so push-only traffic must still get the idle keepalive PING
           Invalidation.decode(elements) match {
             case Some(Invalidation.Evict(keys)) => keys.foreach(cache.invalidate)
             case Some(Invalidation.FlushAll)    => cache.flush()
             case None                           => ()
           }
         case reply                =>
+          lastReplyAtMillis = scheduler.nowMillis
           val entry = pending.poll()
           if (entry == null) close()
           else {
@@ -336,7 +337,6 @@ final private[client] class MultiplexedConnection private (
           }
           if (Poison.isReadonly(reply)) close()
       }
-    }
 
     private def onClosed(): Unit = {
       var entry = pending.poll()


### PR DESCRIPTION
Bug-fix pass over the client connection/routing machinery. Three independent edge cases surfaced by review, all in `sage-client` internals; no API or behavior change on the happy path.

## Master-replica: reads stuck against a stale topology
`MasterReplicaLive` refreshes roles only on events. A read that reached **no live candidate** (strict `ReadFrom.Replica` with the replica set changed out from under it, or a down master) produced no wire fault, so nothing ever triggered re-discovery and the read failed `NotConnected` indefinitely.

- `tryRead` base case (single read) and `submitPipeline` (`nc == null`) now trigger a rediscovery before failing.
- The refresh stays **throttled** by `minRefreshInterval` (honoring the public config contract) — in a pure-read workload no fault-driven refresh has run recently, so the throttle lets it through and recovery happens within one cycle; if refreshes are already firing, topology is being kept fresh anyway.

## Cluster: Pipeline ASK redirect
A Pipeline position hit by `-ASK` was re-routed through topology-based `dispatch`, which sends it back to the **exporting** node (ASK does not change ownership) — wasting a round-trip and a redirect from the budget before the ASK is finally followed.

- The batch failure callback now follows `ASK` straight to the importing node with `ASKING`, matching single-command dispatch. `MOVED` and connection-loss keep their existing topology re-route.
- Strict `ReadFrom.Replica` pipelines do **not** follow ASK onto the importing master, mirroring the single-read guard in `onReadFailure`.

## Multiplexer: idle keepalive suppressed by push traffic
`lastReplyAtMillis` was updated unconditionally in `onFrame`, so invalidation `Push` frames kept resetting the idle clock and suppressed the keepalive PING on a connection receiving only invalidation traffic. The clock now advances on **replies only**, so push-only traffic still gets a periodic PING (which exercises the write path a push does not).

## Testing
- `clientZio/test` — full client unit + state-machine suite (147 tests) passes.
- `scalafmtAll` clean; compiles across backends.
- Note: the `MasterReplicaLive` no-candidate paths are only exercised by the testcontainers integration suite (not run here). A fake-transport unit test for "all replica candidates unreachable → triggers rediscovery" would lock these in — happy to add if wanted.