### PR TITLE
Close integration-test coverage gaps for sampled-only commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,12 +93,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.docker-images
-          key: docker-images-v1-redis8-valkey8
+          # keep the tags here in sync with integration-tests Images.scala; bump the key when they change
+          key: docker-images-v2-redis8.8.0-valkey9.1.0
       - name: Pull and save server images
         if: steps.images.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/.docker-images
-          for img in redis:8 valkey/valkey:8; do
+          for img in redis:8.8.0 valkey/valkey:9.1.0; do
             docker pull "$img"
             docker save "$img" -o ~/.docker-images/"${img//[\/:]/_}".tar
           done

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/ArraysSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/ArraysSuite.scala
@@ -122,6 +122,8 @@ class ArraysSuite extends ServerSuite(Images.redis) {
         min    <- client.arOpMin("ar-op", 0L, 2L)
         max    <- client.arOpMax("ar-op", 0L, 2L)
         and    <- client.arOpAnd("ar-op", 0L, 2L)
+        or     <- client.arOpOr("ar-op", 0L, 2L)
+        xor    <- client.arOpXor("ar-op", 0L, 2L)
         used   <- client.arOpUsed("ar-op", 0L, 2L)
         atMost <- client.arOpMatch("ar-op", 0L, 2L, "20")
       } yield {
@@ -129,6 +131,8 @@ class ArraysSuite extends ServerSuite(Images.redis) {
         assertEquals(min, Some(10.0))
         assertEquals(max, Some(30.0))
         assertEquals(and, Some(0L))
+        assertEquals(or, Some(30L))
+        assertEquals(xor, Some(0L))
         assertEquals(used, 3L)
         assertEquals(atMost, 1L)
       }

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/FunctionsSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/FunctionsSuite.scala
@@ -32,6 +32,23 @@ abstract class FunctionsSuite(image: String) extends ServerSuite(image) {
     }
   }
 
