### PR TITLE
Wake DedicatedPool waiters on Live->Reconnecting (#96)

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -103,6 +103,8 @@ final private[client] class DedicatedPool(
         available.signalAll()
       }
 
+  private[internal] def wakeWaiters(): Unit = locked(available.signalAll())
+
   def close(): Unit = {
     val toClose = locked {
       closing = true
@@ -239,8 +241,8 @@ private[client] object DedicatedPool {
     connection: MultiplexedConnection,
     config: DedicatedPoolConfig,
     connectTimeoutMillis: Long
-  ): DedicatedPool =
-    new DedicatedPool(
+  ): DedicatedPool = {
+    val pool = new DedicatedPool(
       factory,
       bootstrap,
       scheduler,
@@ -250,6 +252,9 @@ private[client] object DedicatedPool {
       config,
       connectTimeoutMillis
     )
+    connection.setOnLivenessLost(() => pool.wakeWaiters())
+    pool
+  }
 
   final case class Idle(connection: DedicatedConnection, idleSinceMillis: Long)
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -46,6 +46,9 @@ final private[client] class MultiplexedConnection private (
   private var watchdogHandle: Scheduler.Cancelable = null
   // bumped when a fresh socket becomes live; the dedicated pool stamps borrowed connections with it to detect ones outliving a reconnect
   private var generation: Generation               = Generation.initial
+  @volatile private var onLivenessLost: () => Unit = () => ()
+
+  private[internal] def setOnLivenessLost(hook: () => Unit): Unit = onLivenessLost = hook
 
   private inline def locked[A](inline body: A): A = {
     lock.lock()
@@ -191,18 +194,23 @@ final private[client] class MultiplexedConnection private (
   }
 
   // Connections that never became `current` (a failed establish) are ignored here; their caller handles them.
-  private def onConnTerminated(conn: Conn): Unit =
+  private def onConnTerminated(conn: Conn): Unit = {
     // Disconnected fires only on the Live edge (a fresh loss, not a failed reconnect attempt), under the lock so it is ordered after the
     // Connected of the connection it ends
-    locked {
+    val lostLiveness = locked {
       if (conn eq current)
         state match {
-          case State.Live         => state = State.Reconnecting; scheduleReconnect(0); events.emit(SageEvent.Connection.Disconnected(node))
-          case State.Reconnecting => scheduleReconnect(0)
-          case State.Draining     => state = State.Closed; stopWatchdog()
-          case State.Closed       => ()
+          case State.Live         =>
+            state = State.Reconnecting; scheduleReconnect(0); events.emit(SageEvent.Connection.Disconnected(node)); true
+          case State.Reconnecting => scheduleReconnect(0); false
+          case State.Draining     => state = State.Closed; stopWatchdog(); false
+          case State.Closed       => false
         }
+      else false
     }
+    // outside the lock: acquire holds the pool lock then calls isLive on this connection's lock, so the reverse order here would deadlock
+    if (lostLiveness) onLivenessLost()
+  }
 
   private def startWatchdog(): Unit =
     if (watchdog.enabled && watchdogHandle == null)

--- a/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
@@ -6,7 +6,7 @@ import scala.util.{Failure, Success, Try}
 
 import sage.Bytes
 import sage.SageException.{ConnectionLost, NotConnected, TimedOut}
-import sage.client.DedicatedPoolConfig
+import sage.client.{BackoffConfig, DedicatedPoolConfig, WatchdogConfig}
 import sage.commands.{BlockTimeout, Connection, Lists}
 import sage.protocol.Frame
 
@@ -238,5 +238,39 @@ class DedicatedPoolSpec extends munit.FunSuite {
     val (pool, _, transports) = make(replyWith(Nil), isLive = () => false)
     intercept[NotConnected](pool.acquireForTransaction())
     assertEquals(transports.size, 0)
+  }
+
+  test("a parked acquire is woken to fail fast NotConnected when the multiplexed connection loses liveness") {
+    val scheduler                                       = new ManualScheduler
+    val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
+      val t = new FakeTransport(onFrame, onClosed, replyWith(Nil)); transports += t; t
+    }
+    val connection                                      = MultiplexedConnection.connect(
+      factory,
+      scheduler,
+      Vector(Connection.hello()),
+      BackoffConfig(1.milli, 1.milli, 1.0),
+      WatchdogConfig(enabled = false),
+      1.second,
+      Duration.Zero
+    )
+    val config                                          = DedicatedPoolConfig(maxConnections = 1, acquireTimeout = 10.seconds, idleTimeout = Duration.Inf)
+    val pool                                            = DedicatedPool.forConnection(factory, Vector(Connection.hello()), scheduler, connection, config, 1000L)
+
+    val held = pool.acquireForTransaction()
+
+    @volatile var result: Option[Try[DedicatedConnection]] = None
+    val waiter                                             = new Thread(() => result = Some(Try(pool.acquireForTransaction())))
+    waiter.start()
+    Thread.sleep(100) // let the second acquire park in awaitNanos
+
+    transports.head.emit(Frame.SimpleString("stray"))
+    assert(!connection.isLive)
+
+    waiter.join(3000)
+    assert(!waiter.isAlive, "the parked waiter must be woken, not sleep out the 10s acquireTimeout")
+    assert(result.exists(_.failed.toOption.exists(_.isInstanceOf[NotConnected])), s"expected NotConnected, got $result")
+    pool.releaseTransaction(held, reusable = false)
   }
 }


### PR DESCRIPTION
Fixes #96.

## Problem

`acquire` re-checks `isLive()` on every wakeup, but nothing signaled `available` when the multiplexed connection transitioned Live → Reconnecting. A caller parked in `awaitNanos` while the pool is at capacity slept until the full `acquireTimeout` and then failed `TimedOut`, instead of failing fast with `NotConnected` (the documented contract, and what ordinary commands get). This bites when borrowed dedicated connections outlive the multiplexed socket's loss.

## Fix

Push a notification on the liveness-loss edge:

- `MultiplexedConnection` fires an `onLivenessLost` hook when `onConnTerminated` takes the Live → Reconnecting transition. It runs **outside** the connection lock to respect the pool's lock ordering (`acquire` holds the pool lock and calls `isLive()` on the connection lock, so the reverse order would risk a deadlock).
- `DedicatedPool.forConnection` registers the hook to call `wakeWaiters()`, which signals `available`. Parked waiters re-check `isLive()` — now false — and fail fast `NotConnected`.

## Test

`DedicatedPoolSpec`: a pool of capacity 1 (built over a real `MultiplexedConnection` via `forConnection`) with one slot held and a second acquire parked; dropping the multiplexed connection (Live → Reconnecting) must wake the parked waiter to fail `NotConnected` well within the 10s `acquireTimeout`. The test fails without the fix (the waiter sleeps out the timeout) and passes with it.