### PR TITLE
Deepen three runtime seams: generation liveness, bootstrap, decode combinators

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/Bootstrap.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Bootstrap.scala
@@ -1,0 +1,53 @@
+package sage.client.internal
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.util.{Failure, Success, Try}
+
+import sage.SageException.ConnectionLost
+import sage.client.{AuthConfig, BuildInfo}
+import sage.commands.{Command, Connection}
+
+private[client] object Bootstrap {
+
+  /**
+    * The setup commands every connection runs after `HELLO` and re-runs on reconnection, shared by the standalone, cluster, and
+    * master-replica paths so identification is never applied to one topology and dropped on another. `SELECT` lives here, never as a
+    * runtime command, because it would move the database under every fiber sharing the connection.
+    */
+  def commands(auth: Option[AuthConfig], database: Int, clientName: Option[String]): Vector[Command[?]] = {
+    val identification = Vector(
+      Connection.clientSetInfo("LIB-NAME", "sage"),
+      Connection.clientSetInfo("LIB-VER", BuildInfo.version)
+    ) ++ clientName.map(Connection.clientSetName).toVector
+    val selectDb       = if (database > 0) Vector(Connection.select(database)) else Vector.empty
+    (Connection.hello(auth.map(a => a.username -> a.password)) +: identification) ++ selectDb
+  }
+
+  /**
+    * Runs the connection-setup handshake on a freshly opened connection: submits each command in turn and blocks for its reply up to
+    * `connectTimeoutMillis`, then closes the half-built connection and throws on a timeout or a failed reply so the caller discards it.
+    * `submit` enqueues one command and delivers its decoded reply; replies are FIFO, so each command is awaited before the next is sent.
+    * Used by the Multiplexed, Dedicated, and Subscription connections, which differ only in how a single command's reply is obtained.
+    */
+  def run(
+    commands: Vector[Command[?]],
+    connectTimeoutMillis: Long,
+    submit: (Command[?], Try[Any] => Unit) => Unit,
+    close: () => Unit
+  ): Unit =
+    commands.foreach { command =>
+      val latch   = new CountDownLatch(1)
+      val outcome = new AtomicReference[Try[Any]]()
+      submit(command, result => { outcome.set(result); latch.countDown() })
+      if (!latch.await(connectTimeoutMillis, TimeUnit.MILLISECONDS)) {
+        close()
+        throw ConnectionLost(mayHaveExecuted = false)
+      }
+      outcome.get() match {
+        case Failure(error) => close(); throw error
+        case Success(_)     => ()
+      }
+    }
+}

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -13,7 +13,7 @@ import kyo.compat.*
 
 import sage.{Bytes, Message, Outcome, PatternMessage, SageEvent, SageException}
 import sage.SageException.{ConnectionLost, NotCacheable, NotConnected, ServerError, TimedOut, TlsError, UnsupportedServer}
-import sage.client.{AuthConfig, BackoffConfig, BuildInfo, DedicatedPoolConfig, Endpoint, PubSubConfig, ReadFrom, SageConfig, Topology, WatchdogConfig}
+import sage.client.{AuthConfig, BackoffConfig, DedicatedPoolConfig, Endpoint, PubSubConfig, ReadFrom, SageConfig, Topology, WatchdogConfig}
 import sage.cluster.Node
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
@@ -2196,18 +2196,6 @@ object Client {
       )
     }
 
