### PR TITLE
Fix socket death in establish->Live window leaving a connection permanently Live (#92)

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -130,11 +130,14 @@ final private[client] class MultiplexedConnection private (
     // emit under the lock so the enqueue is ordered with the state transition: a socket dropping immediately after cannot deliver
     // Disconnected before this Connected (the same lock serializes both)
     locked {
-      current = conn
-      state = State.Live
-      generation = generation.next
-      startWatchdog()
-      events.emit(SageEvent.Connection.Connected(node))
+      if (conn.isTerminated) scheduleReconnect(0)
+      else {
+        current = conn
+        state = State.Live
+        generation = generation.next
+        startWatchdog()
+        events.emit(SageEvent.Connection.Connected(node))
+      }
     }
   }
 
@@ -179,7 +182,7 @@ final private[client] class MultiplexedConnection private (
       try {
         val conn = establish()
         val live = locked {
-          if (state == State.Reconnecting) {
+          if (state == State.Reconnecting && !conn.isTerminated) {
             current = conn
             state = State.Live
             generation = generation.next
@@ -187,7 +190,10 @@ final private[client] class MultiplexedConnection private (
             true
           } else false
         }
-        if (!live) conn.close()
+        if (!live) {
+          conn.close()
+          locked(if (state == State.Reconnecting) scheduleReconnect(attempt + 1))
+        }
       } catch {
         case NonFatal(_) => locked(if (state == State.Reconnecting) scheduleReconnect(attempt + 1))
       }
@@ -245,6 +251,9 @@ final private[client] class MultiplexedConnection private (
     @volatile private var lastReplyAtMillis: Long    = scheduler.nowMillis
     @volatile private var drainLatch: CountDownLatch = null
     @volatile private var aborted: Boolean           = false
+    @volatile private var terminated: Boolean        = false
+
+    def isTerminated: Boolean = terminated
 
     // transportRef is published before start()'s blocking connect, so a concurrent close() can abort it; `aborted` covers the
     // narrow gap where close() lands before the transport is published.
@@ -347,6 +356,7 @@ final private[client] class MultiplexedConnection private (
       }
 
     private def onClosed(): Unit = {
+      terminated = true
       var entry = pending.poll()
       while (entry != null) {
         entry.fail(ConnectionLost(mayHaveExecuted = true))

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -151,31 +151,43 @@ final private[client] class SubscriptionConnection(
 
   // bring a freshly-established socket Live, resubscribing everything registered (counters reset to this generation). In cluster mode it runs
   // once per connection with at most one Slot's worth of Shard channels registered, so the single SSUBSCRIBE never spans slots (CROSSSLOT).
-  private def goLive(conn: Conn): Unit = locked {
-    if (state == State.Establishing || state == State.Reconnecting) {
-      current = conn
-      subscribeSent = 0L
-      subscribeConfirmed = 0L
-      pingSentAtMillis = 0L
-      lastReplyAtMillis = scheduler.nowMillis
-      val channels = channelSinks.keys.toVector
-      val patterns = patternSinks.keys.toVector
-      val shards   = shardSinks.keys.toVector
-      if (channels.nonEmpty) sendSubscribe(conn, Kind.Channel, channels)
-      if (patterns.nonEmpty) sendSubscribe(conn, Kind.Pattern, patterns)
-      if (shards.nonEmpty) sendSubscribe(conn, Kind.Shard, shards)
-      if (channels.isEmpty && patterns.isEmpty && shards.isEmpty) {
-        // everything closed during the establish; tear back down rather than hold an idle socket open
-        conn.close()
-        current = null
-        state = State.Idle
+  private def goLive(conn: Conn): Unit = {
+    var reconnect = false
+    var notify    = false
+    locked {
+      if (state != State.Establishing && state != State.Reconnecting) conn.close()
+      else if (conn.isTerminated) {
+        if (cluster) { stopWatchdog(); current = null; state = State.Closed; notify = true }
+        else { state = State.Reconnecting; reconnect = true }
+        established.signalAll()
+        confirmed.signalAll()
       } else {
-        state = State.Live
-        startWatchdog()
+        current = conn
+        subscribeSent = 0L
+        subscribeConfirmed = 0L
+        pingSentAtMillis = 0L
+        lastReplyAtMillis = scheduler.nowMillis
+        val channels = channelSinks.keys.toVector
+        val patterns = patternSinks.keys.toVector
+        val shards   = shardSinks.keys.toVector
+        if (channels.nonEmpty) sendSubscribe(conn, Kind.Channel, channels)
+        if (patterns.nonEmpty) sendSubscribe(conn, Kind.Pattern, patterns)
+        if (shards.nonEmpty) sendSubscribe(conn, Kind.Shard, shards)
+        if (channels.isEmpty && patterns.isEmpty && shards.isEmpty) {
+          // everything closed during the establish; tear back down rather than hold an idle socket open
+          conn.close()
+          current = null
+          state = State.Idle
+        } else {
+          state = State.Live
+          startWatchdog()
+        }
+        established.signalAll()
+        confirmed.signalAll()
       }
-      established.signalAll()
-      confirmed.signalAll()
-    } else conn.close()
+    }
+    if (reconnect) scheduleReconnect(0)
+    if (notify) onTerminated()
   }
 
   private def sendSubscribe(conn: Conn, kind: Kind, names: Vector[String]): Unit = {
@@ -387,10 +399,13 @@ final private[client] class SubscriptionConnection(
 
   final private class Conn {
 
-    private val transportRef = new AtomicReference[Transport]()
+    private val transportRef         = new AtomicReference[Transport]()
+    @volatile private var terminated = false
+
+    def isTerminated: Boolean = terminated
 
     def start(): Unit = {
-      val transport = factory(onFrame, () => onConnClosed(this))
+      val transport = factory(onFrame, () => { terminated = true; onConnClosed(this) })
       transportRef.set(transport)
       transport.start()
     }

--- a/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
@@ -258,6 +258,41 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     assertEquals(afterReconnect, Some(Success("PONG")))
   }
 
+  test("a socket dying in the establish->Live window is not published Live, and the reconnect loop recovers") {
+    final class DyingAfterBootstrap(onFrame: Frame => Unit, onClosed: () => Unit) extends Transport {
+      def start(): Unit                    = ()
+      def send(item: Transport.Item): Unit = {
+        item.writeAttempted()
+        onFrame(Frame.SimpleString("PONG"))
+        onClosed()
+      }
+      def close(): Unit                    = ()
+    }
+    val healthy = mutable.ArrayBuffer.empty[FakeTransport]
+    var first                                           = true
+    val scheduler                                       = new ManualScheduler
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) =>
+      if (first) { first = false; new DyingAfterBootstrap(onFrame, onClosed) }
+      else {
+        val t = new FakeTransport(onFrame, onClosed, _ => Seq(Frame.SimpleString("PONG")))
+        healthy += t
+        t
+      }
+    val connection                                      =
+      MultiplexedConnection.connect(factory, scheduler, Vector(Connection.ping()), fixedBackoff, noWatchdog, 1.second, Duration.Zero)
+
+    assertEquals(connection.currentState, MultiplexedConnection.State.Reconnecting)
+
+    scheduler.advance(1.milli)
+    assertEquals(connection.currentState, MultiplexedConnection.State.Live)
+    assertEquals(healthy.size, 1)
+
+    var afterRecovery: Option[Try[String]] = None
+    connection.submit(Connection.ping(), r => afterRecovery = Some(r))
+    healthy.head.emit(Frame.SimpleString("PONG"))
+    assertEquals(afterRecovery, Some(Success("PONG")))
+  }
+
   test("isCurrent gates on liveness: a stamp is current only while Live, never during a reconnect window at the same generation") {
     val (connection, scheduler, transports) = make()
     val g                                   = connection.liveGeneration().getOrElse(fail("expected a live generation"))

--- a/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
@@ -210,4 +210,37 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
     transports.head.emit(message("a", "from-a"))
     assertChannel(nextBlocking(sub), "a", "from-a")
   }
+
+  test("a socket dying in the establish->live window fires onTerminated in cluster mode instead of going silently Live") {
+    final class DyingAfterBootstrap(onFrame: Frame => Unit, onClosed: () => Unit) extends Transport {
+      private var bootstrapped             = false
+      def start(): Unit                    = ()
+      def send(item: Transport.Item): Unit = {
+        item.writeAttempted()
+        serverResponder(item.payload).foreach(onFrame)
+        if (!bootstrapped) { bootstrapped = true; onClosed() }
+      }
+      def close(): Unit                    = ()
+    }
+    var terminatedCalled = false
+    val scheduler                                       = new ManualScheduler
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => new DyingAfterBootstrap(onFrame, onClosed)
+    val connection                                      = new SubscriptionConnection(
+      factory,
+      Vector(Connection.ping()),
+      scheduler,
+      fixedBackoff,
+      noWatchdog,
+      1000L,
+      16,
+      () => true,
+      cluster = true,
+      onTerminated = () => terminatedCalled = true
+    )
+
+    val sink = new SubscriptionConnection.Sink(Vector("news"), SubscriptionConnection.Kind.Channel, 16)
+    connection.attach(sink, Vector("news"), SubscriptionConnection.Kind.Channel)
+
+    assert(terminatedCalled, "a connection that died in the establish->live window must notify the manager, not go silently Live")
+  }
 }


### PR DESCRIPTION
Fixes #92.

## Problem

`onConnTerminated` ignores any `conn` that is not yet `current` (a failed establish is handled by its caller). But there is a window after `establish()` completes the HELLO bootstrap and returns, and before `connectInitial`/`attemptReconnect` takes the lock to set `current = conn; state = Live`.

A socket dying in that window fires `onClosed` exactly once → `onConnTerminated` sees `conn ne current` → ignored. The dead conn is then published `Live`, and because the transport's `terminate` is CAS-guarded, `onClosed` can never fire again. Result: every command fails `ConnectionLost`/`NotConnected` forever, the watchdog can't help (entries never reach `pending`), and no reconnect is ever scheduled.

## Fix

Add a `terminated` flag to `Conn`, set at the top of `onClosed`, and re-check `conn.isTerminated` under the lock at the establish→Live commit in both `connectInitial` and `attemptReconnect`. The lock serializes this check with `onConnTerminated`, so in every interleaving the connection recovers:

- if `onConnTerminated` ran first (and was ignored), the commit observes the flag and retries the reconnect loop;
- if the commit ran first and went Live, `onConnTerminated` runs afterward, sees `conn == current`, and drives the normal reconnect.

`SubscriptionConnection.goLive` had the same window (listed in the issue). A window-death is now routed through the existing recovery — reconnect for standalone, `onTerminated` for cluster — instead of being published silently `Live`.

## Tests

- `MultiplexedConnectionSpec`: a transport that answers the bootstrap then immediately dies must leave the connection `Reconnecting` (not `Live`), and the reconnect loop must recover to a healthy generation.
- `SubscriptionConnectionSpec`: in cluster mode, a window-death must fire `onTerminated` (so the manager re-homes) instead of going silently `Live`.

Both tests fail without the fix.