### PR TITLE
Add confirmed-subscription variants to pub/sub

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -239,48 +239,51 @@ The distinction is covered in [Pipelines & transactions](/pipelines-transactions
 
 Subscribing yields a stream of messages in your ecosystem's native stream type: an Ox `Flow`, a ZIO `ZStream`, an fs2 `Stream`, or a Kyo `Stream`. Ending the stream unsubscribes.
 
+Because publishing here happens right after subscribing, these examples use the variant that returns only once the server has confirmed the subscription, so the publish can't outrun the registration: `subscribeScoped` on ZIO and Kyo, `subscribeResource` on cats-effect, and plain `subscribe` on Ox (where the call is already synchronous). The plain stream-returning `subscribe` registers lazily on first pull and is the right choice for a long-lived consumer that isn't racing its own publisher.
+
 ::: code-group
 
 ```scala [Ox]
-val collector =
-  fork(client.subscribe[String]("news").take(3).runToList())
+val news      = client.subscribe[String]("news")
+val collector = fork(news.take(3).runToList())
 (1 to 3).foreach(i => client.publish("news", s"item-$i"))
 val messages = collector.join() // the three published payloads
 ```
 
 ```scala [ZIO]
-for {
-  sub      <- client.subscribe[String]("news").take(3).runCollect.fork
-  _        <- ZIO.sleep(300.millis)
-  _        <- ZIO.foreachDiscard(1 to 3) { i =>
-                client.publish("news", s"item-$i")
-              }
-  messages <- sub.join
-} yield messages.map(_.payload).toList
+ZIO.scoped {
+  for {
+    stream   <- client.subscribeScoped[String]("news")
+    sub      <- stream.take(3).runCollect.fork
+    _        <- ZIO.foreachDiscard(1 to 3) { i =>
+                  client.publish("news", s"item-$i")
+                }
+    messages <- sub.join
+  } yield messages.map(_.payload).toList
+}
 ```
 
 ```scala [Cats Effect]
-for {
-  sub      <- client.subscribe[String]("news").take(3).compile.toVector.start
-  _        <- IO.sleep(300.millis)
-  _        <- (1 to 3).toList.traverse_ { i =>
-                client.publish("news", s"item-$i")
-              }
-  messages <- sub.joinWithNever
-} yield messages.map(_.payload).toList
+client.subscribeResource[String]("news").use { stream =>
+  for {
+    sub      <- stream.take(3).compile.toVector.start
+    _        <- (1 to 3).toList.traverse_ { i =>
+                  client.publish("news", s"item-$i")
+                }
+    messages <- sub.joinWithNever
+  } yield messages.map(_.payload).toList
+}
 ```
 
 ```scala [Kyo]
 for {
+  stream    <- client.subscribeScoped[String]("news")
   publisher <- Fiber.init {
-                 for {
-                   _ <- Async.sleep(300.millis)
-                   _ <- Kyo.foreachDiscard(1 to 3) { i =>
-                          client.publish("news", s"item-$i")
-                        }
-                 } yield ()
+                 Kyo.foreachDiscard(1 to 3) { i =>
+                   client.publish("news", s"item-$i")
+                 }
                }
-  chunk     <- client.subscribe[String]("news").take(3).run
+  chunk     <- stream.take(3).run
   _         <- publisher.get
 } yield chunk.toList.map(_.payload)
 ```

--- a/docs/pubsub.md
+++ b/docs/pubsub.md
@@ -9,45 +9,46 @@ Subscribing yields a stream of messages in your ecosystem's native stream type: 
 ::: code-group
 
 ```scala [Ox]
-val collector =
-  fork(client.subscribe[String]("news").take(3).runToList())
+val news      = client.subscribe[String]("news")
+val collector = fork(news.take(3).runToList())
 (1 to 3).foreach(i => client.publish("news", s"item-$i"))
 val messages = collector.join() // the three published payloads
 ```
 
 ```scala [ZIO]
-for {
-  sub      <- client.subscribe[String]("news").take(3).runCollect.fork
-  _        <- ZIO.sleep(300.millis)
-  _        <- ZIO.foreachDiscard(1 to 3) { i =>
-                client.publish("news", s"item-$i")
-              }
-  messages <- sub.join
-} yield messages.map(_.payload).toList
+ZIO.scoped {
+  for {
+    stream   <- client.subscribeScoped[String]("news")
+    sub      <- stream.take(3).runCollect.fork
+    _        <- ZIO.foreachDiscard(1 to 3) { i =>
+                  client.publish("news", s"item-$i")
+                }
+    messages <- sub.join
+  } yield messages.map(_.payload).toList
+}
 ```
 
 ```scala [Cats Effect]
-for {
-  sub      <- client.subscribe[String]("news").take(3).compile.toVector.start
-  _        <- IO.sleep(300.millis)
-  _        <- (1 to 3).toList.traverse_ { i =>
-                client.publish("news", s"item-$i")
-              }
-  messages <- sub.joinWithNever
-} yield messages.map(_.payload).toList
+client.subscribeResource[String]("news").use { stream =>
+  for {
+    sub      <- stream.take(3).compile.toVector.start
+    _        <- (1 to 3).toList.traverse_ { i =>
+                  client.publish("news", s"item-$i")
+                }
+    messages <- sub.joinWithNever
+  } yield messages.map(_.payload).toList
+}
 ```
 
 ```scala [Kyo]
 for {
+  stream    <- client.subscribeScoped[String]("news")
   publisher <- Fiber.init {
-                 for {
-                   _ <- Async.sleep(300.millis)
-                   _ <- Kyo.foreachDiscard(1 to 3) { i =>
-                          client.publish("news", s"item-$i")
-                        }
-                 } yield ()
+                 Kyo.foreachDiscard(1 to 3) { i =>
+                   client.publish("news", s"item-$i")
+                 }
                }
-  chunk     <- client.subscribe[String]("news").take(3).run
+  chunk     <- stream.take(3).run
   _         <- publisher.get
 } yield chunk.toList.map(_.payload)
 ```
@@ -55,6 +56,10 @@ for {
 :::
 
 Pattern subscriptions are also available; they deliver a **pattern message** that additionally names the glob that matched.
+
+::: tip Confirmed subscriptions
+The plain `subscribe` returns the stream immediately and registers the subscription lazily, on the first pull. That is fine for a long-lived consumer, but a `publish` sequenced right after it can outrun the registration and be missed. To close that gap, the effectful backends expose a variant that returns only once the server has confirmed the SUBSCRIBE: `subscribeScoped` / `pSubscribeScoped` / `sSubscribeScoped` on ZIO (a `ZIO[Scope, _, _]`) and Kyo, and `subscribeResource` / `pSubscribeResource` / `sSubscribeResource` on cats-effect (a `Resource`). On Ox the plain `subscribe` is already this: the call is synchronous and returns once confirmed. The examples above use these so the publisher can't race the subscriber.
+:::
 
 ::: tip Connection isolation
 All classic subscriptions share one **subscription connection**, created the first time you subscribe and closed when the last subscription ends. It is separate from the connection that carries your commands, so a slow consumer can backpressure its own subscriptions but can never stall command replies. The subscription connection re-issues every active subscription automatically on reconnect.
@@ -65,12 +70,14 @@ All classic subscriptions share one **subscription connection**, created the fir
 In a cluster, a **shard channel** keeps its traffic within the shard that owns the channel's slot: `sSubscribe` and `sPublish` target that owning node rather than broadcasting across the whole cluster. There is no pattern form, and a delivery surfaces as an ordinary message.
 
 ```scala [ZIO]
-for {
-  sub      <- client.sSubscribe[String]("orders").take(1).runCollect.fork
-  _        <- ZIO.sleep(300.millis)
-  _        <- client.sPublish("orders", "placed")
-  messages <- sub.join
-} yield messages.map(_.payload).toList
+ZIO.scoped {
+  for {
+    stream   <- client.sSubscribeScoped[String]("orders")
+    sub      <- stream.take(1).runCollect.fork
+    _        <- client.sPublish("orders", "placed")
+    messages <- sub.join
+  } yield messages.map(_.payload).toList
+}
 ```
 
 The shape is the same on every backend, using each one's native stream type exactly as classic pub/sub does. Sage holds one sharded subscription connection per owning node and re-homes the affected subscriptions automatically when a slot migrates or a node fails over.

--- a/examples/ce/src/main/scala/sage/examples/ce/PubSubExample.scala
+++ b/examples/ce/src/main/scala/sage/examples/ce/PubSubExample.scala
@@ -1,7 +1,5 @@
 package sage.examples.ce
 
-import scala.concurrent.duration.*
-
 import cats.effect.IO
 import cats.syntax.all.*
 
@@ -15,11 +13,12 @@ import sage.ce.*
 object PubSubExample {
 
   def run(client: SageClient): IO[Unit] =
-    for {
-      subscriber <- client.subscribe[String]("news").take(3).compile.toVector.start
-      _          <- IO.sleep(300.millis) // let SUBSCRIBE register before publishing
-      _          <- (1 to 3).toList.traverse_(i => client.publish("news", s"item-$i"))
-      messages   <- subscriber.joinWithNever
-      _          <- IO.println(s"received=${messages.map(_.payload).toList}")
-    } yield ()
+    client.subscribeResource[String]("news").use { stream =>
+      for {
+        subscriber <- stream.take(3).compile.toVector.start
+        _          <- (1 to 3).toList.traverse_(i => client.publish("news", s"item-$i"))
+        messages   <- subscriber.joinWithNever
+        _          <- IO.println(s"received=${messages.map(_.payload).toList}")
+      } yield ()
+    }
 }

--- a/examples/kyo/src/main/scala/sage/examples/kyo/PubSubExample.scala
+++ b/examples/kyo/src/main/scala/sage/examples/kyo/PubSubExample.scala
@@ -13,13 +13,9 @@ object PubSubExample {
 
   def run(client: SageClient): Unit < (Scope & Abort[Throwable] & Async) =
     for {
-      publisher <- Fiber.init {
-                     for {
-                       _ <- Async.sleep(300.millis)                                             // let SUBSCRIBE register
-                       _ <- Kyo.foreachDiscard(1 to 3)(i => client.publish("news", s"item-$i")) // sequential: preserves order
-                     } yield ()
-                   }
-      chunk     <- client.subscribe[String]("news").take(3).run
+      stream    <- client.subscribeScoped[String]("news")
+      publisher <- Fiber.init(Kyo.foreachDiscard(1 to 3)(i => client.publish("news", s"item-$i")))
+      chunk     <- stream.take(3).run
       _         <- publisher.get
       _         <- Console.printLine(s"received=${chunk.toList.map(_.payload)}")
     } yield ()

--- a/examples/ox/src/main/scala/sage/examples/ox/PubSubExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/PubSubExample.scala
@@ -12,12 +12,12 @@ import sage.ox.*
 object PubSubExample {
 
   def run(client: SageClient)(using Ox): Unit = {
-    val collector = fork(client.subscribe[String]("news").take(3).runToList())
-    Thread.sleep(300) // let SUBSCRIBE register before publishing
+    val news      = client.subscribe[String]("news")
+    val collector = fork(news.take(3).runToList())
     (1 to 3).foreach { i =>
       val _ = client.publish("news", s"item-$i")
     }
-    val messages = collector.join()
+    val messages  = collector.join()
     println(s"received=${messages.map(_.payload)}")
   }
 }

--- a/examples/zio/src/main/scala/sage/examples/zio/ClusterExample.scala
+++ b/examples/zio/src/main/scala/sage/examples/zio/ClusterExample.scala
@@ -19,8 +19,8 @@ object ClusterExample {
     ZIO.scoped {
       for {
         client     <- SageClient.scoped(config)
-        subscriber <- client.sSubscribe[String]("orders").take(1).runCollect.fork
-        _          <- ZIO.sleep(Duration.fromMillis(300)) // let SSUBSCRIBE register before publishing
+        stream     <- client.sSubscribeScoped[String]("orders")
+        subscriber <- stream.take(1).runCollect.fork
         _          <- client.sPublish("orders", "placed")
         messages   <- subscriber.join
         _          <- Console.printLine(s"sharded=${messages.map(_.payload).toList}")

--- a/examples/zio/src/main/scala/sage/examples/zio/PubSubExample.scala
+++ b/examples/zio/src/main/scala/sage/examples/zio/PubSubExample.scala
@@ -13,12 +13,14 @@ object PubSubExample {
 
   val run: ZIO[SageClient, Throwable, Unit] =
     ZIO.serviceWithZIO[SageClient] { client =>
-      for {
-        subscriber <- client.subscribe[String]("news").take(3).runCollect.fork
-        _          <- ZIO.sleep(Duration.fromMillis(300)) // let SUBSCRIBE register before publishing
-        _          <- ZIO.foreachDiscard(1 to 3)(i => client.publish("news", s"item-$i"))
-        messages   <- subscriber.join
-        _          <- Console.printLine(s"received=${messages.map(_.payload).toList}")
-      } yield ()
+      ZIO.scoped {
+        for {
+          stream     <- client.subscribeScoped[String]("news")
+          subscriber <- stream.take(3).runCollect.fork
+          _          <- ZIO.foreachDiscard(1 to 3)(i => client.publish("news", s"item-$i"))
+          messages   <- subscriber.join
+          _          <- Console.printLine(s"received=${messages.map(_.payload).toList}")
+        } yield ()
+      }
     }
 }

--- a/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
+++ b/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
@@ -1,7 +1,5 @@
 package sage.integration
 
-import scala.concurrent.duration.*
-
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
@@ -90,14 +88,15 @@ class CeSmokeSuite extends ServerSuite(Images.redis) {
     withContainers { server =>
       val program: IO[Unit] =
         SageClient.resource(configOf(server)).use { client =>
-          for {
-            collected <- client.subscribe[String]("smoke").take(3).compile.toVector.start
-            _         <- IO.sleep(300.millis) // let SUBSCRIBE register before publishing
-            _         <- (1 to 3).toList.traverse_(i => client.publish("smoke", s"m$i"))
-            messages  <- collected.joinWithNever
-          } yield {
-            assertEquals(messages.map(_.channel).toSet, Set("smoke"))
-            assertEquals(messages.map(_.payload).toList, List("m1", "m2", "m3"))
+          client.subscribeResource[String]("smoke").use { stream =>
+            for {
+              collected <- stream.take(3).compile.toVector.start
+              _         <- (1 to 3).toList.traverse_(i => client.publish("smoke", s"m$i"))
+              messages  <- collected.joinWithNever
+            } yield {
+              assertEquals(messages.map(_.channel).toSet, Set("smoke"))
+              assertEquals(messages.map(_.payload).toList, List("m1", "m2", "m3"))
+            }
           }
         }
 

--- a/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
+++ b/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
@@ -87,13 +87,9 @@ class KyoSmokeSuite extends ServerSuite(Images.redis) {
       val program: Unit < (Scope & Abort[Throwable] & Async) =
         for {
           client    <- SageClient.scoped(configOf(server))
-          publisher <- Fiber.init {
-                         for {
-                           _ <- Async.sleep(300.millis)                                          // let SUBSCRIBE register before publishing
-                           _ <- Kyo.foreachDiscard(1 to 3)(i => client.publish("smoke", s"m$i")) // sequential: preserves order
-                         } yield ()
-                       }
-          chunk     <- client.subscribe[String]("smoke").take(3).run
+          stream    <- client.subscribeScoped[String]("smoke")
+          publisher <- Fiber.init(Kyo.foreachDiscard(1 to 3)(i => client.publish("smoke", s"m$i")))
+          chunk     <- stream.take(3).run
           _         <- publisher.get
         } yield {
           val messages = chunk.toList

--- a/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
+++ b/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
@@ -74,12 +74,12 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
     withContainers { server =>
       supervised {
         val client    = SageClient.scoped(configOf(server))
-        val collector = fork(client.subscribe[String]("smoke").take(3).runToList())
-        Thread.sleep(300) // let SUBSCRIBE register before publishing
+        val stream    = client.subscribe[String]("smoke")
+        val collector = fork(stream.take(3).runToList())
         (1 to 3).foreach { i =>
           val _ = client.publish("smoke", s"m$i")
         }
-        val messages = collector.join()
+        val messages  = collector.join()
         assertEquals(messages.map(_.channel).toSet, Set("smoke"))
         assertEquals(messages.map(_.payload), List("m1", "m2", "m3"))
       }

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
@@ -107,7 +107,6 @@ abstract class ClusterSuite(image: String, serverBinary: String) extends munit.F
             for {
               shard    <- client.subscribeShardChannels[String]("orders")
               classic  <- client.subscribeChannels[String]("news")
-              _        <- CIO.sleep(300.millis) // let both subscriptions register before publishing
               sCount   <- client.sPublish("orders", "placed")
               cCount   <- client.publish("news", "hello")
               sMsg     <- shard.next

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/PubsubSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/PubsubSuite.scala
@@ -7,14 +7,13 @@ import sage.integration.{Images, ServerSuite}
 
 abstract class PubsubSuite(image: String) extends ServerSuite(image) {
 
-  // SUBSCRIBE rides the Subscription Connection while PUBLISH rides the Multiplexed one, so let the subscription register before publishing
+  // a subscribe blocks until the server confirms it, but UNSUBSCRIBE is fire-and-forget, so let it propagate before re-checking PUBSUB
   private def settle: CIO[Unit] = CIO.blocking(Thread.sleep(300))
 
   test("PUBLISH delivers to a channel subscriber; PUBSUB introspection reflects the subscription") {
     withClient { client =>
       for {
         sub      <- client.subscribeChannels[String]("news")
-        _        <- settle
         channels <- client.pubsubChannels()
         numSub   <- client.pubsubNumSub("news")
         numPat   <- client.pubsubNumPat
@@ -38,7 +37,6 @@ abstract class PubsubSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         sub    <- client.subscribePatterns[String]("news.*")
-        _      <- settle
         numPat <- client.pubsubNumPat
         _      <- client.publish("news.sports", "goal")
         msg    <- sub.next
@@ -54,7 +52,6 @@ abstract class PubsubSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         sub      <- client.subscribeShardChannels[String]("orders")
-        _        <- settle
         channels <- client.pubsubShardChannels()
         numSub   <- client.pubsubShardNumSub("orders")
         received <- client.sPublish("orders", "placed")
@@ -73,7 +70,6 @@ abstract class PubsubSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         sub      <- client.subscribeChannels[String]("bye")
-        _        <- settle
         active   <- client.pubsubChannels()
         _        <- sub.close
         _        <- settle

--- a/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
+++ b/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
@@ -92,8 +92,8 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
         ZIO.scoped {
           for {
             client    <- SageClient.scoped(configOf(server))
-            collected <- client.subscribe[String]("smoke").take(3).runCollect.fork
-            _         <- ZIO.sleep(Duration.fromMillis(300)) // let SUBSCRIBE register before publishing
+            stream    <- client.subscribeScoped[String]("smoke")
+            collected <- stream.take(3).runCollect.fork
             _         <- ZIO.foreachDiscard(1 to 3)(i => client.publish("smoke", s"m$i"))
             messages  <- collected.join
           } yield {

--- a/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
+++ b/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
@@ -215,10 +215,32 @@ extension (client: SageClient) {
   def sSubscribe[V: ValueCodec](channel: String, rest: String*): fs2.Stream[IO, Message[V]] =
     streamOf(client.subscribeShardChannels[V](channel, rest*))
 
+  /**
+    * Like [[subscribe]], but the `Resource` allocates only once the server has confirmed the SUBSCRIBE, so a publish sequenced after the
+    * acquisition cannot race the registration. Releasing the `Resource` unsubscribes.
+    */
+  def subscribeResource[V: ValueCodec](channel: String, rest: String*): Resource[IO, fs2.Stream[IO, Message[V]]] =
+    resourceOf(client.subscribeChannels[V](channel, rest*))
+
+  /**
+    * Like [[pSubscribe]], but the `Resource` allocates only once the server has confirmed the PSUBSCRIBE. Releasing the `Resource`
+    * unsubscribes.
+    */
+  def pSubscribeResource[V: ValueCodec](pattern: String, rest: String*): Resource[IO, fs2.Stream[IO, PatternMessage[V]]] =
+    resourceOf(client.subscribePatterns[V](pattern, rest*))
+
+  /**
+    * Like [[sSubscribe]], but the `Resource` allocates only once the server has confirmed the SSUBSCRIBE. Releasing the `Resource`
+    * unsubscribes.
+    */
+  def sSubscribeResource[V: ValueCodec](channel: String, rest: String*): Resource[IO, fs2.Stream[IO, Message[V]]] =
+    resourceOf(client.subscribeShardChannels[V](channel, rest*))
+
   private def streamOf[A](open: IO[Subscription[IO, A]]): fs2.Stream[IO, A] =
-    fs2.Stream
-      .resource(Resource.make(open)(_.close.voidError))
-      .flatMap(sub => fs2.Stream.repeatEval(sub.next).unNoneTerminate)
+    fs2.Stream.resource(resourceOf(open)).flatten
+
+  private def resourceOf[A](open: IO[Subscription[IO, A]]): Resource[IO, fs2.Stream[IO, A]] =
+    Resource.make(open)(_.close.voidError).map(sub => fs2.Stream.repeatEval(sub.next).unNoneTerminate)
 }
 
 object SageClient {

--- a/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
+++ b/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
@@ -223,13 +223,49 @@ extension (client: SageClient) {
   def sSubscribe[V: ValueCodec](channel: String, rest: String*)(using Tag[Message[V]], Frame): Stream[Message[V], Abort[Throwable] & Async & Scope] =
     streamOf(client.subscribeShardChannels[V](channel, rest*))
 
+  /**
+    * Like [[subscribe]], but the returned effect settles only once the server has confirmed the SUBSCRIBE, so a publish sequenced after it
+    * cannot race the registration. Closing the enclosing `Scope` unsubscribes.
+    */
+  def subscribeScoped[V: ValueCodec](channel: String, rest: String*)(
+    using Tag[Message[V]],
+    Frame
+  ): Stream[Message[V], Abort[Throwable] & Async & Scope] < (Abort[Throwable] & Async & Scope) =
+    scopedStreamOf(client.subscribeChannels[V](channel, rest*))
+
+  /**
+    * Like [[pSubscribe]], but the returned effect settles only once the server has confirmed the PSUBSCRIBE. Closing the enclosing `Scope`
+    * unsubscribes.
+    */
+  def pSubscribeScoped[V: ValueCodec](pattern: String, rest: String*)(
+    using Tag[PatternMessage[V]],
+    Frame
+  ): Stream[PatternMessage[V], Abort[Throwable] & Async & Scope] < (Abort[Throwable] & Async & Scope) =
+    scopedStreamOf(client.subscribePatterns[V](pattern, rest*))
+
+  /**
+    * Like [[sSubscribe]], but the returned effect settles only once the server has confirmed the SSUBSCRIBE. Closing the enclosing `Scope`
+    * unsubscribes.
+    */
+  def sSubscribeScoped[V: ValueCodec](channel: String, rest: String*)(
+    using Tag[Message[V]],
+    Frame
+  ): Stream[Message[V], Abort[Throwable] & Async & Scope] < (Abort[Throwable] & Async & Scope) =
+    scopedStreamOf(client.subscribeShardChannels[V](channel, rest*))
+
   private def streamOf[A](
     open: => Subscription[KyoEff, A] < (Abort[Throwable] & Async)
   )(using Tag[A], Frame): Stream[A, Abort[Throwable] & Async & Scope] =
-    // chunkSize = 1: emit each message as it arrives — the default rechunks to 4096, withholding a live stream until that many accumulate
-    Stream
-      .init(Scope.acquireRelease(open)(_.close).map(Seq(_)))
-      .flatMap(sub => Stream.repeatPresent(sub.next.map(opt => Maybe.fromOption(opt.map(Seq(_)))), chunkSize = 1))
+    Stream.init(Scope.acquireRelease(open)(_.close).map(Seq(_))).flatMap(deliveries)
+
+  private def scopedStreamOf[A](
+    open: => Subscription[KyoEff, A] < (Abort[Throwable] & Async)
+  )(using Tag[A], Frame): Stream[A, Abort[Throwable] & Async & Scope] < (Abort[Throwable] & Async & Scope) =
+    Scope.acquireRelease(open)(_.close).map(deliveries)
+
+  // chunkSize = 1: emit each message as it arrives — the default rechunks to 4096, withholding a live stream until that many accumulate
+  private def deliveries[A](sub: Subscription[KyoEff, A])(using Tag[A], Frame): Stream[A, Abort[Throwable] & Async & Scope] =
+    Stream.repeatPresent(sub.next.map(opt => Maybe.fromOption(opt.map(Seq(_)))), chunkSize = 1)
 }
 
 object SageClient {

--- a/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
@@ -198,7 +198,8 @@ extension (client: SageClient) {
       .lower
 
   /**
-    * Subscribes to one or more channels; ending the flow unsubscribes. Survives reconnects via auto-resubscribe, dropping messages
+    * Subscribes to one or more channels, returning once the server has confirmed the SUBSCRIBE — a publish issued after this call cannot
+    * race the registration. Closing the enclosing `Ox` scope unsubscribes. Survives reconnects via auto-resubscribe, dropping messages
     * published during the reconnect gap.
     */
   def subscribe[V: ValueCodec](channel: String, rest: String*): Ox ?=> Flow[Message[V]] =
@@ -217,18 +218,18 @@ extension (client: SageClient) {
   def sSubscribe[V: ValueCodec](channel: String, rest: String*): Ox ?=> Flow[Message[V]] =
     streamOf(client.subscribeShardChannels[V](channel, rest*))
 
-  private def streamOf[A](open: => Subscription[[X] =>> Ox ?=> X, A]): Ox ?=> Flow[A] =
+  // acquire eagerly so the SUBSCRIBE is server-confirmed before this returns; bind the unsubscribe to the enclosing Ox scope
+  private def streamOf[A](open: => Subscription[[X] =>> Ox ?=> X, A]): Ox ?=> Flow[A] = {
+    val sub = useInScope(open)(_.close)
     Flow.usingEmit { emit =>
-      val sub = open
-      try {
-        var continue = true
-        while (continue)
-          sub.next match {
-            case Some(a) => emit(a)
-            case None    => continue = false
-          }
-      } finally sub.close
+      var continue = true
+      while (continue)
+        sub.next match {
+          case Some(a) => emit(a)
+          case None    => continue = false
+        }
     }
+  }
 }
 
 object SageClient {

--- a/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
@@ -1,6 +1,7 @@
 package sage.ox
 
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -198,9 +199,9 @@ extension (client: SageClient) {
       .lower
 
   /**
-    * Subscribes to one or more channels, returning once the server has confirmed the SUBSCRIBE — a publish issued after this call cannot
-    * race the registration. Closing the enclosing `Ox` scope unsubscribes. Survives reconnects via auto-resubscribe, dropping messages
-    * published during the reconnect gap.
+    * Subscribes to one or more channels, returning once the server has confirmed the SUBSCRIBE so a publish issued after this call cannot
+    * race the registration. Ending the flow unsubscribes. Survives reconnects via auto-resubscribe, dropping messages published during the
+    * reconnect gap.
     */
   def subscribe[V: ValueCodec](channel: String, rest: String*): Ox ?=> Flow[Message[V]] =
     streamOf(client.subscribeChannels[V](channel, rest*))
@@ -218,16 +219,21 @@ extension (client: SageClient) {
   def sSubscribe[V: ValueCodec](channel: String, rest: String*): Ox ?=> Flow[Message[V]] =
     streamOf(client.subscribeShardChannels[V](channel, rest*))
 
-  // acquire eagerly so the SUBSCRIBE is server-confirmed before this returns; bind the unsubscribe to the enclosing Ox scope
+  // subscribe eagerly so the SUBSCRIBE is confirmed before returning; unsubscribe once, when the flow ends or (if never run) at scope close
   private def streamOf[A](open: => Subscription[[X] =>> Ox ?=> X, A]): Ox ?=> Flow[A] = {
-    val sub = useInScope(open)(_.close)
+    val sub                 = open
+    val closed              = new AtomicBoolean(false)
+    def unsubscribe(): Unit = if (closed.compareAndSet(false, true)) sub.close
+    val _                   = useInScope(sub)(_ => unsubscribe())
     Flow.usingEmit { emit =>
-      var continue = true
-      while (continue)
-        sub.next match {
-          case Some(a) => emit(a)
-          case None    => continue = false
-        }
+      try {
+        var continue = true
+        while (continue)
+          sub.next match {
+            case Some(a) => emit(a)
+            case None    => continue = false
+          }
+      } finally unsubscribe()
     }
   }
 }

--- a/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
+++ b/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
@@ -221,15 +221,37 @@ extension (client: SageClient) {
   def sSubscribe[V: ValueCodec](channel: String, rest: String*): ZStream[Any, Throwable, Message[V]] =
     streamOf(client.subscribeShardChannels[V](channel, rest*))
 
+  /**
+    * Like [[subscribe]], but the returned effect completes only once the server has confirmed the SUBSCRIBE, so a publish sequenced after it
+    * cannot race the registration. Closing the `Scope` unsubscribes.
+    */
+  def subscribeScoped[V: ValueCodec](channel: String, rest: String*): ZIO[Scope, Throwable, ZStream[Any, Throwable, Message[V]]] =
+    scopedStreamOf(client.subscribeChannels[V](channel, rest*))
+
+  /**
+    * Like [[pSubscribe]], but the returned effect completes only once the server has confirmed the PSUBSCRIBE. Closing the `Scope`
+    * unsubscribes.
+    */
+  def pSubscribeScoped[V: ValueCodec](pattern: String, rest: String*): ZIO[Scope, Throwable, ZStream[Any, Throwable, PatternMessage[V]]] =
+    scopedStreamOf(client.subscribePatterns[V](pattern, rest*))
+
+  /**
+    * Like [[sSubscribe]], but the returned effect completes only once the server has confirmed the SSUBSCRIBE. Closing the `Scope`
+    * unsubscribes.
+    */
+  def sSubscribeScoped[V: ValueCodec](channel: String, rest: String*): ZIO[Scope, Throwable, ZStream[Any, Throwable, Message[V]]] =
+    scopedStreamOf(client.subscribeShardChannels[V](channel, rest*))
+
   private def streamOf[A](open: Task[Subscription[Task, A]]): ZStream[Any, Throwable, A] =
-    ZStream.unwrapScoped(
-      ZIO.acquireRelease(open)(_.close.ignore).map { sub =>
-        ZStream.repeatZIOOption(sub.next.mapError(Some(_)).flatMap {
-          case Some(a) => ZIO.succeed(a)
-          case None    => ZIO.fail(None)
-        })
-      }
-    )
+    ZStream.unwrapScoped(scopedStreamOf(open))
+
+  private def scopedStreamOf[A](open: Task[Subscription[Task, A]]): ZIO[Scope, Throwable, ZStream[Any, Throwable, A]] =
+    ZIO.acquireRelease(open)(_.close.ignore).map { sub =>
+      ZStream.repeatZIOOption(sub.next.mapError(Some(_)).flatMap {
+        case Some(a) => ZIO.succeed(a)
+        case None    => ZIO.fail(None)
+      })
+    }
 }
 
 object SageClient {


### PR DESCRIPTION
## Why

The plain `subscribe` returns its stream immediately and registers the subscription lazily, on the first pull. A `publish` sequenced right after it can therefore outrun the registration and be missed, forcing callers (and our examples/tests) into `sleep(300ms)` workarounds.

The underlying `subscribeChannels` already blocks until the server confirms the SUBSCRIBE (`ownedSubscription` → `attachInternal(failIfUnconfirmed = true)` → `awaitActive`). The plain `subscribe` just buries that effect inside the stream's lazy acquisition. These new variants surface it so a caller can sequence on it.

## What

New confirmed-subscription API, idiomatic per backend (3 methods each):

| Backend | Methods | Returns |
|---|---|---|
| ZIO | `subscribeScoped` / `pSubscribeScoped` / `sSubscribeScoped` | `ZIO[Scope, Throwable, ZStream[…]]` |
| cats-effect | `subscribeResource` / `pSubscribeResource` / `sSubscribeResource` | `Resource[IO, fs2.Stream[…]]` |
| Kyo | `subscribeScoped` / `pSubscribeScoped` / `sSubscribeScoped` | `Stream[…] < (Abort & Async & Scope)` |
| Ox | plain `subscribe` / `pSubscribe` / `sSubscribe` (no new method) | `Ox ?=> Flow[…]`, now **eager** |

- The effectful backends' plain `subscribe` delegates to the same helper and is unchanged; the new variant is for when you must order a `publish` after the registration.
- On Ox the acquisition is now eager (`useInScope(open)(_.close)`), with the unsubscribe bound to the enclosing `Ox` scope. Its direct-style call has no describe/run split, so there's no second method.

## Also

- Examples (zio/ce/kyo/ox `PubSubExample`, zio `ClusterExample`) and smoke suites updated to the new APIs; publish-after-subscribe sleeps removed.
- Shared low-level `PubsubSuite` and cluster `ClusterSuite`: removed the now-redundant pre-publish sleeps (subscribe already blocks until confirmed), keeping the one post-`close` sleep for the fire-and-forget UNSUBSCRIBE.
- Docs (`getting-started.md`, `pubsub.md`) rewritten, with a tip explaining when to reach for the confirmed variant vs. plain `subscribe`.

Compiles on Scala 3.3.7 (LTS) and 3.8.3; `fmt`/`check` clean.