-  // The setup commands every connection runs after HELLO and re-runs on reconnection. Shared by the standalone and cluster paths so
-  // identification is never applied to one topology and dropped on the other. SELECT lives here, never as a runtime command, because it
-  // would move the db under every fiber sharing the connection.
-  private[client] def bootstrapCommands(auth: Option[AuthConfig], database: Int, clientName: Option[String]): Vector[Command[?]] = {
-    val identification = Vector(
-      Connection.clientSetInfo("LIB-NAME", "sage"),
-      Connection.clientSetInfo("LIB-VER", BuildInfo.version)
-    ) ++ clientName.map(Connection.clientSetName).toVector
-    val selectDb       = if (database > 0) Vector(Connection.select(database)) else Vector.empty
-    (Connection.hello(auth.map(a => a.username -> a.password)) +: identification) ++ selectDb
-  }
-
   // The HELLO 3 handshake is the bootstrap re-run on every (re)connection; the first connect propagates its failure, reconnects retry it.
   private[client] def connectWith(
     factory: MultiplexedConnection.TransportFactory,
@@ -2225,7 +2213,7 @@ object Client {
     database: Int = 0,
     clientName: Option[String] = None
   ): CIO[Client[CIO]] = {
-    val bootstrap            = bootstrapCommands(auth, database, clientName)
+    val bootstrap            = Bootstrap.commands(auth, database, clientName)
     // only the Multiplexed Connection caches reads, so only it enables tracking; the dedicated pool and subscription connection keep the
     // plain bootstrap. Tracking is skipped entirely when caching is disabled, so a server that denies CLIENT TRACKING still connects.
     val multiplexedBootstrap = if (cachingEnabled) bootstrap :+ Connection.clientTrackingOnOptin else bootstrap

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -845,7 +845,7 @@ private[client] object ClusterLive {
   ): CIO[Client[CIO]] =
     CIO.blocking[Client[CIO]] {
       // cluster validation forces database 0, so this adds no SELECT
-      val bootstrap                                               = Client.bootstrapCommands(config.auth, config.database, config.clientName)
+      val bootstrap                                               = Bootstrap.commands(config.auth, config.database, config.clientName)
       val factory: Node => MultiplexedConnection.TransportFactory = node => {
         val upgrade = Tls.buildUpgrade(config.tls, node.host, node.port)
         (onFrame, onClosed) => SocketTransport.connect(node.host, node.port, config.connectTimeout, upgrade, onFrame, onClosed)

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
@@ -1,6 +1,6 @@
 package sage.client.internal
 
-import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference, AtomicReferenceArray}
 
 import scala.util.{Failure, Success, Try}
@@ -67,29 +67,8 @@ final private[client] class DedicatedConnection private (
     transport.start()
   }
 
-  // blocks on each reply in turn; throws on failure so the caller discards the half-built connection
   private def runBootstrap(bootstrap: Vector[Command[?]]): Unit =
-    bootstrap.foreach { command =>
-      val latch   = new CountDownLatch(1)
-      val outcome = new AtomicReference[Try[Any]]()
-      submit(
-        command,
-        result => {
-          outcome.set(result)
-          latch.countDown()
-        }
-      )
-      if (!latch.await(connectTimeoutMillis, TimeUnit.MILLISECONDS)) {
-        close()
-        throw ConnectionLost(mayHaveExecuted = false)
-      }
-      outcome.get() match {
-        case Failure(error) =>
-          close()
-          throw error
-        case Success(_)     => ()
-      }
-    }
+    Bootstrap.run(bootstrap, connectTimeoutMillis, (c, cb) => submit(c, cb), () => close())
 
   private def onFrame(frame: Frame): Unit =
     frame match {

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -362,7 +362,7 @@ private[client] object MasterReplicaLive {
     translate: Throwable => Throwable
   ): CIO[Client[CIO]] =
     CIO.blocking[Client[CIO]] {
-      val bootstrap                                               = Client.bootstrapCommands(config.auth, config.database, config.clientName)
+      val bootstrap                                               = Bootstrap.commands(config.auth, config.database, config.clientName)
       val factory: Node => MultiplexedConnection.TransportFactory = node => {
         val upgrade = Tls.buildUpgrade(config.tls, node.host, node.port)
         (onFrame, onClosed) => SocketTransport.connect(node.host, node.port, config.connectTimeout, upgrade, onFrame, onClosed)

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -46,6 +46,9 @@ final private[client] class MultiplexedConnection private (
   private var watchdogHandle: Scheduler.Cancelable = null
   // bumped when a fresh socket becomes live; the dedicated pool stamps borrowed connections with it to detect ones outliving a reconnect
   private var generation: Generation               = Generation.initial
+  // the live epoch (or `notLive`), published so liveness reads are lock-free: the pool reads it under its own lock without crossing into
+  // this lifecycle lock, so there is no pool<->connection lock order to keep
+  private val liveEpoch                            = new AtomicReference[Generation](Generation.notLive)
   @volatile private var onLivenessLost: () => Unit = () => ()
 
   private[internal] def setOnLivenessLost(hook: () => Unit): Unit = onLivenessLost = hook
@@ -54,6 +57,12 @@ final private[client] class MultiplexedConnection private (
     lock.lock()
     try body
     finally lock.unlock()
+  }
+
+  // the sole mutator of `state`, keeping `liveEpoch` in step. Must hold `lock`; at a Live edge the caller bumps `generation` first.
+  private def transition(to: State): Unit = {
+    state = to
+    liveEpoch.set(if (to == State.Live) generation else Generation.notLive)
   }
 
   // the live connection, or null when not Live so callers fail fast rather than join a dead or reconnecting generation
@@ -104,11 +113,11 @@ final private[client] class MultiplexedConnection private (
       state match {
         case State.Closed | State.Draining => (null, null)
         case State.Reconnecting            =>
-          state = State.Closed
+          transition(State.Closed)
           stopWatchdog()
           (null, establishing)
         case State.Live                    =>
-          state = State.Draining
+          transition(State.Draining)
           (current, null)
       }
     }
@@ -122,15 +131,18 @@ final private[client] class MultiplexedConnection private (
 
   private[internal] def currentState: State = locked(state)
 
-  private[internal] def isLive: Boolean = locked(state == State.Live)
+  private[internal] def isLive: Boolean = liveEpoch.get() != Generation.notLive
 
-  // the Generation to stamp a fresh Dedicated Connection with, captured atomically and only while live; None means a borrower must fail
-  // fast rather than join a connection to a dead or reconnecting epoch
-  private[internal] def liveGeneration(): Option[Generation] = locked(if (state == State.Live) Some(generation) else None)
+  // the Generation to stamp a fresh Dedicated Connection with, read only while live; None means a borrower must fail fast rather than join
+  // a connection to a dead or reconnecting epoch
+  private[internal] def liveGeneration(): Option[Generation] = {
+    val g = liveEpoch.get()
+    if (g == Generation.notLive) None else Some(g)
+  }
 
-  // whether a stamped Generation is still the live one; gated on Live, since the epoch only bumps on the next live socket and would
-  // otherwise still match during a reconnect window
-  private[internal] def isCurrent(g: Generation): Boolean = locked(state == State.Live && generation == g)
+  // whether a stamped Generation is still the live one; the `notLive` sentinel makes a stamp read stale throughout a reconnect window, even
+  // at the same generation number, since the epoch only bumps on the next live socket
+  private[internal] def isCurrent(g: Generation): Boolean = liveEpoch.get() == g
 
   private def connectInitial(): Unit = {
     val conn = establish() // the first connect propagates a handshake failure; only reconnects retry
@@ -140,8 +152,8 @@ final private[client] class MultiplexedConnection private (
       if (conn.isTerminated) scheduleReconnect(0)
       else {
         current = conn
-        state = State.Live
         generation = generation.next
+        transition(State.Live)
         startWatchdog()
         events.emit(SageEvent.Connection.Connected(node))
       }
@@ -153,30 +165,9 @@ final private[client] class MultiplexedConnection private (
     locked { establishing = conn }
     try {
       conn.start()
-      bootstrap.foreach { command =>
-        val latch   = new CountDownLatch(1)
-        val outcome = new AtomicReference[Try[Any]]()
-        conn.reserve(1) // submit no longer self-increments; balance the retire() the reply will trigger
-        conn.submit(
-          command,
-          result => {
-            outcome.set(result)
-            latch.countDown()
-          }
-        )
-        // a half-open peer can accept the socket yet never answer HELLO; bound the wait so the reconnect loop can't stall on it forever
-        val replied = latch.await(connectTimeout.toMillis, TimeUnit.MILLISECONDS)
-        if (!replied) {
-          conn.close()
-          throw ConnectionLost(mayHaveExecuted = false)
-        }
-        outcome.get() match {
-          case Failure(error) =>
-            conn.close()
-            throw error
-          case Success(_)     => ()
-        }
-      }
+      // reserve(1) per command: submit does not self-increment, so this balances the retire() the reply will trigger. A half-open peer can
+      // accept the socket yet never answer HELLO, so the runner bounds each wait and the reconnect loop can't stall on it forever.
+      Bootstrap.run(bootstrap, connectTimeout.toMillis, (c, cb) => { conn.reserve(1); conn.submit(c, cb) }, () => conn.close())
       conn
     } finally locked { if (establishing eq conn) establishing = null }
   }
@@ -192,8 +183,8 @@ final private[client] class MultiplexedConnection private (
         val live = locked {
           if (state == State.Reconnecting && !conn.isTerminated) {
             current = conn
-            state = State.Live
             generation = generation.next
+            transition(State.Live)
             events.emit(SageEvent.Connection.Connected(node))
             true
           } else false
@@ -215,14 +206,14 @@ final private[client] class MultiplexedConnection private (
       if (conn eq current)
         state match {
           case State.Live         =>
-            state = State.Reconnecting; scheduleReconnect(0); events.emit(SageEvent.Connection.Disconnected(node)); true
+            transition(State.Reconnecting); scheduleReconnect(0); events.emit(SageEvent.Connection.Disconnected(node)); true
           case State.Reconnecting => scheduleReconnect(0); false
-          case State.Draining     => state = State.Closed; stopWatchdog(); false
+          case State.Draining     => transition(State.Closed); stopWatchdog(); false
           case State.Closed       => false
         }
       else false
     }
-    // outside the lock: acquire holds the pool lock then calls isLive on this connection's lock, so the reverse order here would deadlock
+    // fired off the lock so the lifecycle lock is not held across the pool's signal
     if (lostLiveness) onLivenessLost()
   }
 
@@ -430,6 +421,8 @@ private[client] object MultiplexedConnection {
   opaque type Generation = Long
   object Generation {
     val initial: Generation                        = 0L
+    // distinct from every real epoch (they start at 0 and only increase), so a stamped generation never reads as current while not Live
+    val notLive: Generation                        = -1L
     extension (g: Generation) def next: Generation = g + 1L
   }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -1,15 +1,16 @@
 package sage.client.internal
 
-import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.collection.mutable
 import scala.concurrent.duration.*
+import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
 
 import sage.Bytes
-import sage.SageException.{ConnectionLost, NotConnected}
+import sage.SageException.NotConnected
 import sage.client.{BackoffConfig, WatchdogConfig}
 import sage.commands.{Command, Connection, Pubsub, Reply}
 import sage.protocol.Frame
@@ -231,23 +232,24 @@ final private[client] class SubscriptionConnection(
     conn
   }
 
+  // the subscription connection has no pending-command queue, so each bootstrap command parks the single `bootstrapWaiter` for its reply;
+  // the finally clears it so a later watchdog PONG is not misrouted to a stale waiter (which would never reset pingSentAtMillis)
   private def runBootstrap(conn: Conn): Unit =
-    bootstrap.foreach { command =>
-      val latch   = new CountDownLatch(1)
-      val box     = new AtomicReference[Frame]()
-      bootstrapWaiter = frame => { box.set(frame); latch.countDown() }
-      conn.send(command.encode)
-      val replied = latch.await(connectTimeoutMillis, TimeUnit.MILLISECONDS)
-      bootstrapWaiter = null
-      if (!replied) {
-        conn.close()
-        throw ConnectionLost(mayHaveExecuted = false)
-      }
-      Reply.run(command, box.get()) match {
-        case Left(error) => conn.close(); throw error
-        case Right(_)    => ()
-      }
-    }
+    try
+      Bootstrap.run(
+        bootstrap,
+        connectTimeoutMillis,
+        (command, cb) => {
+          bootstrapWaiter = frame =>
+            cb(Reply.run(command, frame) match {
+              case Right(value) => Success(value)
+              case Left(error)  => Failure(error)
+            })
+          conn.send(command.encode)
+        },
+        () => conn.close()
+      )
+    finally bootstrapWaiter = null
 
   private def scheduleReconnect(attempt: Int): Unit =
     scheduler.after(Backoff.jitteredMillis(backoff, attempt, scheduler).millis)(attemptReconnect(attempt))

--- a/sage-client/shared/src/test/scala/sage/client/internal/BootstrapSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/BootstrapSpec.scala
@@ -5,7 +5,7 @@ import sage.client.AuthConfig
 class BootstrapSpec extends munit.FunSuite {
 
   private def lines(auth: Option[AuthConfig], database: Int, clientName: Option[String]): Vector[String] =
-    Client.bootstrapCommands(auth, database, clientName).map(c => (c.name +: c.args.map(_.asUtf8String)).mkString(" "))
+    Bootstrap.commands(auth, database, clientName).map(c => (c.name +: c.args.map(_.asUtf8String)).mkString(" "))
 
   test("the default bootstrap is HELLO then library identification, no SELECT") {
     val cmds = lines(None, 0, None)
@@ -26,7 +26,7 @@ class BootstrapSpec extends munit.FunSuite {
   }
 
   test("HELLO carries AUTH when credentials are configured") {
-    val first = Client.bootstrapCommands(Some(AuthConfig("pw", "alice")), 0, None).head
+    val first = Bootstrap.commands(Some(AuthConfig("pw", "alice")), 0, None).head
     assertEquals(first.name, "HELLO")
     assert(first.args.map(_.asUtf8String).containsSlice(Vector("AUTH", "alice", "pw")))
   }

--- a/sage-core/src/main/scala/sage/commands/Decode.scala
+++ b/sage-core/src/main/scala/sage/commands/Decode.scala
@@ -124,6 +124,39 @@ private[commands] object Decode {
     Right(builder.result())
   }
 
+  def each[A, B](items: IterableOnce[A])(f: A => Either[DecodeError, B]): Either[DecodeError, Vector[B]] =
+    buildEach(items, Vector.newBuilder[B])(f)
+
+  // a fixed-arity RESP Array decoded position by position; `label` is the structural description reported on a shape mismatch
+  def array2[A, B, R](a: Frame => Either[DecodeError, A], b: Frame => Either[DecodeError, B], label: String)(
+    combine: (A, B) => R
+  ): Frame => Either[DecodeError, R] = {
+    case Frame.Array(Vector(fa, fb)) => for { x <- a(fa); y <- b(fb) } yield combine(x, y)
+    case other                       => Left(DecodeError(label, Frame.describe(other)))
+  }
+
+  def array3[A, B, C, R](
+    a: Frame => Either[DecodeError, A],
+    b: Frame => Either[DecodeError, B],
+    c: Frame => Either[DecodeError, C],
+    label: String
+  )(combine: (A, B, C) => R): Frame => Either[DecodeError, R] = {
+    case Frame.Array(Vector(fa, fb, fc)) => for { x <- a(fa); y <- b(fb); z <- c(fc) } yield combine(x, y, z)
+    case other                           => Left(DecodeError(label, Frame.describe(other)))
+  }
+
+  def array4[A, B, C, D, R](
+    a: Frame => Either[DecodeError, A],
+    b: Frame => Either[DecodeError, B],
+    c: Frame => Either[DecodeError, C],
+    d: Frame => Either[DecodeError, D],
+    label: String
+  )(combine: (A, B, C, D) => R): Frame => Either[DecodeError, R] = {
+    case Frame.Array(Vector(fa, fb, fc, fd)) =>
+      for { w <- a(fa); x <- b(fb); y <- c(fc); z <- d(fd) } yield combine(w, x, y, z)
+    case other                               => Left(DecodeError(label, Frame.describe(other)))
+  }
+
   def vector[A](element: Frame => Either[DecodeError, A]): Frame => Either[DecodeError, Vector[A]] = {
     case Frame.Array(elements) => buildEach(elements, Vector.newBuilder[A])(element)
     case other                 => Left(DecodeError("array", Frame.describe(other)))
@@ -171,30 +204,21 @@ private[commands] object Decode {
   }
 
   def nestedPairs[K, V](using KeyCodec[K], ValueCodec[V]): Frame => Either[DecodeError, Vector[(K, V)]] = {
-    case Frame.Array(rows) =>
-      buildEach(rows, Vector.newBuilder[(K, V)]) {
-        case Frame.Array(Vector(fieldFrame, valueFrame)) =>
-          for {
-            field <- key(fieldFrame)
-            value <- this.value(valueFrame)
-          } yield field -> value
-        case other                                       => Left(DecodeError("field/value pair", Frame.describe(other)))
-      }
-    case other             => Left(DecodeError("array of field/value pairs", Frame.describe(other)))
+    val pair = array2(key[K], value[V], "field/value pair")(_ -> _)
+    {
+      case Frame.Array(rows) => each(rows)(pair)
+      case other             => Left(DecodeError("array of field/value pairs", Frame.describe(other)))
+    }
   }
 
-  def scanPage[A](items: Frame => Either[DecodeError, Vector[A]]): Frame => Either[DecodeError, ScanPage[A]] = {
-    case Frame.Array(Vector(cursorFrame, itemsFrame)) =>
-      for {
-        next    <- cursorFrame match {
-                     case Frame.BulkString(bytes) =>
-                       Right(if (bytes.sameBytes(ScanCursor.bytes(ScanCursor.start))) None else Some(ScanCursor.wrap(bytes)))
-                     case other                   => Left(DecodeError("cursor bulk string", Frame.describe(other)))
-                   }
-        decoded <- items(itemsFrame)
-      } yield ScanPage(decoded, next)
-    case other                                        => Left(DecodeError("array of cursor and items", Frame.describe(other)))
+  private val scanCursor: Frame => Either[DecodeError, Option[ScanCursor]] = {
+    case Frame.BulkString(bytes) =>
+      Right(if (bytes.sameBytes(ScanCursor.bytes(ScanCursor.start))) None else Some(ScanCursor.wrap(bytes)))
+    case other                   => Left(DecodeError("cursor bulk string", Frame.describe(other)))
   }
+
+  def scanPage[A](items: Frame => Either[DecodeError, Vector[A]]): Frame => Either[DecodeError, ScanPage[A]] =
+    array2(scanCursor, items, "array of cursor and items")((next, decoded) => ScanPage(decoded, next))
 
   // RESP3 returns set-typed replies (SMEMBERS, SINTER, …) as a Set frame, never an Array
   def set[V](using ValueCodec[V]): Frame => Either[DecodeError, Set[V]] = {
@@ -213,30 +237,21 @@ private[commands] object Decode {
     case other               => Left(DecodeError("double or null", Frame.describe(other)))
   }
 
+  private def memberScore[V](using ValueCodec[V]): Frame => Either[DecodeError, (V, Double)] =
+    array2(value[V], score, "member/score pair")(_ -> _)
+
   // RESP3 nests each member with its Double score in a two-element array (ZRANGE WITHSCORES, ZPOPMIN count, …)
   def scoredMembers[V](using ValueCodec[V]): Frame => Either[DecodeError, Vector[(V, Double)]] = {
-    case Frame.Array(rows) =>
-      buildEach(rows, Vector.newBuilder[(V, Double)]) {
-        case Frame.Array(Vector(memberFrame, scoreFrame)) =>
-          for {
-            member <- value(memberFrame)
-            s      <- score(scoreFrame)
-          } yield member -> s
-        case other                                        => Left(DecodeError("member/score pair", Frame.describe(other)))
-      }
+    case Frame.Array(rows) => each(rows)(memberScore[V])
     case other             => Left(DecodeError("array of member/score pairs", Frame.describe(other)))
   }
 
   // ZPOPMIN/ZPOPMAX without a count: a flat [member, score], or an empty array when the key is absent
   def optionalScoredMember[V](using ValueCodec[V]): Frame => Either[DecodeError, Option[(V, Double)]] = {
-    case Frame.Null                                   => Right(None)
-    case Frame.Array(Vector())                        => Right(None)
-    case Frame.Array(Vector(memberFrame, scoreFrame)) =>
-      for {
-        member <- value(memberFrame)
-        s      <- score(scoreFrame)
-      } yield Some(member -> s)
-    case other                                        => Left(DecodeError("member/score pair or empty array", Frame.describe(other)))
+    case Frame.Null                      => Right(None)
+    case Frame.Array(Vector())           => Right(None)
+    case arr @ Frame.Array(Vector(_, _)) => memberScore[V](arr).map(Some(_))
+    case other                           => Left(DecodeError("member/score pair or empty array", Frame.describe(other)))
   }
 
   // ZSCAN's items are a flat member, score, member, score array with scores as bulk strings, not RESP3 doubles

--- a/sage-core/src/main/scala/sage/commands/Geo.scala
+++ b/sage-core/src/main/scala/sage/commands/Geo.scala
@@ -214,14 +214,8 @@ private[sage] object Geo {
 
   private def coordArg(value: Double): Bytes = Bytes.utf8(Doubles.format(value))
 
-  private val coordinates: Frame => Either[DecodeError, GeoCoordinates] = {
-    case Frame.Array(Vector(lon, lat)) =>
-      for {
-        x <- Decode.lenientDouble(lon)
-        y <- Decode.lenientDouble(lat)
-      } yield GeoCoordinates(x, y)
-    case other                         => Left(DecodeError("longitude/latitude pair", Frame.describe(other)))
-  }
+  private val coordinates: Frame => Either[DecodeError, GeoCoordinates] =
+    Decode.array2(Decode.lenientDouble, Decode.lenientDouble, "longitude/latitude pair")(GeoCoordinates(_, _))
 
   private val optionalCoordinates: Frame => Either[DecodeError, Option[GeoCoordinates]] = {
     case Frame.Null => Right(None)

--- a/sage-core/src/main/scala/sage/commands/Lists.scala
+++ b/sage-core/src/main/scala/sage/commands/Lists.scala
@@ -186,26 +186,17 @@ private[sage] object Lists {
       keyIndices = Vector.tabulate(keys.size)(identity),
       args = keys :+ BlockTimeout.wire(timeout),
       decode = {
-        case Frame.Null                                => Right(None)
-        case Frame.Array(Vector(keyFrame, valueFrame)) =>
-          for {
-            key   <- Decode.key[K](keyFrame)
-            value <- Decode.value[V](valueFrame)
-          } yield Some((key, value))
-        case other                                     => Left(DecodeError("array of key and value or null", Frame.describe(other)))
+        case Frame.Null => Right(None)
+        case other      => Decode.array2(Decode.key[K], Decode.value[V], "array of key and value or null")(_ -> _)(other).map(Some(_))
       },
       execution = Execution.Blocking
     )
   }
 
   private def mpopReply[K, V](using KeyCodec[K], ValueCodec[V]): Frame => Either[DecodeError, Option[(K, Vector[V])]] = {
-    case Frame.Null                                 => Right(None)
-    case Frame.Array(Vector(keyFrame, valuesFrame)) =>
-      for {
-        key    <- Decode.key[K](keyFrame)
-        values <- Decode.vector(Decode.value[V])(valuesFrame)
-      } yield Some((key, values))
-    case other                                      => Left(DecodeError("array of key and values or null", Frame.describe(other)))
+    case Frame.Null => Right(None)
+    case other      =>
+      Decode.array2(Decode.key[K], Decode.vector(Decode.value[V]), "array of key and values or null")(_ -> _)(other).map(Some(_))
   }
 
   private def longArg(keyword: Bytes, value: Option[Long]): Vector[Bytes] =

--- a/sage-core/src/main/scala/sage/commands/SortedSets.scala
+++ b/sage-core/src/main/scala/sage/commands/SortedSets.scala
@@ -327,37 +327,25 @@ private[sage] object SortedSets {
       keyIndices = Vector.tabulate(keys.size)(identity),
       args = keys :+ BlockTimeout.wire(timeout),
       decode = {
-        case Frame.Null                                             => Right(None)
-        case Frame.Array(Vector(keyFrame, memberFrame, scoreFrame)) =>
-          for {
-            key    <- Decode.key[K](keyFrame)
-            member <- Decode.value[V](memberFrame)
-            s      <- Decode.score(scoreFrame)
-          } yield Some((key, member, s))
-        case other                                                  => Left(DecodeError("key, member and score or null", Frame.describe(other)))
+        case Frame.Null => Right(None)
+        case other      =>
+          Decode.array3(Decode.key[K], Decode.value[V], Decode.score, "key, member and score or null") { (key, member, s) =>
+            (key, member, s)
+          }(other).map(Some(_))
       },
       execution = Execution.Blocking
     )
   }
 
   private def mpopReply[K, V](using KeyCodec[K], ValueCodec[V]): Frame => Either[DecodeError, Option[(K, Vector[(V, Double)])]] = {
-    case Frame.Null                                  => Right(None)
-    case Frame.Array(Vector(keyFrame, membersFrame)) =>
-      for {
-        key     <- Decode.key[K](keyFrame)
-        members <- Decode.scoredMembers[V](membersFrame)
-      } yield Some((key, members))
-    case other                                       => Left(DecodeError("key and members or null", Frame.describe(other)))
+    case Frame.Null => Right(None)
+    case other      =>
+      Decode.array2(Decode.key[K], Decode.scoredMembers[V], "key and members or null")(_ -> _)(other).map(Some(_))
   }
 
   private val rankWithScore: Frame => Either[DecodeError, Option[(Long, Double)]] = {
-    case Frame.Null                                 => Right(None)
-    case Frame.Array(Vector(rankFrame, scoreFrame)) =>
-      for {
-        rank <- Decode.long(rankFrame)
-        s    <- Decode.score(scoreFrame)
-      } yield Some((rank, s))
-    case other                                      => Left(DecodeError("rank/score pair or null", Frame.describe(other)))
+    case Frame.Null => Right(None)
+    case other      => Decode.array2(Decode.long, Decode.score, "rank/score pair or null")(_ -> _)(other).map(Some(_))
   }
 
   private def numKeyed[K](keys: Vector[K])(using keyCodec: KeyCodec[K]): (Vector[Int], Vector[Bytes]) = {

--- a/sage-core/src/main/scala/sage/commands/StreamInfo.scala
+++ b/sage-core/src/main/scala/sage/commands/StreamInfo.scala
@@ -193,34 +193,24 @@ private[sage] object StreamInfo {
         } yield FullConsumerInfo(name, seen, active, pel, pending)
       }
 
-  // a group-level FULL PEL row carries its owning consumer: [id, consumer, delivery-time-ms, delivery-count]
-  private val groupPendingReply: Frame => Either[DecodeError, FullPendingEntry] = {
-    case Frame.Array(Vector(idFrame, consumerFrame, deliveredFrame, countFrame)) =>
-      for {
-        id        <- Streams.streamId(idFrame)
-        consumer  <- Decode.utf8String(consumerFrame)
-        delivered <- millisInstant(deliveredFrame)
-        count     <- Decode.long(countFrame)
-      } yield FullPendingEntry(id, Some(consumer), delivered, count)
-    case other                                                                   => Left(DecodeError("group pending [id, consumer, delivery-time, delivery-count]", Frame.describe(other)))
-  }
-
-  // a consumer-level FULL PEL row omits the (implied) consumer: [id, delivery-time-ms, delivery-count]
-  private val consumerPendingReply: Frame => Either[DecodeError, FullPendingEntry] = {
-    case Frame.Array(Vector(idFrame, deliveredFrame, countFrame)) =>
-      for {
-        id        <- Streams.streamId(idFrame)
-        delivered <- millisInstant(deliveredFrame)
-        count     <- Decode.long(countFrame)
-      } yield FullPendingEntry(id, None, delivered, count)
-    case other                                                    => Left(DecodeError("consumer pending [id, delivery-time, delivery-count]", Frame.describe(other)))
-  }
-
+  // defined before the decoders that compose them: the array combinators force their decoder arguments when those vals initialize
   private val millisDuration: Frame => Either[DecodeError, FiniteDuration] =
     frame => Decode.long(frame).map(ms => FiniteDuration(ms, TimeUnit.MILLISECONDS))
 
   private val millisInstant: Frame => Either[DecodeError, Instant] =
     frame => Decode.long(frame).map(Instant.ofEpochMilli)
+
+  // a group-level FULL PEL row carries its owning consumer: [id, consumer, delivery-time-ms, delivery-count]
+  private val groupPendingReply: Frame => Either[DecodeError, FullPendingEntry] =
+    Decode.array4(Streams.streamId, Decode.utf8String, millisInstant, Decode.long, "group pending [id, consumer, delivery-time, delivery-count]") {
+      (id, consumer, delivered, count) => FullPendingEntry(id, Some(consumer), delivered, count)
+    }
+
+  // a consumer-level FULL PEL row omits the (implied) consumer: [id, delivery-time-ms, delivery-count]
+  private val consumerPendingReply: Frame => Either[DecodeError, FullPendingEntry] =
+    Decode.array3(Streams.streamId, millisInstant, Decode.long, "consumer pending [id, delivery-time, delivery-count]") {
+      (id, delivered, count) => FullPendingEntry(id, None, delivered, count)
+    }
 
   /**
     * A lenient view over an introspection reply map: read fields by known name, ignore the rest.

--- a/sage-core/src/main/scala/sage/commands/Streams.scala
+++ b/sage-core/src/main/scala/sage/commands/Streams.scala
@@ -578,15 +578,11 @@ private[sage] object Streams {
 
   // an entry is `[id, [field, value, …]]`; a tombstone (claimed entry whose data was deleted) is `[id, nil]`
   private[commands] def streamEntry[F, V](using KeyCodec[F], ValueCodec[V]): Frame => Either[DecodeError, StreamEntry[F, V]] = {
-    case Frame.Array(Vector(idFrame, fieldsFrame)) =>
-      for {
-        id     <- streamId(idFrame)
-        fields <- fieldsFrame match {
-                    case Frame.Null => Right(Vector.empty[(F, V)])
-                    case other      => Decode.flatPairs[F, V](other)
-                  }
-      } yield StreamEntry(id, fields)
-    case other                                     => Left(DecodeError("stream entry [id, fields]", Frame.describe(other)))
+    val fields: Frame => Either[DecodeError, Vector[(F, V)]] = {
+      case Frame.Null => Right(Vector.empty)
+      case other      => Decode.flatPairs[F, V](other)
+    }
+    Decode.array2(streamId, fields, "stream entry [id, fields]")(StreamEntry(_, _))
   }
 
   // XREAD/XREADGROUP reply: RESP3 map of stream-name -> entries (RESP2 array of [name, entries] pairs); null when nothing is ready
@@ -604,9 +600,9 @@ private[sage] object Streams {
     frame =>
       frame match {
         case Frame.Null        => Right(Vector.empty)
-        case Frame.Map(rows)   => collectPairs(rows) { case (n, e) => pair(n, e) }
+        case Frame.Map(rows)   => Decode.each(rows) { case (n, e) => pair(n, e) }
         case Frame.Array(rows) =>
-          collect(rows) {
+          Decode.each(rows) {
             case Frame.Array(Vector(n, e)) => pair(n, e)
             case other                     => Left(DecodeError("stream [name, entries] pair", Frame.describe(other)))
           }
@@ -654,40 +650,23 @@ private[sage] object Streams {
 
   // XPENDING summary: [total, min-id, max-id, [[consumer, count], …]]; an empty group replies [0, nil, nil, nil]
   private val pendingSummaryReply: Frame => Either[DecodeError, PendingSummary] = {
-    case Frame.Array(Vector(totalFrame, minFrame, maxFrame, consumersFrame)) =>
-      for {
-        total     <- Decode.long(totalFrame)
-        min       <- optionalStreamId(minFrame)
-        max       <- optionalStreamId(maxFrame)
-        consumers <- consumersFrame match {
-                       case Frame.Null        => Right(Vector.empty[(String, Long)])
-                       case Frame.Array(rows) => collect(rows)(consumerCount)
-                       case other             => Left(DecodeError("consumer counts array or null", Frame.describe(other)))
-                     }
-      } yield PendingSummary(total, min, max, consumers)
-    case other                                                               => Left(DecodeError("xpending summary", Frame.describe(other)))
+    val consumers: Frame => Either[DecodeError, Vector[(String, Long)]] = {
+      case Frame.Null        => Right(Vector.empty)
+      case Frame.Array(rows) => Decode.each(rows)(consumerCount)
+      case other             => Left(DecodeError("consumer counts array or null", Frame.describe(other)))
+    }
+    Decode.array4(Decode.long, optionalStreamId, optionalStreamId, consumers, "xpending summary")(PendingSummary(_, _, _, _))
   }
 
-  private val consumerCount: Frame => Either[DecodeError, (String, Long)] = {
-    case Frame.Array(Vector(nameFrame, countFrame)) =>
-      for {
-        name  <- Decode.utf8String(nameFrame)
-        count <- countText(countFrame)
-      } yield name -> count
-    case other                                      => Left(DecodeError("[consumer, count] pair", Frame.describe(other)))
-  }
+  private val consumerCount: Frame => Either[DecodeError, (String, Long)] =
+    Decode.array2(Decode.utf8String, countText, "[consumer, count] pair")(_ -> _)
 
   // XPENDING extended row: [id, consumer, idle-ms, delivery-count]
-  private val pendingEntryElement: Frame => Either[DecodeError, PendingEntry] = {
-    case Frame.Array(Vector(idFrame, consumerFrame, idleFrame, deliveriesFrame)) =>
-      for {
-        id         <- streamId(idFrame)
-        consumer   <- Decode.utf8String(consumerFrame)
-        idle       <- Decode.long(idleFrame)
-        deliveries <- Decode.long(deliveriesFrame)
-      } yield PendingEntry(id, consumer, FiniteDuration(idle, java.util.concurrent.TimeUnit.MILLISECONDS), deliveries)
-    case other                                                                   => Left(DecodeError("xpending entry [id, consumer, idle, count]", Frame.describe(other)))
-  }
+  private val pendingEntryElement: Frame => Either[DecodeError, PendingEntry] =
+    Decode.array4(streamId, Decode.utf8String, Decode.long, Decode.long, "xpending entry [id, consumer, idle, count]") {
+      (id, consumer, idle, deliveries) =>
+        PendingEntry(id, consumer, FiniteDuration(idle, java.util.concurrent.TimeUnit.MILLISECONDS), deliveries)
+    }
 
   // XPENDING per-consumer counts come back as bulk-string integers
   private def countText(frame: Frame): Either[DecodeError, Long] =
@@ -697,29 +676,4 @@ private[sage] object Streams {
       case other                   => Left(DecodeError("integer", Frame.describe(other)))
     }
 
-  private def collect[A](frames: Vector[Frame])(f: Frame => Either[DecodeError, A]): Either[DecodeError, Vector[A]] = {
-    val builder = Vector.newBuilder[A]
-    builder.sizeHint(frames.length)
-    val it      = frames.iterator
-    while (it.hasNext)
-      f(it.next()) match {
-        case Right(value) => builder += value
-        case Left(error)  => return Left(error)
-      }
-    Right(builder.result())
-  }
-
-  private def collectPairs[A](pairs: Vector[(Frame, Frame)])(f: (Frame, Frame) => Either[DecodeError, A]): Either[DecodeError, Vector[A]] = {
-    val builder = Vector.newBuilder[A]
-    builder.sizeHint(pairs.length)
-    val it      = pairs.iterator
-    while (it.hasNext) {
-      val (a, b) = it.next()
-      f(a, b) match {
-        case Right(value) => builder += value
-        case Left(error)  => return Left(error)
-      }
-    }
-    Right(builder.result())
-  }
 }


### PR DESCRIPTION
Three independent, behaviour-preserving refactors, each concentrating logic behind a smaller interface. No public API or wire behaviour changes.

## 1. Lock-free `Generation` liveness — `MultiplexedConnection`
`isLive`/`liveGeneration`/`isCurrent` no longer acquire the lifecycle lock. A single atomic `liveEpoch` is published at the Live/loss edges through one `transition` mutator (the sole writer of `state`), using a `notLive` sentinel so a stamp reads stale throughout a reconnect window — exactly the semantics the existing spec pins.

The `DedicatedPool` now reads liveness under its own lock without crossing into the connection's lock, so the manually-maintained `pool <-> connection` lock-order rule (and its warning comment) is removed. `DedicatedPool` itself is unchanged — its three callbacks just call lock-free methods now.

## 2. Shared `Bootstrap` runner — new `Bootstrap.scala`
The `HELLO`/`AUTH`/`CLIENT SETINFO`/`SELECT`/`CLIENT TRACKING` handshake loop was hand-rolled three times (Multiplexed, Dedicated, Subscription connections). `Bootstrap.run` owns the loop + latch + `connectTimeout` + close-and-throw unroll behind a two-function seam (`submit` + `close`); each connection supplies only how a single command's reply is obtained (the Subscription one clears its `bootstrapWaiter` in a `finally` so a later watchdog `PONG` isn't misrouted). `Bootstrap.commands` (the shared command vector, moved out of the 2464-line `Client`) sits next to the runner, so the cluster/master-replica runtimes no longer reach into `Client` for a builder.

## 3. Decode tuple combinators — `Decode.array2/3/4`, `Decode.each`
Fills the gap in the decode-combinator vocabulary: heterogeneous fixed-arity `Array` replies were destructured by hand at ~30 sites (5 inside `Decode` itself), each re-spelling the `Frame.Array(Vector(...))` match + `DecodeError` fallback. `array2/3/4` localize it (with an explicit `label` to preserve every error message); `each` exposes the previously-private `buildEach`, so `Streams` stops reinventing it (`collect`/`collectPairs` deleted). Genuinely variable-arity decoders (e.g. `XAUTOCLAIM` 2-or-3) and terse typed-inner-pattern sites (`Server`/`Strings`/`Arrays`) are deliberately left inline.

## Testing
`core` 693/693, `clientZio` internal suite 103/103. Includes the generation-liveness reconnect-window spec, the bootstrap-timeout cases, and the `XINFO STREAM FULL` decode (which caught a val-init-order trap during development, fixed by ordering helper decoders before the decoders that compose them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)