### PR TITLE
Public API surface: import sage.* vocabulary, hide internals (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ It is built as a **pure sans-IO core** (RESP3 protocol, typed commands, codecs â
 
 ## Getting started
 
-Two imports: `import sage.*` for the command vocabulary (backend-independent), and `import sage.<backend>.*` for the client and connection config.
+Two imports: `import sage.*` for the command vocabulary and connection config (backend-independent), and `import sage.<backend>.*` for the client.
 
 ```scala
-import sage.*       // Commands, options/results, codecs, Frame, Pipeline
-import sage.zio.*   // SageClient + connection config, ZIO-native
+import sage.*       // Commands, options/results, codecs, Frame, Pipeline, connection config
+import sage.zio.*   // SageClient, ZIO-native
 
 val program =
   ZIO.scoped {

--- a/README.md
+++ b/README.md
@@ -18,6 +18,28 @@ It is built as a **pure sans-IO core** (RESP3 protocol, typed commands, codecs �
 - **Client-side caching** — invalidation-driven local reads, opt-in per call
 - **TLS and ACL auth** out of the box
 
+## Getting started
+
+Two imports: `import sage.*` for the command vocabulary (backend-independent), and `import sage.<backend>.*` for the client and connection config.
+
+```scala
+import sage.*       // Commands, options/results, codecs, Frame, Pipeline
+import sage.zio.*   // SageClient + connection config, ZIO-native
+
+val program =
+  ZIO.scoped {
+    for {
+      client <- SageClient.scoped(SageConfig(Endpoint("localhost", 6379)))
+      _      <- client.set("greeting", "hello")
+      value  <- client.get[String, String]("greeting")                  // Some("hello")
+      popped <- client.blPop[String, String]("queue")(BlockTimeout.Forever) // blocking pop
+      tuple  <- client.pipeline((Commands.incr[String]("a"), Commands.incr[String]("b")).pipeline)
+    } yield (value, popped, tuple)
+  }
+```
+
+Swap `sage.zio` for `sage.ce`, `sage.ox`, or `sage.kyo` and the same vocabulary returns that ecosystem's native types. (`import sage.*` brings the `sage.*` subpackage names into scope, so qualify cross-library prefixes via the unqualified form — e.g. `Duration`, not `zio.Duration`.)
+
 ## Design
 
 The design is documented in the repo: [`CONTEXT.md`](CONTEXT.md) (glossary), [`docs/adr/`](docs/adr/) (architecture decision records), and [`docs/PRD.md`](docs/PRD.md).

--- a/docs/adr/0040-public-api-surface-flattened-imports-and-private-internals.md
+++ b/docs/adr/0040-public-api-surface-flattened-imports-and-private-internals.md
@@ -1,0 +1,32 @@
+# Public API surface: flattened `sage.*` vocabulary and `private[sage]` internals
+
+The public surface is frozen behind two wildcard imports: `import sage.*` brings the whole command vocabulary, and `import sage.<backend>.*` (zio/ce/ox/kyo) brings the client plus its connection config. A hello-world — connect, GET/SET, a blocking pop, a pipeline, an `eval` — needs only those two. The layered packages (`sage.commands`, `sage.codec`, `sage.protocol`, `sage.cluster`) remain the code's organization, not the user's; `import sage.*` is the user's.
+
+## How the vocabulary is surfaced
+
+`sage.*` is a set of top-level `export` clauses in one file — the command facade `Commands`, `Command`, `Execution`, `Pipeline` and its `pipeline` extension, every option/result enum and ADT, `Frame` with the `FrameDecode` extensions (`as`, `asArray`, …) named individually, the `KeyCodec`/`ValueCodec` typeclasses, `Node`, and the connection config (`SageConfig`, `Endpoint`, `Topology`, `ReadFrom`, …). A package cannot be wildcard-exported (`export sage.commands.*` does not compile, top-level or inside an object), so the surface is enumerated — which also makes it the one place the public API is reviewed. Forgetting to add a new public type there is the maintenance risk; a completeness check is a candidate follow-up.
+
+Two Scala constraints shaped the form:
+
+- **Exactly one module may contribute top-level members to `package sage`.** A package's top-level `export` forwarders are silently dropped from a wildcard import when a *second* module also contributes top-level members to the same package and a subpackage of it is wildcard-imported in the same scope (`import sage.*` + `import sage.zio.*`); `Bytes` and the other real classes in `package sage` survive, but the export forwarders do not. Core's `package sage` holds only type *definitions* (direct package members, no synthetic `sage$package` holder), so the aggregator lives in the **shared client module** as the sole `sage$package`, and carries both the (core) vocabulary and the (client) config in one file — config is backend-independent and a user always depends on a backend. This is why config is not re-exported per backend, and why the aggregator is not in core.
+
+- **`import sage.*` brings the subpackage names** (`zio`, `commands`, …), so a *qualified* `zio.Duration` resolves to `sage.zio` and fails; use the unqualified form (from `import zio.*`). Ordinary unqualified usage is unaffected; this only bites code that qualifies with a name that collides with a sage subpackage.
+
+An aggregator `object` (`import sage.api.*`) was prototyped to dodge the first constraint but rejected: the headline import should be `sage.*`, and the single-`sage$package` rule recovers it.
+
+## What is hidden, and the constraint that pins what cannot be
+
+Types shared core→client cannot be fully `private`, so `private[sage]` hides them from users while preserving cross-module access. `private[sage]` is the established core mechanism (already pervasive: the per-family builder objects, `Decode`, `RespWriter`). Newly hidden: `RespParser`, `Reply`, `HelloReply`, and the cluster-routing internals (`ClusterTopology`, `Shard`, `SlotRange`, `Route`, `Redirect`, `RedirectKind`, `SplitPlan`, `NodeGroup`, `Rejected`, `Slot`). The per-family objects (`Strings`/`Keys`/…) stay `private[sage]`; `Commands` re-exports their members, so `Commands.get` is public while `Strings` is not importable.
+
+Three types look like internals but are pinned public by existing design and must stay exposed:
+
+- **`Frame`** (trait, cases, and the `FrameDecode` extension) — `eval`/`fcall` return `Command[Frame]` whose reply shape is defined by user code (ADR-0033); the cases stay public so a caller can pattern-match an arbitrary script reply, not only decode it through `.as[A]`. It is also a public field of the public `Command` (`decode: Frame => …`).
+- **`Node`** — surfaced by the Listener SPI through `SageEvent.CommandCompleted`, `Connected`/`Disconnected`, and `TopologyChanged(masters: Vector[Node])` (ADR-0035), so a Listener author must be able to name it. It is the only `sage.cluster` type that stays public.
+- **`Execution`** — a public field of the public `Command`.
+
+## Considered Options
+
+- **Keep layered** (`sage.commands.*` canonical) — rejected: it forces users to mirror the library's internal organization for every call, with no payoff.
+- **Flatten per-backend** (`import sage.zio.*` brings everything) — rejected: it dumps the entire vocabulary into each effect ecosystem's namespace (collision surface, unclear provenance) and duplicates the re-export across four backends.
+- **Aggregator `object` (`import sage.api.*`)** — rejected once the single-module rule recovered plain `import sage.*`.
+- **`internal` subpackages instead of `private[sage]`** — rejected: a package named `internal` does not make types non-importable (only an access modifier does), it is absent from `sage-core` today, and core's internals are interleaved with public vocabulary in the same files.

--- a/docs/adr/0040-public-api-surface-flattened-imports-and-private-internals.md
+++ b/docs/adr/0040-public-api-surface-flattened-imports-and-private-internals.md
@@ -1,6 +1,6 @@
 # Public API surface: flattened `sage.*` vocabulary and `private[sage]` internals
 
-The public surface is frozen behind two wildcard imports: `import sage.*` brings the whole command vocabulary, and `import sage.<backend>.*` (zio/ce/ox/kyo) brings the client plus its connection config. A hello-world — connect, GET/SET, a blocking pop, a pipeline, an `eval` — needs only those two. The layered packages (`sage.commands`, `sage.codec`, `sage.protocol`, `sage.cluster`) remain the code's organization, not the user's; `import sage.*` is the user's.
+The public surface is frozen behind two wildcard imports: `import sage.*` brings the whole command vocabulary and the connection config, and `import sage.<backend>.*` (zio/ce/ox/kyo) brings the client. A hello-world — connect, GET/SET, a blocking pop, a pipeline, an `eval` — needs only those two. The layered packages (`sage.commands`, `sage.codec`, `sage.protocol`, `sage.cluster`) remain the code's organization, not the user's; `import sage.*` is the user's.
 
 ## How the vocabulary is surfaced
 

--- a/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
+++ b/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
@@ -6,9 +6,8 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 
+import sage.*
 import sage.ce.*
-import sage.commands.Commands
-import sage.commands.Pipeline.pipeline
 
 class CeSmokeSuite extends ServerSuite(Images.redis) {
 

--- a/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
+++ b/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
@@ -2,8 +2,7 @@ package sage.integration
 
 import kyo.*
 
-import sage.commands.Commands
-import sage.commands.Pipeline.pipeline
+import sage.*
 import sage.kyo.*
 
 class KyoSmokeSuite extends ServerSuite(Images.redis) {

--- a/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
+++ b/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
@@ -2,8 +2,7 @@ package sage.integration
 
 import ox.{fork, supervised}
 
-import sage.commands.Commands
-import sage.commands.Pipeline.pipeline
+import sage.*
 import sage.ox.*
 
 class OxSmokeSuite extends ServerSuite(Images.redis) {

--- a/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
+++ b/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
@@ -2,8 +2,7 @@ package sage.integration
 
 import zio.*
 
-import sage.commands.{BlockTimeout, Commands, GroupStartId, StreamId, XAddId}
-import sage.commands.Pipeline.pipeline
+import sage.*
 import sage.zio.*
 
 class ZioSmokeSuite extends ServerSuite(Images.redis) {
@@ -94,7 +93,7 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
           for {
             client    <- SageClient.scoped(configOf(server))
             collected <- client.subscribe[String]("smoke").take(3).runCollect.fork
-            _         <- ZIO.sleep(zio.Duration.fromMillis(300)) // let SUBSCRIBE register before publishing
+            _         <- ZIO.sleep(Duration.fromMillis(300)) // let SUBSCRIBE register before publishing
             _         <- ZIO.foreachDiscard(1 to 3)(i => client.publish("smoke", s"m$i"))
             messages  <- collected.join
           } yield {
@@ -186,7 +185,7 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
                           seen.update(_ :+ entry.fields.head._2)
                         }
                         .fork
-            _      <- seen.get.repeatUntil(_.size >= 3).timeoutFail(new RuntimeException("xConsume did not deliver"))(zio.Duration.fromSeconds(10))
+            _      <- seen.get.repeatUntil(_.size >= 3).timeoutFail(new RuntimeException("xConsume did not deliver"))(Duration.fromSeconds(10))
             _      <- fiber.interrupt
             got    <- seen.get
             pend   <- client.xPending("xconsume", "g")

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
@@ -16,6 +16,7 @@ import sage.protocol.Frame
   */
 final private[client] class ClientCache(maxBytes: Long) {
   import ClientCache.*
+  import ClientCache.Acquire.*
 
   private val lock            = new ReentrantLock()
   // accessOrder = true: a lookup promotes the entry to most-recently-used, so eviction sheds the genuinely cold entries
@@ -143,10 +144,11 @@ private[client] object ClientCache {
     }
   }
 
-  sealed trait Acquire
-  final case class Hit(frame: Frame) extends Acquire
-  case object Fetch                  extends Acquire
-  case object Wait                   extends Acquire
+  enum Acquire {
+    case Hit(frame: Frame)
+    case Fetch
+    case Wait
+  }
 
   final private class Entry(val frame: Frame, val sizeBytes: Long, val expiresAt: Long, val keys: Vector[Key])
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -269,9 +269,9 @@ final private[client] class MultiplexedConnection private (
       }
       cache.acquire(commandBytes, keys, scheduler.nowMillis, waiter) match {
         // a Hit serves locally; a Wait coalesces onto an in-flight fetch — both avoid a server round trip, so both are reported as a hit
-        case ClientCache.Hit(frame) => events.emit(SageEvent.Cache.Hit(command.name)); deliver(frame)
-        case ClientCache.Wait       => events.emit(SageEvent.Cache.Hit(command.name))
-        case ClientCache.Fetch      =>
+        case ClientCache.Acquire.Hit(frame) => events.emit(SageEvent.Cache.Hit(command.name)); deliver(frame)
+        case ClientCache.Acquire.Wait       => events.emit(SageEvent.Cache.Hit(command.name))
+        case ClientCache.Acquire.Fetch      =>
           events.emit(SageEvent.Cache.Miss(command.name))
           val started                     = System.nanoTime()
           val raw                         = Command[Frame](command.name, command.keyIndices, command.args, frame => Right(frame))

--- a/sage-client/shared/src/main/scala/sage/exports.scala
+++ b/sage-client/shared/src/main/scala/sage/exports.scala
@@ -1,0 +1,138 @@
+package sage
+
+// `import sage.*` — the one import for everything backend-independent: the command vocabulary (facade, model, options, results, raw-`Frame`
+// decode, codecs) and the connection config. The backend client comes from `import sage.<backend>.*`.
+//
+// These top-level `export` clauses live in the shared client module, and it is the ONLY module that contributes top-level members to
+// package `sage`: such members are silently dropped from a wildcard import when a SECOND module also contributes them and a subpackage is
+// wildcard-imported in the same scope (`import sage.*` + `import sage.zio.*`). Core's `package sage` holds only type definitions (direct
+// package members, no synthetic holder), so this file is the sole `sage$package` — vocabulary and config can therefore sit together here.
+//
+// A package cannot be wildcard-exported, so the surface is enumerated here — which also makes this the one place the public API is reviewed;
+// a new public option/result type must be added below to appear under `sage.*`.
+
+// connection configuration
+export sage.client.{
+  AuthConfig,
+  BackoffConfig,
+  CacheConfig,
+  ClusterConfig,
+  DedicatedPoolConfig,
+  Endpoint,
+  MasterReplicaConfig,
+  PubSubConfig,
+  ReadFrom,
+  SageConfig,
+  TlsConfig,
+  Topology,
+  TrustSource,
+  WatchdogConfig
+}
+// the cluster node a Listener observes (SageEvent), the only cluster type users name
+export sage.cluster.Node
+// codec typeclasses (built-in givens live in their companions, already in implicit scope)
+export sage.codec.{KeyCodec, ValueCodec}
+// option inputs and typed results
+export sage.commands.{
+  AclLogEntry,
+  AclUser,
+  Aggregate,
+  ArGrepCombine,
+  ArMatch,
+  ArrayInfo,
+  ArrayInfoFull,
+  BitFieldOffset,
+  BitFieldOp,
+  BitFieldOverflow,
+  BitFieldType,
+  BitPosRange,
+  BitRange,
+  BitUnit,
+  BlockTimeout,
+  ClaimIdle,
+  CommandFilterBy,
+  CommandHistogram,
+  CommandInfo,
+  CommandLogEntry,
+  CommandLogType,
+  ConsumerInfo,
+  DelexCondition,
+  EngineStats,
+  ExpireCondition,
+  ExpiryTime,
+  FieldExpiry,
+  FieldExpiryTime,
+  FieldPersist,
+  FieldTtl,
+  FlushMode,
+  FullConsumerInfo,
+  FullGroupInfo,
+  FullPendingEntry,
+  FunctionInfo,
+  FunctionStats,
+  GeoAddCondition,
+  GeoCoordinates,
+  GeoCount,
+  GeoOrigin,
+  GeoSearchResult,
+  GeoShape,
+  GeoSort,
+  GeoUnit,
+  GetExpiry,
+  GroupInfo,
+  GroupReadId,
+  GroupStartId,
+  HSetExCondition,
+  IncrExpiry,
+  IncrExResult,
+  InsertPosition,
+  LatencyEntry,
+  LcsMatch,
+  LcsMatches,
+  LexBoundary,
+  LibraryInfo,
+  Limit,
+  ListSide,
+  MatchRange,
+  MigrateAuth,
+  MigrateResult,
+  MinMax,
+  NackMode,
+  PendingEntry,
+  PendingSummary,
+  ReadId,
+  RedisType,
+  ReplicaNode,
+  RestoreExpiry,
+  RestorePolicy,
+  Role,
+  RunningScript,
+  ScanCursor,
+  ScanPage,
+  ScoreBoundary,
+  SetCondition,
+  SetExpiry,
+  SlowLogEntry,
+  SortOrder,
+  StreamDeletionPolicy,
+  StreamEntry,
+  StreamEntryDeletion,
+  StreamId,
+  StreamInfo,
+  StreamInfoFull,
+  StreamRangeId,
+  Trimming,
+  TrimThreshold,
+  Ttl,
+  XAddId,
+  XAutoClaimJustIdResult,
+  XAutoClaimResult,
+  ZAddCondition,
+  ZRange
+}
+export sage.commands.{as, asArray, asArrayOf, asLong, asString}
+// command facade and model
+export sage.commands.{Command, Commands, Execution, Pipeline}
+export sage.commands.Pipeline.pipeline
+// raw-Frame escape hatch for eval/fcall replies (ADR-0033)
+export sage.protocol.Frame

--- a/sage-client/shared/src/main/scala/sage/internal/ApiSurfaceCheck.scala
+++ b/sage-client/shared/src/main/scala/sage/internal/ApiSurfaceCheck.scala
@@ -1,0 +1,7 @@
+package sage.internal
+
+// Forces the public-surface completeness check at compile time. Lives in the client module because the
+// `sage.*` export aggregator (sage/exports.scala) does, and the check must see those exports.
+private[sage] object ApiSurfaceCheck {
+  ApiSurface.verifyCommandsExported()
+}

--- a/sage-client/shared/src/test/scala/sage/client/internal/ClientCacheSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ClientCacheSpec.scala
@@ -19,20 +19,20 @@ class ClientCacheSpec extends munit.FunSuite {
     val cmd        = key("GET foo")
     val (w1, get1) = collector()
     val (w2, get2) = collector()
-    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, w1), ClientCache.Fetch)
-    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, w2), ClientCache.Wait)
+    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, w1), ClientCache.Acquire.Fetch)
+    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, w2), ClientCache.Acquire.Wait)
     cache.store(cmd, Vector(key("foo")), frame("bar"), 0L, 1000L)
     assertEquals(get1(), Some(Success(frame("bar"))))
     assertEquals(get2(), Some(Success(frame("bar"))))
-    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, _ => ()), ClientCache.Hit(frame("bar")))
+    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, _ => ()), ClientCache.Acquire.Hit(frame("bar")))
   }
 
   test("absolute TTL: a hit before expiry, a refetch at expiry") {
     val cache = new ClientCache(1024)
     val cmd   = key("GET foo")
     cache.store(cmd, Vector(key("foo")), frame("bar"), 0L, 1000L)
-    assertEquals(cache.acquire(cmd, Vector(key("foo")), 999L, _ => ()), ClientCache.Hit(frame("bar")))
-    assertEquals(cache.acquire(cmd, Vector(key("foo")), 1000L, _ => ()), ClientCache.Fetch)
+    assertEquals(cache.acquire(cmd, Vector(key("foo")), 999L, _ => ()), ClientCache.Acquire.Hit(frame("bar")))
+    assertEquals(cache.acquire(cmd, Vector(key("foo")), 1000L, _ => ()), ClientCache.Acquire.Fetch)
   }
 
   test("an invalidation for a tracked key evicts every entry that touched it") {
@@ -42,8 +42,8 @@ class ClientCacheSpec extends munit.FunSuite {
     cache.store(get, Vector(key("foo")), frame("bar"), 0L, 10000L)
     cache.store(range, Vector(key("foo")), frame("ba"), 0L, 10000L)
     cache.invalidate(key("foo"))
-    assertEquals(cache.acquire(get, Vector(key("foo")), 0L, _ => ()), ClientCache.Fetch)
-    assertEquals(cache.acquire(range, Vector(key("foo")), 0L, _ => ()), ClientCache.Fetch)
+    assertEquals(cache.acquire(get, Vector(key("foo")), 0L, _ => ()), ClientCache.Acquire.Fetch)
+    assertEquals(cache.acquire(range, Vector(key("foo")), 0L, _ => ()), ClientCache.Acquire.Fetch)
   }
 
   test("flush drops the whole cache") {
@@ -51,18 +51,18 @@ class ClientCacheSpec extends munit.FunSuite {
     val cmd   = key("GET foo")
     cache.store(cmd, Vector(key("foo")), frame("bar"), 0L, 10000L)
     cache.flush()
-    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, _ => ()), ClientCache.Fetch)
+    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, _ => ()), ClientCache.Acquire.Fetch)
   }
 
   test("an invalidation mid-flight delivers the reply but does not cache it") {
     val cache      = new ClientCache(1024)
     val cmd        = key("GET foo")
     val (w1, get1) = collector()
-    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, w1), ClientCache.Fetch)
-    cache.invalidate(key("foo"))                                                         // arrives before the fetch completes
+    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, w1), ClientCache.Acquire.Fetch)
+    cache.invalidate(key("foo"))                                                                 // arrives before the fetch completes
     cache.store(cmd, Vector(key("foo")), frame("bar"), 0L, 10000L)
-    assertEquals(get1(), Some(Success(frame("bar"))))                                    // waiter still gets the value
-    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, _ => ()), ClientCache.Fetch) // but it was not stored
+    assertEquals(get1(), Some(Success(frame("bar"))))                                            // waiter still gets the value
+    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, _ => ()), ClientCache.Acquire.Fetch) // but it was not stored
   }
 
   test("a failed fetch reaches every waiter and stores nothing") {
@@ -70,10 +70,10 @@ class ClientCacheSpec extends munit.FunSuite {
     val cmd        = key("GET foo")
     val (w1, get1) = collector()
     val boom       = new RuntimeException("boom")
-    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, w1), ClientCache.Fetch)
+    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, w1), ClientCache.Acquire.Fetch)
     cache.fail(cmd, boom)
     assertEquals(get1(), Some(Failure(boom)))
-    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, _ => ()), ClientCache.Fetch)
+    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, _ => ()), ClientCache.Acquire.Fetch)
   }
 
   test("the bytes cap evicts the least-recently-used entry") {
@@ -81,7 +81,7 @@ class ClientCacheSpec extends munit.FunSuite {
     val big   = frame("x" * 50)
     cache.store(key("GET a"), Vector(key("a")), big, 0L, 10000L)
     cache.store(key("GET b"), Vector(key("b")), big, 0L, 10000L)
-    assertEquals(cache.acquire(key("GET a"), Vector(key("a")), 0L, _ => ()), ClientCache.Fetch) // evicted
-    assertEquals(cache.acquire(key("GET b"), Vector(key("b")), 0L, _ => ()), ClientCache.Hit(big))
+    assertEquals(cache.acquire(key("GET a"), Vector(key("a")), 0L, _ => ()), ClientCache.Acquire.Fetch) // evicted
+    assertEquals(cache.acquire(key("GET b"), Vector(key("b")), 0L, _ => ()), ClientCache.Acquire.Hit(big))
   }
 }

--- a/sage-core/src/main/scala/sage/SageEvent.scala
+++ b/sage-core/src/main/scala/sage/SageEvent.scala
@@ -60,12 +60,12 @@ object SageEvent {
 /**
   * A command's terminal result, stripped of its value: it either succeeded or failed with the error the caller saw.
   */
-sealed trait Outcome
+enum Outcome {
+  case Succeeded
+  case Failed(error: Throwable)
+}
 
 object Outcome {
-  case object Succeeded                     extends Outcome
-  final case class Failed(error: Throwable) extends Outcome
-
   def of(result: Try[?]): Outcome =
     result match {
       case Success(_) => Succeeded

--- a/sage-core/src/main/scala/sage/cluster/Redirect.scala
+++ b/sage-core/src/main/scala/sage/cluster/Redirect.scala
@@ -4,16 +4,16 @@ package sage.cluster
   * `Moved` is permanent — the slot's owner changed, refresh the topology — while `Ask` is a one-shot hand-off during a live migration:
   * send the single command (prefixed `ASKING`) to the named node without touching the topology.
   */
-enum RedirectKind {
+private[sage] enum RedirectKind {
   case Moved, Ask
 }
 
 /**
   * A parsed `MOVED`/`ASK` reply. An empty target host means the IP of the current connection, which the runtime substitutes.
   */
-final case class Redirect(kind: RedirectKind, slot: Slot, target: Node)
+final private[sage] case class Redirect(kind: RedirectKind, slot: Slot, target: Node)
 
-object Redirect {
+private[sage] object Redirect {
 
   def parse(error: String): Option[Redirect] = {
     val parts = error.split(' ')

--- a/sage-core/src/main/scala/sage/cluster/Route.scala
+++ b/sage-core/src/main/scala/sage/cluster/Route.scala
@@ -5,7 +5,7 @@ package sage.cluster
   * each case means — send to the node, pick any node (`Keyless`), refresh the topology (`Unowned`), or fail (`CrossSlot`, `Malformed`).
   * `Malformed` means the command's declared key positions don't match its arguments — a programmer error the runtime fails, never routes.
   */
-enum Route {
+private[sage] enum Route {
   case ToNode(node: Node, slot: Slot)
   case Keyless
   case Unowned(slot: Slot)

--- a/sage-core/src/main/scala/sage/cluster/Slot.scala
+++ b/sage-core/src/main/scala/sage/cluster/Slot.scala
@@ -5,9 +5,9 @@ import sage.Bytes
 /**
   * One of the [[Slot.Count]] hash slots a cluster partitions the keyspace into, fixed by CRC16 of the key's hash tag (or the whole key).
   */
-opaque type Slot = Int
+private[sage] opaque type Slot = Int
 
-object Slot {
+private[sage] object Slot {
 
   val Count = 16384
 

--- a/sage-core/src/main/scala/sage/cluster/SplitPlan.scala
+++ b/sage-core/src/main/scala/sage/cluster/SplitPlan.scala
@@ -1,8 +1,8 @@
 package sage.cluster
 
-final case class NodeGroup(node: Node, positions: Vector[Int])
+final private[sage] case class NodeGroup(node: Node, positions: Vector[Int])
 
-enum Rejected {
+private[sage] enum Rejected {
   case CrossSlot(slots: Set[Slot])
   case Unowned(slot: Slot)
   case Malformed
@@ -12,7 +12,7 @@ enum Rejected {
   * The plan for running a Pipeline across a cluster. `perNode` groups keep their original positions so results merge back in submission
   * order; `keyless` positions the runtime folds into any group; `rejected` positions fail per-position. Every index appears in one bucket.
   */
-final case class SplitPlan(
+final private[sage] case class SplitPlan(
   perNode: Vector[NodeGroup],
   keyless: Vector[Int],
   rejected: Vector[(Int, Rejected)]

--- a/sage-core/src/main/scala/sage/cluster/Topology.scala
+++ b/sage-core/src/main/scala/sage/cluster/Topology.scala
@@ -9,15 +9,15 @@ final case class Node(host: String, port: Int)
 /**
   * Inclusive on both ends.
   */
-final case class SlotRange(start: Slot, end: Slot)
+final private[sage] case class SlotRange(start: Slot, end: Slot)
 
-final case class Shard(master: Node, replicas: Vector[Node], slots: Vector[SlotRange])
+final private[sage] case class Shard(master: Node, replicas: Vector[Node], slots: Vector[SlotRange])
 
 /**
   * A pure snapshot of which masters own which slots. Routing and splitting are total classifications over it — they never raise, choose a
   * connection, or decide a retry.
   */
-final class ClusterTopology private (val shards: Vector[Shard], owners: Array[Node], shardOwners: Array[Shard]) {
+final private[sage] class ClusterTopology private (val shards: Vector[Shard], owners: Array[Node], shardOwners: Array[Shard]) {
 
   def nodeForSlot(slot: Slot): Option[Node] = Option(owners(slot.value))
 
@@ -67,7 +67,7 @@ final class ClusterTopology private (val shards: Vector[Shard], owners: Array[No
     command.keyIndices.iterator.map(index => Slot.of(command.args(index))).toSet
 }
 
-object ClusterTopology {
+private[sage] object ClusterTopology {
 
   /**
     * Total: uncovered slots stay unowned (routed as a refresh) and an overlapping range resolves last-listed-wins — the server is the

--- a/sage-core/src/main/scala/sage/commands/HelloReply.scala
+++ b/sage-core/src/main/scala/sage/commands/HelloReply.scala
@@ -3,9 +3,9 @@ package sage.commands
 import sage.SageException.DecodeError
 import sage.protocol.Frame
 
-final case class HelloReply(server: String, version: String, proto: Int, role: String)
+final private[sage] case class HelloReply(server: String, version: String, proto: Int, role: String)
 
-object HelloReply {
+private[sage] object HelloReply {
 
   private[commands] def decode(frame: Frame): Either[DecodeError, HelloReply] =
     frame match {

--- a/sage-core/src/main/scala/sage/commands/Invalidation.scala
+++ b/sage-core/src/main/scala/sage/commands/Invalidation.scala
@@ -8,12 +8,12 @@ import sage.protocol.Frame
   * names the keys the server says changed; `FlushAll` is the null-payload form the server sends on `FLUSHALL`/`FLUSHDB` or when it drops
   * tracking state, meaning the whole local cache is now untrustworthy.
   */
-enum Invalidation {
+private[sage] enum Invalidation {
   case Evict(keys: Vector[Bytes])
   case FlushAll
 }
 
-object Invalidation {
+private[sage] object Invalidation {
 
   /**
     * Classifies a push frame's elements. `None` for any push that is not an `invalidate` message (so it sits beside [[Pubsub.decode]],

--- a/sage-core/src/main/scala/sage/commands/Reply.scala
+++ b/sage-core/src/main/scala/sage/commands/Reply.scala
@@ -8,7 +8,7 @@ import sage.protocol.Frame
   * Converts a raw reply frame into a command's typed result. Error frames are intercepted here, at the top level only: errors nested in
   * aggregates (an `EXEC` reply) still reach decoders.
   */
-object Reply {
+private[sage] object Reply {
 
   def run[Out](command: Command[Out], frame: Frame): Either[SageException, Out] =
     frame match {

--- a/sage-core/src/main/scala/sage/internal/ApiSurface.scala
+++ b/sage-core/src/main/scala/sage/internal/ApiSurface.scala
@@ -39,7 +39,7 @@ private[sage] object ApiSurface {
     if (missing.nonEmpty)
       report.errorAndAbort(
         s"${missing.size} public type(s) in `sage.commands` are not re-exported from `sage` — add them to " +
-          s"sage-client/shared/src/main/scala/sage/exports.scala so `import sage.*` exposes them:\n  " +
+          s"the `sage.*` aggregator (sage/exports.scala) so `import sage.*` exposes them:\n  " +
           missing.mkString(", ")
       )
 

--- a/sage-core/src/main/scala/sage/internal/ApiSurface.scala
+++ b/sage-core/src/main/scala/sage/internal/ApiSurface.scala
@@ -1,0 +1,48 @@
+package sage.internal
+
+import scala.quoted.*
+
+// Compile-time guard: every user-visible type in `sage.commands` must be re-exported from package `sage`
+// (the hand-written aggregator in sage-client/shared/.../sage/exports.scala). Forgetting to add a new
+// option/result type there silently shrinks `import sage.*`; this turns that omission into a build error.
+private[sage] object ApiSurface {
+  inline def verifyCommandsExported(): Unit = ${ verifyCommandsExportedImpl }
+
+  private def verifyCommandsExportedImpl(using Quotes): Expr[Unit] = {
+    import quotes.reflect.*
+
+    val commands = Symbol.requiredPackage("sage.commands")
+    val sage     = Symbol.requiredPackage("sage")
+
+    // Source-level public types of `sage.commands`. Names are grouped because each type carries both a
+    // type symbol and a term (companion/module) symbol; `private[sage]` is recorded as `privateWithin` on
+    // the term, so a name is user-visible only when none of its symbols restrict visibility. `$`-mangled
+    // names are JVM-flattened companions/nested cases and top-level `*$package` holders — never user types.
+    val publicTypes =
+      commands.declarations
+        .groupBy(_.name)
+        .collect {
+          case (name, syms)
+              if !name.contains("$") && syms.exists(_.isType) &&
+                syms.forall(s => s.privateWithin.isEmpty && !s.flags.is(Flags.Private) && !s.flags.is(Flags.Protected)) =>
+            name
+        }
+        .toList
+
+    // Everything reachable through `import sage.*`: type aliases surface as type members of the package;
+    // term forwarders live in the synthetic per-file `*$package` holder objects.
+    val exported =
+      sage.declarations.filter(_.name.endsWith("$package")).flatMap(_.declarations).map(_.name).toSet
+
+    val missing = publicTypes.filterNot(n => exported.contains(n) || sage.typeMember(n) != Symbol.noSymbol).sorted
+
+    if (missing.nonEmpty)
+      report.errorAndAbort(
+        s"${missing.size} public type(s) in `sage.commands` are not re-exported from `sage` — add them to " +
+          s"sage-client/shared/src/main/scala/sage/exports.scala so `import sage.*` exposes them:\n  " +
+          missing.mkString(", ")
+      )
+
+    '{ () }
+  }
+}

--- a/sage-core/src/main/scala/sage/protocol/RespParser.scala
+++ b/sage-core/src/main/scala/sage/protocol/RespParser.scala
@@ -10,7 +10,7 @@ import sage.SageException.ProtocolError
   * thread-safe. After a `ProtocolError` the parser is poisoned — RESP3 has no resynchronization point — and the connection must be
   * discarded. RESP2 null forms (`$-1`, `*-1`) parse as [[Frame.Null]]; streamed types are not supported (no server sends them).
   */
-final class RespParser {
+final private[sage] class RespParser {
 
   private var buf: Array[Byte]       = Array.emptyByteArray
   private var readPos: Int           = 0 // start of unconsumed input


### PR DESCRIPTION
Closes #40.

Freezes the public API surface behind a consistent import convention and tightens implementation types.

## Imports — two wildcards

- `import sage.*` → backend-independent **vocabulary** (command facade `Commands`, `Command`/`Execution`/`Pipeline`, every option/result type, `Frame` + `FrameDecode`, codec typeclasses, `Node`) **and connection config** (`SageConfig`, `Endpoint`, `Topology`, `ReadFrom`, …).
- `import sage.zio.*` (or `.ce`/`.ox`/`.kyo`) → the client + effect-typed sugar.

A hello-world — connect, GET/SET, blocking pop, pipeline, `eval` — needs only those two.

### Why one aggregator file in the shared client module

A package can't be wildcard-exported (`export sage.commands.*` doesn't compile), so the surface is enumerated. It lives in **one** module on purpose: a package's top-level `export` forwarders are silently dropped from a wildcard import when a *second* module also contributes top-level members to that package and a subpackage is wildcard-imported alongside (`import sage.*` + `import sage.zio.*`). Core's `package sage` holds only type *definitions* (no synthetic `sage$package`), so the shared client module is the sole `sage$package` and carries vocabulary + config together.

Note: `import sage.*` brings the `sage.*` subpackage names into scope, so a *qualified* `zio.Duration` resolves to `sage.zio`; use the unqualified form. Only bites code that qualifies with a colliding prefix.

## Hidden internals (`private[sage]`)

`RespParser`, `Reply`, `HelloReply`, `Invalidation`, and the cluster-routing internals (`ClusterTopology`, `Shard`, `SlotRange`, `Route`, `Redirect`, `RedirectKind`, `SplitPlan`, `NodeGroup`, `Rejected`, `Slot`). The per-family builder objects were already `private[sage]`; `Commands` re-exports their members.

### Kept public (pinned by existing design)

- `Frame` + cases + `FrameDecode` — `eval`/`fcall` return `Command[Frame]` (ADR-0033).
- `Node` — exposed by the Listener SPI via `SageEvent` (ADR-0035).
- `Execution` — a public field of `Command`.

## Also

- Four backend smoke suites migrated to the two-import convention.
- README "Getting started"; ADR-0040.

## Verification

`scalafmtCheckAll` clean; compiles on every cell (core + zio/ce/ox/kyo + Future anchor, Scala 3.3.7 and 3.8.3). Integration suites compile (running needs Docker).

## Known follow-up

The enumerated vocabulary list is maintained by hand — a public type added to `sage.commands` must be added to the aggregator to appear under `sage.*`. A completeness check to fail the build on omission is a candidate follow-up (deliberately not included here).