### PR TITLE
Refresh master/replica roles on transaction faults (#93)

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2363,10 +2363,21 @@ object Client {
       case Left(error)  => throw error
     }
 
-  final private[internal] class TxScope(val conn: DedicatedConnection) extends TransactionScope[CIO] {
+  final private[internal] class TxScope(val conn: DedicatedConnection, onFault: Throwable => Unit = _ => ()) extends TransactionScope[CIO] {
 
     // tracks whether watched keys may still be armed on the connection; set as soon as WATCH is attempted, cleared by EXEC/UNWATCH
     val armed = new AtomicBoolean(false)
+
+    private def faulting[A](complete: Try[A] => Unit): Try[A] => Unit = {
+      case failure @ Failure(error) => onFault(error); complete(failure)
+      case success                  => complete(success)
+    }
+
+    // an EXEC fault arrives as an error *frame* in a Success, invisible to `faulting`, so scan the top level and the EXEC array
+    private def refreshOnExecFault(frames: Vector[Frame]): Unit = {
+      val nested = frames.lastOption match { case Some(Frame.Array(elems)) => elems.iterator; case _ => Iterator.empty[Frame] }
+      (frames.iterator ++ nested).flatMap(TxSupport.errorOf).foreach(message => onFault(ServerError.of(message)))
+    }
 
     // The lock makes "reject if released, else submit" atomic with the finalizer's seal-and-decide ([[sealAndReusable]]): a command
     // submitted under it is in-flight before the finalizer reads quiescence, so a handle captured past the block and raced against release
@@ -2399,7 +2410,7 @@ object Client {
       CIO.async[Unit] { complete =>
         submitting(complete) {
           armed.set(true)
-          conn.submit(Connection.watch(key, rest*), complete)
+          conn.submit(Connection.watch(key, rest*), faulting(complete))
         }
       }
 
@@ -2409,13 +2420,13 @@ object Client {
       else if (command.isBlocking)
         CIO.fail(new IllegalArgumentException("a Transaction cannot run blocking commands; run them individually on the client"))
       else
-        CIO.async[A](complete => submitting(complete)(conn.submit(command, complete)))
+        CIO.async[A](complete => submitting(complete)(conn.submit(command, faulting(complete))))
 
     def discard: CIO[Unit] =
       CIO.async[Unit] { complete =>
         submitting(complete) {
           armed.set(false)
-          conn.submit(Connection.unwatch, complete)
+          conn.submit(Connection.unwatch, faulting(complete))
         }
       }
 
@@ -2440,10 +2451,11 @@ object Client {
       else
         CIO
           .async[Vector[Frame]] { complete =>
-            submitting(complete)(conn.submitRaw(Connection.multi +: p.commands :+ Connection.exec, complete))
+            submitting(complete)(conn.submitRaw(Connection.multi +: p.commands :+ Connection.exec, faulting(complete)))
           }
           .flatMap { frames =>
             armed.set(false) // EXEC clears WATCH/MULTI state server-side whether it committed or aborted
+            refreshOnExecFault(frames)
             TxSupport.interpretExec(p.commands, frames)
           }
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -276,16 +276,21 @@ final private[client] class MasterReplicaLive(
   def transaction[A](body: TransactionScope[CIO] => CIO[A]): CIO[A] =
     CIO.acquireReleaseWith(acquireScope)(releaseScope)(lease => body(lease.scope))
 
+  private def refreshOnTxFault(error: Throwable): Unit = if (isOwnershipFault(error)) triggerRefresh()
+
   private def acquireScope: CIO[MasterReplicaLive.TxLease] =
     CIO.blocking {
       val nc =
         try masterPool.getOrEstablish(masterNodeRef.get())
-        catch { case e: NotConnected => throw e; case NonFatal(_) => throw ConnectionLost(mayHaveExecuted = false) }
-      try new MasterReplicaLive.TxLease(new Client.TxScope(nc.acquireForTransaction()), nc)
+        catch {
+          case e: NotConnected => triggerRefresh(); throw e
+          case NonFatal(_)     => triggerRefresh(); throw ConnectionLost(mayHaveExecuted = false)
+        }
+      try new MasterReplicaLive.TxLease(new Client.TxScope(nc.acquireForTransaction(), refreshOnTxFault), nc)
       catch {
-        case e: NotConnected => throw e
+        case e: NotConnected => triggerRefresh(); throw e
         case e: TimedOut     => throw e
-        case NonFatal(_)     => throw ConnectionLost(mayHaveExecuted = false)
+        case NonFatal(_)     => triggerRefresh(); throw ConnectionLost(mayHaveExecuted = false)
       }
     }
 

--- a/sage-client/zio/src/test/scala/sage/client/internal/TxScopeFaultSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/internal/TxScopeFaultSpec.scala
@@ -1,0 +1,63 @@
+package sage.client.internal
+
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext
+
+import kyo.compat.*
+
+import sage.Bytes
+import sage.SageException.{ConnectionLost, ServerError}
+import sage.client.DedicatedPoolConfig
+import sage.commands.{Connection, Pipeline, Strings}
+import sage.protocol.Frame
+
+class TxScopeFaultSpec extends munit.FunSuite {
+
+  private given ExecutionContext = munitExecutionContext
+
+  private val helloReply: Frame =
+    Frame.Map(
+      Vector(
+        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
+        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
+        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
+        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
+      )
+    )
+
+  private val readonly = Frame.SimpleError("READONLY You can't write against a read only replica.")
+
+  private def txScope(respond: Bytes => Seq[Frame]): (Client.TxScope, mutable.ArrayBuffer[Throwable]) = {
+    val scheduler                                       = new ManualScheduler
+    val gen                                             = MultiplexedConnection.Generation.initial
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => new FakeTransport(onFrame, onClosed, respond)
+    val pool                                            =
+      new DedicatedPool(factory, Vector(Connection.hello()), scheduler, () => true, () => Some(gen), _ == gen, DedicatedPoolConfig(), 1000L)
+    val faults                                          = mutable.ArrayBuffer.empty[Throwable]
+    (new Client.TxScope(pool.acquireForTransaction(), faults += _), faults)
+  }
+
+  private def isOwnershipFault(error: Throwable): Boolean = error match {
+    case e: ServerError    => e.code == "READONLY"
+    case _: ConnectionLost => true
+    case _                 => false
+  }
+
+  test("a READONLY command fault invokes the onFault hook") {
+    val (scope, faults) = txScope(p => if (p.asUtf8String.contains("HELLO")) Seq(helloReply) else Seq(readonly))
+    scope.run(Strings.set("k", "v")).unsafeRun.failed.map { _ =>
+      assert(faults.exists(isOwnershipFault), s"expected an ownership fault, got $faults")
+    }
+  }
+
+  test("a transaction whose EXEC hits a READONLY invokes the onFault hook") {
+    val respond: Bytes => Seq[Frame] = p =>
+      if (p.asUtf8String.contains("HELLO")) Seq(helloReply)
+      else if (p.asUtf8String.contains("MULTI")) Seq(Frame.SimpleString("OK"), readonly, Frame.SimpleError("EXECABORT discarded"))
+      else Seq(Frame.SimpleString("OK"))
+    val (scope, faults)              = txScope(respond)
+    scope.exec(Pipeline.sequence(Vector(Strings.set("k", "v")))).unsafeRun.failed.map { _ =>
+      assert(faults.exists(isOwnershipFault), s"expected an ownership fault, got $faults")
+    }
+  }
+}


### PR DESCRIPTION
Fixes #93.

## Problem

`MasterReplicaLive` transactions reuse the standalone `Client.TxScope`, which has no fault hook, and neither `acquireScope` (which swallowed establish failures into `NotConnected`/`ConnectionLost`) nor the scope's command/EXEC paths called `triggerRefresh()`.

So a transaction-only workload that met an in-place failover — a `READONLY` from the demoted master, or a connection loss — retried the same demoted node forever, never kicking off rediscovery, until some non-transactional command happened to run and trip `triggerRefresh()`. This contradicts the class's own documented failover contract; the ordinary command path already honors it via `sendMaster`, and the cluster runtime wires the equivalent through `ClusterTxScope`.

## Fix

- Add an optional `onFault: Throwable => Unit` hook to `Client.TxScope` (default no-op, so the standalone client is unchanged). It mirrors `ClusterTxScope`: every `watch`/`run`/`discard`/`exec` command fault is surfaced via a `faulting` wrapper, and every EXEC error frame via `refreshOnExecFault`.
- `MasterReplicaLive` passes a hook that calls `triggerRefresh()` on ownership/loss faults (`READONLY`, `NotConnected`, `ConnectionLost`), and `acquireScope` now also refreshes on establish failure — matching `sendMaster`.

## Tests

`TxScopeFaultSpec` drives a `TxScope` with a recording hook and asserts it fires on:
- a `READONLY` command fault (`run`), and
- a transaction whose EXEC hits a `READONLY` (which poisons the dedicated connection and fails the batch).

The full standalone `TransactionSpec` still passes unchanged (default no-op hook).