### PR TITLE
Enable client-side caching on master-replica clients

### DIFF
--- a/docs/client-side-caching.md
+++ b/docs/client-side-caching.md
@@ -36,3 +36,7 @@ Only reads whose result is a pure function of the named keys' current state are 
 :::
 
 Tune cache sizing and behavior through `clientCache` on [`SageConfig`](/configuration).
+
+## Topology
+
+Caching works on a standalone client and on a master-replica client (cached reads run on the master, which holds the tracking-backed cache; a failover starts the new master's cache cold). On a cluster client, `cached` currently runs the read without caching so the call stays portable; per-node tracking through redirects and failover is a planned follow-up. In every case the result is correct, you only forgo the local hit where caching is not active.

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -59,7 +59,7 @@ final private[client] class ClusterLive(
     connectTimeout,
     closeTimeout,
     dedicatedPool,
-    events
+    events = events
   )
   // per-master round-robin cursor over its shard's replicas
   private val replicaCursors = new java.util.concurrent.ConcurrentHashMap[Node, java.util.concurrent.atomic.AtomicInteger]()
@@ -730,8 +730,8 @@ final private[client] class ClusterLive(
             connectTimeout,
             closeTimeout,
             dedicatedPool,
-            Some(node),
-            events
+            node = Some(node),
+            events = events
           )
         // a close that landed during the blocking connect must not re-publish this bundle into a closed client
         val stale = lockedNodes { pendingEstablish.remove(node); if (closed) true else { established.put(node, nc); false } }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -160,7 +160,7 @@ final private[client] class MasterReplicaLive(
   def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =
     if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command))
     else if (!cachingEnabled) CIO.async[A](complete => offload(sendMaster(command, Events.trackCommand(events, command, complete))))
-    else CIO.async[A](complete => offload(sendMasterCached(command, ttl.toMillis, Events.trackCommand(events, command, complete))))
+    else CIO.async[A](complete => offload(sendMasterCached(command, ttl.toMillis, complete)))
 
   private def sendMaster[A](command: Command[A], complete: Try[A] => Unit): Unit =
     onMaster(complete)((nc, _, cb) => nc.submit[A](command, asking = false, cb))

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -40,7 +40,7 @@ final private[client] class MasterReplicaLive(
   private val readFrom       = config.readFrom
   private val cachingEnabled = config.clientCache.enabled
 
-  // only the master pool caches: cached reads run on the master, replicas never serve them
+  // only the master multiplexed connection caches: cached reads run on the master, replicas and dedicated connections never serve them
   private val masterPool  = pool(caching = true)
   private val replicaPool = pool(caching = false)
 
@@ -58,7 +58,8 @@ final private[client] class MasterReplicaLive(
       config.closeTimeout,
       config.dedicatedPool,
       cacheMaxBytes,
-      events
+      events,
+      dedicatedBootstrap = Some(bootstrap)
     )
   }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -15,7 +15,7 @@ import sage.SageException.{ConnectionLost, NotConnected, ServerError, TimedOut}
 import sage.client.{ReadFrom, SageConfig}
 import sage.cluster.Node
 import sage.codec.ValueCodec
