### PR TITLE
Fence the reader before onClosed in SocketTransport (#94)

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
@@ -94,7 +94,8 @@ final private[client] class SocketTransport private (
         else if (parser.feed(buffer, 0, n)(onFrame).isDefined) done = true
       }
     } catch {
-      case NonFatal(_) => ()
+      case _: InterruptedException => () // terminate() interrupts the reader to fence it
+      case NonFatal(_)             => ()
     } finally terminate()
   }
 
@@ -176,6 +177,9 @@ final private[client] class SocketTransport private (
       if (locked(threadsStarted)) {
         writer.interrupt()
         if (Thread.currentThread() ne writer) writer.join()
+        // fence the reader before onClosed, else an in-flight reply races the consumer's pending drain (#94); interrupt frees a reader
+        // parked on backpressure so the join cannot hang
+        if (Thread.currentThread() ne reader) { reader.interrupt(); reader.join() }
       }
       drainQueue()
       onClosed()

--- a/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
@@ -3,6 +3,8 @@ package sage.client.internal
 import java.io.InputStream
 import java.net.{ServerSocket, Socket}
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.concurrent.duration.*
 
@@ -134,6 +136,28 @@ class SocketTransportSpec extends munit.FunSuite {
       awaitUntil(closedCount == 1, "the poisoned connection to close")
       transport.close()
       assertEquals(closedCount, 1)
+    }
+  }
+
+  test("onClosed runs only after the reader is fenced, so a buffered frame cannot race the close") {
+    val readerAliveAtClose                      = new AtomicBoolean(false)
+    val inOnFrame                               = new CountDownLatch(1)
+    val proceed                                 = new CountDownLatch(1)
+    @volatile var transportRef: SocketTransport = null
+    withTransport(
+      onClosed = () => { readerAliveAtClose.set(transportRef.reader.isAlive); proceed.countDown() },
+      onFrame = _ => { inOnFrame.countDown(); proceed.await() }
+    ) { (transport, peer) =>
+      transportRef = transport
+      peer.getOutputStream.write("+PONG\r\n".getBytes(StandardCharsets.UTF_8))
+      peer.getOutputStream.flush()
+      assert(inOnFrame.await(5, TimeUnit.SECONDS), "reader should reach frame delivery")
+
+      val closer = new Thread(() => transport.close())
+      closer.start()
+      closer.join(5000)
+      assert(!closer.isAlive, "close() must not hang")
+      assert(!readerAliveAtClose.get(), "onClosed must run only after the reader has been joined")
     }
   }
 


### PR DESCRIPTION
Fixes #94.

## Problem

`terminate()` closed the socket, joined **only the writer**, then ran `drainQueue()` and `onClosed()`. The reader is joined only later, in `close()` — *after* `onClosed` has already run. When termination is initiated by the writer (a write failure in `writeLoop`'s finally) or by an external `close()`, the reader can still be mid-`parser.feed`, delivering buffered frames concurrently with `onClosed`.

Both `MultiplexedConnection.Conn.onClosed` and `DedicatedConnection.onClosed` drain `pending` by polling, while `onFrame` concurrently polls `pending` to match a reply FIFO. `ConcurrentLinkedQueue.poll` is atomic per entry, but the *pairing* breaks: `onClosed` can fail `e1` with `ConnectionLost` while `onFrame(r1)` polls `e2` and completes it with `r1`'s frame — a successful but **wrong** reply delivered to the wrong caller. If the frame shapes coincide, the decoder succeeds and the corruption is silent. This is the only data-corruption-class finding.

## Fix

Join the reader before invoking `onClosed`, so all buffered frames are delivered (and matched against `pending`) before the consumer drains `pending`.

The reader is **interrupted** first, then joined: a `SubscriptionConnection` reader can be parked on consumer backpressure (a full sink), which `socket.close()` does not unblock — a plain join there would hang termination. The interrupt frees it; `readLoop` now treats `InterruptedException` as a clean unwind. When `terminate()` is itself called from the reader thread (a read-side failure), the self-join is skipped as before.

## Test

`SocketTransportSpec`: an `onFrame` that parks the reader inside frame delivery, then an external `close()` on another thread. The test asserts `close()` does not hang and that by the time `onClosed` runs the reader has been joined (`reader.isAlive == false`). It fails without the fix (onClosed observes a live reader) and passes with it. The full client suite still passes.