### PR TITLE
Validate dedicatedPool.idleTimeout and clientCache.maxBytes (#97)

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2143,6 +2143,8 @@ object Client {
       cond(config.reconnect.multiplier >= 1.0, "reconnect.multiplier must be >= 1.0"),
       cond(config.dedicatedPool.maxConnections >= 1, "dedicatedPool.maxConnections must be >= 1"),
       positive(config.dedicatedPool.acquireTimeout, "dedicatedPool.acquireTimeout"),
+      positiveOrInfinite(config.dedicatedPool.idleTimeout, "dedicatedPool.idleTimeout"),
+      cond(!config.clientCache.enabled || config.clientCache.maxBytes > 0L, "clientCache.maxBytes must be positive when caching is enabled"),
       cond(config.pubsub.bufferSize >= 1, "pubsub.bufferSize must be >= 1")
     ) ++ watchdog ++ (config.topology match {
       case Topology.Cluster(seeds, cluster)             =>
@@ -2168,9 +2170,11 @@ object Client {
     checks.flatten.headOption
   }
 
-  private def cond(ok: Boolean, problem: String): Option[String]             = if (ok) None else Some(problem)
-  private def port(value: Int, label: String): Option[String]                = cond(value >= 1 && value <= 65535, s"$label must be in 1..65535")
-  private def positive(value: FiniteDuration, label: String): Option[String] = cond(value.toNanos > 0L, s"$label must be positive")
+  private def cond(ok: Boolean, problem: String): Option[String]                 = if (ok) None else Some(problem)
+  private def port(value: Int, label: String): Option[String]                    = cond(value >= 1 && value <= 65535, s"$label must be in 1..65535")
+  private def positive(value: FiniteDuration, label: String): Option[String]     = cond(value.toNanos > 0L, s"$label must be positive")
+  private def positiveOrInfinite(value: Duration, label: String): Option[String] =
+    cond(value == Duration.Inf || (value.isFinite && value.toNanos > 0L), s"$label must be positive (or Inf)")
 
   private def connectStandalone(config: SageConfig, endpoint: Endpoint): CIO[Client[CIO]] =
     // build the TLS context once (eager failure on bad trust material), then capture it in the reconnect factory so every connection — the

--- a/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
@@ -76,6 +76,24 @@ class ConnectSpec extends munit.FunSuite {
     }
   }
 
+  test("a non-positive finite dedicatedPool.idleTimeout is rejected by validation, not thrown after connecting") {
+    Client.connect(SageConfig(dedicatedPool = DedicatedPoolConfig(idleTimeout = Duration.Zero))).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+    }
+  }
+
+  test("a non-finite, non-Inf dedicatedPool.idleTimeout (MinusInf) is rejected; only Duration.Inf disables the sweep") {
+    Client.connect(SageConfig(dedicatedPool = DedicatedPoolConfig(idleTimeout = Duration.MinusInf))).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+    }
+  }
+
+  test("clientCache.maxBytes <= 0 with caching enabled is rejected by validation") {
+    Client.connect(SageConfig(clientCache = CacheConfig(enabled = true, maxBytes = 0L))).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+    }
+  }
+
   test("readFrom = ReplicaPreferred on a Standalone topology passes validation (degrades to the one node)") {
     // it may connect (a local server) or fail to connect (none) — either way it must not be rejected by validation
     Client


### PR DESCRIPTION
Fixes #97.

## Problem

`validate` checked `dedicatedPool.maxConnections` and `acquireTimeout` but not `idleTimeout`. A zero or negative *finite* `idleTimeout` reaches `scheduler.every(interval)` → `scheduleAtFixedRate(period <= 0)`, which throws `IllegalArgumentException` from inside the `DedicatedPool` constructor — **after** the multiplexed connection has already been established. So the error bypasses the validation contract ("a misconfigured client is a programmer error, surfaced through the connect effect") and leaks the just-opened connection. In cluster mode the same throw is swallowed per node and surfaces as `NotConnected`, masking the misconfiguration entirely.

## Fix

- Validate `dedicatedPool.idleTimeout`: a finite value must be positive; `Duration.Inf` stays valid (it disables the idle sweep).
- Also validate `clientCache.maxBytes > 0` when caching is enabled (the related lower-priority item the issue flags — otherwise caching silently never stores).

Both are surfaced through the connect effect before any connection is opened.

## Tests

`ConnectSpec`: a `dedicatedPool.idleTimeout = Duration.Zero` and a `clientCache.maxBytes = 0` (caching enabled) are each rejected with `IllegalArgumentException` from the connect effect. Both fail without the fix (the connect proceeds instead of rejecting upfront).