-import sage.commands.{Command, Pipeline, Role, Server}
+import sage.commands.{Command, Connection, Pipeline, Role, Server}
 
 /**
   * The master-replica runtime: a non-cluster deployment of one master and its replicas, discovered from seeds by asking each its `ROLE`.
@@ -37,23 +37,30 @@ final private[client] class MasterReplicaLive(
   events: Events = Events.disabled
 ) extends Client[CIO] {
 
-  private val readFrom = config.readFrom
+  private val readFrom       = config.readFrom
+  private val cachingEnabled = config.clientCache.enabled
 
-  private val masterPool  = pool()
-  private val replicaPool = pool() // non-cluster replicas serve reads without READONLY, so the same plain bootstrap as the master
+  // only the master pool caches: cached reads run on the master, replicas never serve them
+  private val masterPool  = pool(caching = true)
+  private val replicaPool = pool(caching = false)
 
-  private def pool(): NodePool =
+  private def pool(caching: Boolean): NodePool = {
+    val cached        = caching && cachingEnabled
+    val poolBootstrap = if (cached) bootstrap :+ Connection.clientTrackingOnOptin else bootstrap
+    val cacheMaxBytes = if (cached) config.clientCache.maxBytes else 0L
     new NodePool(
       nodeFactory,
       scheduler,
-      bootstrap,
+      poolBootstrap,
       config.reconnect,
       config.watchdog,
       config.connectTimeout,
       config.closeTimeout,
       config.dedicatedPool,
+      cacheMaxBytes,
       events
     )
+  }
 
   private val masterNodeRef    = new AtomicReference[Node](null)
   private val replicasRef      = new AtomicReference[Vector[Node]](Vector.empty)
@@ -109,8 +116,8 @@ final private[client] class MasterReplicaLive(
       config.connectTimeout,
       config.closeTimeout,
       config.dedicatedPool,
-      Some(node),
-      events
+      node = Some(node),
+      events = events
     )
     try {
       val latch   = new CountDownLatch(1)
@@ -150,13 +157,19 @@ final private[client] class MasterReplicaLive(
       offload(if (readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command)) sendRead(command, tracked) else sendMaster(command, tracked))
     }
 
-  // cached reads always go to the master (caching is anchored to its tracking stream); the cache itself is a follow-up, so the read runs
-  // uncached but stays on the master to keep the call portable
   def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =
     if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command))
-    else CIO.async[A](complete => offload(sendMaster(command, Events.trackCommand(events, command, complete))))
+    else if (!cachingEnabled) CIO.async[A](complete => offload(sendMaster(command, Events.trackCommand(events, command, complete))))
+    else CIO.async[A](complete => offload(sendMasterCached(command, ttl.toMillis, Events.trackCommand(events, command, complete))))
 
-  private def sendMaster[A](command: Command[A], complete: Try[A] => Unit): Unit = {
+  private def sendMaster[A](command: Command[A], complete: Try[A] => Unit): Unit =
+    onMaster(complete)((nc, _, cb) => nc.submit[A](command, asking = false, cb))
+
+  private def sendMasterCached[A](command: Command[A], ttlMillis: Long, complete: Try[A] => Unit): Unit =
+    onMaster(complete)((nc, _, cb) => nc.cachedSubmit[A](command, ttlMillis, cb))
+
+  // run `submit` on the master, completing with node attribution; an ownership fault (a demoted master) kicks a re-discovery
+  private def onMaster[A](complete: Try[A] => Unit)(submit: (NodeClient, Node, Try[A] => Unit) => Unit): Unit = {
     if (closed) { complete(Failure(NotConnected())); return }
     val node = masterNodeRef.get()
     val nc   =
@@ -164,9 +177,9 @@ final private[client] class MasterReplicaLive(
       catch { case NonFatal(_) => null }
     if (nc == null) { triggerRefresh(); complete(Failure(NotConnected())) }
     else
-      nc.submit[A](
-        command,
-        asking = false,
+      submit(
+        nc,
+        node,
         {
           case s @ Success(_) => Events.attributeNode(complete, node); complete(s)
           case f @ Failure(e) => if (isOwnershipFault(e)) triggerRefresh(); Events.attributeNode(complete, node); complete(f)

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
@@ -18,6 +18,9 @@ final private[client] class NodeClient(connection: MultiplexedConnection, pool: 
     else if (asking) connection.submitAsking(command, callback)
     else connection.submit(command, callback)
 
+  def cachedSubmit[A](command: Command[A], ttlMillis: Long, callback: Try[A] => Unit): Unit =
+    connection.cachedSubmit(command, ttlMillis, callback)
+
   // a pipeline's per-node batch: one round-trip on this node's Multiplexed Connection. False when not connected (nothing submitted), so
   // the caller re-routes each position rather than fabricating per-position errors. Blocking commands never reach here (rejected up front).
   def submitAll(commands: Vector[Command[?]], callbacks: Vector[Try[Any] => Unit]): Boolean =
@@ -50,11 +53,12 @@ private[client] object NodeClient {
     connectTimeout: FiniteDuration,
     closeTimeout: FiniteDuration,
     dedicatedPool: DedicatedPoolConfig,
+    cacheMaxBytes: Long = 0L,
     node: Option[Node] = None,
     events: Events = Events.disabled
   ): NodeClient = {
     val connection =
-      MultiplexedConnection.connect(factory, scheduler, bootstrap, reconnect, watchdog, connectTimeout, closeTimeout, 0L, node, events)
+      MultiplexedConnection.connect(factory, scheduler, bootstrap, reconnect, watchdog, connectTimeout, closeTimeout, cacheMaxBytes, node, events)
     val pool       = DedicatedPool.forConnection(factory, bootstrap, scheduler, connection, dedicatedPool, connectTimeout.toMillis)
     new NodeClient(connection, pool)
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
@@ -55,11 +55,13 @@ private[client] object NodeClient {
     dedicatedPool: DedicatedPoolConfig,
     cacheMaxBytes: Long = 0L,
     node: Option[Node] = None,
-    events: Events = Events.disabled
+    events: Events = Events.disabled,
+    dedicatedBootstrap: Option[Vector[Command[?]]] = None
   ): NodeClient = {
     val connection =
       MultiplexedConnection.connect(factory, scheduler, bootstrap, reconnect, watchdog, connectTimeout, closeTimeout, cacheMaxBytes, node, events)
-    val pool       = DedicatedPool.forConnection(factory, bootstrap, scheduler, connection, dedicatedPool, connectTimeout.toMillis)
+    val pool       =
+      DedicatedPool.forConnection(factory, dedicatedBootstrap.getOrElse(bootstrap), scheduler, connection, dedicatedPool, connectTimeout.toMillis)
     new NodeClient(connection, pool)
   }
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -29,7 +29,8 @@ final private[client] class NodePool(
   closeTimeout: FiniteDuration,
   dedicatedPool: DedicatedPoolConfig,
   cacheMaxBytes: Long = 0L,
-  events: Events = Events.disabled
+  events: Events = Events.disabled,
+  dedicatedBootstrap: Option[Vector[Command[?]]] = None
 ) {
 
   private val lock             = new ReentrantLock()
@@ -75,7 +76,8 @@ final private[client] class NodePool(
           dedicatedPool,
           cacheMaxBytes,
           Some(node),
-          events
+          events,
+          dedicatedBootstrap
         )
         val stale = locked { pendingEstablish.remove(node); if (closed) true else { established.put(node, nc); false } }
         if (stale) { nc.close(); throw NotConnected() }

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -28,6 +28,7 @@ final private[client] class NodePool(
   connectTimeout: FiniteDuration,
   closeTimeout: FiniteDuration,
   dedicatedPool: DedicatedPoolConfig,
+  cacheMaxBytes: Long = 0L,
   events: Events = Events.disabled
 ) {
 
@@ -72,6 +73,7 @@ final private[client] class NodePool(
           connectTimeout,
           closeTimeout,
           dedicatedPool,
+          cacheMaxBytes,
           Some(node),
           events
         )


### PR DESCRIPTION
Client-side caching previously worked only on a standalone client; on master-replica it ran `cached` as a plain uncached read. But master-replica caching has no fundamental blocker the way cluster does: `cached` reads are pinned to the single master (ADR-0028), and the master is reached through an ordinary per-node connection identical to a standalone client's. No slots, no redirects, no per-node tracking problem.

## Change

- The **master** pool's multiplexed connection now enables RESP3 OPTIN tracking (`CLIENT TRACKING ON OPTIN` in its bootstrap) and carries a per-generation cache; replicas stay plain, since they never serve cached reads.
- Tracking is kept *off* the master's dedicated-pool connections: only the multiplexed connection runs cached reads, while dedicated connections (blocking commands, transactions) never send `CLIENT CACHING YES` and use strict one-reply-per-command matching, so they handshake with the plain bootstrap (`dedicatedBootstrap`).
- `MasterReplicaLive.cached` routes to the master connection's `cachedSubmit` (with the same ownership-fault re-discovery as a normal master send), or runs uncached when `clientCache.enabled = false`.
- `cacheMaxBytes` is threaded through `NodePool` and `NodeClient` (default `0`, so cluster and replica pools are unchanged), and `NodeClient` gains `cachedSubmit`.

## Events

The cached path passes the user callback straight to `cachedSubmit`, which already emits its own cache events (`Cache.Hit`/`Cache.Miss`) and, on a miss, a `CommandCompleted` with the node attributed by the connection. It is deliberately *not* wrapped in `trackCommand`, matching standalone, so a hit emits no `CommandCompleted` and a miss emits exactly one.

## Why it is safe across failover

The cache is per connection generation. On a failover, `rediscover()` prunes the demoted master's `NodeClient` (closing it and dropping its cache) and the promoted master's connection starts with an empty cache and fresh tracking. This is the same flush-on-reconnect model standalone already relies on (ADR-0028), keyed on the master node instead of the reconnect generation. A write that meets a demoted master still fails fast with `READONLY` and triggers re-discovery, so no stale value is served from a demoted master's cache.

Cluster caching remains the planned follow-up (per-node tracking through redirects).

## Verification

Compiles on Scala 3.3.7 and 3.8.3 across all four backends; `scalafmtCheck` clean. (No master-replica integration-test harness exists yet, so this reuses the standalone-tested `cachedSubmit` path; an MR caching suite would need an MR container fixture, which is a separate addition.)
