### PR TITLE
Correct docs: TimedOut and closeTimeout scope

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,7 +90,7 @@ The remaining fields tune connection lifecycle, pooling, and observability. Each
 | `connectTimeout` | wait for a connection and its `HELLO 3` setup | `10.seconds` |
 | `reconnect` (`BackoffConfig`) | exponential reconnect backoff with full jitter | `50.millis` to `5.seconds`, ×2 |
 | `watchdog` (`WatchdogConfig`) | idle-connection liveness ping (death detector) | ping every `60.seconds`, `30.seconds` timeout |
-| `closeTimeout` | how long `close` waits for in-flight commands to drain | `5.seconds` |
+| `closeTimeout` | how long `close` waits for in-flight commands on the multiplexed connection to drain (blocking commands and transactions on the dedicated pool are force-closed at once) | `5.seconds` |
 | `dedicatedPool` (`DedicatedPoolConfig`) | the pool behind blocking commands and transactions | max `8`, acquire `5.seconds`, idle `30.seconds` |
 | `pubsub` (`PubSubConfig`) | per-subscription message buffer size | `128` |
 | `clientCache` (`CacheConfig`) | client-side caching on/off and size cap | enabled, `64 MB` |

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -14,7 +14,7 @@ Every sage failure is a `SageException`, a single sealed hierarchy you can match
 | `UnsupportedServer(message)` | The server rejected `HELLO 3` (it predates RESP3, or is a RESP2-only proxy). |
 | `TlsError(message)` | TLS could not be established (rejected certificate or unusable trust material). |
 | `CrossSlot(message)` | A multi-key command or transaction touched keys in more than one cluster slot. |
-| `TimedOut(message)` | A command did not complete within its configured timeout. |
+| `TimedOut(message)` | A blocking command or transaction waited past `dedicatedPool.acquireTimeout` for a free pooled connection. Not a per-command timeout; bound a command's own duration with your backend's timeout combinator. |
 | `TransactionDiscarded(message)` | A transaction was discarded server-side (`EXECABORT`); nothing ran. |
 | `NotCacheable(message)` | `cached` was given a command that cannot be safely cached. |
 

--- a/sage-core/src/main/scala/sage/SageException.scala
+++ b/sage-core/src/main/scala/sage/SageException.scala
@@ -67,7 +67,7 @@ object SageException {
   final case class CrossSlot(message: String) extends SageException(message)
 
   /**
-    * A command did not complete within its configured timeout.
+    * A blocking command or transaction waited past `dedicatedPool.acquireTimeout` for a free pooled connection. Not a per-command timeout.
     */
   final case class TimedOut(message: String) extends SageException(message)
 


### PR DESCRIPTION
Two documentation accuracy fixes for launch, surfaced by the production-readiness audit. No behavior change.

- **`TimedOut`** — the scaladoc and `error-handling.md` claimed "a command did not complete within its configured timeout", implying a per-command timeout that does not exist. `TimedOut` is only ever raised when a blocking command or transaction waits past `dedicatedPool.acquireTimeout` for a free pooled connection. Reworded both, and point to the backend's own timeout combinator for bounding a command.
- **`closeTimeout`** — clarified that it drains the multiplexed connection only; blocking commands and transactions on the dedicated pool are force-closed at once.

(Client-side caching docs moved to #110, which enables caching on master-replica clients.)