+  test("FCALL_RO invokes a function flagged no-writes") {
+    withClient { client =>
+      for {
+        _  <- client.functionFlush(Some(FlushMode.Sync))
+        _  <- client.functionLoad(
+                """#!lua name=saregg
+                  |redis.register_function{function_name='saregg_ro', callback=function(keys, args) return args[1] end, flags={'no-writes'}}
+                  |""".stripMargin
+              )
+        ro <- client.fCallRo("saregg_ro", Seq.empty[String], Seq("hi"))
+      } yield ro match {
+        case Frame.BulkString(b) => assertEquals(b.asUtf8String, "hi")
+        case other               => fail(s"expected bulk string, got $other")
+      }
+    }
+  }
+
   test("FUNCTION LIST and STATS describe loaded libraries; DELETE removes them") {
     withClient { client =>
       for {

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/KeysSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/KeysSuite.scala
@@ -305,6 +305,35 @@ abstract class KeysSuite(image: String) extends ServerSuite(image) {
     }
   }
 
+  test("OBJECT FREQ reports access frequency under an LFU policy, None for a missing key") {
+    withClient { client =>
+      for {
+        _       <- client.configSet("maxmemory-policy" -> "allkeys-lfu")
+        _       <- client.set("keys-freq", "v")
+        freq    <- client.objectFreq("keys-freq")
+        missing <- client.objectFreq("keys-freq-missing")
+        _       <- client.configSet("maxmemory-policy" -> "noeviction")
+      } yield {
+        assert(freq.exists(_ >= 0L))
+        assertEquals(missing, None)
+      }
+    }
+  }
+
+  test("FLUSHALL empties the keyspace") {
+    withClient { client =>
+      for {
+        _      <- client.set("keys-flush", "v")
+        before <- client.exists("keys-flush")
+        _      <- client.flushAll()
+        after  <- client.exists("keys-flush")
+      } yield {
+        assertEquals(before, 1L)
+        assertEquals(after, 0L)
+      }
+    }
+  }
+
   private def scanAll(
     client: Client[CIO],
     pattern: Option[String],

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/ListsSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/ListsSuite.scala
@@ -61,6 +61,19 @@ abstract class ListsSuite(image: String) extends ServerSuite(image) {
     }
   }
 
+  test("RPOP with a count pops several elements from the tail in pop order") {
+    withClient { client =>
+      for {
+        _    <- client.rPush("list-rpopc", "a", "b", "c", "d")
+        tail <- client.rPopCount[String, String]("list-rpopc", 2L)
+        rest <- client.lRange[String, String]("list-rpopc", 0L, -1L)
+      } yield {
+        assertEquals(tail, Vector("d", "c"))
+        assertEquals(rest, Vector("a", "b"))
+      }
+    }
+  }
+
   test("LSET LINSERT LREM and LTRIM edit the list in place") {
     withClient { client =>
       for {

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/RedisHashFieldExpirySuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/RedisHashFieldExpirySuite.scala
@@ -58,6 +58,25 @@ class RedisHashFieldExpirySuite extends ServerSuite(Images.redis) {
     }
   }
 
+  test("HPTTL and HPEXPIRETIME read the millisecond-precision TTL and absolute deadline") {
+    withClient { client =>
+      val at = Instant.ofEpochSecond(Instant.now().getEpochSecond + 3600)
+      for {
+        _    <- client.hSet("hfe-px", ("a", "1"))
+        _    <- client.hExpireAt("hfe-px", at)("a")
+        ttl  <- client.hpTtl("hfe-px")("a", "missing")
+        time <- client.hpExpireTime("hfe-px")("a")
+      } yield {
+        assert(ttl(0) match {
+          case FieldTtl.Expires(d) => d > Duration.Zero
+          case _                   => false
+        })
+        assertEquals(ttl(1), FieldTtl.NoField)
+        assertEquals(time, Vector(FieldExpiryTime.At(at)))
+      }
+    }
+  }
+
   test("HGETDEL returns field values and removes them") {
     withClient { client =>
       for {

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/ScriptingSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/ScriptingSuite.scala
@@ -35,10 +35,12 @@ abstract class ScriptingSuite(image: String) extends ServerSuite(image) {
       for {
         sha    <- client.scriptLoad("return 7")
         ran    <- client.evalSha(sha)
+        ranRo  <- client.evalShaRo(sha)
         exists <- client.scriptExists(sha, absent)
       } yield {
         assertEquals(sha.length, 40)
         assertEquals(ran, Frame.Integer(7L))
+        assertEquals(ranRo, Frame.Integer(7L))
         assertEquals(exists, Vector(true, false))
       }
     }

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/SortedSetsSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/SortedSetsSuite.scala
@@ -232,6 +232,40 @@ abstract class SortedSetsSuite(image: String) extends ServerSuite(image) {
       } yield assertEquals(page.items.toMap, Map("a" -> 1.0, "b" -> 2.0, "c" -> 3.0))
     }
   }
+
+  test("ZUNION ZINTER WITHSCORES, ZDIFF WITHSCORES, and ZREVRANK WITHSCORE return members with their scores") {
+    withClient { client =>
+      for {
+        _       <- client.zAdd("zgap-a")(("x", 1.0), ("y", 2.0))
+        _       <- client.zAdd("zgap-b")(("y", 3.0), ("z", 4.0))
+        union   <- client.zUnion[String, String]("zgap-a", "zgap-b")()
+        inter   <- client.zInterWithScores[String, String]("zgap-a", "zgap-b")()
+        diff    <- client.zDiffWithScores[String, String]("zgap-a", "zgap-b")
+        revRank <- client.zRevRankWithScore[String, String]("zgap-a", "x")
+      } yield {
+        assertEquals(union.toSet, Set("x", "y", "z"))
+        assertEquals(inter, Vector("y" -> 5.0))
+        assertEquals(diff, Vector("x" -> 1.0))
+        assertEquals(revRank, Some((1L, 1.0)))
+      }
+    }
+  }
+
+  test("ZPOPMAX with a count and BZPOPMAX pop the highest-scored members") {
+    withClient { client =>
+      for {
+        _      <- client.zAdd("zgap-pop")(("a", 1.0), ("b", 2.0), ("c", 3.0))
+        topTwo <- client.zPopMaxCount[String, String]("zgap-pop", 2L)
+        _      <- client.zAdd("zgap-bz")(("a", 1.0), ("b", 2.0))
+        bzMax  <- client.bzPopMax[String, String]("zgap-bz")(BlockTimeout.After(1.second))
+        none   <- client.bzPopMax[String, String]("zgap-bz-missing")(BlockTimeout.After(100.millis))
+      } yield {
+        assertEquals(topTwo, Vector("c" -> 3.0, "b" -> 2.0))
+        assertEquals(bzMax, Some(("zgap-bz", "b", 2.0)))
+        assertEquals(none, None)
+      }
+    }
+  }
 }
 
 class RedisSortedSetsSuite extends SortedSetsSuite(Images.redis)

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/StreamsSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/StreamsSuite.scala
@@ -116,6 +116,46 @@ abstract class StreamsSuite(image: String) extends ServerSuite(image) {
     }
   }
 
+  test("XGROUP CREATECONSUMER/DELCONSUMER/SETID/DESTROY and XSETID manage a group and the stream's last id") {
+    withClient { client =>
+      for {
+        _         <- client.xAdd("s-mgmt", XAddId.Explicit(StreamId(1L, 0L)))(("f", "1"))
+        _         <- client.xGroupCreate("s-mgmt", "g", GroupStartId.At(StreamId(0L, 0L)))
+        created   <- client.xGroupCreateConsumer("s-mgmt", "g", "c1")
+        again     <- client.xGroupCreateConsumer("s-mgmt", "g", "c1")
+        delPel    <- client.xGroupDelConsumer("s-mgmt", "g", "c1")
+        _         <- client.xGroupSetId("s-mgmt", "g", GroupStartId.At(StreamId(1L, 0L)))
+        _         <- client.xSetId("s-mgmt", GroupStartId.At(StreamId(5L, 0L)))
+        info      <- client.xInfoStream[String, String, String]("s-mgmt")
+        destroyed <- client.xGroupDestroy("s-mgmt", "g")
+        groups    <- client.xInfoGroups("s-mgmt")
+      } yield {
+        assertEquals(created, true)
+        assertEquals(again, false)
+        assertEquals(delPel, 0L)
+        assertEquals(info.lastGeneratedId, StreamId(5L, 0L))
+        assertEquals(destroyed, true)
+        assert(groups.isEmpty)
+      }
+    }
+  }
+
+  test("XCLAIM and XAUTOCLAIM JUSTID transfer pending ids without the payload") {
+    withClient { client =>
+      for {
+        _       <- client.xAdd("s-justid", XAddId.Explicit(StreamId(1L, 0L)))(("f", "1"))
+        _       <- client.xAdd("s-justid", XAddId.Explicit(StreamId(2L, 0L)))(("f", "2"))
+        _       <- client.xGroupCreate("s-justid", "g", GroupStartId.At(StreamId(0L, 0L)))
+        _       <- client.xReadGroup[String, String, String]("g", "c1")(("s-justid", GroupReadId.New))()
+        claimed <- client.xClaimJustId("s-justid", "g", "c2", Duration.Zero)(StreamId(1L, 0L))()
+        auto    <- client.xAutoClaimJustId("s-justid", "g", "c3", Duration.Zero)
+      } yield {
+        assertEquals(claimed, Vector(StreamId(1L, 0L)))
+        assertEquals(auto.claimed, Vector(StreamId(1L, 0L), StreamId(2L, 0L)))
+      }
+    }
+  }
+
   test("XINFO STREAM FULL decodes the group PEL after a consumer has read but not acked") {
     withClient { client =>
       for {


### PR DESCRIPTION
## What

`CoverageSpec` guarantees every server command has an *encoding sample* or is explicitly skipped — but a sample only checks encoding against the builder itself, so a wrong keyword and its sample can agree and both be wrong. The guard that actually catches a bad keyword is a **live round-trip test** against a real server.

Auditing sampled command methods against those invoked via `client.*` in the integration suites surfaced **43 commands with a sample but no live test**. This PR adds round-trip coverage for the 22 deterministic ones, mirroring each suite's existing style:

| Suite | Commands now exercised live |
|---|---|
| SortedSets | `zUnion`, `zInterWithScores`, `zDiffWithScores`, `zRevRankWithScore`, `zPopMaxCount`, `bzPopMax` |
| Lists | `rPopCount` |
| Hashes (Redis) | `hpTtl`, `hpExpireTime` |
| Streams | `xGroupCreateConsumer`, `xGroupDelConsumer`, `xGroupSetId`, `xGroupDestroy`, `xSetId`, `xClaimJustId`, `xAutoClaimJustId` |
| Arrays | `arOpOr`, `arOpXor` |
| Scripting / Functions | `evalShaRo`, `fCallRo` |
| Keys | `objectFreq` (under an LFU policy), `flushAll` |

The remaining ~20 gaps are admin/introspection/connection commands (`info`, `hello`, `cluster*`, `latency*`, `slowLogGet`, `aclCat/List/Log`, `memoryPurge`, `waitAof`, `scriptKill`, `functionKill`, …) — hard to assert deterministically or unsafe on the shared multiplexed connection, so left as-is.

## Also

Aligns the CI cached server images with the tags pinned in `Images.scala` (`redis:8.8.0` / `valkey/valkey:9.1.0`). CI was pulling/caching `redis:8` / `valkey/valkey:8`, but Testcontainers pulls the pinned tags — so the cache never hit and re-pulled every run. Cache key bumped to `v2`.

## Verification

All new and existing tests in the touched suites pass against both `redis:8.8.0` and `valkey:9.1.0` (146/146 across the modified suites); `scalafmtCheck` passes.

## Context

This started as #90 (HSETEX `FIELDS`→`FVS`). That turned out to be a false positive — the live server's own `COMMAND DOCS`, the official docs, and the existing `RedisHashFieldExpirySuite` test all confirm `FIELDS` is correct (the proposed `FVS` makes every `hSetEx` fail with `ERR unknown argument: FVS`). Issue closed; this PR addresses the broader "what else is sampled but never run live" question it raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)