### PR TITLE
Re-home master-replica pub/sub across a master failover

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -60,8 +60,7 @@ final private[client] class MasterReplicaLive(
   private val cursor           = new AtomicInteger()
   @volatile private var closed = false
 
-  // lazily created on the first subscription, pinned to the master discovered then; classic pub/sub re-homing across a master failover is a
-  // follow-up (the connection re-issues its subscriptions on reconnect to the same address, which a stable endpoint repoints)
+  // lazily created on the first subscription; re-homes onto the promoted master across a failover (see subs())
   private val subLock                                         = new ReentrantLock()
   @volatile private var subscriptions: SubscriptionConnection = null
 
@@ -124,6 +123,9 @@ final private[client] class MasterReplicaLive(
   }
 
   private def triggerRefresh(): Unit = offload(refreshThrottle(force = false)(rediscover()))
+
+  // forced + synchronous so masterNodeRef names the promoted master before the reconnect's establish() reads it via the factory
+  private def refreshRolesBeforeRehome(): Unit = refreshThrottle(force = true)(rediscover())
 
   private def rediscover(): Unit = {
     val candidates = (Option(masterNodeRef.get()).toVector ++ replicasRef.get() ++ seeds).distinct
@@ -305,16 +307,19 @@ final private[client] class MasterReplicaLive(
       subLock.lock()
       try {
         if (subscriptions == null) {
-          val master = masterNodeRef.get()
+          // resolves the current master per (re)connect, not once, so onReconnect's refresh lets a failover re-home the subscription
+          val rehomingFactory: MultiplexedConnection.TransportFactory =
+            (onFrame, onClosed) => nodeFactory(masterNodeRef.get())(onFrame, onClosed)
           subscriptions = new SubscriptionConnection(
-            nodeFactory(master),
+            rehomingFactory,
             bootstrap,
             scheduler,
             config.reconnect,
             config.watchdog,
             config.connectTimeout.toMillis,
             config.pubsub.bufferSize,
-            () => masterPool.existingLive(masterNodeRef.get()).isDefined
+            () => masterPool.existingLive(masterNodeRef.get()).isDefined,
+            onReconnect = () => refreshRolesBeforeRehome()
           )
         }
         s = subscriptions

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -60,7 +60,6 @@ final private[client] class MasterReplicaLive(
   private val cursor           = new AtomicInteger()
   @volatile private var closed = false
 
-  // lazily created on the first subscription; re-homes onto the promoted master across a failover (see subs())
   private val subLock                                         = new ReentrantLock()
   @volatile private var subscriptions: SubscriptionConnection = null
 
@@ -307,7 +306,7 @@ final private[client] class MasterReplicaLive(
       subLock.lock()
       try {
         if (subscriptions == null) {
-          // resolves the current master per (re)connect, not once, so onReconnect's refresh lets a failover re-home the subscription
+          // resolves the current master per (re)connect, not once, so onReconnect's refresh re-homes the subscription across a failover
           val rehomingFactory: MultiplexedConnection.TransportFactory =
             (onFrame, onClosed) => nodeFactory(masterNodeRef.get())(onFrame, onClosed)
           subscriptions = new SubscriptionConnection(

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -131,13 +131,14 @@ final private[client] class SubscriptionConnection(
     } finally lock.unlock()
 
     if (doEstablish)
-      try goLive(establish())
-      catch {
-        case e: Throwable =>
-          // establish failed after the sink was registered; drop it so a later reconnect doesn't resubscribe a phantom name
-          locked { deregister(sink, names, kind); state = State.Idle; established.signalAll() }
-          throw e
-      }
+      confirmTarget =
+        try goLive(establish())
+        catch {
+          case e: Throwable =>
+            // establish failed after the sink was registered; drop it so a later reconnect doesn't resubscribe a phantom name
+            locked { deregister(sink, names, kind); state = State.Idle; established.signalAll() }
+            throw e
+        }
     awaitActive(failIfUnconfirmed, confirmTarget)
   }
 
@@ -160,9 +161,12 @@ final private[client] class SubscriptionConnection(
 
   // bring a freshly-established socket Live, resubscribing everything registered (counters reset to this generation). In cluster mode it runs
   // once per connection with at most one Slot's worth of Shard channels registered, so the single SSUBSCRIBE never spans slots (CROSSSLOT).
-  private def goLive(conn: Conn): Unit = {
+  // Returns the ack count to wait for (captured under the lock, before signalAll wakes other attachers, so a later attach can't inflate it),
+  // or -1 when it did not go Live; the establishing caller uses it as its awaitActive target.
+  private def goLive(conn: Conn): Long = {
     var reconnect = false
     var notify    = false
+    var target    = -1L
     locked {
       if (state != State.Establishing && state != State.Reconnecting) conn.close()
       else if (conn.isTerminated) {
@@ -190,6 +194,7 @@ final private[client] class SubscriptionConnection(
         } else {
           state = State.Live
           startWatchdog()
+          target = subscribeSent
         }
         established.signalAll()
         confirmed.signalAll()
@@ -197,6 +202,7 @@ final private[client] class SubscriptionConnection(
     }
     if (reconnect) scheduleReconnect(0)
     if (notify) onTerminated()
+    target
   }
 
   private def sendSubscribe(conn: Conn, kind: Kind, names: Vector[String]): Unit = {
@@ -270,7 +276,7 @@ final private[client] class SubscriptionConnection(
     val proceed = locked(state == State.Reconnecting)
     if (proceed) {
       onReconnect()
-      try goLive(establish())
+      try { val _ = goLive(establish()) }
       catch { case NonFatal(_) => locked(if (state == State.Reconnecting) scheduleReconnect(attempt + 1)) }
     }
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -118,8 +118,10 @@ final private[client] class SubscriptionConnection(
           case State.Establishing => established.await()
           case State.Live         =>
             val fresh = register(sink, names, kind)
-            if (fresh.nonEmpty) sendSubscribe(current, kind, fresh)
-            confirmTarget = subscribeSent
+            // wait for our own SUBSCRIBE's ack; if we sent nothing (names already subscribed), wait only for what's already confirmed, not
+            // an unrelated concurrent attach's pending ack
+            if (fresh.nonEmpty) { sendSubscribe(current, kind, fresh); confirmTarget = subscribeSent }
+            else confirmTarget = subscribeConfirmed
             settled = true
           case State.Reconnecting =>
             register(sink, names, kind) // the next successful reconnect resubscribes everything currently registered

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -102,7 +102,10 @@ final private[client] class SubscriptionConnection(
   def attach(sink: Sink, names: Vector[String], kind: Kind): Unit = attachInternal(sink, names, kind, failIfUnconfirmed = false)
 
   private def attachInternal(sink: Sink, names: Vector[String], kind: Kind, failIfUnconfirmed: Boolean): Unit = {
-    var doEstablish = false
+    var doEstablish   = false
+    // the SUBSCRIBE-ack count this attach waits for, captured under the same lock as its send so a concurrent attach bumping subscribeSent
+    // can't inflate it; -1 means capture it lazily on the next Live (the send happens later, in goLive's resubscribe)
+    var confirmTarget = -1L
     lock.lock()
     try {
       var settled = false
@@ -113,6 +116,7 @@ final private[client] class SubscriptionConnection(
           case State.Live         =>
             val fresh = register(sink, names, kind)
             if (fresh.nonEmpty) sendSubscribe(current, kind, fresh)
+            confirmTarget = subscribeSent
             settled = true
           case State.Reconnecting =>
             register(sink, names, kind) // the next successful reconnect resubscribes everything currently registered
@@ -134,7 +138,7 @@ final private[client] class SubscriptionConnection(
           locked { deregister(sink, names, kind); state = State.Idle; established.signalAll() }
           throw e
       }
-    awaitActive(failIfUnconfirmed)
+    awaitActive(failIfUnconfirmed, confirmTarget)
   }
 
   /**
@@ -200,15 +204,16 @@ final private[client] class SubscriptionConnection(
     subscribeSent += names.size
   }
 
-  // Waits (bounded by the connect timeout) for the server to confirm every SUBSCRIBE sent; re-arms across a reconnect mid-wait. When
-  // `failIfUnconfirmed` (the owned standalone/master-replica path), an unconfirmed deadline throws NotConnected so `subscribe` fails loudly
-  // instead of returning a stream whose SUBSCRIBE never took effect; cluster passes false (its manager owns re-home/retry).
-  private def awaitActive(failIfUnconfirmed: Boolean): Unit = {
+  // Waits (bounded by the connect timeout) until subscribeConfirmed reaches `target` — the ack count captured under this attach's send lock,
+  // so it waits for its own SUBSCRIBE, not a concurrent attach's. A reconnect resets the counters, so it re-arms to the full resubscribe count
+  // of the new generation. When `failIfUnconfirmed` (the owned standalone/master-replica path), an unconfirmed deadline throws NotConnected so
+  // `subscribe` fails loudly instead of returning a stream whose SUBSCRIBE never took effect; cluster passes false (its manager owns retry).
+  private def awaitActive(failIfUnconfirmed: Boolean, target0: Long): Unit = {
     var active = false
     lock.lock()
     try {
       val deadline = scheduler.nowMillis + connectTimeoutMillis
-      var target   = -1L
+      var target   = target0
       var settled  = false
       while (!settled)
         state match {
@@ -218,7 +223,7 @@ final private[client] class SubscriptionConnection(
             if (subscribeConfirmed >= target) { active = true; settled = true }
             else if (awaitOrTimeout(deadline)) settled = true
           case _            =>
-            target = -1L // re-arm against the next live generation
+            target = -1L // a reconnect reset the counters: re-arm against the next generation's full resubscribe
             if (awaitOrTimeout(deadline)) settled = true
         }
     } finally lock.unlock()

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -55,8 +55,7 @@ final private[client] class SubscriptionConnection(
   // waits until `subscribeConfirmed` catches `subscribeSent` before returning — otherwise `subscribe` then `publish` races across the sockets.
   private var subscribeSent: Long      = 0L
   private var subscribeConfirmed: Long = 0L
-  // the resubscribe ack count of the current generation, captured in goLive under the lock before it wakes waiters; a caller re-arming after a
-  // reconnect waits for this, never a later subscribe's inflated subscribeSent
+  // this generation's resubscribe ack count, set in goLive before waiters wake so a re-arming waiter never adopts a later subscribe's count
   private var liveTarget: Long         = -1L
 
   private var watchdogHandle: Scheduler.Cancelable     = null
@@ -106,8 +105,7 @@ final private[client] class SubscriptionConnection(
 
   private def attachInternal(sink: Sink, names: Vector[String], kind: Kind, failIfUnconfirmed: Boolean): Unit = {
     var doEstablish   = false
-    // the SUBSCRIBE-ack count this attach waits for, captured under the same lock as its send so a concurrent attach bumping subscribeSent
-    // can't inflate it; -1 (the send happens later, in goLive's resubscribe) means adopt the generation's liveTarget in awaitActive
+    // the ack count this attach waits for, captured under its send lock; -1 means it sends later (in goLive) and adopts liveTarget
     var confirmTarget = -1L
     lock.lock()
     try {
@@ -118,8 +116,7 @@ final private[client] class SubscriptionConnection(
           case State.Establishing => established.await()
           case State.Live         =>
             val fresh = register(sink, names, kind)
-            // wait for our own SUBSCRIBE's ack; if we sent nothing (names already subscribed), wait only for what's already confirmed, not
-            // an unrelated concurrent attach's pending ack
+            // nothing sent (names already subscribed): target the confirmed count, not subscribeSent, so we don't wait on an unrelated pending ack
             if (fresh.nonEmpty) { sendSubscribe(current, kind, fresh); confirmTarget = subscribeSent }
             else confirmTarget = subscribeConfirmed
             settled = true
@@ -195,7 +192,7 @@ final private[client] class SubscriptionConnection(
         } else {
           state = State.Live
           startWatchdog()
-          liveTarget = subscribeSent // this generation's full resubscribe count, captured before signalAll so a later subscribe can't inflate it
+          liveTarget = subscribeSent
         }
         established.signalAll()
         confirmed.signalAll()
@@ -210,11 +207,8 @@ final private[client] class SubscriptionConnection(
     subscribeSent += names.size
   }
 
-  // Waits (bounded by the connect timeout) until subscribeConfirmed reaches `target`. A Live attach passes its own post-send count (`target0`),
-  // so it waits for its own SUBSCRIBE, not a concurrent attach's; a caller that registered before going Live passes -1 and adopts `liveTarget`,
-  // the generation's full resubscribe count captured in goLive before waiters wake — never a later subscribe's inflated subscribeSent. A
-  // reconnect re-arms to the next generation's liveTarget. When `failIfUnconfirmed` (the owned standalone/master-replica path), an unconfirmed
-  // deadline throws NotConnected so `subscribe` fails loudly instead of returning a stream whose SUBSCRIBE never took effect; cluster passes false.
+  // Waits (bounded by the connect timeout) for subscribeConfirmed to reach `target`; -1 (re)arms to liveTarget, e.g. after a reconnect. When
+  // `failIfUnconfirmed` (owned standalone/master-replica), an unconfirmed deadline throws NotConnected instead of returning an inactive stream.
   private def awaitActive(failIfUnconfirmed: Boolean, target0: Long): Unit = {
     var active = false
     lock.lock()
@@ -230,7 +224,7 @@ final private[client] class SubscriptionConnection(
             if (subscribeConfirmed >= target) { active = true; settled = true }
             else if (awaitOrTimeout(deadline)) settled = true
           case _            =>
-            target = -1L // a reconnect reset the counters: re-arm to the next generation's liveTarget
+            target = -1L // a reconnect reset the counters: re-arm to liveTarget
             if (awaitOrTimeout(deadline)) settled = true
         }
     } finally lock.unlock()

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -55,6 +55,9 @@ final private[client] class SubscriptionConnection(
   // waits until `subscribeConfirmed` catches `subscribeSent` before returning — otherwise `subscribe` then `publish` races across the sockets.
   private var subscribeSent: Long      = 0L
   private var subscribeConfirmed: Long = 0L
+  // the resubscribe ack count of the current generation, captured in goLive under the lock before it wakes waiters; a caller re-arming after a
+  // reconnect waits for this, never a later subscribe's inflated subscribeSent
+  private var liveTarget: Long         = -1L
 
   private var watchdogHandle: Scheduler.Cancelable     = null
   @volatile private var readerBlocked: Boolean         = false
@@ -104,7 +107,7 @@ final private[client] class SubscriptionConnection(
   private def attachInternal(sink: Sink, names: Vector[String], kind: Kind, failIfUnconfirmed: Boolean): Unit = {
     var doEstablish   = false
     // the SUBSCRIBE-ack count this attach waits for, captured under the same lock as its send so a concurrent attach bumping subscribeSent
-    // can't inflate it; -1 means capture it lazily on the next Live (the send happens later, in goLive's resubscribe)
+    // can't inflate it; -1 (the send happens later, in goLive's resubscribe) means adopt the generation's liveTarget in awaitActive
     var confirmTarget = -1L
     lock.lock()
     try {
@@ -131,14 +134,13 @@ final private[client] class SubscriptionConnection(
     } finally lock.unlock()
 
     if (doEstablish)
-      confirmTarget =
-        try goLive(establish())
-        catch {
-          case e: Throwable =>
-            // establish failed after the sink was registered; drop it so a later reconnect doesn't resubscribe a phantom name
-            locked { deregister(sink, names, kind); state = State.Idle; established.signalAll() }
-            throw e
-        }
+      try goLive(establish())
+      catch {
+        case e: Throwable =>
+          // establish failed after the sink was registered; drop it so a later reconnect doesn't resubscribe a phantom name
+          locked { deregister(sink, names, kind); state = State.Idle; established.signalAll() }
+          throw e
+      }
     awaitActive(failIfUnconfirmed, confirmTarget)
   }
 
@@ -161,12 +163,9 @@ final private[client] class SubscriptionConnection(
 
   // bring a freshly-established socket Live, resubscribing everything registered (counters reset to this generation). In cluster mode it runs
   // once per connection with at most one Slot's worth of Shard channels registered, so the single SSUBSCRIBE never spans slots (CROSSSLOT).
-  // Returns the ack count to wait for (captured under the lock, before signalAll wakes other attachers, so a later attach can't inflate it),
-  // or -1 when it did not go Live; the establishing caller uses it as its awaitActive target.
-  private def goLive(conn: Conn): Long = {
+  private def goLive(conn: Conn): Unit = {
     var reconnect = false
     var notify    = false
-    var target    = -1L
     locked {
       if (state != State.Establishing && state != State.Reconnecting) conn.close()
       else if (conn.isTerminated) {
@@ -194,7 +193,7 @@ final private[client] class SubscriptionConnection(
         } else {
           state = State.Live
           startWatchdog()
-          target = subscribeSent
+          liveTarget = subscribeSent // this generation's full resubscribe count, captured before signalAll so a later subscribe can't inflate it
         }
         established.signalAll()
         confirmed.signalAll()
@@ -202,7 +201,6 @@ final private[client] class SubscriptionConnection(
     }
     if (reconnect) scheduleReconnect(0)
     if (notify) onTerminated()
-    target
   }
 
   private def sendSubscribe(conn: Conn, kind: Kind, names: Vector[String]): Unit = {
@@ -210,10 +208,11 @@ final private[client] class SubscriptionConnection(
     subscribeSent += names.size
   }
 
-  // Waits (bounded by the connect timeout) until subscribeConfirmed reaches `target` — the ack count captured under this attach's send lock,
-  // so it waits for its own SUBSCRIBE, not a concurrent attach's. A reconnect resets the counters, so it re-arms to the full resubscribe count
-  // of the new generation. When `failIfUnconfirmed` (the owned standalone/master-replica path), an unconfirmed deadline throws NotConnected so
-  // `subscribe` fails loudly instead of returning a stream whose SUBSCRIBE never took effect; cluster passes false (its manager owns retry).
+  // Waits (bounded by the connect timeout) until subscribeConfirmed reaches `target`. A Live attach passes its own post-send count (`target0`),
+  // so it waits for its own SUBSCRIBE, not a concurrent attach's; a caller that registered before going Live passes -1 and adopts `liveTarget`,
+  // the generation's full resubscribe count captured in goLive before waiters wake — never a later subscribe's inflated subscribeSent. A
+  // reconnect re-arms to the next generation's liveTarget. When `failIfUnconfirmed` (the owned standalone/master-replica path), an unconfirmed
+  // deadline throws NotConnected so `subscribe` fails loudly instead of returning a stream whose SUBSCRIBE never took effect; cluster passes false.
   private def awaitActive(failIfUnconfirmed: Boolean, target0: Long): Unit = {
     var active = false
     lock.lock()
@@ -225,11 +224,11 @@ final private[client] class SubscriptionConnection(
         state match {
           case State.Closed => settled = true
           case State.Live   =>
-            if (target < 0) target = subscribeSent
+            if (target < 0) target = liveTarget
             if (subscribeConfirmed >= target) { active = true; settled = true }
             else if (awaitOrTimeout(deadline)) settled = true
           case _            =>
-            target = -1L // a reconnect reset the counters: re-arm against the next generation's full resubscribe
+            target = -1L // a reconnect reset the counters: re-arm to the next generation's liveTarget
             if (awaitOrTimeout(deadline)) settled = true
         }
     } finally lock.unlock()
@@ -276,7 +275,7 @@ final private[client] class SubscriptionConnection(
     val proceed = locked(state == State.Reconnecting)
     if (proceed) {
       onReconnect()
-      try { val _ = goLive(establish()) }
+      try goLive(establish())
       catch { case NonFatal(_) => locked(if (state == State.Reconnecting) scheduleReconnect(attempt + 1)) }
     }
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -22,7 +22,8 @@ import sage.protocol.Frame
   * connection but never commands; the watchdog therefore skips its liveness kill while the reader is so blocked.
   *
   * Two lifecycles share this one machinery. Standalone (`cluster = false`): the connection owns its sinks, runs its own reconnect loop, and
-  * re-issues every active subscription on reconnect. Cluster (`cluster = true`): the [[ClusterSubscriptions]] manager owns the sinks and
+  * re-issues every active subscription on reconnect; each attempt first calls `onReconnect`, which a master-replica subscription uses to
+  * re-discover roles and re-home onto a promoted master. Cluster (`cluster = true`): the [[ClusterSubscriptions]] manager owns the sinks and
   * attaches them per Node; a socket loss is terminal for the connection — it fires `onTerminated` and the manager re-homes the surviving
   * sinks onto the current owner rather than blindly reconnecting to a node that may no longer own the slot.
   */
@@ -36,7 +37,8 @@ final private[client] class SubscriptionConnection(
   bufferSize: Int,
   isLive: () => Boolean,
   cluster: Boolean = false,
-  onTerminated: () => Unit = () => ()
+  onTerminated: () => Unit = () => (),
+  onReconnect: () => Unit = () => ()
 ) extends Placement.ShardConn {
   import SubscriptionConnection.*
 
@@ -85,7 +87,7 @@ final private[client] class SubscriptionConnection(
     val sink = new Sink(names, kind, bufferSize)
     // closeOwned, not bare terminate: if attach registered the sink but awaitActive then threw, fully unwind it so no phantom channel is
     // resubscribed on the next reconnect
-    try attach(sink, names, kind)
+    try attachInternal(sink, names, kind, failIfUnconfirmed = true)
     catch { case e: Throwable => closeOwned(sink); throw e }
     new RawSubscription(sink, () => closeOwned(sink))
   }
@@ -97,7 +99,9 @@ final private[client] class SubscriptionConnection(
     * timeout) until the server confirms. The caller must pass names that hash to a single Slot for the Shard kind in cluster mode, so the
     * one `SSUBSCRIBE` this emits never spans slots (`CROSSSLOT`).
     */
-  def attach(sink: Sink, names: Vector[String], kind: Kind): Unit = {
+  def attach(sink: Sink, names: Vector[String], kind: Kind): Unit = attachInternal(sink, names, kind, failIfUnconfirmed = false)
+
+  private def attachInternal(sink: Sink, names: Vector[String], kind: Kind, failIfUnconfirmed: Boolean): Unit = {
     var doEstablish = false
     lock.lock()
     try {
@@ -130,7 +134,7 @@ final private[client] class SubscriptionConnection(
           locked { deregister(sink, names, kind); state = State.Idle; established.signalAll() }
           throw e
       }
-    awaitActive()
+    awaitActive(failIfUnconfirmed)
   }
 
   /**
@@ -196,9 +200,11 @@ final private[client] class SubscriptionConnection(
     subscribeSent += names.size
   }
 
-  // Best-effort, bounded by the connect timeout: a down or backpressured connection degrades to fire-and-forget rather than blocking forever.
-  // The target is (re)captured whenever the connection is Live, so a reconnect mid-wait re-arms against the new generation's resubscribe.
-  private def awaitActive(): Unit = {
+  // Waits (bounded by the connect timeout) for the server to confirm every SUBSCRIBE sent; re-arms across a reconnect mid-wait. When
+  // `failIfUnconfirmed` (the owned standalone/master-replica path), an unconfirmed deadline throws NotConnected so `subscribe` fails loudly
+  // instead of returning a stream whose SUBSCRIBE never took effect; cluster passes false (its manager owns re-home/retry).
+  private def awaitActive(failIfUnconfirmed: Boolean): Unit = {
+    var active = false
     lock.lock()
     try {
       val deadline = scheduler.nowMillis + connectTimeoutMillis
@@ -209,13 +215,14 @@ final private[client] class SubscriptionConnection(
           case State.Closed => settled = true
           case State.Live   =>
             if (target < 0) target = subscribeSent
-            if (subscribeConfirmed >= target) settled = true
-            else settled = awaitOrTimeout(deadline)
+            if (subscribeConfirmed >= target) { active = true; settled = true }
+            else if (awaitOrTimeout(deadline)) settled = true
           case _            =>
             target = -1L // re-arm against the next live generation
-            settled = awaitOrTimeout(deadline)
+            if (awaitOrTimeout(deadline)) settled = true
         }
     } finally lock.unlock()
+    if (failIfUnconfirmed && !active) throw NotConnected()
   }
 
   // true (stop) on timeout; must hold `lock`
@@ -256,9 +263,11 @@ final private[client] class SubscriptionConnection(
 
   private def attemptReconnect(attempt: Int): Unit = {
     val proceed = locked(state == State.Reconnecting)
-    if (proceed)
+    if (proceed) {
+      onReconnect()
       try goLive(establish())
       catch { case NonFatal(_) => locked(if (state == State.Reconnecting) scheduleReconnect(attempt + 1)) }
+    }
   }
 
   private def onConnClosed(conn: Conn): Unit =


### PR DESCRIPTION
## Problem

In a master-replica deployment, a classic pub/sub subscription pinned its connection to the master captured at first subscribe and reconnect-looped that **same address forever**. After a failover to a different node, commands recovered via role rediscovery but the subscription **silently stopped delivering messages** until restart — contradicting ADR-0039's claim that a seed-list deployment "stays correct" across failover.

## Fix

Port the cluster runtime's disconnect-driven re-home (ADR-0029) to `MasterReplicaLive`, adapted for the single-master case:

- The subscription's transport factory now resolves the **current** master on every (re)connect rather than capturing one.
- A new `SubscriptionConnection.onReconnect` hook fires on each standalone reconnect attempt (no-op for plain standalone). `MasterReplicaLive` wires it to a **synchronous, forced** role re-discovery that runs *before* `establish()`, so `masterNodeRef` already names the promoted master when the factory reads it. This closes the race where a reconnect lands on a demoted-but-still-reachable old master and stays there (`rediscover()` reaches the new master even starting from the demoted node, since `resolveFrom` follows a replica to its master).

### `subscribe` fails loudly on unconfirmed SUBSCRIBE

`awaitActive` previously swallowed the connect-timeout and returned a live `Subscription` even when the `SUBSCRIBE` was never acknowledged (a silent subscribe-then-publish message gap). On the owned standalone/master-replica path it now throws `NotConnected` instead; the cluster manager keeps best-effort confirmation since it owns its own re-home/retry.

### Race-safe confirmation targets

Each attach waits for the right ack count without inheriting unrelated concurrent attaches' pending acks:

- **Live attach that sends a SUBSCRIBE** → its own post-send `subscribeSent`.
- **Live attach that sends nothing** (names already subscribed) → the already-confirmed count.
- **Registered before going Live** (establish / reconnect waiter / re-arm) → the generation's `liveTarget`, captured in `goLive` under the lock before it wakes waiters, so a later subscribe can't inflate it.

## Verification

Compiles on Scala 3.3.7 and 3.8.3 across all four backends (zio/ce/ox/kyo); `scalafmtCheck` clean.