### PR TITLE
Lift key type to the client, retain KeyCodec

### DIFF
--- a/benchmarks/ce/src/main/scala/sage/benchmarks/Clients.scala
+++ b/benchmarks/ce/src/main/scala/sage/benchmarks/Clients.scala
@@ -41,7 +41,7 @@ final class SageCeBench(host: String, port: Int) extends BenchClient {
     Payloads
       .groups(keys, concurrency)
       .toList
-      .parTraverse(_.toList.traverse(client.get[String, String]))
+      .parTraverse(_.toList.traverse(client.get[String]))
       .map(_.flatten.flatten.map(_.length.toLong).sum)
       .unsafeRunSync()
 
@@ -54,9 +54,9 @@ final class SageCeBench(host: String, port: Int) extends BenchClient {
       .unsafeRunSync()
 
   def mget(keys: Array[String]): Long =
-    client.mGet[String, String](keys.head, keys.tail*).map(_.flatten.map(_.length.toLong).sum).unsafeRunSync()
+    client.mGet[String](keys.head, keys.tail*).map(_.flatten.map(_.length.toLong).sum).unsafeRunSync()
 
-  def hgetall(key: String): Long = client.hGetAll[String, String, String](key).map(_.size.toLong).unsafeRunSync()
+  def hgetall(key: String): Long = client.hGetAll[String, String](key).map(_.size.toLong).unsafeRunSync()
 
   def close(): Unit = client.close.unsafeRunSync()
 }

--- a/benchmarks/kyo/src/main/scala/sage/benchmarks/Clients.scala
+++ b/benchmarks/kyo/src/main/scala/sage/benchmarks/Clients.scala
@@ -38,7 +38,7 @@ final class SageKyoBench(host: String, port: Int) extends BenchClient {
   def getAll(keys: Array[String], concurrency: Int): Long =
     Run(
       Async
-        .foreach(Payloads.groups(keys, concurrency).toList)(g => Kyo.foreach(g.toList)(k => client.get[String, String](k)).map(_.toList))
+        .foreach(Payloads.groups(keys, concurrency).toList)(g => Kyo.foreach(g.toList)(k => client.get[String](k)).map(_.toList))
         .map(_.toList.flatten.flatten.map(_.length.toLong).sum)
     )
 
@@ -50,9 +50,9 @@ final class SageKyoBench(host: String, port: Int) extends BenchClient {
     )
 
   def mget(keys: Array[String]): Long =
-    Run(client.mGet[String, String](keys.head, keys.tail*).map(_.flatten.map(_.length.toLong).sum))
+    Run(client.mGet[String](keys.head, keys.tail*).map(_.flatten.map(_.length.toLong).sum))
 
-  def hgetall(key: String): Long = Run(client.hGetAll[String, String, String](key).map(_.size.toLong))
+  def hgetall(key: String): Long = Run(client.hGetAll[String, String](key).map(_.size.toLong))
 
   def close(): Unit = Run(client.close)
 }

--- a/benchmarks/ox/src/main/scala/sage/benchmarks/Clients.scala
+++ b/benchmarks/ox/src/main/scala/sage/benchmarks/Clients.scala
@@ -59,7 +59,7 @@ final class SageOxBench(host: String, port: Int) extends BenchClient {
     Payloads
       .groups(keys, concurrency)
       .toList
-      .map(g => fork(g.foldLeft(0L)((t, k) => t + client.get[String, String](k).fold(0L)(_.length.toLong))))
+      .map(g => fork(g.foldLeft(0L)((t, k) => t + client.get[String](k).fold(0L)(_.length.toLong))))
       .map(_.join())
       .sum
   }
@@ -77,9 +77,9 @@ final class SageOxBench(host: String, port: Int) extends BenchClient {
       .sum
   }
 
-  def mget(keys: Array[String]): Long = supervised(client.mGet[String, String](keys.head, keys.tail*).flatten.map(_.length.toLong).sum)
+  def mget(keys: Array[String]): Long = supervised(client.mGet[String](keys.head, keys.tail*).flatten.map(_.length.toLong).sum)
 
-  def hgetall(key: String): Long = supervised(client.hGetAll[String, String, String](key).size.toLong)
+  def hgetall(key: String): Long = supervised(client.hGetAll[String, String](key).size.toLong)
 
   def close(): Unit = {
     shutdown.countDown()

--- a/benchmarks/zio/src/main/scala/sage/benchmarks/Clients.scala
+++ b/benchmarks/zio/src/main/scala/sage/benchmarks/Clients.scala
@@ -45,7 +45,7 @@ final class SageZioBench(host: String, port: Int) extends BenchClient {
   def getAll(keys: Array[String], concurrency: Int): Long =
     Run(
       ZIO
-        .foreachPar(Payloads.groups(keys, concurrency).toList)(g => ZIO.foreach(g.toList)(k => client.get[String, String](k)))
+        .foreachPar(Payloads.groups(keys, concurrency).toList)(g => ZIO.foreach(g.toList)(k => client.get[String](k)))
         .map(_.flatten.flatten.map(_.length.toLong).sum)
     )
 
@@ -57,9 +57,9 @@ final class SageZioBench(host: String, port: Int) extends BenchClient {
     )
 
   def mget(keys: Array[String]): Long =
-    Run(client.mGet[String, String](keys.head, keys.tail*).map(_.flatten.map(_.length.toLong).sum))
+    Run(client.mGet[String](keys.head, keys.tail*).map(_.flatten.map(_.length.toLong).sum))
 
-  def hgetall(key: String): Long = Run(client.hGetAll[String, String, String](key).map(_.size.toLong))
+  def hgetall(key: String): Long = Run(client.hGetAll[String, String](key).map(_.size.toLong))
 
   def close(): Unit = Run(client.close)
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,7 +10,7 @@ A `Command[Out]` is a pure description of one server command: its name, its argu
 
 ```scala [Ox]
 // per-command sugar
-val greeting = client.get[String, String]("greeting")
+val greeting = client.get[String]("greeting")
 
 // the same command, built as a value and run explicitly
 val same = client.run(Commands.get[String, String]("greeting"))
@@ -18,7 +18,7 @@ val same = client.run(Commands.get[String, String]("greeting"))
 
 ```scala [ZIO · Cats Effect · Kyo]
 for {
-  greeting <- client.get[String, String]("greeting")
+  greeting <- client.get[String]("greeting")
   // the same command, built as a value and run explicitly
   same     <- client.run(Commands.get[String, String]("greeting"))
 } yield (greeting, same)
@@ -45,12 +45,14 @@ The full surface lives on the client and on `Commands`; the API docs list every 
 
 ## Typed keys and values
 
-Keys and values are typed. The type parameters select which codec converts them to and from wire bytes:
+Keys and values are typed, and a codec converts each to and from wire bytes. The **key type is fixed on the client**: the default `SageClient` is String-keyed, so a command only ever needs the value type at the call site:
 
 ```scala
-client.set("user:1", 42)                    // value typed as Int
-val n = client.get[String, Int]("user:1")   // key String, value Int
+client.set("user:1", 42)            // value inferred as Int
+val n = client.get[Int]("user:1")   // value Int; the key is the client's String
 ```
+
+A read like `get` returns the value, so its type cannot be inferred and is named explicitly; a write infers the value from its argument and needs no type parameter.
 
 There are two separate typeclasses, by design:
 
@@ -58,6 +60,18 @@ There are two separate typeclasses, by design:
 - `ValueCodec[A]` for **payloads**.
 
 They are deliberately unrelated, which keeps `given` resolution unambiguous and lets key positions carry the cluster-slot hashing that value positions do not need.
+
+### Non-String keys
+
+Redis keys are binary-safe, so any type with a `KeyCodec` (`Int`, `Long`, raw bytes, your own newtype) is a valid key. Re-type the client with `as[K]` to work over one on the same connection, with no new connection opened:
+
+```scala
+val binary = client.as[Array[Byte]]
+binary.set(idBytes, 42)
+val n = binary.get[Int](idBytes)
+```
+
+`as[K]` returns a full client over `K`, so its whole surface follows the new key type: commands, pipelines, transactions, subscriptions, and the streaming helpers (`scanAll`, `hScanAll`, and so on). It also composes inside a transaction (`tx.as[Array[Byte]].get(k)`). The `Commands.*` builder facade used for pipelines names both type parameters explicitly (`Commands.get[K, V]`), since it is keyless on its own.
 
 ### Built-in codecs
 
@@ -108,7 +122,7 @@ With that `given` in scope, a `User` is read and written exactly like a `String`
 
 ```scala
 client.set("user:ada", User("Ada", 36))
-val ada = client.get[String, User]("user:ada") // Some(User("Ada", 36))
+val ada = client.get[User]("user:ada") // Some(User("Ada", 36))
 ```
 
 You can also build a codec from scratch with `ValueCodec.from` (or `KeyCodec.from`), supplying an encode function and a decode that returns `Either`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,7 +49,7 @@ import sage.ox.*
     )
     val client   = SageClient.scoped(config)
     client.set("greeting", "hello")
-    val greeting = client.get[String, String]("greeting")
+    val greeting = client.get[String]("greeting")
     println(s"greeting=$greeting") // Some("hello")
   }
 ```
@@ -69,7 +69,7 @@ object Main extends ZIOAppDefault {
     ZIO.serviceWithZIO[SageClient] { client =>
       for {
         _        <- client.set("greeting", "hello")
-        greeting <- client.get[String, String]("greeting")
+        greeting <- client.get[String]("greeting")
       } yield greeting
     }.provide(SageClient.layer(config))
 }
@@ -90,7 +90,7 @@ object Main extends IOApp.Simple {
     SageClient.resource(config).use { client =>
       for {
         _        <- client.set("greeting", "hello")
-        greeting <- client.get[String, String]("greeting")
+        greeting <- client.get[String]("greeting")
       } yield ()
     }
 }
@@ -112,7 +112,7 @@ object Main extends KyoApp {
       for {
         client   <- SageClient.scoped(config)
         _        <- client.set("greeting", "hello")
-        greeting <- client.get[String, String]("greeting")
+        greeting <- client.get[String]("greeting")
       } yield greeting
     }
   }
@@ -133,32 +133,32 @@ The snippets below show the same operations on each backend: pick your tab. In O
 
 ### Commands
 
-Methods are named one-for-one with Redis commands, grouped by family (strings, hashes, lists, sets, sorted sets, and so on). Keys and values are typed, with the codec selected by the type parameters. Any type with a `ValueCodec` (here, a `User`) rides over the wire the same way as a `String`.
+Methods are named one-for-one with Redis commands, grouped by family (strings, hashes, lists, sets, sorted sets, and so on). Keys and values are typed: the key type is fixed on the client (String by default), so a read only names its value type. Any type with a `ValueCodec` (here, a `User`) rides over the wire the same way as a `String`.
 
 ::: code-group
 
 ```scala [Ox]
 client.set("greeting", "hello")
-val greeting = client.get[String, String]("greeting") // Some("hello")
+val greeting = client.get[String]("greeting") // Some("hello")
 client.incrBy("counter", 10)
 
 client.hSet("user:1", ("name", "Ada"), ("age", "36"))
-val profile = client.hGetAll[String, String, String]("user:1")
+val profile = client.hGetAll[String, String]("user:1")
 // Map("name" -> "Ada", "age" -> "36")
 
 client.set("user:ada", User("Ada", 36))
-val ada = client.get[String, User]("user:ada") // Some(User("Ada", 36))
+val ada = client.get[User]("user:ada") // Some(User("Ada", 36))
 ```
 
 ```scala [ZIO · Cats Effect · Kyo]
 for {
   _        <- client.set("greeting", "hello")
-  greeting <- client.get[String, String]("greeting")
+  greeting <- client.get[String]("greeting")
   _        <- client.incrBy("counter", 10)
   _        <- client.hSet("user:1", ("name", "Ada"), ("age", "36"))
-  profile  <- client.hGetAll[String, String, String]("user:1")
+  profile  <- client.hGetAll[String, String]("user:1")
   _        <- client.set("user:ada", User("Ada", 36))
-  ada      <- client.get[String, User]("user:ada")
+  ada      <- client.get[User]("user:ada")
 } yield (greeting, profile, ada)
 ```
 
@@ -206,7 +206,7 @@ A **transaction** runs a pipeline atomically via `MULTI`/`EXEC`, optionally guar
 client.set("tx:n", 1)
 val result = client.transaction { tx =>
   tx.watch("tx:n")
-  tx.get[String, Int]("tx:n")
+  tx.get[Int]("tx:n")
   tx.exec(
     (Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)).pipeline
   )
@@ -219,7 +219,7 @@ for {
   result <- client.transaction { tx =>
               for {
                 _   <- tx.watch("tx:n")
-                _   <- tx.get[String, Int]("tx:n")
+                _   <- tx.get[Int]("tx:n")
                 res <- tx.exec(
                          (
                            Commands.incr("tx:n"),

--- a/docs/pipelines-transactions.md
+++ b/docs/pipelines-transactions.md
@@ -79,7 +79,7 @@ A transaction runs a pipeline atomically via `MULTI`/`EXEC` on a leased dedicate
 client.set("tx:n", 1)
 val result = client.transaction { tx =>
   tx.watch("tx:n")
-  tx.get[String, Int]("tx:n")
+  tx.get[Int]("tx:n")
   tx.exec(
     (Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)).pipeline
   )
@@ -93,7 +93,7 @@ for {
   result <- client.transaction { tx =>
               for {
                 _   <- tx.watch("tx:n")
-                _   <- tx.get[String, Int]("tx:n")
+                _   <- tx.get[Int]("tx:n")
                 res <- tx.exec(
                          (
                            Commands.incr("tx:n"),

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -13,7 +13,7 @@ client.del("stream:orders")
 client.xAdd("stream:orders")(("item", "book"), ("qty", "2"))
 client.xAdd("stream:orders")(("item", "pen"), ("qty", "5"))
 val len     = client.xLen("stream:orders") // 2
-val entries = client.xRange[String, String, String]("stream:orders")
+val entries = client.xRange[String, String]("stream:orders")
 // Vector(StreamEntry(id, Vector(("item","book"), ("qty","2"))), ...)
 ```
 
@@ -23,7 +23,7 @@ for {
   _       <- client.xAdd("stream:orders")(("item", "book"), ("qty", "2"))
   _       <- client.xAdd("stream:orders")(("item", "pen"), ("qty", "5"))
   len     <- client.xLen("stream:orders")
-  entries <- client.xRange[String, String, String]("stream:orders")
+  entries <- client.xRange[String, String]("stream:orders")
 } yield (len, entries)
 ```
 
@@ -44,7 +44,7 @@ client.xGroupCreate(
   "workers",
   id = GroupStartId.At(StreamId.Zero)
 )
-val batches = client.xReadGroup[String, String, String]("workers", "w1")(
+val batches = client.xReadGroup[String, String]("workers", "w1")(
   ("stream:orders", GroupReadId.New)
 )()
 val ids = batches.flatMap(_._2).map(_.id)
@@ -58,7 +58,7 @@ for {
                "workers",
                id = GroupStartId.At(StreamId.Zero)
              )
-  batches <- client.xReadGroup[String, String, String]("workers", "w1")(
+  batches <- client.xReadGroup[String, String]("workers", "w1")(
                ("stream:orders", GroupReadId.New)
              )()
   ids      = batches.flatMap(_._2).map(_.id)

--- a/examples/ce/src/main/scala/sage/examples/ce/CommandsExample.scala
+++ b/examples/ce/src/main/scala/sage/examples/ce/CommandsExample.scala
@@ -17,21 +17,21 @@ object CommandsExample {
     for {
       // strings, numbers, and a conditional write with a TTL
       _        <- client.set("greeting", "hello")
-      greeting <- client.get[String, String]("greeting")
+      greeting <- client.get[String]("greeting")
       _        <- client.incrBy("counter", 10)
       _        <- client.set("session", "token", expiry = SetExpiry.In(1.minute), condition = SetCondition.IfNotExists)
       // hashes
       _        <- client.hSet("user:1", ("name", "Ada"), ("age", "36"))
-      profile  <- client.hGetAll[String, String, String]("user:1")
+      profile  <- client.hGetAll[String, String]("user:1")
       // lists: a blocking pop off a Dedicated Connection (data is pushed first, so it returns at once)
       _        <- client.rPush("queue", "a", "b", "c")
-      head     <- client.blPop[String, String]("queue")(BlockTimeout.Forever)
+      head     <- client.blPop[String]("queue")(BlockTimeout.Forever)
       // sets and sorted sets
       _        <- client.sAdd("tags", "scala", "redis")
       _        <- client.zAdd("scores")(("ada", 36.0))
       // a custom-codec round-trip: User rides on the given ValueCodec from the shared module
       _        <- client.set("user:ada", User("Ada", 36))
-      ada      <- client.get[String, User]("user:ada")
+      ada      <- client.get[User]("user:ada")
       // a raw Lua eval yields a Frame; decode it with the strict helpers
       sum      <- client.eval("return 1 + 1")
       _        <- IO.println(s"greeting=$greeting profile=$profile head=$head ada=$ada sum=${sum.asLong}")

--- a/examples/ce/src/main/scala/sage/examples/ce/StreamsExample.scala
+++ b/examples/ce/src/main/scala/sage/examples/ce/StreamsExample.scala
@@ -17,10 +17,10 @@ object StreamsExample {
       _       <- client.xAdd("stream:orders")(("item", "book"), ("qty", "2"))
       _       <- client.xAdd("stream:orders")(("item", "pen"), ("qty", "5"))
       len     <- client.xLen("stream:orders")
-      entries <- client.xRange[String, String, String]("stream:orders")
+      entries <- client.xRange[String, String]("stream:orders")
       // a Consumer Group reading from the start of the stream
       _       <- client.xGroupCreate("stream:orders", "workers", id = GroupStartId.At(StreamId.Zero))
-      batches <- client.xReadGroup[String, String, String]("workers", "w1")(("stream:orders", GroupReadId.New))()
+      batches <- client.xReadGroup[String, String]("workers", "w1")(("stream:orders", GroupReadId.New))()
       ids      = batches.flatMap(_._2).map(_.id)
       _       <- client.xAck("stream:orders", "workers")(ids.head, ids.tail*)
       _       <- IO.println(s"len=$len read=${entries.size} acked=${ids.size}")

--- a/examples/ce/src/main/scala/sage/examples/ce/TransactionsExample.scala
+++ b/examples/ce/src/main/scala/sage/examples/ce/TransactionsExample.scala
@@ -17,7 +17,7 @@ object TransactionsExample {
       result <- client.transaction { tx =>
                   for {
                     _   <- tx.watch("tx:n")
-                    _   <- tx.get[String, Int]("tx:n")
+                    _   <- tx.get[Int]("tx:n")
                     res <- tx.exec((Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)).pipeline)
                   } yield res
                 }

--- a/examples/kyo/src/main/scala/sage/examples/kyo/CommandsExample.scala
+++ b/examples/kyo/src/main/scala/sage/examples/kyo/CommandsExample.scala
@@ -21,21 +21,21 @@ object CommandsExample {
     for {
       // strings, numbers, and a conditional write with a TTL
       _        <- client.set("greeting", "hello")
-      greeting <- client.get[String, String]("greeting")
+      greeting <- client.get[String]("greeting")
       _        <- client.incrBy("counter", 10)
       _        <- client.set("session", "token", expiry = SetExpiry.In(oneMinute), condition = SetCondition.IfNotExists)
       // hashes
       _        <- client.hSet("user:1", ("name", "Ada"), ("age", "36"))
-      profile  <- client.hGetAll[String, String, String]("user:1")
+      profile  <- client.hGetAll[String, String]("user:1")
       // lists: a blocking pop off a Dedicated Connection (data is pushed first, so it returns at once)
       _        <- client.rPush("queue", "a", "b", "c")
-      head     <- client.blPop[String, String]("queue")(BlockTimeout.Forever)
+      head     <- client.blPop[String]("queue")(BlockTimeout.Forever)
       // sets and sorted sets
       _        <- client.sAdd("tags", "scala", "redis")
       _        <- client.zAdd("scores")(("ada", 36.0))
       // a custom-codec round-trip: User rides on the given ValueCodec from the shared module
       _        <- client.set("user:ada", User("Ada", 36))
-      ada      <- client.get[String, User]("user:ada")
+      ada      <- client.get[User]("user:ada")
       // a raw Lua eval yields a Frame; decode it with the strict helpers
       sum      <- client.eval("return 1 + 1")
       _        <- Console.printLine(s"greeting=$greeting profile=$profile head=$head ada=$ada sum=${sum.asLong}")

--- a/examples/kyo/src/main/scala/sage/examples/kyo/StreamsExample.scala
+++ b/examples/kyo/src/main/scala/sage/examples/kyo/StreamsExample.scala
@@ -17,10 +17,10 @@ object StreamsExample {
       _       <- client.xAdd("stream:orders")(("item", "book"), ("qty", "2"))
       _       <- client.xAdd("stream:orders")(("item", "pen"), ("qty", "5"))
       len     <- client.xLen("stream:orders")
-      entries <- client.xRange[String, String, String]("stream:orders")
+      entries <- client.xRange[String, String]("stream:orders")
       // a Consumer Group reading from the start of the stream
       _       <- client.xGroupCreate("stream:orders", "workers", id = GroupStartId.At(StreamId.Zero))
-      batches <- client.xReadGroup[String, String, String]("workers", "w1")(("stream:orders", GroupReadId.New))()
+      batches <- client.xReadGroup[String, String]("workers", "w1")(("stream:orders", GroupReadId.New))()
       ids      = batches.flatMap(_._2).map(_.id)
       _       <- client.xAck("stream:orders", "workers")(ids.head, ids.tail*)
       _       <- Console.printLine(s"len=$len read=${entries.size} acked=${ids.size}")

--- a/examples/kyo/src/main/scala/sage/examples/kyo/TransactionsExample.scala
+++ b/examples/kyo/src/main/scala/sage/examples/kyo/TransactionsExample.scala
@@ -17,7 +17,7 @@ object TransactionsExample {
       result <- client.transaction { tx =>
                   for {
                     _   <- tx.watch("tx:n")
-                    _   <- tx.get[String, Int]("tx:n")
+                    _   <- tx.get[Int]("tx:n")
                     res <- tx.exec((Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)).pipeline)
                   } yield res
                 }

--- a/examples/ox/src/main/scala/sage/examples/ox/CommandsExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/CommandsExample.scala
@@ -16,21 +16,21 @@ object CommandsExample {
   def run(client: SageClient)(using Ox): Unit = {
     // strings, numbers, and a conditional write with a TTL
     val _        = client.set("greeting", "hello")
-    val greeting = client.get[String, String]("greeting")
+    val greeting = client.get[String]("greeting")
     val _        = client.incrBy("counter", 10)
     val _        = client.set("session", "token", expiry = SetExpiry.In(1.minute), condition = SetCondition.IfNotExists)
     // hashes
     val _        = client.hSet("user:1", ("name", "Ada"), ("age", "36"))
-    val profile  = client.hGetAll[String, String, String]("user:1")
+    val profile  = client.hGetAll[String, String]("user:1")
     // lists: a blocking pop off a Dedicated Connection (data is pushed first, so it returns at once)
     val _        = client.rPush("queue", "a", "b", "c")
-    val head     = client.blPop[String, String]("queue")(BlockTimeout.Forever)
+    val head     = client.blPop[String]("queue")(BlockTimeout.Forever)
     // sets and sorted sets
     val _        = client.sAdd("tags", "scala", "redis")
     val _        = client.zAdd("scores")(("ada", 36.0))
     // a custom-codec round-trip: User rides on the given ValueCodec from the shared module
     val _        = client.set("user:ada", User("Ada", 36))
-    val ada      = client.get[String, User]("user:ada")
+    val ada      = client.get[User]("user:ada")
     // a raw Lua eval yields a Frame; decode it with the strict helpers
     val sum      = client.eval("return 1 + 1")
     println(s"greeting=$greeting profile=$profile head=$head ada=$ada sum=${sum.asLong}")

--- a/examples/ox/src/main/scala/sage/examples/ox/MasterReplicaExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/MasterReplicaExample.scala
@@ -20,8 +20,8 @@ object MasterReplicaExample {
 
   def run(using Ox): Unit = {
     val client = SageClient.scoped(config)
-    val _      = client.set("k", "v")            // writes always go to the master
-    val value  = client.get[String, String]("k") // reads may be served by a replica, per the policy
+    val _      = client.set("k", "v")    // writes always go to the master
+    val value  = client.get[String]("k") // reads may be served by a replica, per the policy
     println(s"value=$value")
   }
 }

--- a/examples/ox/src/main/scala/sage/examples/ox/StreamsExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/StreamsExample.scala
@@ -17,11 +17,11 @@ object StreamsExample {
     val _   = client.xAdd("stream:orders")(("item", "pen"), ("qty", "5"))
     val len = client.xLen("stream:orders")
 
-    val entries = client.xRange[String, String, String]("stream:orders")
+    val entries = client.xRange[String, String]("stream:orders")
 
     // a Consumer Group reading from the start of the stream
     val _       = client.xGroupCreate("stream:orders", "workers", id = GroupStartId.At(StreamId.Zero))
-    val batches = client.xReadGroup[String, String, String]("workers", "w1")(("stream:orders", GroupReadId.New))()
+    val batches = client.xReadGroup[String, String]("workers", "w1")(("stream:orders", GroupReadId.New))()
     val ids     = batches.flatMap(_._2).map(_.id)
     val _       = client.xAck("stream:orders", "workers")(ids.head, ids.tail*)
 

--- a/examples/ox/src/main/scala/sage/examples/ox/TransactionsExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/TransactionsExample.scala
@@ -15,7 +15,7 @@ object TransactionsExample {
     val _      = client.set("tx:n", 1)
     val result = client.transaction { tx =>
       val _ = tx.watch("tx:n")
-      val _ = tx.get[String, Int]("tx:n")
+      val _ = tx.get[Int]("tx:n")
       tx.exec((Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)).pipeline)
     }
     println(s"transaction result=$result")

--- a/examples/zio/src/main/scala/sage/examples/zio/CommandsExample.scala
+++ b/examples/zio/src/main/scala/sage/examples/zio/CommandsExample.scala
@@ -23,21 +23,21 @@ object CommandsExample {
       for {
         // strings, numbers, and a conditional write with a TTL
         _        <- client.set("greeting", "hello")
-        greeting <- client.get[String, String]("greeting")
+        greeting <- client.get[String]("greeting")
         _        <- client.incrBy("counter", 10)
         _        <- client.set("session", "token", expiry = SetExpiry.In(oneMinute), condition = SetCondition.IfNotExists)
         // hashes
         _        <- client.hSet("user:1", ("name", "Ada"), ("age", "36"))
-        profile  <- client.hGetAll[String, String, String]("user:1")
+        profile  <- client.hGetAll[String, String]("user:1")
         // lists: a blocking pop off a Dedicated Connection (data is pushed first, so it returns at once)
         _        <- client.rPush("queue", "a", "b", "c")
-        head     <- client.blPop[String, String]("queue")(BlockTimeout.Forever)
+        head     <- client.blPop[String]("queue")(BlockTimeout.Forever)
         // sets and sorted sets
         _        <- client.sAdd("tags", "scala", "redis")
         _        <- client.zAdd("scores")(("ada", 36.0))
         // a custom-codec round-trip: User rides on the given ValueCodec from the shared module
         _        <- client.set("user:ada", User("Ada", 36))
-        ada      <- client.get[String, User]("user:ada")
+        ada      <- client.get[User]("user:ada")
         // a raw Lua eval yields a Frame; decode it with the strict helpers
         sum      <- client.eval("return 1 + 1")
         _        <- Console.printLine(s"greeting=$greeting profile=$profile head=$head ada=$ada sum=${sum.asLong}")

--- a/examples/zio/src/main/scala/sage/examples/zio/StreamsExample.scala
+++ b/examples/zio/src/main/scala/sage/examples/zio/StreamsExample.scala
@@ -18,10 +18,10 @@ object StreamsExample {
         _       <- client.xAdd("stream:orders")(("item", "book"), ("qty", "2"))
         _       <- client.xAdd("stream:orders")(("item", "pen"), ("qty", "5"))
         len     <- client.xLen("stream:orders")
-        entries <- client.xRange[String, String, String]("stream:orders")
+        entries <- client.xRange[String, String]("stream:orders")
         // a Consumer Group reading from the start of the stream
         _       <- client.xGroupCreate("stream:orders", "workers", id = GroupStartId.At(StreamId.Zero))
-        batches <- client.xReadGroup[String, String, String]("workers", "w1")(("stream:orders", GroupReadId.New))()
+        batches <- client.xReadGroup[String, String]("workers", "w1")(("stream:orders", GroupReadId.New))()
         ids      = batches.flatMap(_._2).map(_.id)
         _       <- client.xAck("stream:orders", "workers")(ids.head, ids.tail*)
         _       <- Console.printLine(s"len=$len read=${entries.size} acked=${ids.size}")

--- a/examples/zio/src/main/scala/sage/examples/zio/TransactionsExample.scala
+++ b/examples/zio/src/main/scala/sage/examples/zio/TransactionsExample.scala
@@ -18,7 +18,7 @@ object TransactionsExample {
         result <- client.transaction { tx =>
                     for {
                       _   <- tx.watch("tx:n")
-                      _   <- tx.get[String, Int]("tx:n")
+                      _   <- tx.get[Int]("tx:n")
                       res <- tx.exec((Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)).pipeline)
                     } yield res
                   }

--- a/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
+++ b/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
@@ -18,7 +18,7 @@ class CeSmokeSuite extends ServerSuite(Images.redis) {
           for {
             pong   <- client.ping()
             _      <- (1 to 50).toList.parTraverse_(i => client.set(s"key-$i", s"value-$i"))
-            values <- (1 to 50).toList.parTraverse(i => client.get[String, String](s"key-$i"))
+            values <- (1 to 50).toList.parTraverse(i => client.get[String](s"key-$i"))
           } yield {
             assertEquals(pong, "PONG")
             assertEquals(values, (1 to 50).toList.map(i => Some(s"value-$i")))
@@ -59,7 +59,7 @@ class CeSmokeSuite extends ServerSuite(Images.redis) {
             out <- client.transaction { tx =>
                      for {
                        _   <- tx.watch("tx:n")
-                       _   <- tx.get[String, Int]("tx:n")
+                       _   <- tx.get[Int]("tx:n")
                        res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)).pipeline)
                      } yield res
                    }
@@ -76,7 +76,7 @@ class CeSmokeSuite extends ServerSuite(Images.redis) {
         SageClient.resource(configOf(server)).use { client =>
           for {
             _    <- (1 to 50).toList.parTraverse_(i => client.set(s"scan-$i", "v"))
-            keys <- client.scanAll[String](pattern = Some("scan-*"), count = Some(10L)).compile.toVector
+            keys <- client.scanAll(pattern = Some("scan-*"), count = Some(10L)).compile.toVector
           } yield assertEquals(keys.toSet, (1 to 50).map(i => s"scan-$i").toSet)
         }
 
@@ -109,7 +109,7 @@ class CeSmokeSuite extends ServerSuite(Images.redis) {
         SageClient.resource(configOf(server)).use { client =>
           for {
             _     <- (1 to 50).toList.parTraverse_(i => client.hSet("hscan", (s"f$i", s"v$i")))
-            pairs <- client.hScanAll[String, String, String]("hscan", count = Some(10L)).compile.toVector
+            pairs <- client.hScanAll[String, String]("hscan", count = Some(10L)).compile.toVector
           } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"f$i" -> s"v$i").toMap)
         }
 
@@ -123,7 +123,7 @@ class CeSmokeSuite extends ServerSuite(Images.redis) {
         SageClient.resource(configOf(server)).use { client =>
           for {
             _       <- (1 to 50).toList.parTraverse_(i => client.sAdd("sscan", s"m$i"))
-            members <- client.sScanAll[String, String]("sscan", count = Some(10L)).compile.toVector
+            members <- client.sScanAll[String]("sscan", count = Some(10L)).compile.toVector
           } yield assertEquals(members.toSet, (1 to 50).map(i => s"m$i").toSet)
         }
 
@@ -137,7 +137,7 @@ class CeSmokeSuite extends ServerSuite(Images.redis) {
         SageClient.resource(configOf(server)).use { client =>
           for {
             _     <- (1 to 50).toList.parTraverse_(i => client.zAdd("zscan")((s"m$i", i.toDouble)))
-            pairs <- client.zScanAll[String, String]("zscan", count = Some(10L)).compile.toVector
+            pairs <- client.zScanAll[String]("zscan", count = Some(10L)).compile.toVector
           } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
         }
 

--- a/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
+++ b/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
@@ -16,7 +16,7 @@ class KyoSmokeSuite extends ServerSuite(Images.redis) {
           client <- SageClient.scoped(config)
           pong   <- client.ping()
           _      <- Async.foreachDiscard(1 to 50)(i => client.set(s"key-$i", s"value-$i"))
-          values <- Async.foreach((1 to 50).toList)(i => client.get[String, String](s"key-$i"))
+          values <- Async.foreach((1 to 50).toList)(i => client.get[String](s"key-$i"))
         } yield {
           assertEquals(pong, "PONG")
           assertEquals(values.toList, (1 to 50).toList.map(i => Some(s"value-$i")))
@@ -57,7 +57,7 @@ class KyoSmokeSuite extends ServerSuite(Images.redis) {
           out    <- client.transaction { tx =>
                       for {
                         _   <- tx.watch("tx:n")
-                        _   <- tx.get[String, Int]("tx:n")
+                        _   <- tx.get[Int]("tx:n")
                         res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)).pipeline)
                       } yield res
                     }
@@ -74,7 +74,7 @@ class KyoSmokeSuite extends ServerSuite(Images.redis) {
         for {
           client <- SageClient.scoped(configOf(server))
           _      <- Async.foreachDiscard(1 to 50)(i => client.set(s"scan-$i", "v"))
-          keys   <- client.scanAll[String](pattern = Some("scan-*"), count = Some(10L)).run
+          keys   <- client.scanAll(pattern = Some("scan-*"), count = Some(10L)).run
         } yield assertEquals(keys.toSet, (1 to 50).map(i => s"scan-$i").toSet)
 
       import AllowUnsafe.embrace.danger
@@ -107,7 +107,7 @@ class KyoSmokeSuite extends ServerSuite(Images.redis) {
         for {
           client <- SageClient.scoped(configOf(server))
           _      <- Async.foreachDiscard(1 to 50)(i => client.hSet("hscan", (s"f$i", s"v$i")))
-          pairs  <- client.hScanAll[String, String, String]("hscan", count = Some(10L)).run
+          pairs  <- client.hScanAll[String, String]("hscan", count = Some(10L)).run
         } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"f$i" -> s"v$i").toMap)
 
       import AllowUnsafe.embrace.danger
@@ -121,7 +121,7 @@ class KyoSmokeSuite extends ServerSuite(Images.redis) {
         for {
           client  <- SageClient.scoped(configOf(server))
           _       <- Async.foreachDiscard(1 to 50)(i => client.sAdd("sscan", s"m$i"))
-          members <- client.sScanAll[String, String]("sscan", count = Some(10L)).run
+          members <- client.sScanAll[String]("sscan", count = Some(10L)).run
         } yield assertEquals(members.toSet, (1 to 50).map(i => s"m$i").toSet)
 
       import AllowUnsafe.embrace.danger
@@ -135,7 +135,7 @@ class KyoSmokeSuite extends ServerSuite(Images.redis) {
         for {
           client <- SageClient.scoped(configOf(server))
           _      <- Async.foreachDiscard(1 to 50)(i => client.zAdd("zscan")((s"m$i", i.toDouble)))
-          pairs  <- client.zScanAll[String, String]("zscan", count = Some(10L)).run
+          pairs  <- client.zScanAll[String]("zscan", count = Some(10L)).run
         } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
 
       import AllowUnsafe.embrace.danger

--- a/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
+++ b/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
@@ -17,7 +17,7 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
           .map(i =>
             fork {
               val _ = client.set(s"key-$i", s"value-$i")
-              client.get[String, String](s"key-$i")
+              client.get[String](s"key-$i")
             }
           )
           .map(_.join())
@@ -49,7 +49,7 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
         val _      = client.set("tx:n", 1)
         val out    = client.transaction { tx =>
           val _ = tx.watch("tx:n")
-          val _ = tx.get[String, Int]("tx:n")
+          val _ = tx.get[Int]("tx:n")
           tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)).pipeline)
         }
         assertEquals(out, Some((2L, 6L)))
@@ -64,7 +64,7 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
         (1 to 50).foreach { i =>
           val _ = client.set(s"scan-$i", "v")
         }
-        val keys   = client.scanAll[String](pattern = Some("scan-*"), count = Some(10L)).runToList()
+        val keys   = client.scanAll(pattern = Some("scan-*"), count = Some(10L)).runToList()
         assertEquals(keys.toSet, (1 to 50).map(i => s"scan-$i").toSet)
       }
     }
@@ -92,7 +92,7 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
         (1 to 50).foreach { i =>
           val _ = client.hSet("hscan", (s"f$i", s"v$i"))
         }
-        val pairs  = client.hScanAll[String, String, String]("hscan", count = Some(10L)).runToList()
+        val pairs  = client.hScanAll[String, String]("hscan", count = Some(10L)).runToList()
         assertEquals(pairs.toMap, (1 to 50).map(i => s"f$i" -> s"v$i").toMap)
       }
     }
@@ -105,7 +105,7 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
         (1 to 50).foreach { i =>
           val _ = client.sAdd("sscan", s"m$i")
         }
-        val members = client.sScanAll[String, String]("sscan", count = Some(10L)).runToList()
+        val members = client.sScanAll[String]("sscan", count = Some(10L)).runToList()
         assertEquals(members.toSet, (1 to 50).map(i => s"m$i").toSet)
       }
     }
@@ -118,7 +118,7 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
         (1 to 50).foreach { i =>
           val _ = client.zAdd("zscan")((s"m$i", i.toDouble))
         }
-        val pairs  = client.zScanAll[String, String]("zscan", count = Some(10L)).runToList()
+        val pairs  = client.zScanAll[String]("zscan", count = Some(10L)).runToList()
         assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
       }
     }

--- a/integration-tests/shared/src/test/scala/sage/integration/ContainerClient.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/ContainerClient.scala
@@ -15,8 +15,8 @@ trait ContainerClient {
   protected def configOf(server: GenericContainer): SageConfig =
     SageConfig(topology = Topology.Standalone(Endpoint(server.host, server.mappedPort(6379))))
 
-  // CIO.acquireReleaseWith fails to compile on the Ox/Future cells when its type argument nests CIO (Client[CIO]); fold instead
-  protected def connectAndUse[A](config: SageConfig)(body: Client[CIO] => CIO[A]): CIO[A] =
+  // CIO.acquireReleaseWith fails to compile on the Ox/Future cells when its type argument nests CIO (Client[CIO, String]); fold instead
+  protected def connectAndUse[A](config: SageConfig)(body: Client[CIO, String] => CIO[A]): CIO[A] =
     Client.connect(config).flatMap { client =>
       body(client).fold(
         result => client.close.map(_ => result),

--- a/integration-tests/shared/src/test/scala/sage/integration/RoundTripSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/RoundTripSuite.scala
@@ -21,7 +21,7 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _     <- client.set("greeting", "hello")
-        value <- client.get[String, String]("greeting")
+        value <- client.get[String]("greeting")
       } yield assertEquals(value, Some("hello"))
     }
   }
@@ -31,8 +31,8 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
       for {
         _     <- client.set("count", 42)
         _     <- client.set("flag", true)
-        count <- client.get[String, Int]("count")
-        flag  <- client.get[String, Boolean]("flag")
+        count <- client.get[Int]("count")
+        flag  <- client.get[Boolean]("flag")
       } yield {
         assertEquals(count, Some(42))
         assertEquals(flag, Some(true))
@@ -41,7 +41,7 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
   }
 
   test("get of a missing key is None") {
-    withClient(client => client.get[String, String]("missing-key").map(value => assertEquals(value, None)))
+    withClient(client => client.get[String]("missing-key").map(value => assertEquals(value, None)))
   }
 
   test("concurrent fibers pipeline onto the Multiplexed Connection and match FIFO") {
@@ -50,7 +50,7 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
         .foreach(1 to 200) { i =>
           for {
             _     <- client.set(s"key-$i", s"value-$i")
-            value <- client.get[String, String](s"key-$i")
+            value <- client.get[String](s"key-$i")
           } yield assertEquals(value, Some(s"value-$i"))
         }
         .unit
@@ -58,7 +58,7 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
   }
 
   test("no reply misattribution under high fiber concurrency") {
-    def pingLoop(client: Client[CIO], fiber: Int, i: Int): CIO[Unit] =
+    def pingLoop(client: Client[CIO, String], fiber: Int, i: Int): CIO[Unit] =
       if (i > 100) CIO.value(())
       else {
         val token = s"$fiber-$i"
@@ -104,7 +104,7 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       val n = 200
       client.pipeline(Pipeline.sequence(Vector.fill(n)(Commands.incr[String]("p:rtt")))).flatMap { results =>
-        client.get[String, Int]("p:rtt").map { stored =>
+        client.get[Int]("p:rtt").map { stored =>
           assertEquals(results.length, n)
           assertEquals(results, (1 to n).map(_.toLong).toVector)
           assertEquals(stored, Some(n))
@@ -129,11 +129,11 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
         out    <- client.transaction { tx =>
                     for {
                       _   <- tx.watch("t:rmw")
-                      cur <- tx.get[String, Int]("t:rmw")
+                      cur <- tx.get[Int]("t:rmw")
                       res <- tx.exec(Pipeline.sequence(Vector(Commands.set[String, Int]("t:rmw", cur.getOrElse(0) + 1))))
                     } yield res
                   }
-        stored <- client.get[String, Int]("t:rmw")
+        stored <- client.get[Int]("t:rmw")
       } yield {
         assert(out.isDefined, s"expected a committed transaction, got $out")
         assertEquals(stored, Some(6))
@@ -150,13 +150,13 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
           out    <- client.transaction { tx =>
                       for {
                         _   <- tx.watch("t:w")
-                        _   <- tx.get[String, Int]("t:w")
+                        _   <- tx.get[Int]("t:w")
                         _   <- other.set("t:w", 99) // a different connection changes the watched key before EXEC
                         res <- tx.exec(Pipeline.sequence(Vector(Commands.incr[String]("t:w"))))
                       } yield res
                     }
           _      <- other.close
-          stored <- client.get[String, Int]("t:w")
+          stored <- client.get[Int]("t:w")
         } yield {
           assertEquals(out, None)        // aborted
           assertEquals(stored, Some(99)) // the INCR never ran
@@ -170,7 +170,7 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
       for {
         _   <- client.set("t:str", "x")
         res <- client.transaction(tx => tx.execAttempt((Commands.incr[String]("t:fresh"), Commands.incr[String]("t:str")).pipeline))
-        ok  <- client.get[String, Int]("t:fresh")
+        ok  <- client.get[Int]("t:fresh")
       } yield {
         val (a, b) = res.getOrElse(fail("expected a committed transaction"))
         assertEquals(a, Right(1L))
@@ -205,10 +205,10 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
       }
     )
 
-  private def connectionCount(client: Client[CIO]): CIO[Int] =
+  private def connectionCount(client: Client[CIO, String]): CIO[Int] =
     client.run(clientList).map(_.linesIterator.count(_.nonEmpty))
 
-  private def awaitConnectionCount(client: Client[CIO], expected: Int, attempts: Int): CIO[Unit] =
+  private def awaitConnectionCount(client: Client[CIO, String], expected: Int, attempts: Int): CIO[Unit] =
     connectionCount(client).flatMap { count =>
       if (count == expected) CIO.value(())
       else if (attempts <= 1) CIO.fail(new AssertionError(s"expected $expected connections, still $count"))

--- a/integration-tests/shared/src/test/scala/sage/integration/ServerSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/ServerSuite.scala
@@ -15,6 +15,6 @@ abstract class ServerSuite(image: String) extends munit.FunSuite with TestContai
   // not private: only the Ox cell's unsafeRun consumes it, and a private given would be flagged unused on the other cells
   given ExecutionContext = munitExecutionContext
 
-  protected def withClient[A](body: Client[CIO] => CIO[A]): Future[A] =
+  protected def withClient[A](body: Client[CIO, String] => CIO[A]): Future[A] =
     withContainers(server => connectAndUse(configOf(server))(body).unsafeRun)
 }

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
@@ -44,7 +44,7 @@ abstract class ClusterSuite(image: String, serverBinary: String) extends munit.F
     )
 
   // a single node owning every slot, announcing the host-mapped endpoint so the address it reports is reachable from the test
-  private def formSingleNodeCluster(admin0: Client[CIO], host: String, port: Int): CIO[Unit] =
+  private def formSingleNodeCluster(admin0: Client[CIO, String], host: String, port: Int): CIO[Unit] =
     for {
       _    <- admin0.run(admin("CONFIG", "SET", "cluster-announce-ip", host))
       _    <- admin0.run(admin("CONFIG", "SET", "cluster-announce-port", port.toString))
@@ -54,7 +54,7 @@ abstract class ClusterSuite(image: String, serverBinary: String) extends munit.F
       _    <- awaitClusterOk(admin0, 50)
     } yield ()
 
-  private def awaitClusterOk(admin0: Client[CIO], attempts: Int): CIO[Unit] =
+  private def awaitClusterOk(admin0: Client[CIO, String], attempts: Int): CIO[Unit] =
     admin0.run(clusterInfo).flatMap { info =>
       if (info.contains("cluster_state:ok")) CIO.value(())
       else if (attempts <= 0) CIO.fail(new RuntimeException(s"cluster did not converge: $info"))
@@ -74,7 +74,7 @@ abstract class ClusterSuite(image: String, serverBinary: String) extends munit.F
           connectAndUse(clustered) { client =>
             for {
               _      <- client.set("greeting", "hello")
-              value  <- client.get[String, String]("greeting")
+              value  <- client.get[String]("greeting")
               count  <- client.incr("counter")
               _      <- client.set("{t}a", "1")
               _      <- client.set("{t}b", "2")
@@ -136,10 +136,10 @@ abstract class ClusterSuite(image: String, serverBinary: String) extends munit.F
       val clustered  = SageConfig(topology = Topology.Cluster(Vector(Endpoint(host, port))))
       val expected   = (1 to 50).map(i => s"cscan:$i").toSet
 
-      def writeKeys(client: Client[CIO], i: Int): CIO[Unit] =
+      def writeKeys(client: Client[CIO, String], i: Int): CIO[Unit] =
         if (i > 50) CIO.value(()) else client.set(s"cscan:$i", i.toString).flatMap(_ => writeKeys(client, i + 1))
 
-      def scanNode(client: Client[CIO], target: ScanTarget, cursor: ScanCursor, found: Set[String]): CIO[Set[String]] =
+      def scanNode(client: Client[CIO, String], target: ScanTarget, cursor: ScanCursor, found: Set[String]): CIO[Set[String]] =
         client.runOn(target, Commands.scan[String](cursor, pattern = Some("cscan:*"), count = Some(10L))).flatMap { page =>
           page.next match {
             case Some(next) => scanNode(client, target, next, found ++ page.items)
@@ -147,7 +147,7 @@ abstract class ClusterSuite(image: String, serverBinary: String) extends munit.F
           }
         }
 
-      def sweep(client: Client[CIO], targets: Vector[ScanTarget], found: Set[String]): CIO[Set[String]] =
+      def sweep(client: Client[CIO, String], targets: Vector[ScanTarget], found: Set[String]): CIO[Set[String]] =
         targets match {
           case head +: tail => scanNode(client, head, ScanCursor.start, found).flatMap(sweep(client, tail, _))
           case _            => CIO.value(found)

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/ArraysSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/ArraysSuite.scala
@@ -14,8 +14,8 @@ class ArraysSuite extends ServerSuite(Images.redis) {
     withClient { client =>
       for {
         filled  <- client.arSet("ar-basic", 0L, "a", "b", "c")
-        b       <- client.arGet[String, String]("ar-basic", 1L)
-        missing <- client.arGet[String, String]("ar-basic", 99L)
+        b       <- client.arGet[String]("ar-basic", 1L)
+        missing <- client.arGet[String]("ar-basic", 99L)
         len     <- client.arLen("ar-basic")
         count   <- client.arCount("ar-basic")
       } yield {
@@ -33,8 +33,8 @@ class ArraysSuite extends ServerSuite(Images.redis) {
       for {
         _     <- client.arSet("ar-sparse", 0L, "a", "b", "c")
         _     <- client.arMSet("ar-sparse", 10L -> "x", 20L -> "y")
-        got   <- client.arMGet[String, String]("ar-sparse", 10L, 11L, 20L)
-        range <- client.arGetRange[String, String]("ar-sparse", 0L, 2L)
+        got   <- client.arMGet[String]("ar-sparse", 10L, 11L, 20L)
+        range <- client.arGetRange[String]("ar-sparse", 0L, 2L)
       } yield {
         assertEquals(got, Vector(Some("x"), None, Some("y")))
         assertEquals(range, Vector(Some("a"), Some("b"), Some("c")))
@@ -47,8 +47,8 @@ class ArraysSuite extends ServerSuite(Images.redis) {
       for {
         last  <- client.arRing("ar-ring", 3L, "a", "b", "c", "d", "e")
         len   <- client.arLen("ar-ring")
-        items <- client.arLastItems[String, String]("ar-ring", 2L)
-        rev   <- client.arLastItems[String, String]("ar-ring", 2L, rev = true)
+        items <- client.arLastItems[String]("ar-ring", 2L)
+        rev   <- client.arLastItems[String]("ar-ring", 2L, rev = true)
       } yield {
         assertEquals(last, 1L)
         assertEquals(len, 3L)
@@ -79,7 +79,7 @@ class ArraysSuite extends ServerSuite(Images.redis) {
       for {
         _    <- client.arSet("ar-scan", 0L, "a")
         _    <- client.arSet("ar-scan", 5L, "f")
-        scan <- client.arScan[String, String]("ar-scan", 0L, 10L)
+        scan <- client.arScan[String]("ar-scan", 0L, 10L)
       } yield assertEquals(scan, Vector(0L -> "a", 5L -> "f"))
     }
   }
@@ -90,7 +90,7 @@ class ArraysSuite extends ServerSuite(Images.redis) {
         _       <- client.arSet("ar-del", 0L, "a", "b", "c", "d", "e", "f", "g", "h")
         deleted <- client.arDelRange("ar-del", 0L -> 1L, 4L -> 5L)
         one     <- client.arDel("ar-del", 2L)
-        scan    <- client.arScan[String, String]("ar-del", 0L, 10L)
+        scan    <- client.arScan[String]("ar-del", 0L, 10L)
       } yield {
         assertEquals(deleted, 4L)
         assertEquals(one, 1L)
@@ -104,7 +104,7 @@ class ArraysSuite extends ServerSuite(Images.redis) {
       for {
         _       <- client.arSet("ar-grep", 0L, "apple", "banana", "apricot", "cherry")
         glob    <- client.arGrep("ar-grep", 0L, 10L)(ArMatch.Glob("ap*"))
-        withVal <- client.arGrepWithValues[String, String]("ar-grep", 0L, 10L)(ArMatch.Glob("ap*"))
+        withVal <- client.arGrepWithValues[String]("ar-grep", 0L, 10L)(ArMatch.Glob("ap*"))
         anded   <- client.arGrep("ar-grep", 0L, 10L, combine = ArGrepCombine.And)(ArMatch.Glob("a*"), ArMatch.Glob("*e"))
       } yield {
         assertEquals(glob, Vector(0L, 2L))

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/CachingSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/CachingSuite.scala
@@ -13,14 +13,14 @@ import sage.integration.{Images, ServerSuite}
 abstract class CachingSuite(image: String) extends ServerSuite(image) {
 
   // a reader (whose cache we observe) plus a writer on a separate connection, so a write is a genuine server-side change
-  private def withReaderAndWriter[A](body: (Client[CIO], Client[CIO]) => CIO[A]): Future[A] =
+  private def withReaderAndWriter[A](body: (Client[CIO, String], Client[CIO, String]) => CIO[A]): Future[A] =
     withContainers { server =>
       val config = configOf(server)
       connectAndUse(config)(reader => connectAndUse(config)(writer => body(reader, writer))).unsafeRun
     }
 
   // cached reads served locally never re-contact the server, so an external write only shows up once its invalidation push lands; poll
-  private def awaitCached(client: Client[CIO], key: String, expected: String, attempts: Int): CIO[Option[String]] =
+  private def awaitCached(client: Client[CIO, String], key: String, expected: String, attempts: Int): CIO[Option[String]] =
     client.cached(Commands.get[String, String](key), 1.minute).flatMap { value =>
       if (value.contains(expected) || attempts <= 1) CIO.value(value)
       else CIO.sleep(100.millis).flatMap(_ => awaitCached(client, key, expected, attempts - 1))

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/GeoSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/GeoSuite.scala
@@ -35,7 +35,7 @@ abstract class GeoSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _       <- client.geoAdd("Sicily2")(("Palermo", palermo), ("Catania", catania))
-        members <- client.geoSearch[String, String](
+        members <- client.geoSearch[String](
                      "Sicily2",
                      GeoOrigin.FromLonLat(GeoCoordinates(15.0, 37.0)),
                      GeoShape.ByRadius(200.0, GeoUnit.Kilometers),
@@ -79,13 +79,13 @@ abstract class GeoSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _       <- client.geoAdd("Sicily4")(("Palermo", palermo), ("Catania", catania))
-        stored  <- client.geoSearchStore[String, String](
+        stored  <- client.geoSearchStore[String](
                      "Sicily4Store",
                      "Sicily4",
                      GeoOrigin.FromLonLat(GeoCoordinates(15.0, 37.0)),
                      GeoShape.ByRadius(200.0, GeoUnit.Kilometers)
                    )
-        members <- client.geoSearch[String, String](
+        members <- client.geoSearch[String](
                      "Sicily4Store",
                      GeoOrigin.FromLonLat(GeoCoordinates(15.0, 37.0)),
                      GeoShape.ByRadius(200.0, GeoUnit.Kilometers)

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/HashesSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/HashesSuite.scala
@@ -11,8 +11,8 @@ abstract class HashesSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         added   <- client.hSet("hash-basic", ("f1", "v1"), ("f2", "v2"))
-        one     <- client.hGet[String, String, String]("hash-basic", "f1")
-        many    <- client.hmGet[String, String, String]("hash-basic", "f1", "missing", "f2")
+        one     <- client.hGet[String, String]("hash-basic", "f1")
+        many    <- client.hmGet[String, String]("hash-basic", "f1", "missing", "f2")
         present <- client.hExists("hash-basic", "f1")
         removed <- client.hDel("hash-basic", "f1", "missing")
         gone    <- client.hExists("hash-basic", "f1")
@@ -32,7 +32,7 @@ abstract class HashesSuite(image: String) extends ServerSuite(image) {
       for {
         first  <- client.hSetNx("hash-setnx", "f", "one")
         second <- client.hSetNx("hash-setnx", "f", "two")
-        value  <- client.hGet[String, String, String]("hash-setnx", "f")
+        value  <- client.hGet[String, String]("hash-setnx", "f")
       } yield {
         assertEquals(first, true)
         assertEquals(second, false)
@@ -45,9 +45,9 @@ abstract class HashesSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _      <- client.hSet("hash-view", ("a", "1"), ("b", "22"))
-        all    <- client.hGetAll[String, String, String]("hash-view")
-        keys   <- client.hKeys[String, String]("hash-view")
-        vals   <- client.hVals[String, String]("hash-view")
+        all    <- client.hGetAll[String, String]("hash-view")
+        keys   <- client.hKeys[String]("hash-view")
+        vals   <- client.hVals[String]("hash-view")
         len    <- client.hLen("hash-view")
         strLen <- client.hStrLen("hash-view", "b")
       } yield {
@@ -77,10 +77,10 @@ abstract class HashesSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _      <- client.hSet("hash-rand", ("a", "1"), ("b", "2"), ("c", "3"))
-        single <- client.hRandField[String, String]("hash-rand")
-        few    <- client.hRandField[String, String]("hash-rand", 2L)
-        pairs  <- client.hRandFieldWithValues[String, String, String]("hash-rand", -5L)
-        empty  <- client.hRandField[String, String]("hash-rand-missing")
+        single <- client.hRandField[String]("hash-rand")
+        few    <- client.hRandField[String]("hash-rand", 2L)
+        pairs  <- client.hRandFieldWithValues[String, String]("hash-rand", -5L)
+        empty  <- client.hRandField[String]("hash-rand-missing")
       } yield {
         assert(single.exists(Set("a", "b", "c")))
         assertEquals(few.size, 2)
@@ -96,8 +96,8 @@ abstract class HashesSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _         <- client.hSet("hash-scan", ("a", "1"), ("b", "2"), ("c", "3"))
-        page      <- client.hScan[String, String, String]("hash-scan", ScanCursor.start)
-        fieldPage <- client.hScanNoValues[String, String]("hash-scan", ScanCursor.start)
+        page      <- client.hScan[String, String]("hash-scan", ScanCursor.start)
+        fieldPage <- client.hScanNoValues[String]("hash-scan", ScanCursor.start)
       } yield {
         assertEquals(page.items.toMap, Map("a" -> "1", "b" -> "2", "c" -> "3"))
         assertEquals(fieldPage.items.toSet, Set("a", "b", "c"))

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/HyperLogLogSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/HyperLogLogSuite.scala
@@ -12,7 +12,7 @@ abstract class HyperLogLogSuite(image: String) extends ServerSuite(image) {
         first <- client.pfAdd("hll", "a", "b", "c")
         again <- client.pfAdd("hll", "a")
         count <- client.pfCount("hll")
-        empty <- client.pfAdd[String, String]("hll-empty")
+        empty <- client.pfAdd[String]("hll-empty")
       } yield {
         assertEquals(first, true)
         assertEquals(again, false)

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/KeysSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/KeysSuite.scala
@@ -20,7 +20,7 @@ abstract class KeysSuite(image: String) extends ServerSuite(image) {
         fresh     <- client.copy("keys-copy-src", "keys-copy-dst")
         ontoTaken <- client.copy("keys-copy-src", "keys-copy-taken")
         replaced  <- client.copy("keys-copy-src", "keys-copy-taken", replace = true)
-        copied    <- client.get[String, String]("keys-copy-dst")
+        copied    <- client.get[String]("keys-copy-dst")
       } yield {
         assertEquals(fresh, true)
         assertEquals(ontoTaken, false)
@@ -135,7 +135,7 @@ abstract class KeysSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _       <- client.mSet(("keys-glob:1", "a"), ("keys-glob:2", "b"), ("keys-other", "c"))
-        matched <- client.keys[String]("keys-glob:*")
+        matched <- client.keys("keys-glob:*")
       } yield assertEquals(matched.toSet, Set("keys-glob:1", "keys-glob:2"))
     }
   }
@@ -144,7 +144,7 @@ abstract class KeysSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _      <- client.set("keys-random", "v")
-        random <- client.randomKey[String]
+        random <- client.randomKey
       } yield assert(random.isDefined)
     }
   }
@@ -155,7 +155,7 @@ abstract class KeysSuite(image: String) extends ServerSuite(image) {
         _        <- client.set("keys-ren-a", "v")
         _        <- client.set("keys-ren-taken", "w")
         _        <- client.rename("keys-ren-a", "keys-ren-b")
-        moved    <- client.get[String, String]("keys-ren-b")
+        moved    <- client.get[String]("keys-ren-b")
         refused  <- client.renameNx("keys-ren-b", "keys-ren-taken")
         accepted <- client.renameNx("keys-ren-b", "keys-ren-c")
       } yield {
@@ -206,9 +206,9 @@ abstract class KeysSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _       <- client.rPush("keys-sort", "3", "1", "2")
-        numeric <- client.sort[String, String]("keys-sort")
-        desc    <- client.sort[String, String]("keys-sort", order = SortOrder.Desc, limit = Some(Limit(0L, 2L)))
-        alpha   <- client.sort[String, String]("keys-sort", alpha = true, order = SortOrder.Desc)
+        numeric <- client.sort[String]("keys-sort")
+        desc    <- client.sort[String]("keys-sort", order = SortOrder.Desc, limit = Some(Limit(0L, 2L)))
+        alpha   <- client.sort[String]("keys-sort", alpha = true, order = SortOrder.Desc)
       } yield {
         assertEquals(numeric, Vector(Some("1"), Some("2"), Some("3")))
         assertEquals(desc, Vector(Some("3"), Some("2")))
@@ -223,7 +223,7 @@ abstract class KeysSuite(image: String) extends ServerSuite(image) {
         _   <- client.rPush("keys-sortby", "1", "2", "3")
         _   <- client.mSet(("keys-w-1", "30"), ("keys-w-2", "10"), ("keys-w-3", "20"))
         _   <- client.mSet(("keys-d-1", "A"), ("keys-d-3", "C"))
-        got <- client.sort[String, String]("keys-sortby", by = Some("keys-w-*"), get = Vector("keys-d-*", "#"))
+        got <- client.sort[String]("keys-sortby", by = Some("keys-w-*"), get = Vector("keys-d-*", "#"))
       } yield assertEquals(got, Vector(None, Some("2"), Some("C"), Some("3"), Some("A"), Some("1")))
     }
   }
@@ -232,9 +232,9 @@ abstract class KeysSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _      <- client.rPush("keys-sortstore", "b", "a", "c")
-        ro     <- client.sortRo[String, String]("keys-sortstore", alpha = true)
+        ro     <- client.sortRo[String]("keys-sortstore", alpha = true)
         stored <- client.sortStore("keys-sortstore-dst", "keys-sortstore", alpha = true)
-        dst    <- client.lRange[String, String]("keys-sortstore-dst", 0L, -1L)
+        dst    <- client.lRange[String]("keys-sortstore-dst", 0L, -1L)
       } yield {
         assertEquals(ro, Vector(Some("a"), Some("b"), Some("c")))
         assertEquals(stored, 3L)
@@ -264,7 +264,7 @@ abstract class KeysSuite(image: String) extends ServerSuite(image) {
         _        <- client.set("keys-dump", "payload")
         dumped   <- client.dump("keys-dump")
         restored <- dumped.fold(CIO.value(()))(bytes => client.restore("keys-restore", bytes))
-        value    <- client.get[String, String]("keys-restore")
+        value    <- client.get[String]("keys-restore")
         replaced <- dumped.fold(CIO.value(false))(bytes => client.restore("keys-restore", bytes, replace = true).map(_ => true))
         missing  <- client.dump("keys-dump-missing")
       } yield {
@@ -335,13 +335,13 @@ abstract class KeysSuite(image: String) extends ServerSuite(image) {
   }
 
   private def scanAll(
-    client: Client[CIO],
+    client: Client[CIO, String],
     pattern: Option[String],
     count: Option[Long],
     ofType: Option[RedisType]
   ): CIO[Set[String]] = {
     def loop(cursor: ScanCursor, found: Set[String]): CIO[Set[String]] =
-      client.scan[String](cursor, pattern, count, ofType).flatMap { page =>
+      client.scan(cursor, pattern, count, ofType).flatMap { page =>
         val collected = found ++ page.items
         page.next match {
           case Some(next) => loop(next, collected)

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/ListsSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/ListsSuite.scala
@@ -14,9 +14,9 @@ abstract class ListsSuite(image: String) extends ServerSuite(image) {
       for {
         _      <- client.rPush("list-build", "b", "c")
         _      <- client.lPush("list-build", "a")
-        all    <- client.lRange[String, String]("list-build", 0L, -1L)
+        all    <- client.lRange[String]("list-build", 0L, -1L)
         len    <- client.lLen("list-build")
-        second <- client.lIndex[String, String]("list-build", 1L)
+        second <- client.lIndex[String]("list-build", 1L)
       } yield {
         assertEquals(all, Vector("a", "b", "c"))
         assertEquals(len, 3L)
@@ -32,7 +32,7 @@ abstract class ListsSuite(image: String) extends ServerSuite(image) {
         _       <- client.rPush("list-x", "a")
         present <- client.rPushX("list-x", "b")
         head    <- client.lPushX("list-x", "z")
-        all     <- client.lRange[String, String]("list-x", 0L, -1L)
+        all     <- client.lRange[String]("list-x", 0L, -1L)
       } yield {
         assertEquals(absent, 0L)
         assertEquals(present, 2L)
@@ -46,11 +46,11 @@ abstract class ListsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _       <- client.rPush("list-pop", "a", "b", "c", "d")
-        head    <- client.lPop[String, String]("list-pop")
-        tail    <- client.rPop[String, String]("list-pop")
-        twoHead <- client.lPopCount[String, String]("list-pop", 2L)
-        drained <- client.lPopCount[String, String]("list-pop", 2L)
-        none    <- client.lPop[String, String]("list-pop")
+        head    <- client.lPop[String]("list-pop")
+        tail    <- client.rPop[String]("list-pop")
+        twoHead <- client.lPopCount[String]("list-pop", 2L)
+        drained <- client.lPopCount[String]("list-pop", 2L)
+        none    <- client.lPop[String]("list-pop")
       } yield {
         assertEquals(head, Some("a"))
         assertEquals(tail, Some("d"))
@@ -65,8 +65,8 @@ abstract class ListsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _    <- client.rPush("list-rpopc", "a", "b", "c", "d")
-        tail <- client.rPopCount[String, String]("list-rpopc", 2L)
-        rest <- client.lRange[String, String]("list-rpopc", 0L, -1L)
+        tail <- client.rPopCount[String]("list-rpopc", 2L)
+        rest <- client.lRange[String]("list-rpopc", 0L, -1L)
       } yield {
         assertEquals(tail, Vector("d", "c"))
         assertEquals(rest, Vector("a", "b"))
@@ -83,7 +83,7 @@ abstract class ListsSuite(image: String) extends ServerSuite(image) {
         noPivot  <- client.lInsert("list-edit", InsertPosition.After, "zzz", "y")
         removed  <- client.lRem("list-edit", 0L, "b")
         _        <- client.lTrim("list-edit", 0L, 1L)
-        all      <- client.lRange[String, String]("list-edit", 0L, -1L)
+        all      <- client.lRange[String]("list-edit", 0L, -1L)
       } yield {
         assertEquals(inserted, 5L)
         assertEquals(noPivot, -1L)
@@ -114,10 +114,10 @@ abstract class ListsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _       <- client.rPush("list-src", "a", "b", "c")
-        moved   <- client.lMove[String, String]("list-src", "list-dst", ListSide.Left, ListSide.Right)
-        dst     <- client.lRange[String, String]("list-dst", 0L, -1L)
-        popped  <- client.lMpop[String, String]("list-empty", "list-src")(ListSide.Left, count = Some(2L))
-        emptyOk <- client.lMpop[String, String]("list-empty")(ListSide.Left)
+        moved   <- client.lMove[String]("list-src", "list-dst", ListSide.Left, ListSide.Right)
+        dst     <- client.lRange[String]("list-dst", 0L, -1L)
+        popped  <- client.lMpop[String]("list-empty", "list-src")(ListSide.Left, count = Some(2L))
+        emptyOk <- client.lMpop[String]("list-empty")(ListSide.Left)
       } yield {
         assertEquals(moved, Some("a"))
         assertEquals(dst, Vector("a"))
@@ -131,9 +131,9 @@ abstract class ListsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _     <- client.rPush("blpop-data", "a", "b")
-        head  <- client.blPop[String, String]("blpop-data")(BlockTimeout.After(1.second))
-        tail  <- client.brPop[String, String]("blpop-data")(BlockTimeout.After(1.second))
-        empty <- client.blPop[String, String]("blpop-empty")(BlockTimeout.After(100.millis))
+        head  <- client.blPop[String]("blpop-data")(BlockTimeout.After(1.second))
+        tail  <- client.brPop[String]("blpop-data")(BlockTimeout.After(1.second))
+        empty <- client.blPop[String]("blpop-empty")(BlockTimeout.After(100.millis))
       } yield {
         assertEquals(head, Some(("blpop-data", "a")))
         assertEquals(tail, Some(("blpop-data", "b")))
@@ -146,10 +146,10 @@ abstract class ListsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _      <- client.rPush("blmove-src", "a", "b")
-        moved  <- client.blMove[String, String]("blmove-src", "blmove-dst", ListSide.Left, ListSide.Right, BlockTimeout.After(1.second))
-        dst    <- client.lRange[String, String]("blmove-dst", 0L, -1L)
-        popped <- client.blMpop[String, String]("blmpop-empty", "blmove-src")(ListSide.Left, BlockTimeout.After(1.second), count = Some(2L))
-        none   <- client.blMpop[String, String]("blmpop-empty")(ListSide.Left, BlockTimeout.After(100.millis))
+        moved  <- client.blMove[String]("blmove-src", "blmove-dst", ListSide.Left, ListSide.Right, BlockTimeout.After(1.second))
+        dst    <- client.lRange[String]("blmove-dst", 0L, -1L)
+        popped <- client.blMpop[String]("blmpop-empty", "blmove-src")(ListSide.Left, BlockTimeout.After(1.second), count = Some(2L))
+        none   <- client.blMpop[String]("blmpop-empty")(ListSide.Left, BlockTimeout.After(100.millis))
       } yield {
         assertEquals(moved, Some("a"))
         assertEquals(dst, Vector("a"))
@@ -163,7 +163,7 @@ abstract class ListsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       CIO
         .zip(
-          client.blPop[String, String]("nonstall-queue")(BlockTimeout.After(5.seconds)),
+          client.blPop[String]("nonstall-queue")(BlockTimeout.After(5.seconds)),
           for {
             pong <- client.ping()
             _    <- client.rPush("nonstall-queue", "payload")

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/RedisHashFieldExpirySuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/RedisHashFieldExpirySuite.scala
@@ -81,8 +81,8 @@ class RedisHashFieldExpirySuite extends ServerSuite(Images.redis) {
     withClient { client =>
       for {
         _    <- client.hSet("hfe-getdel", ("a", "1"), ("b", "2"))
-        got  <- client.hGetDel[String, String, String]("hfe-getdel")("a", "missing")
-        left <- client.hGetAll[String, String, String]("hfe-getdel")
+        got  <- client.hGetDel[String, String]("hfe-getdel")("a", "missing")
+        left <- client.hGetAll[String, String]("hfe-getdel")
       } yield {
         assertEquals(got, Vector(Some("1"), None))
         assertEquals(left, Map("b" -> "2"))
@@ -94,7 +94,7 @@ class RedisHashFieldExpirySuite extends ServerSuite(Images.redis) {
     withClient { client =>
       for {
         _   <- client.hSet("hfe-getex", ("a", "1"))
-        got <- client.hGetEx[String, String, String]("hfe-getex", GetExpiry.In(100.seconds))("a")
+        got <- client.hGetEx[String, String]("hfe-getex", GetExpiry.In(100.seconds))("a")
         ttl <- client.hTtl("hfe-getex")("a")
       } yield {
         assertEquals(got, Vector(Some("1")))
@@ -112,9 +112,9 @@ class RedisHashFieldExpirySuite extends ServerSuite(Images.redis) {
         created <- client.hSetEx("hfe-setex", SetExpiry.In(100.seconds), HSetExCondition.IfNoneExist)(("a", "1"), ("b", "2"))
         ttl     <- client.hTtl("hfe-setex")("a")
         blocked <- client.hSetEx("hfe-setex", condition = HSetExCondition.IfNoneExist)(("a", "9"))
-        aStill  <- client.hGet[String, String, String]("hfe-setex", "a")
+        aStill  <- client.hGet[String, String]("hfe-setex", "a")
         updated <- client.hSetEx("hfe-setex", SetExpiry.KeepTtl, HSetExCondition.IfAllExist)(("a", "10"))
-        aNew    <- client.hGet[String, String, String]("hfe-setex", "a")
+        aNew    <- client.hGet[String, String]("hfe-setex", "a")
       } yield {
         assertEquals(created, true)
         assert(ttl(0) match {

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/RedisStreamExtrasSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/RedisStreamExtrasSuite.scala
@@ -44,7 +44,7 @@ class RedisStreamExtrasSuite extends ServerSuite(Images.redis) {
       for {
         _      <- client.xAdd("sx-ackdel", XAddId.Explicit(StreamId(1L, 0L)))(("f", "1"))
         _      <- client.xGroupCreate("sx-ackdel", "g", GroupStartId.At(StreamId(0L, 0L)))
-        _      <- client.xReadGroup[String, String, String]("g", "c1")(("sx-ackdel", GroupReadId.New))()
+        _      <- client.xReadGroup[String, String]("g", "c1")(("sx-ackdel", GroupReadId.New))()
         status <- client.xAckDel("sx-ackdel", "g")(StreamId(1L, 0L))
         len    <- client.xLen("sx-ackdel")
         pend   <- client.xPending("sx-ackdel", "g")
@@ -61,7 +61,7 @@ class RedisStreamExtrasSuite extends ServerSuite(Images.redis) {
       for {
         _        <- client.xAdd("sx-nack", XAddId.Explicit(StreamId(1L, 0L)))(("f", "1"))
         _        <- client.xGroupCreate("sx-nack", "g", GroupStartId.At(StreamId(0L, 0L)))
-        _        <- client.xReadGroup[String, String, String]("g", "c1")(("sx-nack", GroupReadId.New))()
+        _        <- client.xReadGroup[String, String]("g", "c1")(("sx-nack", GroupReadId.New))()
         released <- client.xNack("sx-nack", "g", NackMode.Fail)(StreamId(1L, 0L))()
         pend     <- client.xPending("sx-nack", "g")
       } yield {

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/RedisStringExtrasSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/RedisStringExtrasSuite.scala
@@ -34,7 +34,7 @@ class RedisStringExtrasSuite extends ServerSuite(Images.redis) {
         noMatch <- client.delex("sx-delex", DelexCondition.IfEq("other"))
         present <- client.exists("sx-delex")
         digest  <- client.digest("sx-delex")
-        notNe   <- client.delex[String, String]("sx-delex", DelexCondition.IfDigestNe(digest.get))
+        notNe   <- client.delex[String]("sx-delex", DelexCondition.IfDigestNe(digest.get))
         matched <- client.delex("sx-delex", DelexCondition.IfEq("v1"))
         gone    <- client.exists("sx-delex")
       } yield {
@@ -51,10 +51,10 @@ class RedisStringExtrasSuite extends ServerSuite(Images.redis) {
     withClient { client =>
       for {
         set     <- client.msetEx(expiry = SetExpiry.In(100.seconds))(("sx-ms-a", "1"), ("sx-ms-b", "2"))
-        a       <- client.get[String, String]("sx-ms-a")
+        a       <- client.get[String]("sx-ms-a")
         ttl     <- client.ttl("sx-ms-a")
         blocked <- client.msetEx(condition = SetCondition.IfNotExists)(("sx-ms-a", "9"))
-        aStill  <- client.get[String, String]("sx-ms-a")
+        aStill  <- client.get[String]("sx-ms-a")
       } yield {
         assertEquals(set, true)
         assertEquals(a, Some("1"))

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/ScriptingSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/ScriptingSuite.scala
@@ -16,7 +16,7 @@ abstract class ScriptingSuite(image: String) extends ServerSuite(image) {
         one   <- client.eval("return 1")
         keys  <- client.eval("return #KEYS", Seq("a", "b"))
         arg   <- client.eval("return redis.call('set', KEYS[1], ARGV[1])", Seq("eval-k"), Seq("v"))
-        value <- client.get[String, String]("eval-k")
+        value <- client.get[String]("eval-k")
       } yield {
         assertEquals(one, Frame.Integer(1L))
         assertEquals(keys, Frame.Integer(2L))

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/SetsSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/SetsSuite.scala
@@ -13,12 +13,12 @@ abstract class SetsSuite(image: String) extends ServerSuite(image) {
         added   <- client.sAdd("set-basic", "a", "b", "c")
         dup     <- client.sAdd("set-basic", "a")
         card    <- client.sCard("set-basic")
-        members <- client.sMembers[String, String]("set-basic")
+        members <- client.sMembers[String]("set-basic")
         isA     <- client.sIsMember("set-basic", "a")
         isZ     <- client.sIsMember("set-basic", "z")
         multi   <- client.sMisMember("set-basic", "a", "z", "c")
         removed <- client.sRem("set-basic", "a", "z")
-        after   <- client.sMembers[String, String]("set-basic")
+        after   <- client.sMembers[String]("set-basic")
       } yield {
         assertEquals(added, 3L)
         assertEquals(dup, 0L)
@@ -37,11 +37,11 @@ abstract class SetsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _        <- client.sAdd("set-draw", "a", "b", "c", "d")
-        popOne   <- client.sPop[String, String]("set-draw")
-        popTwo   <- client.sPopCount[String, String]("set-draw", 2L)
-        rndOne   <- client.sRandMember[String, String]("set-draw")
-        rndDup   <- client.sRandMemberCount[String, String]("set-draw", -5L)
-        emptyPop <- client.sPop[String, String]("set-missing")
+        popOne   <- client.sPop[String]("set-draw")
+        popTwo   <- client.sPopCount[String]("set-draw", 2L)
+        rndOne   <- client.sRandMember[String]("set-draw")
+        rndDup   <- client.sRandMemberCount[String]("set-draw", -5L)
+        emptyPop <- client.sPop[String]("set-missing")
       } yield {
         assert(popOne.exists(Set("a", "b", "c", "d")))
         assertEquals(popTwo.size, 2)
@@ -60,8 +60,8 @@ abstract class SetsSuite(image: String) extends ServerSuite(image) {
         _      <- client.sAdd("set-dst", "z")
         moved  <- client.sMove("set-src", "set-dst", "x")
         absent <- client.sMove("set-src", "set-dst", "nope")
-        src    <- client.sMembers[String, String]("set-src")
-        dst    <- client.sMembers[String, String]("set-dst")
+        src    <- client.sMembers[String]("set-src")
+        dst    <- client.sMembers[String]("set-dst")
       } yield {
         assertEquals(moved, true)
         assertEquals(absent, false)
@@ -76,15 +76,15 @@ abstract class SetsSuite(image: String) extends ServerSuite(image) {
       for {
         _       <- client.sAdd("ops-a", "1", "2", "3")
         _       <- client.sAdd("ops-b", "2", "3", "4")
-        diff    <- client.sDiff[String, String]("ops-a", "ops-b")
-        inter   <- client.sInter[String, String]("ops-a", "ops-b")
-        union   <- client.sUnion[String, String]("ops-a", "ops-b")
+        diff    <- client.sDiff[String]("ops-a", "ops-b")
+        inter   <- client.sInter[String]("ops-a", "ops-b")
+        union   <- client.sUnion[String]("ops-a", "ops-b")
         card    <- client.sInterCard("ops-a", "ops-b")()
         cardLim <- client.sInterCard("ops-a", "ops-b")(limit = Some(1L))
         diffN   <- client.sDiffStore("ops-diff", "ops-a", "ops-b")
         interN  <- client.sInterStore("ops-inter", "ops-a", "ops-b")
         unionN  <- client.sUnionStore("ops-union", "ops-a", "ops-b")
-        stored  <- client.sMembers[String, String]("ops-union")
+        stored  <- client.sMembers[String]("ops-union")
       } yield {
         assertEquals(diff, Set("1"))
         assertEquals(inter, Set("2", "3"))
@@ -103,7 +103,7 @@ abstract class SetsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _    <- client.sAdd("set-scan", "a", "b", "c")
-        page <- client.sScan[String, String]("set-scan", ScanCursor.start)
+        page <- client.sScan[String]("set-scan", ScanCursor.start)
       } yield assertEquals(page.items.toSet, Set("a", "b", "c"))
     }
   }

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/SortedSetsSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/SortedSetsSuite.scala
@@ -14,8 +14,8 @@ abstract class SortedSetsSuite(image: String) extends ServerSuite(image) {
       for {
         added   <- client.zAdd("zset-basic")(("a", 1.0), ("b", 2.0), ("c", 3.0))
         card    <- client.zCard("zset-basic")
-        score   <- client.zScore[String, String]("zset-basic", "b")
-        scores  <- client.zMScore[String, String]("zset-basic", "a", "missing", "c")
+        score   <- client.zScore[String]("zset-basic", "b")
+        scores  <- client.zMScore[String]("zset-basic", "a", "missing", "c")
         bumped  <- client.zIncrBy("zset-basic", "a", 1.5)
         removed <- client.zRem("zset-basic", "c", "missing")
       } yield {
@@ -52,10 +52,10 @@ abstract class SortedSetsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _         <- client.zAdd("zset-rank")(("a", 1.0), ("b", 2.0), ("c", 3.0))
-        rank      <- client.zRank[String, String]("zset-rank", "b")
-        rev       <- client.zRevRank[String, String]("zset-rank", "b")
-        withScore <- client.zRankWithScore[String, String]("zset-rank", "c")
-        missing   <- client.zRank[String, String]("zset-rank", "z")
+        rank      <- client.zRank[String]("zset-rank", "b")
+        rev       <- client.zRevRank[String]("zset-rank", "b")
+        withScore <- client.zRankWithScore[String]("zset-rank", "c")
+        missing   <- client.zRank[String]("zset-rank", "z")
       } yield {
         assertEquals(rank, Some(1L))
         assertEquals(rev, Some(1L))
@@ -69,14 +69,14 @@ abstract class SortedSetsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _          <- client.zAdd("zset-range")(("a", 1.0), ("b", 2.0), ("c", 3.0))
-        byRank     <- client.zRange[String, String]("zset-range", ZRange.ByRank(0L, -1L))
-        revRank    <- client.zRange[String, String]("zset-range", ZRange.ByRank(0L, -1L, rev = true))
-        byScore    <- client.zRange[String, String]("zset-range", ZRange.ByScore(ScoreBoundary.Inclusive(2.0), ScoreBoundary.PosInf))
+        byRank     <- client.zRange[String]("zset-range", ZRange.ByRank(0L, -1L))
+        revRank    <- client.zRange[String]("zset-range", ZRange.ByRank(0L, -1L, rev = true))
+        byScore    <- client.zRange[String]("zset-range", ZRange.ByScore(ScoreBoundary.Inclusive(2.0), ScoreBoundary.PosInf))
         revScore   <-
-          client.zRange[String, String]("zset-range", ZRange.ByScore(ScoreBoundary.Inclusive(1.0), ScoreBoundary.Inclusive(2.0), rev = true))
-        withScores <- client.zRangeWithScores[String, String]("zset-range", ZRange.ByRank(0L, 1L))
+          client.zRange[String]("zset-range", ZRange.ByScore(ScoreBoundary.Inclusive(1.0), ScoreBoundary.Inclusive(2.0), rev = true))
+        withScores <- client.zRangeWithScores[String]("zset-range", ZRange.ByRank(0L, 1L))
         limited    <-
-          client.zRange[String, String]("zset-range", ZRange.ByScore(ScoreBoundary.NegInf, ScoreBoundary.PosInf, limit = Some(Limit(1L, 1L))))
+          client.zRange[String]("zset-range", ZRange.ByScore(ScoreBoundary.NegInf, ScoreBoundary.PosInf, limit = Some(Limit(1L, 1L))))
       } yield {
         assertEquals(byRank, Vector("a", "b", "c"))
         assertEquals(revRank, Vector("c", "b", "a"))
@@ -92,9 +92,9 @@ abstract class SortedSetsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _     <- client.zAdd("zset-lex")(("a", 0.0), ("b", 0.0), ("c", 0.0))
-        all   <- client.zRange[String, String]("zset-lex", ZRange.ByLex(LexBoundary.Min, LexBoundary.Max))
-        range <- client.zRange[String, String]("zset-lex", ZRange.ByLex(LexBoundary.Inclusive("a"), LexBoundary.Exclusive("c")))
-        count <- client.zLexCount[String, String]("zset-lex", LexBoundary.Min, LexBoundary.Max)
+        all   <- client.zRange[String]("zset-lex", ZRange.ByLex(LexBoundary.Min, LexBoundary.Max))
+        range <- client.zRange[String]("zset-lex", ZRange.ByLex(LexBoundary.Inclusive("a"), LexBoundary.Exclusive("c")))
+        count <- client.zLexCount[String]("zset-lex", LexBoundary.Min, LexBoundary.Max)
       } yield {
         assertEquals(all, Vector("a", "b", "c"))
         assertEquals(range, Vector("a", "b"))
@@ -107,8 +107,8 @@ abstract class SortedSetsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _      <- client.zAdd("zrs-src")(("a", 1.0), ("b", 2.0), ("c", 3.0))
-        n      <- client.zRangeStore[String, String]("zrs-dst", "zrs-src", ZRange.ByScore(ScoreBoundary.Inclusive(2.0), ScoreBoundary.PosInf))
-        stored <- client.zRange[String, String]("zrs-dst", ZRange.ByRank(0L, -1L))
+        n      <- client.zRangeStore[String]("zrs-dst", "zrs-src", ZRange.ByScore(ScoreBoundary.Inclusive(2.0), ScoreBoundary.PosInf))
+        stored <- client.zRange[String]("zrs-dst", ZRange.ByRank(0L, -1L))
       } yield {
         assertEquals(n, 2L)
         assertEquals(stored, Vector("b", "c"))
@@ -133,12 +133,12 @@ abstract class SortedSetsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _       <- client.zAdd("zset-pop")(("a", 1.0), ("b", 2.0), ("c", 3.0), ("d", 4.0))
-        min     <- client.zPopMin[String, String]("zset-pop")
-        max     <- client.zPopMax[String, String]("zset-pop")
-        twoMin  <- client.zPopMinCount[String, String]("zset-pop", 2L)
-        emptied <- client.zPopMin[String, String]("zset-pop")
+        min     <- client.zPopMin[String]("zset-pop")
+        max     <- client.zPopMax[String]("zset-pop")
+        twoMin  <- client.zPopMinCount[String]("zset-pop", 2L)
+        emptied <- client.zPopMin[String]("zset-pop")
         _       <- client.zAdd("zset-mpop")(("x", 1.0), ("y", 2.0))
-        mpopped <- client.zMpop[String, String]("zset-empty", "zset-mpop")(MinMax.Min, count = Some(2L))
+        mpopped <- client.zMpop[String]("zset-empty", "zset-mpop")(MinMax.Min, count = Some(2L))
       } yield {
         assertEquals(min, Some(("a", 1.0)))
         assertEquals(max, Some(("d", 4.0)))
@@ -153,9 +153,9 @@ abstract class SortedSetsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _      <- client.zAdd("bz-data")(("a", 1.0), ("b", 2.0))
-        popped <- client.bzPopMin[String, String]("bz-data")(BlockTimeout.After(1.second))
-        mpop   <- client.bzMpop[String, String]("bz-empty", "bz-data")(MinMax.Max, BlockTimeout.After(1.second))
-        none   <- client.bzPopMin[String, String]("bz-missing")(BlockTimeout.After(100.millis))
+        popped <- client.bzPopMin[String]("bz-data")(BlockTimeout.After(1.second))
+        mpop   <- client.bzMpop[String]("bz-empty", "bz-data")(MinMax.Max, BlockTimeout.After(1.second))
+        none   <- client.bzPopMin[String]("bz-missing")(BlockTimeout.After(100.millis))
       } yield {
         assertEquals(popped, Some(("bz-data", "a", 1.0)))
         assertEquals(mpop, Some(("bz-data", Vector("b" -> 2.0))))
@@ -168,9 +168,9 @@ abstract class SortedSetsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _      <- client.zAdd("zset-rand")(("a", 1.0), ("b", 2.0), ("c", 3.0))
-        one    <- client.zRandMember[String, String]("zset-rand")
-        dup    <- client.zRandMemberCount[String, String]("zset-rand", -5L)
-        scored <- client.zRandMemberWithScores[String, String]("zset-rand", 3L)
+        one    <- client.zRandMember[String]("zset-rand")
+        dup    <- client.zRandMemberCount[String]("zset-rand", -5L)
+        scored <- client.zRandMemberWithScores[String]("zset-rand", 3L)
       } yield {
         assert(one.exists(Set("a", "b", "c")))
         assertEquals(dup.size, 5)
@@ -184,11 +184,11 @@ abstract class SortedSetsSuite(image: String) extends ServerSuite(image) {
       for {
         _        <- client.zAdd("zops-a")(("x", 1.0), ("y", 2.0))
         _        <- client.zAdd("zops-b")(("y", 3.0), ("z", 4.0))
-        union    <- client.zUnionWithScores[String, String]("zops-a", "zops-b")()
-        weighted <- client.zUnionWithScores[String, String]("zops-a", "zops-b")(weights = Some(Vector(1.0, 2.0)))
-        maxAgg   <- client.zUnionWithScores[String, String]("zops-a", "zops-b")(aggregate = Aggregate.Max)
-        inter    <- client.zInter[String, String]("zops-a", "zops-b")()
-        diff     <- client.zDiff[String, String]("zops-a", "zops-b")
+        union    <- client.zUnionWithScores[String]("zops-a", "zops-b")()
+        weighted <- client.zUnionWithScores[String]("zops-a", "zops-b")(weights = Some(Vector(1.0, 2.0)))
+        maxAgg   <- client.zUnionWithScores[String]("zops-a", "zops-b")(aggregate = Aggregate.Max)
+        inter    <- client.zInter[String]("zops-a", "zops-b")()
+        diff     <- client.zDiff[String]("zops-a", "zops-b")
         card     <- client.zInterCard("zops-a", "zops-b")()
         unionN   <- client.zUnionStore("zops-union", "zops-a", "zops-b")()
         interN   <- client.zInterStore("zops-inter", "zops-a", "zops-b")()
@@ -215,7 +215,7 @@ abstract class SortedSetsSuite(image: String) extends ServerSuite(image) {
         _       <- client.zAdd("zrem-score")(("a", 1.0), ("b", 2.0), ("c", 3.0))
         byScore <- client.zRemRangeByScore("zrem-score", ScoreBoundary.Inclusive(2.0), ScoreBoundary.PosInf)
         _       <- client.zAdd("zrem-lex")(("a", 0.0), ("b", 0.0), ("c", 0.0))
-        byLex   <- client.zRemRangeByLex[String, String]("zrem-lex", LexBoundary.Inclusive("a"), LexBoundary.Inclusive("b"))
+        byLex   <- client.zRemRangeByLex[String]("zrem-lex", LexBoundary.Inclusive("a"), LexBoundary.Inclusive("b"))
       } yield {
         assertEquals(byRank, 1L)
         assertEquals(byScore, 2L)
@@ -228,7 +228,7 @@ abstract class SortedSetsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _    <- client.zAdd("zset-scan")(("a", 1.0), ("b", 2.0), ("c", 3.0))
-        page <- client.zScan[String, String]("zset-scan", ScanCursor.start)
+        page <- client.zScan[String]("zset-scan", ScanCursor.start)
       } yield assertEquals(page.items.toMap, Map("a" -> 1.0, "b" -> 2.0, "c" -> 3.0))
     }
   }
@@ -238,10 +238,10 @@ abstract class SortedSetsSuite(image: String) extends ServerSuite(image) {
       for {
         _       <- client.zAdd("zgap-a")(("x", 1.0), ("y", 2.0))
         _       <- client.zAdd("zgap-b")(("y", 3.0), ("z", 4.0))
-        union   <- client.zUnion[String, String]("zgap-a", "zgap-b")()
-        inter   <- client.zInterWithScores[String, String]("zgap-a", "zgap-b")()
-        diff    <- client.zDiffWithScores[String, String]("zgap-a", "zgap-b")
-        revRank <- client.zRevRankWithScore[String, String]("zgap-a", "x")
+        union   <- client.zUnion[String]("zgap-a", "zgap-b")()
+        inter   <- client.zInterWithScores[String]("zgap-a", "zgap-b")()
+        diff    <- client.zDiffWithScores[String]("zgap-a", "zgap-b")
+        revRank <- client.zRevRankWithScore[String]("zgap-a", "x")
       } yield {
         assertEquals(union.toSet, Set("x", "y", "z"))
         assertEquals(inter, Vector("y" -> 5.0))
@@ -255,10 +255,10 @@ abstract class SortedSetsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _      <- client.zAdd("zgap-pop")(("a", 1.0), ("b", 2.0), ("c", 3.0))
-        topTwo <- client.zPopMaxCount[String, String]("zgap-pop", 2L)
+        topTwo <- client.zPopMaxCount[String]("zgap-pop", 2L)
         _      <- client.zAdd("zgap-bz")(("a", 1.0), ("b", 2.0))
-        bzMax  <- client.bzPopMax[String, String]("zgap-bz")(BlockTimeout.After(1.second))
-        none   <- client.bzPopMax[String, String]("zgap-bz-missing")(BlockTimeout.After(100.millis))
+        bzMax  <- client.bzPopMax[String]("zgap-bz")(BlockTimeout.After(1.second))
+        none   <- client.bzPopMax[String]("zgap-bz-missing")(BlockTimeout.After(100.millis))
       } yield {
         assertEquals(topTwo, Vector("c" -> 3.0, "b" -> 2.0))
         assertEquals(bzMax, Some(("zgap-bz", "b", 2.0)))

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/StreamsSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/StreamsSuite.scala
@@ -15,9 +15,9 @@ abstract class StreamsSuite(image: String) extends ServerSuite(image) {
         id1 <- client.xAdd("s-range", XAddId.Explicit(StreamId(1L, 0L)))(("a", "1"), ("b", "2"))
         id2 <- client.xAdd("s-range", XAddId.Explicit(StreamId(2L, 0L)))(("c", "3"))
         len <- client.xLen("s-range")
-        all <- client.xRange[String, String, String]("s-range")
-        rev <- client.xRevRange[String, String, String]("s-range")
-        one <- client.xRange[String, String, String]("s-range", StreamRangeId.Exclusive(StreamId(1L, 0L)))
+        all <- client.xRange[String, String]("s-range")
+        rev <- client.xRevRange[String, String]("s-range")
+        one <- client.xRange[String, String]("s-range", StreamRangeId.Exclusive(StreamId(1L, 0L)))
       } yield {
         assertEquals(id1, StreamId(1L, 0L))
         assertEquals(id2, StreamId(2L, 0L))
@@ -66,7 +66,7 @@ abstract class StreamsSuite(image: String) extends ServerSuite(image) {
       for {
         _    <- client.xAdd("s-info", XAddId.Explicit(StreamId(1L, 0L)))(("f", "v"))
         _    <- client.xAdd("s-info", XAddId.Explicit(StreamId(5L, 0L)))(("g", "w"))
-        info <- client.xInfoStream[String, String, String]("s-info")
+        info <- client.xInfoStream[String, String]("s-info")
       } yield {
         assertEquals(info.length, 2L)
         assertEquals(info.lastGeneratedId, StreamId(5L, 0L))
@@ -81,7 +81,7 @@ abstract class StreamsSuite(image: String) extends ServerSuite(image) {
         _       <- client.xAdd("s-grp", XAddId.Explicit(StreamId(1L, 0L)))(("f", "1"))
         _       <- client.xAdd("s-grp", XAddId.Explicit(StreamId(2L, 0L)))(("f", "2"))
         _       <- client.xGroupCreate("s-grp", "g", GroupStartId.At(StreamId(0L, 0L)))
-        read    <- client.xReadGroup[String, String, String]("g", "c1")(("s-grp", GroupReadId.New))(count = Some(10L))
+        read    <- client.xReadGroup[String, String]("g", "c1")(("s-grp", GroupReadId.New))(count = Some(10L))
         pending <- client.xPending("s-grp", "g")
         acked   <- client.xAck("s-grp", "g")(StreamId(1L, 0L), StreamId(2L, 0L))
         drained <- client.xPending("s-grp", "g")
@@ -104,9 +104,9 @@ abstract class StreamsSuite(image: String) extends ServerSuite(image) {
       for {
         _       <- client.xAdd("s-claim", XAddId.Explicit(StreamId(1L, 0L)))(("f", "1"))
         _       <- client.xGroupCreate("s-claim", "g", GroupStartId.At(StreamId(0L, 0L)))
-        _       <- client.xReadGroup[String, String, String]("g", "c1")(("s-claim", GroupReadId.New))()
-        claimed <- client.xClaim[String, String, String]("s-claim", "g", "c2", Duration.Zero)(StreamId(1L, 0L))()
-        auto    <- client.xAutoClaim[String, String, String]("s-claim", "g", "c3", Duration.Zero)
+        _       <- client.xReadGroup[String, String]("g", "c1")(("s-claim", GroupReadId.New))()
+        claimed <- client.xClaim[String, String]("s-claim", "g", "c2", Duration.Zero)(StreamId(1L, 0L))()
+        auto    <- client.xAutoClaim[String, String]("s-claim", "g", "c3", Duration.Zero)
         owners  <- client.xPendingExtended("s-claim", "g")
       } yield {
         assertEquals(claimed, Vector(StreamEntry(StreamId(1L, 0L), Vector("f" -> "1"))))
@@ -126,7 +126,7 @@ abstract class StreamsSuite(image: String) extends ServerSuite(image) {
         delPel    <- client.xGroupDelConsumer("s-mgmt", "g", "c1")
         _         <- client.xGroupSetId("s-mgmt", "g", GroupStartId.At(StreamId(1L, 0L)))
         _         <- client.xSetId("s-mgmt", GroupStartId.At(StreamId(5L, 0L)))
-        info      <- client.xInfoStream[String, String, String]("s-mgmt")
+        info      <- client.xInfoStream[String, String]("s-mgmt")
         destroyed <- client.xGroupDestroy("s-mgmt", "g")
         groups    <- client.xInfoGroups("s-mgmt")
       } yield {
@@ -146,7 +146,7 @@ abstract class StreamsSuite(image: String) extends ServerSuite(image) {
         _       <- client.xAdd("s-justid", XAddId.Explicit(StreamId(1L, 0L)))(("f", "1"))
         _       <- client.xAdd("s-justid", XAddId.Explicit(StreamId(2L, 0L)))(("f", "2"))
         _       <- client.xGroupCreate("s-justid", "g", GroupStartId.At(StreamId(0L, 0L)))
-        _       <- client.xReadGroup[String, String, String]("g", "c1")(("s-justid", GroupReadId.New))()
+        _       <- client.xReadGroup[String, String]("g", "c1")(("s-justid", GroupReadId.New))()
         claimed <- client.xClaimJustId("s-justid", "g", "c2", Duration.Zero)(StreamId(1L, 0L))()
         auto    <- client.xAutoClaimJustId("s-justid", "g", "c3", Duration.Zero)
       } yield {
@@ -161,8 +161,8 @@ abstract class StreamsSuite(image: String) extends ServerSuite(image) {
       for {
         _    <- client.xAdd("s-full", XAddId.Explicit(StreamId(1L, 0L)))(("f", "1"))
         _    <- client.xGroupCreate("s-full", "g", GroupStartId.At(StreamId(0L, 0L)))
-        _    <- client.xReadGroup[String, String, String]("g", "c1")(("s-full", GroupReadId.New))()
-        full <- client.xInfoStreamFull[String, String, String]("s-full")
+        _    <- client.xReadGroup[String, String]("g", "c1")(("s-full", GroupReadId.New))()
+        full <- client.xInfoStreamFull[String, String]("s-full")
       } yield {
         assertEquals(full.length, 1L)
         assertEquals(full.groups.map(_.name), Vector("g"))
@@ -178,7 +178,7 @@ abstract class StreamsSuite(image: String) extends ServerSuite(image) {
       for {
         _   <- client.xAdd("s-block", XAddId.Explicit(StreamId(1L, 0L)))(("f", "0"))
         out <- CIO.zip(
-                 client.xRead[String, String, String](("s-block", ReadId.After(StreamId(1L, 0L))))(block = Some(BlockTimeout.After(5.seconds))),
+                 client.xRead[String, String](("s-block", ReadId.After(StreamId(1L, 0L))))(block = Some(BlockTimeout.After(5.seconds))),
                  for {
                    pong <- client.ping()
                    _    <- client.xAdd("s-block", XAddId.Explicit(StreamId(2L, 0L)))(("f", "1"))

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/StringsSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/StringsSuite.scala
@@ -16,7 +16,7 @@ abstract class StringsSuite(image: String) extends ServerSuite(image) {
       for {
         _      <- client.set("str-append", "abc")
         length <- client.append("str-append", "def")
-        value  <- client.get[String, String]("str-append")
+        value  <- client.get[String]("str-append")
       } yield {
         assertEquals(length, 6L)
         assertEquals(value, Some("abcdef"))
@@ -54,9 +54,9 @@ abstract class StringsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _       <- client.set("str-getdel", "gone")
-        value   <- client.getDel[String, String]("str-getdel")
-        after   <- client.get[String, String]("str-getdel")
-        missing <- client.getDel[String, String]("str-getdel-missing")
+        value   <- client.getDel[String]("str-getdel")
+        after   <- client.get[String]("str-getdel")
+        missing <- client.getDel[String]("str-getdel-missing")
       } yield {
         assertEquals(value, Some("gone"))
         assertEquals(after, None)
@@ -69,11 +69,11 @@ abstract class StringsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _         <- client.set("str-getex", "v")
-        value     <- client.getEx[String, String]("str-getex", GetExpiry.In(60.seconds))
+        value     <- client.getEx[String]("str-getex", GetExpiry.In(60.seconds))
         withTtl   <- client.ttl("str-getex")
-        kept      <- client.getEx[String, String]("str-getex")
+        kept      <- client.getEx[String]("str-getex")
         stillTtl  <- client.ttl("str-getex")
-        persisted <- client.getEx[String, String]("str-getex", GetExpiry.Persist)
+        persisted <- client.getEx[String]("str-getex", GetExpiry.Persist)
         noTtl     <- client.ttl("str-getex")
       } yield {
         assertEquals(value, Some("v"))
@@ -90,9 +90,9 @@ abstract class StringsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _      <- client.set("str-range", "Hello World")
-        head   <- client.getRange[String, String]("str-range", 0L, 4L)
+        head   <- client.getRange[String]("str-range", 0L, 4L)
         length <- client.setRange("str-range", 6L, "Redis")
-        value  <- client.get[String, String]("str-range")
+        value  <- client.get[String]("str-range")
         len    <- client.strLen("str-range")
       } yield {
         assertEquals(head, "Hello")
@@ -107,7 +107,7 @@ abstract class StringsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _      <- client.mSet(("str-mget-a", "1"), ("str-mget-b", "2"))
-        values <- client.mGet[String, String]("str-mget-a", "str-mget-missing", "str-mget-b")
+        values <- client.mGet[String]("str-mget-a", "str-mget-missing", "str-mget-b")
       } yield assertEquals(values, Vector(Some("1"), None, Some("2")))
     }
   }
@@ -117,7 +117,7 @@ abstract class StringsSuite(image: String) extends ServerSuite(image) {
       for {
         first  <- client.mSetNx(("str-msetnx-a", "1"), ("str-msetnx-b", "2"))
         second <- client.mSetNx(("str-msetnx-b", "x"), ("str-msetnx-c", "3"))
-        c      <- client.get[String, String]("str-msetnx-c")
+        c      <- client.get[String]("str-msetnx-c")
       } yield {
         assertEquals(first, true)
         assertEquals(second, false)
@@ -133,7 +133,7 @@ abstract class StringsSuite(image: String) extends ServerSuite(image) {
         duplicate <- client.set("str-cond", "two", condition = SetCondition.IfNotExists)
         updated   <- client.set("str-cond", "three", condition = SetCondition.IfExists)
         ghost     <- client.set("str-cond-missing", "x", condition = SetCondition.IfExists)
-        value     <- client.get[String, String]("str-cond")
+        value     <- client.get[String]("str-cond")
       } yield {
         assertEquals(created, true)
         assertEquals(duplicate, false)
@@ -147,9 +147,9 @@ abstract class StringsSuite(image: String) extends ServerSuite(image) {
   test("setGet returns the previous value") {
     withClient { client =>
       for {
-        before <- client.setGet[String, String]("str-setget", "one")
-        after  <- client.setGet[String, String]("str-setget", "two")
-        value  <- client.get[String, String]("str-setget")
+        before <- client.setGet[String]("str-setget", "one")
+        after  <- client.setGet[String]("str-setget", "two")
+        value  <- client.get[String]("str-setget")
       } yield {
         assertEquals(before, None)
         assertEquals(after, Some("one"))
@@ -189,7 +189,7 @@ abstract class StringsSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _        <- client.mSet(("str-lcs-1", "ohmytext"), ("str-lcs-2", "mynewtext"))
-        sequence <- client.lcs[String, String]("str-lcs-1", "str-lcs-2")
+        sequence <- client.lcs[String]("str-lcs-1", "str-lcs-2")
         length   <- client.lcsLen("str-lcs-1", "str-lcs-2")
         idx      <- client.lcsIdx("str-lcs-1", "str-lcs-2", minMatchLen = Some(4L), withMatchLen = true)
       } yield {

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/ValkeyServerExtrasSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/ValkeyServerExtrasSuite.scala
@@ -15,7 +15,7 @@ class ValkeyServerExtrasSuite extends ServerSuite(Images.valkey) {
       for {
         _      <- client.configSet(("slowlog-log-slower-than", "0"))
         _      <- client.commandLogReset(CommandLogType.Slow)
-        _      <- client.get[String, String]("cl-probe")
+        _      <- client.get[String]("cl-probe")
         len    <- client.commandLogLen(CommandLogType.Slow)
         recent <- client.commandLogGet(5L, CommandLogType.Slow)
         _      <- client.configSet(("slowlog-log-slower-than", "10000"))

--- a/integration-tests/shared/src/test/scala/sage/integration/security/TlsAuthSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/security/TlsAuthSuite.scala
@@ -93,7 +93,7 @@ abstract class TlsAuthSuite(image: String) extends munit.FunSuite with TestConta
       connectAndUse(configWith(server, TrustSource.Pem(caPath))) { client =>
         for {
           _     <- client.set("tls:key", "value")
-          value <- client.get[String, String]("tls:key")
+          value <- client.get[String]("tls:key")
         } yield value
       }.unsafeRun.map(value => assertEquals(value, Some("value")))
     }

--- a/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
+++ b/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
@@ -17,7 +17,7 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
             client <- SageClient.scoped(config)
             pong   <- client.ping()
             _      <- ZIO.foreachParDiscard(1 to 50)(i => client.set(s"key-$i", s"value-$i"))
-            values <- ZIO.foreachPar((1 to 50).toList)(i => client.get[String, String](s"key-$i"))
+            values <- ZIO.foreachPar((1 to 50).toList)(i => client.get[String](s"key-$i"))
           } yield {
             assertEquals(pong, "PONG")
             assertEquals(values, (1 to 50).toList.map(i => Some(s"value-$i")))
@@ -60,7 +60,7 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
             out    <- client.transaction { tx =>
                         for {
                           _   <- tx.watch("tx:n")
-                          _   <- tx.get[String, Int]("tx:n")
+                          _   <- tx.get[Int]("tx:n")
                           res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)).pipeline)
                         } yield res
                       }
@@ -78,7 +78,7 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
           for {
             client <- SageClient.scoped(configOf(server))
             _      <- ZIO.foreachParDiscard(1 to 50)(i => client.set(s"scan-$i", "v"))
-            keys   <- client.scanAll[String](pattern = Some("scan-*"), count = Some(10L)).runCollect
+            keys   <- client.scanAll(pattern = Some("scan-*"), count = Some(10L)).runCollect
           } yield assertEquals(keys.toSet, (1 to 50).map(i => s"scan-$i").toSet)
         }
 
@@ -112,7 +112,7 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
           for {
             client <- SageClient.scoped(configOf(server))
             _      <- ZIO.foreachParDiscard(1 to 50)(i => client.hSet("hscan", (s"f$i", s"v$i")))
-            pairs  <- client.hScanAll[String, String, String]("hscan", count = Some(10L)).runCollect
+            pairs  <- client.hScanAll[String, String]("hscan", count = Some(10L)).runCollect
           } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"f$i" -> s"v$i").toMap)
         }
 
@@ -127,7 +127,7 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
           for {
             client  <- SageClient.scoped(configOf(server))
             _       <- ZIO.foreachParDiscard(1 to 50)(i => client.sAdd("sscan", s"m$i"))
-            members <- client.sScanAll[String, String]("sscan", count = Some(10L)).runCollect
+            members <- client.sScanAll[String]("sscan", count = Some(10L)).runCollect
           } yield assertEquals(members.toSet, (1 to 50).map(i => s"m$i").toSet)
         }
 
@@ -142,7 +142,7 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
           for {
             client <- SageClient.scoped(configOf(server))
             _      <- ZIO.foreachParDiscard(1 to 50)(i => client.zAdd("zscan")((s"m$i", i.toDouble)))
-            pairs  <- client.zScanAll[String, String]("zscan", count = Some(10L)).runCollect
+            pairs  <- client.zScanAll[String]("zscan", count = Some(10L)).runCollect
           } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
         }
 
@@ -157,7 +157,7 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
           for {
             client  <- SageClient.scoped(configOf(server))
             _       <- ZIO.foreachDiscard(1 to 50)(i => client.xAdd("xrangeall", XAddId.Explicit(StreamId(i.toLong, 0L)))(("f", s"v$i")))
-            entries <- client.xRangeAll[String, String, String]("xrangeall", batch = 10L).runCollect
+            entries <- client.xRangeAll[String, String]("xrangeall", batch = 10L).runCollect
           } yield assertEquals(entries.map(_.id).toList, (1 to 50).map(i => StreamId(i.toLong, 0L)).toList)
         }
 
@@ -175,7 +175,7 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
             _      <- client.xGroupCreate("xconsume", "g", GroupStartId.At(StreamId(0L, 0L)))
             seen   <- Ref.make(Vector.empty[String])
             fiber  <- client
-                        .xConsume[String, String, String](
+                        .xConsume[String, String](
                           "g",
                           "c",
                           "xconsume",

--- a/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
+++ b/sage-client/ce/src/main/scala/sage/ce/SageClient.scala
@@ -2,6 +2,7 @@ package sage.ce
 
 import java.util.concurrent.TimeUnit
 
+import scala.annotation.unused
 import scala.concurrent.duration.FiniteDuration
 
 import cats.effect.{IO, Resource}
@@ -16,15 +17,15 @@ import sage.commands.*
 /**
   * The cats-effect-native surface: the same client, with every method returning `IO`.
   */
-type SageClient = Client[IO]
+type SageClient = Client[IO, String]
 
-extension (client: SageClient) {
+extension [K](client: Client[IO, K])(using @unused ev: KeyCodec[K]) {
 
   /**
     * The full SCAN iteration: stops on the server's zero cursor, never on an empty page. SCAN may return a key more than once. In cluster
     * mode it walks every slot-owning master in turn, each with its own node-local cursor, so the sweep covers the whole keyspace.
     */
-  def scanAll[K: KeyCodec](
+  def scanAll(
     pattern: Option[String] = None,
     count: Option[Long] = None,
     ofType: Option[RedisType] = None
@@ -34,7 +35,7 @@ extension (client: SageClient) {
   /**
     * The full HSCAN iteration over field/value pairs: stops on the server's zero cursor, never on an empty page.
     */
-  def hScanAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def hScanAll[F: KeyCodec, V: ValueCodec](
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
@@ -44,7 +45,7 @@ extension (client: SageClient) {
   /**
     * The full SSCAN iteration over set members: stops on the server's zero cursor, never on an empty page.
     */
-  def sScanAll[K: KeyCodec, V: ValueCodec](
+  def sScanAll[V: ValueCodec](
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
@@ -54,7 +55,7 @@ extension (client: SageClient) {
   /**
     * The full ZSCAN iteration over member/score pairs: stops on the server's zero cursor, never on an empty page.
     */
-  def zScanAll[K: KeyCodec, V: ValueCodec](
+  def zScanAll[V: ValueCodec](
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
@@ -93,7 +94,7 @@ extension (client: SageClient) {
   /**
     * Lazily pages an entire stream by range, batching `XRANGE` and advancing past the last id each page. Stops when a page comes back empty.
     */
-  def xRangeAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def xRangeAll[F: KeyCodec, V: ValueCodec](
     key: K,
     start: StreamRangeId = StreamRangeId.Min,
     end: StreamRangeId = StreamRangeId.Max,
@@ -116,7 +117,7 @@ extension (client: SageClient) {
     * entries — claimed ids whose data was already deleted, which the decoder surfaces with no fields — are skipped, so every emitted entry
     * carries data.
     */
-  def xAutoClaimAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def xAutoClaimAll[F: KeyCodec, V: ValueCodec](
     key: K,
     group: String,
     consumer: String,
@@ -140,7 +141,7 @@ extension (client: SageClient) {
     * last id each round. Blocking on an explicit id (never `$`) leaves no gap for entries arriving mid-loop. No acknowledgement, unlike
     * [[xConsume]]. `from` defaults to the start; pass a later id to tail from there.
     */
-  def xTail[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def xTail[F: KeyCodec, V: ValueCodec](
     key: K,
     from: StreamId = StreamId.Zero,
     count: Option[Long] = None,
@@ -161,19 +162,19 @@ extension (client: SageClient) {
     * entries forever. `handle` runs per entry; the entry is acknowledged only after `handle` succeeds, so a failure leaves it in the PEL for
     * recovery.
     */
-  def xConsume[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def xConsume[F: KeyCodec, V: ValueCodec](
     group: String,
     consumer: String,
     key: K,
     count: Option[Long] = None,
     block: BlockTimeout = SageClient.defaultPoll
   )(handle: StreamEntry[F, V] => IO[Unit]): IO[Unit] =
-    consumeStream[K, F, V](group, consumer, key, count, block)
+    consumeStream[F, V](group, consumer, key, count, block)
       .evalMap(entry => handle(entry) >> client.run(Streams.xAck(key, group)(entry.id)).void)
       .compile
       .drain
 
-  private def consumeStream[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  private def consumeStream[F: KeyCodec, V: ValueCodec](
     group: String,
     consumer: String,
     key: K,
@@ -245,6 +246,12 @@ extension (client: SageClient) {
 
 object SageClient {
 
+  /**
+    * A command surface re-typed to a non-String key, as returned by `client.as[K]`. The unqualified [[SageClient]] is String-keyed;
+    * use `as` to reach any other key type over the same connection.
+    */
+  type Keyed[K] = Client[IO, K]
+
   // bounded poll so xConsume's blocking read returns periodically, keeping cancellation responsive
   private[ce] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, TimeUnit.SECONDS))
 
@@ -254,7 +261,7 @@ object SageClient {
   def resource(config: SageConfig): Resource[IO, SageClient] =
     Resource.make(connect(config))(_.close.voidError)
 
-  final private class Lowered(underlying: Client[CIO]) extends LoweredClient[IO](underlying) {
+  final private class Lowered(underlying: Client[CIO, String]) extends LoweredClient[IO](underlying) {
     protected def lower[A](c: CIO[A]): IO[A] = c.lower
     protected def lift[A](fa: IO[A]): CIO[A] = CIO.lift(fa)
   }

--- a/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
+++ b/sage-client/kyo/src/main/scala/sage/kyo/SageClient.scala
@@ -1,5 +1,6 @@
 package sage.kyo
 
+import scala.annotation.unused
 import scala.concurrent.duration.FiniteDuration
 
 import _root_.kyo.{<, Abort, Async, Duration, Frame, Maybe, Scope, Stream, Tag}
@@ -15,11 +16,11 @@ import sage.commands.*
 /**
   * The Kyo-native surface: the same client, with every method returning a Kyo pending computation.
   */
-type SageClient = Client[[A] =>> A < (Abort[Throwable] & Async)]
+type SageClient = Client[[A] =>> A < (Abort[Throwable] & Async), String]
 
 private type KyoEff[A] = A < (Abort[Throwable] & Async)
 
-extension (client: SageClient) {
+extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @unused ev: KeyCodec[K]) {
 
   /**
     * Runs a read with client-side caching and a Kyo `Duration` TTL — the Kyo-native form of [[sage.client.internal.Client.cached]].
@@ -31,7 +32,7 @@ extension (client: SageClient) {
     * The full SCAN iteration: stops on the server's zero cursor, never on an empty page. SCAN may return a key more than once. In cluster
     * mode it walks every slot-owning master in turn, each with its own node-local cursor, so the sweep covers the whole keyspace.
     */
-  def scanAll[K: KeyCodec](
+  def scanAll(
     pattern: Option[String] = None,
     count: Option[Long] = None,
     ofType: Option[RedisType] = None
@@ -41,7 +42,7 @@ extension (client: SageClient) {
   /**
     * The full HSCAN iteration over field/value pairs: stops on the server's zero cursor, never on an empty page.
     */
-  def hScanAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def hScanAll[F: KeyCodec, V: ValueCodec](
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
@@ -51,7 +52,7 @@ extension (client: SageClient) {
   /**
     * The full SSCAN iteration over set members: stops on the server's zero cursor, never on an empty page.
     */
-  def sScanAll[K: KeyCodec, V: ValueCodec](
+  def sScanAll[V: ValueCodec](
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
@@ -61,7 +62,7 @@ extension (client: SageClient) {
   /**
     * The full ZSCAN iteration over member/score pairs: stops on the server's zero cursor, never on an empty page.
     */
-  def zScanAll[K: KeyCodec, V: ValueCodec](
+  def zScanAll[V: ValueCodec](
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
@@ -100,7 +101,7 @@ extension (client: SageClient) {
   /**
     * Lazily pages an entire stream by range, batching `XRANGE` and advancing past the last id each page. Stops when a page comes back empty.
     */
-  def xRangeAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def xRangeAll[F: KeyCodec, V: ValueCodec](
     key: K,
     start: StreamRangeId = StreamRangeId.Min,
     end: StreamRangeId = StreamRangeId.Max,
@@ -123,7 +124,7 @@ extension (client: SageClient) {
     * entries — claimed ids whose data was already deleted, which the decoder surfaces with no fields — are skipped, so every emitted entry
     * carries data.
     */
-  def xAutoClaimAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def xAutoClaimAll[F: KeyCodec, V: ValueCodec](
     key: K,
     group: String,
     consumer: String,
@@ -147,7 +148,7 @@ extension (client: SageClient) {
     * last id each round. Blocking on an explicit id (never `$`) leaves no gap for entries arriving mid-loop. No acknowledgement, unlike
     * [[xConsume]]. `from` defaults to the start; pass a later id to tail from there.
     */
-  def xTail[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def xTail[F: KeyCodec, V: ValueCodec](
     key: K,
     from: StreamId = StreamId.Zero,
     count: Option[Long] = None,
@@ -168,17 +169,17 @@ extension (client: SageClient) {
     * entries forever. `handle` runs per entry; the entry is acknowledged only after `handle` succeeds, so a failure leaves it in the PEL for
     * recovery.
     */
-  def xConsume[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def xConsume[F: KeyCodec, V: ValueCodec](
     group: String,
     consumer: String,
     key: K,
     count: Option[Long] = None,
     block: BlockTimeout = SageClient.defaultPoll
   )(handle: StreamEntry[F, V] => KyoEff[Unit])(using Tag[F], Tag[V], Frame): KyoEff[Unit] =
-    consumeStream[K, F, V](group, consumer, key, count, block)
+    consumeStream[F, V](group, consumer, key, count, block)
       .foreach(entry => handle(entry).flatMap(_ => client.run(Streams.xAck(key, group)(entry.id)).map(_ => ())))
 
-  private def consumeStream[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  private def consumeStream[F: KeyCodec, V: ValueCodec](
     group: String,
     consumer: String,
     key: K,
@@ -270,6 +271,12 @@ extension (client: SageClient) {
 
 object SageClient {
 
+  /**
+    * A command surface re-typed to a non-String key, as returned by `client.as[K]`. The unqualified [[SageClient]] is String-keyed;
+    * use `as` to reach any other key type over the same connection.
+    */
+  type Keyed[K] = Client[[A] =>> A < (Abort[Throwable] & Async), K]
+
   // bounded poll so xConsume's blocking read returns periodically, keeping cancellation responsive
   private[kyo] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, java.util.concurrent.TimeUnit.SECONDS))
 
@@ -279,7 +286,7 @@ object SageClient {
   def scoped(config: SageConfig): SageClient < (Scope & Abort[Throwable] & Async) =
     Scope.acquireRelease(connect(config))(client => Abort.run(client.close))
 
-  final private class Lowered(underlying: Client[CIO]) extends LoweredClient[[A] =>> A < (Abort[Throwable] & Async)](underlying) {
+  final private class Lowered(underlying: Client[CIO, String]) extends LoweredClient[[A] =>> A < (Abort[Throwable] & Async)](underlying) {
     protected def lower[A](c: CIO[A]): A < (Abort[Throwable] & Async) = c.lower
     protected def lift[A](fa: A < (Abort[Throwable] & Async)): CIO[A] = CIO.lift(fa)
   }

--- a/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/ox/SageClient.scala
@@ -3,6 +3,7 @@ package sage.ox
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
+import scala.annotation.unused
 import scala.concurrent.duration.FiniteDuration
 
 import _root_.ox.{useInScope, Ox}
@@ -18,15 +19,15 @@ import sage.commands.*
 /**
   * The Ox-native surface: direct style, every method usable inside an Ox scope.
   */
-type SageClient = Client[[A] =>> Ox ?=> A]
+type SageClient = Client[[A] =>> Ox ?=> A, String]
 
-extension (client: SageClient) {
+extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]) {
 
   /**
     * The full SCAN iteration: stops on the server's zero cursor, never on an empty page. SCAN may return a key more than once. In cluster
     * mode it walks every slot-owning master in turn, each with its own node-local cursor, so the sweep covers the whole keyspace.
     */
-  def scanAll[K: KeyCodec](
+  def scanAll(
     pattern: Option[String] = None,
     count: Option[Long] = None,
     ofType: Option[RedisType] = None
@@ -36,7 +37,7 @@ extension (client: SageClient) {
   /**
     * The full HSCAN iteration over field/value pairs: stops on the server's zero cursor, never on an empty page.
     */
-  def hScanAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def hScanAll[F: KeyCodec, V: ValueCodec](
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
@@ -46,7 +47,7 @@ extension (client: SageClient) {
   /**
     * The full SSCAN iteration over set members: stops on the server's zero cursor, never on an empty page.
     */
-  def sScanAll[K: KeyCodec, V: ValueCodec](
+  def sScanAll[V: ValueCodec](
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
@@ -56,7 +57,7 @@ extension (client: SageClient) {
   /**
     * The full ZSCAN iteration over member/score pairs: stops on the server's zero cursor, never on an empty page.
     */
-  def zScanAll[K: KeyCodec, V: ValueCodec](
+  def zScanAll[V: ValueCodec](
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
@@ -95,7 +96,7 @@ extension (client: SageClient) {
   /**
     * Lazily pages an entire stream by range, batching `XRANGE` and advancing past the last id each page. Stops when a page comes back empty.
     */
-  def xRangeAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def xRangeAll[F: KeyCodec, V: ValueCodec](
     key: K,
     start: StreamRangeId = StreamRangeId.Min,
     end: StreamRangeId = StreamRangeId.Max,
@@ -118,7 +119,7 @@ extension (client: SageClient) {
     * entries — claimed ids whose data was already deleted, which the decoder surfaces with no fields — are skipped, so every emitted entry
     * carries data.
     */
-  def xAutoClaimAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def xAutoClaimAll[F: KeyCodec, V: ValueCodec](
     key: K,
     group: String,
     consumer: String,
@@ -142,7 +143,7 @@ extension (client: SageClient) {
     * last id each round. Blocking on an explicit id (never `$`) leaves no gap for entries arriving mid-loop. No acknowledgement, unlike
     * [[xConsume]]. `from` defaults to the start; pass a later id to tail from there.
     */
-  def xTail[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def xTail[F: KeyCodec, V: ValueCodec](
     key: K,
     from: StreamId = StreamId.Zero,
     count: Option[Long] = None,
@@ -163,20 +164,20 @@ extension (client: SageClient) {
     * entries forever. `handle` runs per entry; the entry is acknowledged only after `handle` succeeds, so a failure leaves it in the PEL for
     * recovery.
     */
-  def xConsume[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def xConsume[F: KeyCodec, V: ValueCodec](
     group: String,
     consumer: String,
     key: K,
     count: Option[Long] = None,
     block: BlockTimeout = SageClient.defaultPoll
   )(handle: StreamEntry[F, V] => (Ox ?=> Unit)): Ox ?=> Unit =
-    consumeStream[K, F, V](group, consumer, key, count, block).runForeach { entry =>
+    consumeStream[F, V](group, consumer, key, count, block).runForeach { entry =>
       handle(entry)
       client.run(Streams.xAck(key, group)(entry.id))
       ()
     }
 
-  private def consumeStream[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  private def consumeStream[F: KeyCodec, V: ValueCodec](
     group: String,
     consumer: String,
     key: K,
@@ -240,6 +241,12 @@ extension (client: SageClient) {
 
 object SageClient {
 
+  /**
+    * A command surface re-typed to a non-String key, as returned by `client.as[K]`. The unqualified [[SageClient]] is String-keyed;
+    * use `as` to reach any other key type over the same connection.
+    */
+  type Keyed[K] = Client[[A] =>> Ox ?=> A, K]
+
   // bounded poll so xConsume's blocking read returns periodically, keeping cancellation responsive
   private[ox] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, TimeUnit.SECONDS))
 
@@ -252,7 +259,7 @@ object SageClient {
       catch { case _: Throwable => () }
     }
 
-  final private class Lowered(underlying: Client[CIO]) extends LoweredClient[[X] =>> Ox ?=> X](underlying) {
+  final private class Lowered(underlying: Client[CIO, String]) extends LoweredClient[[X] =>> Ox ?=> X](underlying) {
     protected def lower[A](c: CIO[A]): Ox ?=> A = c.lower
     protected def lift[A](fa: Ox ?=> A): CIO[A] = CIO.lift(fa)
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -23,12 +23,25 @@ import sage.protocol.Frame
   * The command surface shared by [[Client]] and [[TransactionScope]]: every command as a concrete method delegating to [[run]], so anything
   * implementing `run` — a fake, or a backend adapter lowering `F` to its native effect — gets the whole catalogue.
   */
-trait CommandRunner[F[_]] {
+trait CommandRunner[F[_], K](using KeyCodec[K]) {
 
   /**
     * Runs a [[sage.commands.Command]] and returns its decoded result. Every method on this trait is sugar over this one call.
     */
   def run[A](command: Command[A]): F[A]
+
+  /**
+    * Re-types this command surface to another key type, reusing the same connection — no new connection is opened. The runner is
+    * key-agnostic (keys are encoded to bytes in the command builders before `run`), so this is a zero-cost view: `client.as[Array[Byte]]`
+    * yields a command surface over binary keys, and it composes inside a transaction too (`tx.as[Array[Byte]].get(k)`).
+    * [[Client]] and [[TransactionScope]] override this with a narrower return so the re-typed view keeps their full surface.
+    */
+  def as[K2](using KeyCodec[K2]): CommandRunner[F, K2] = {
+    val self = this
+    new CommandRunner[F, K2] {
+      def run[A](command: Command[A]): F[A] = self.run(command)
+    }
+  }
 
   /**
     * Pings the server, returning `PONG` or the echoed `message` when one is given.
@@ -38,73 +51,73 @@ trait CommandRunner[F[_]] {
   /**
     * Appends `value` to the string at `key`, returning the new length.
     */
-  final def append[K: KeyCodec, V: ValueCodec](key: K, value: V): F[Long] = run(Strings.append(key, value))
+  final def append[V: ValueCodec](key: K, value: V): F[Long] = run(Strings.append(key, value))
 
   /**
     * Decrements the integer at `key` by one, returning the new value.
     */
-  final def decr[K: KeyCodec](key: K): F[Long] = run(Strings.decr(key))
+  final def decr(key: K): F[Long] = run(Strings.decr(key))
 
   /**
     * Decrements the integer at `key` by `decrement`, returning the new value.
     */
-  final def decrBy[K: KeyCodec](key: K, decrement: Long): F[Long] = run(Strings.decrBy(key, decrement))
+  final def decrBy(key: K, decrement: Long): F[Long] = run(Strings.decrBy(key, decrement))
 
   /**
     * Gets the value at `key`, or `None` if it does not exist.
     */
-  final def get[K: KeyCodec, V: ValueCodec](key: K): F[Option[V]] = run(Strings.get(key))
+  final def get[V: ValueCodec](key: K): F[Option[V]] = run(Strings.get(key))
 
   /**
     * Gets the value at `key` and deletes it atomically, returning the value (or `None`).
     */
-  final def getDel[K: KeyCodec, V: ValueCodec](key: K): F[Option[V]] = run(Strings.getDel(key))
+  final def getDel[V: ValueCodec](key: K): F[Option[V]] = run(Strings.getDel(key))
 
   /**
     * Gets the value at `key`, optionally updating its expiry per `expiry`.
     */
-  final def getEx[K: KeyCodec, V: ValueCodec](key: K, expiry: GetExpiry = GetExpiry.Keep): F[Option[V]] =
+  final def getEx[V: ValueCodec](key: K, expiry: GetExpiry = GetExpiry.Keep): F[Option[V]] =
     run(Strings.getEx(key, expiry))
 
   /**
     * Returns the substring of the value at `key` between `start` and `end`, inclusive; negative indices count from the end.
     */
-  final def getRange[K: KeyCodec, V: ValueCodec](key: K, start: Long, end: Long): F[V] = run(Strings.getRange(key, start, end))
+  final def getRange[V: ValueCodec](key: K, start: Long, end: Long): F[V] = run(Strings.getRange(key, start, end))
 
   /**
     * Increments the integer at `key` by one, returning the new value.
     */
-  final def incr[K: KeyCodec](key: K): F[Long] = run(Strings.incr(key))
+  final def incr(key: K): F[Long] = run(Strings.incr(key))
 
   /**
     * Increments the integer at `key` by `increment`, returning the new value.
     */
-  final def incrBy[K: KeyCodec](key: K, increment: Long): F[Long] = run(Strings.incrBy(key, increment))
+  final def incrBy(key: K, increment: Long): F[Long] = run(Strings.incrBy(key, increment))
 
   /**
     * Increments the floating-point value at `key` by `increment`, returning the new value.
     */
-  final def incrByFloat[K: KeyCodec](key: K, increment: Double): F[Double] = run(Strings.incrByFloat(key, increment))
+  final def incrByFloat(key: K, increment: Double): F[Double] = run(Strings.incrByFloat(key, increment))
 
   /**
     * Gets the values at several keys in request order, each `None` if that key is absent.
     */
-  final def mGet[K: KeyCodec, V: ValueCodec](first: K, rest: K*): F[Vector[Option[V]]] = run(Strings.mGet(first, rest*))
+  final def mGet[V: ValueCodec](first: K, rest: K*): F[Vector[Option[V]]] = run(Strings.mGet(first, rest*))
 
   /**
     * Sets several key/value pairs atomically.
     */
-  final def mSet[K: KeyCodec, V: ValueCodec](first: (K, V), rest: (K, V)*): F[Unit] = run(Strings.mSet(first, rest*))
+  final def mSet[V: ValueCodec](first: (K, V), rest: (K, V)*): F[Unit] = run(Strings.mSet(first, rest*))
 
   /**
     * Sets several key/value pairs only if none of the keys already exist, returning whether it applied.
     */
-  final def mSetNx[K: KeyCodec, V: ValueCodec](first: (K, V), rest: (K, V)*): F[Boolean] = run(Strings.mSetNx(first, rest*))
+  final def mSetNx[V: ValueCodec](first: (K, V), rest: (K, V)*): F[Boolean] = run(Strings.mSetNx(first, rest*))
 
   /**
     * Sets `key` to `value` with optional `expiry` and a set `condition`, returning whether the write was applied.
     */
-  final def set[K: KeyCodec, V: ValueCodec](
+  final def set[V: ValueCodec](
     key: K,
     value: V,
     expiry: SetExpiry = SetExpiry.Clear,
@@ -114,7 +127,7 @@ trait CommandRunner[F[_]] {
   /**
     * Like [[set]], but returns the previous value (`SET … GET`).
     */
-  final def setGet[K: KeyCodec, V: ValueCodec](
+  final def setGet[V: ValueCodec](
     key: K,
     value: V,
     expiry: SetExpiry = SetExpiry.Clear,
@@ -124,44 +137,44 @@ trait CommandRunner[F[_]] {
   /**
     * Overwrites part of the string at `key` starting at `offset`, zero-padding if needed, returning the new length.
     */
-  final def setRange[K: KeyCodec, V: ValueCodec](key: K, offset: Long, value: V): F[Long] = run(Strings.setRange(key, offset, value))
+  final def setRange[V: ValueCodec](key: K, offset: Long, value: V): F[Long] = run(Strings.setRange(key, offset, value))
 
   /**
     * Returns the length of the string at `key`, or 0 if it is absent.
     */
-  final def strLen[K: KeyCodec](key: K): F[Long] = run(Strings.strLen(key))
+  final def strLen(key: K): F[Long] = run(Strings.strLen(key))
 
   /**
     * Returns the longest common subsequence of the strings at `key1` and `key2`.
     */
-  final def lcs[K: KeyCodec, V: ValueCodec](key1: K, key2: K): F[V] = run(Strings.lcs(key1, key2))
+  final def lcs[V: ValueCodec](key1: K, key2: K): F[V] = run(Strings.lcs(key1, key2))
 
   /**
     * Returns the length of the longest common subsequence of the strings at `key1` and `key2`.
     */
-  final def lcsLen[K: KeyCodec](key1: K, key2: K): F[Long] = run(Strings.lcsLen(key1, key2))
+  final def lcsLen(key1: K, key2: K): F[Long] = run(Strings.lcsLen(key1, key2))
 
   /**
     * Returns the matched ranges of the longest common subsequence; see [[sage.commands.LcsMatches]].
     */
-  final def lcsIdx[K: KeyCodec](key1: K, key2: K, minMatchLen: Option[Long] = None, withMatchLen: Boolean = false): F[LcsMatches] =
+  final def lcsIdx(key1: K, key2: K, minMatchLen: Option[Long] = None, withMatchLen: Boolean = false): F[LcsMatches] =
     run(Strings.lcsIdx(key1, key2, minMatchLen, withMatchLen))
 
   /**
     * Returns a digest of the value at `key` (Valkey `DIGEST`), or `None` if the key is absent.
     */
-  final def digest[K: KeyCodec](key: K): F[Option[String]] = run(Strings.digest(key))
+  final def digest(key: K): F[Option[String]] = run(Strings.digest(key))
 
   /**
     * Deletes `key` only if `condition` holds against its current value (Valkey `DELEX`), returning whether it was deleted.
     */
-  final def delex[K: KeyCodec, V: ValueCodec](key: K, condition: DelexCondition[V] = DelexCondition.Always): F[Boolean] =
+  final def delex[V: ValueCodec](key: K, condition: DelexCondition[V] = DelexCondition.Always): F[Boolean] =
     run(Strings.delex(key, condition))
 
   /**
     * Atomically sets several key/value pairs with a shared `expiry` and set `condition` (Valkey `MSETEX`), returning whether applied.
     */
-  final def msetEx[K: KeyCodec, V: ValueCodec](
+  final def msetEx[V: ValueCodec](
     expiry: SetExpiry = SetExpiry.Clear,
     condition: SetCondition = SetCondition.Always
   )(first: (K, V), rest: (K, V)*): F[Boolean] = run(Strings.msetEx(expiry, condition)(first, rest*))
@@ -169,7 +182,7 @@ trait CommandRunner[F[_]] {
   /**
     * Increments the integer at `key` (Valkey `INCREX`), optionally clamping to bounds and updating expiry; see [[sage.commands.IncrExResult]].
     */
-  final def increxBy[K: KeyCodec](
+  final def increxBy(
     key: K,
     increment: Long = 1,
     saturate: Boolean = false,
@@ -181,7 +194,7 @@ trait CommandRunner[F[_]] {
   /**
     * The floating-point form of [[increxBy]] (Valkey `INCREX`).
     */
-  final def increxByFloat[K: KeyCodec](
+  final def increxByFloat(
     key: K,
     increment: Double,
     saturate: Boolean = false,
@@ -193,80 +206,80 @@ trait CommandRunner[F[_]] {
   /**
     * Copies the value at `source` to `destination`; `replace` overwrites an existing destination. Returns whether it copied.
     */
-  final def copy[K: KeyCodec](source: K, destination: K, replace: Boolean = false): F[Boolean] =
+  final def copy(source: K, destination: K, replace: Boolean = false): F[Boolean] =
     run(Keys.copy(source, destination, replace))
 
   /**
     * Deletes the given keys, returning how many existed.
     */
-  final def del[K: KeyCodec](first: K, rest: K*): F[Long] = run(Keys.del(first, rest*))
+  final def del(first: K, rest: K*): F[Long] = run(Keys.del(first, rest*))
 
   /**
     * Deletes `key` only if its current value equals `value` (Valkey `DELIFEQ`), returning whether it was deleted.
     */
-  final def delIfEq[K: KeyCodec, V: ValueCodec](key: K, value: V): F[Boolean] = run(Keys.delIfEq(key, value))
+  final def delIfEq[V: ValueCodec](key: K, value: V): F[Boolean] = run(Keys.delIfEq(key, value))
 
   /**
     * Returns how many of the given keys exist (counting duplicates).
     */
-  final def exists[K: KeyCodec](first: K, rest: K*): F[Long] = run(Keys.exists(first, rest*))
+  final def exists(first: K, rest: K*): F[Long] = run(Keys.exists(first, rest*))
 
   /**
     * Sets a TTL of `in` on `key`, guarded by `condition`, returning whether the expiry was set.
     */
-  final def expire[K: KeyCodec](key: K, in: FiniteDuration, condition: ExpireCondition = ExpireCondition.Always): F[Boolean] =
+  final def expire(key: K, in: FiniteDuration, condition: ExpireCondition = ExpireCondition.Always): F[Boolean] =
     run(Keys.expire(key, in, condition))
 
   /**
     * Sets `key` to expire at the absolute instant `at`, guarded by `condition`, returning whether the expiry was set.
     */
-  final def expireAt[K: KeyCodec](key: K, at: Instant, condition: ExpireCondition = ExpireCondition.Always): F[Boolean] =
+  final def expireAt(key: K, at: Instant, condition: ExpireCondition = ExpireCondition.Always): F[Boolean] =
     run(Keys.expireAt(key, at, condition))
 
   /**
     * Returns when `key` expires; see [[sage.commands.ExpiryTime]].
     */
-  final def expireTime[K: KeyCodec](key: K): F[ExpiryTime] = run(Keys.expireTime(key))
+  final def expireTime(key: K): F[ExpiryTime] = run(Keys.expireTime(key))
 
   /**
     * Like [[expireTime]], in milliseconds (`PEXPIRETIME`).
     */
-  final def pExpireTime[K: KeyCodec](key: K): F[ExpiryTime] = run(Keys.pExpireTime(key))
+  final def pExpireTime(key: K): F[ExpiryTime] = run(Keys.pExpireTime(key))
 
   /**
     * Returns all keys matching the glob `pattern`. O(n) over the keyspace — prefer [[scan]] on large databases.
     */
-  final def keys[K: KeyCodec](pattern: String): F[Vector[K]] = run(Keys.keys(pattern))
+  final def keys(pattern: String): F[Vector[K]] = run(Keys.keys(pattern))
 
   /**
     * Removes any expiry from `key`, returning whether one was removed.
     */
-  final def persist[K: KeyCodec](key: K): F[Boolean] = run(Keys.persist(key))
+  final def persist(key: K): F[Boolean] = run(Keys.persist(key))
 
   /**
     * Returns the remaining TTL of `key` in millisecond precision; see [[sage.commands.Ttl]].
     */
-  final def pTtl[K: KeyCodec](key: K): F[Ttl] = run(Keys.pTtl(key))
+  final def pTtl(key: K): F[Ttl] = run(Keys.pTtl(key))
 
   /**
     * Returns a random key from the current database, or `None` if it is empty.
     */
-  final def randomKey[K: KeyCodec]: F[Option[K]] = run(Keys.randomKey)
+  final def randomKey: F[Option[K]] = run(Keys.randomKey)
 
   /**
     * Renames `source` to `destination`, overwriting it if it exists.
     */
-  final def rename[K: KeyCodec](source: K, destination: K): F[Unit] = run(Keys.rename(source, destination))
+  final def rename(source: K, destination: K): F[Unit] = run(Keys.rename(source, destination))
 
   /**
     * Renames `source` to `destination` only if `destination` does not exist, returning whether it renamed.
     */
-  final def renameNx[K: KeyCodec](source: K, destination: K): F[Boolean] = run(Keys.renameNx(source, destination))
+  final def renameNx(source: K, destination: K): F[Boolean] = run(Keys.renameNx(source, destination))
 
   /**
     * One `SCAN` page over the keyspace from `cursor`, optionally filtered by `pattern`/`ofType` with a `count` hint; see [[sage.commands.ScanPage]].
     */
-  final def scan[K: KeyCodec](
+  final def scan(
     cursor: ScanCursor,
     pattern: Option[String] = None,
     count: Option[Long] = None,
@@ -276,27 +289,27 @@ trait CommandRunner[F[_]] {
   /**
     * Updates the last-access time of the given keys without reading them, returning how many existed.
     */
-  final def touch[K: KeyCodec](first: K, rest: K*): F[Long] = run(Keys.touch(first, rest*))
+  final def touch(first: K, rest: K*): F[Long] = run(Keys.touch(first, rest*))
 
   /**
     * Returns the remaining TTL of `key` in second precision; see [[sage.commands.Ttl]].
     */
-  final def ttl[K: KeyCodec](key: K): F[Ttl] = run(Keys.ttl(key))
+  final def ttl(key: K): F[Ttl] = run(Keys.ttl(key))
 
   /**
     * Returns the data type held at `key`, or `None` if it is absent; see [[sage.commands.RedisType]].
     */
-  final def typeOf[K: KeyCodec](key: K): F[Option[RedisType]] = run(Keys.typeOf(key))
+  final def typeOf(key: K): F[Option[RedisType]] = run(Keys.typeOf(key))
 
   /**
     * Deletes the given keys, reclaiming memory asynchronously, returning how many existed.
     */
-  final def unlink[K: KeyCodec](first: K, rest: K*): F[Long] = run(Keys.unlink(first, rest*))
+  final def unlink(first: K, rest: K*): F[Long] = run(Keys.unlink(first, rest*))
 
   /**
     * Sorts the list/set/sorted-set at `key`, optionally by an external pattern and projecting via `get`; see [[sage.commands.SortOrder]].
     */
-  final def sort[K: KeyCodec, V: ValueCodec](
+  final def sort[V: ValueCodec](
     key: K,
     by: Option[String] = None,
     limit: Option[Limit] = None,
@@ -308,7 +321,7 @@ trait CommandRunner[F[_]] {
   /**
     * Like [[sort]], but stores the result in `destination` and returns its length.
     */
-  final def sortStore[K: KeyCodec](
+  final def sortStore(
     destination: K,
     key: K,
     by: Option[String] = None,
@@ -321,7 +334,7 @@ trait CommandRunner[F[_]] {
   /**
     * The read-only form of [[sort]] (`SORT_RO`), eligible for replica routing.
     */
-  final def sortRo[K: KeyCodec, V: ValueCodec](
+  final def sortRo[V: ValueCodec](
     key: K,
     by: Option[String] = None,
     limit: Option[Limit] = None,
@@ -333,17 +346,17 @@ trait CommandRunner[F[_]] {
   /**
     * Moves `key` to database `db` on the same server, returning whether it was moved. Not available on a cluster.
     */
-  final def move[K: KeyCodec](key: K, db: Int): F[Boolean] = run(Keys.move(key, db))
+  final def move(key: K, db: Int): F[Boolean] = run(Keys.move(key, db))
 
   /**
     * Returns the serialized form of the value at `key` for use with [[restore]], or `None` if absent.
     */
-  final def dump[K: KeyCodec](key: K): F[Option[Bytes]] = run(Keys.dump(key))
+  final def dump(key: K): F[Option[Bytes]] = run(Keys.dump(key))
 
   /**
     * Recreates `key` from a [[dump]] `payload`, with optional expiry/idle/freq metadata; `replace` overwrites an existing key.
     */
-  final def restore[K: KeyCodec](
+  final def restore(
     key: K,
     payload: Bytes,
     expiry: RestoreExpiry = RestoreExpiry.NoExpiry,
@@ -355,7 +368,7 @@ trait CommandRunner[F[_]] {
   /**
     * Transfers the given keys to another server, optionally keeping them locally (`copy`); see [[sage.commands.MigrateResult]].
     */
-  final def migrate[K: KeyCodec](
+  final def migrate(
     host: String,
     port: Int,
     destinationDb: Int,
@@ -368,113 +381,113 @@ trait CommandRunner[F[_]] {
   /**
     * Returns the internal encoding of the value at `key` (`OBJECT ENCODING`), e.g. `listpack`/`skiplist`, or `None` if absent.
     */
-  final def objectEncoding[K: KeyCodec](key: K): F[Option[String]] = run(Keys.objectEncoding(key))
+  final def objectEncoding(key: K): F[Option[String]] = run(Keys.objectEncoding(key))
 
   /**
     * Returns the reference count of the value at `key` (`OBJECT REFCOUNT`), or `None` if absent.
     */
-  final def objectRefCount[K: KeyCodec](key: K): F[Option[Long]] = run(Keys.objectRefCount(key))
+  final def objectRefCount(key: K): F[Option[Long]] = run(Keys.objectRefCount(key))
 
   /**
     * Returns the access frequency counter of `key` (`OBJECT FREQ`, requires an LFU eviction policy), or `None` if absent.
     */
-  final def objectFreq[K: KeyCodec](key: K): F[Option[Long]] = run(Keys.objectFreq(key))
+  final def objectFreq(key: K): F[Option[Long]] = run(Keys.objectFreq(key))
 
   /**
     * Returns how long `key` has been idle (`OBJECT IDLETIME`), or `None` if absent.
     */
-  final def objectIdleTime[K: KeyCodec](key: K): F[Option[FiniteDuration]] = run(Keys.objectIdleTime(key))
+  final def objectIdleTime(key: K): F[Option[FiniteDuration]] = run(Keys.objectIdleTime(key))
 
   /**
     * Sets one or more fields in the hash at `key`, returning how many were newly added.
     */
-  final def hSet[K: KeyCodec, F0: KeyCodec, V: ValueCodec](key: K, first: (F0, V), rest: (F0, V)*): F[Long] =
+  final def hSet[F0: KeyCodec, V: ValueCodec](key: K, first: (F0, V), rest: (F0, V)*): F[Long] =
     run(Hashes.hSet(key, first, rest*))
 
   /**
     * Sets `field` in the hash at `key` only if it does not already exist, returning whether it was set.
     */
-  final def hSetNx[K: KeyCodec, F0: KeyCodec, V: ValueCodec](key: K, field: F0, value: V): F[Boolean] =
+  final def hSetNx[F0: KeyCodec, V: ValueCodec](key: K, field: F0, value: V): F[Boolean] =
     run(Hashes.hSetNx(key, field, value))
 
   /**
     * Gets the value of `field` in the hash at `key`, or `None` if the field or key is absent.
     */
-  final def hGet[K: KeyCodec, F0: KeyCodec, V: ValueCodec](key: K, field: F0): F[Option[V]] = run(Hashes.hGet(key, field))
+  final def hGet[F0: KeyCodec, V: ValueCodec](key: K, field: F0): F[Option[V]] = run(Hashes.hGet(key, field))
 
   /**
     * Gets several fields' values from the hash at `key`, in request order, each `None` if absent.
     */
-  final def hmGet[K: KeyCodec, F0: KeyCodec, V: ValueCodec](key: K, first: F0, rest: F0*): F[Vector[Option[V]]] =
+  final def hmGet[F0: KeyCodec, V: ValueCodec](key: K, first: F0, rest: F0*): F[Vector[Option[V]]] =
     run(Hashes.hmGet(key, first, rest*))
 
   /**
     * Deletes the given fields from the hash at `key`, returning how many existed.
     */
-  final def hDel[K: KeyCodec, F0: KeyCodec](key: K, first: F0, rest: F0*): F[Long] = run(Hashes.hDel(key, first, rest*))
+  final def hDel[F0: KeyCodec](key: K, first: F0, rest: F0*): F[Long] = run(Hashes.hDel(key, first, rest*))
 
   /**
     * Returns whether `field` exists in the hash at `key`.
     */
-  final def hExists[K: KeyCodec, F0: KeyCodec](key: K, field: F0): F[Boolean] = run(Hashes.hExists(key, field))
+  final def hExists[F0: KeyCodec](key: K, field: F0): F[Boolean] = run(Hashes.hExists(key, field))
 
   /**
     * Returns the number of fields in the hash at `key`.
     */
-  final def hLen[K: KeyCodec](key: K): F[Long] = run(Hashes.hLen(key))
+  final def hLen(key: K): F[Long] = run(Hashes.hLen(key))
 
   /**
     * Returns the string length of `field`'s value in the hash at `key`, or 0 if absent.
     */
-  final def hStrLen[K: KeyCodec, F0: KeyCodec](key: K, field: F0): F[Long] = run(Hashes.hStrLen(key, field))
+  final def hStrLen[F0: KeyCodec](key: K, field: F0): F[Long] = run(Hashes.hStrLen(key, field))
 
   /**
     * Returns all field names in the hash at `key`.
     */
-  final def hKeys[K: KeyCodec, F0: KeyCodec](key: K): F[Vector[F0]] = run(Hashes.hKeys(key))
+  final def hKeys[F0: KeyCodec](key: K): F[Vector[F0]] = run(Hashes.hKeys(key))
 
   /**
     * Returns all values in the hash at `key`.
     */
-  final def hVals[K: KeyCodec, V: ValueCodec](key: K): F[Vector[V]] = run(Hashes.hVals(key))
+  final def hVals[V: ValueCodec](key: K): F[Vector[V]] = run(Hashes.hVals(key))
 
   /**
     * Returns the whole hash at `key` as a map.
     */
-  final def hGetAll[K: KeyCodec, F0: KeyCodec, V: ValueCodec](key: K): F[Map[F0, V]] = run(Hashes.hGetAll(key))
+  final def hGetAll[F0: KeyCodec, V: ValueCodec](key: K): F[Map[F0, V]] = run(Hashes.hGetAll(key))
 
   /**
     * Increments the integer field `field` in the hash at `key` by `increment`, returning the new value.
     */
-  final def hIncrBy[K: KeyCodec, F0: KeyCodec](key: K, field: F0, increment: Long): F[Long] =
+  final def hIncrBy[F0: KeyCodec](key: K, field: F0, increment: Long): F[Long] =
     run(Hashes.hIncrBy(key, field, increment))
 
   /**
     * Increments the floating-point field `field` in the hash at `key` by `increment`, returning the new value.
     */
-  final def hIncrByFloat[K: KeyCodec, F0: KeyCodec](key: K, field: F0, increment: Double): F[Double] =
+  final def hIncrByFloat[F0: KeyCodec](key: K, field: F0, increment: Double): F[Double] =
     run(Hashes.hIncrByFloat(key, field, increment))
 
   /**
     * Returns a random field name from the hash at `key`, or `None` if it is empty.
     */
-  final def hRandField[K: KeyCodec, F0: KeyCodec](key: K): F[Option[F0]] = run(Hashes.hRandField(key))
+  final def hRandField[F0: KeyCodec](key: K): F[Option[F0]] = run(Hashes.hRandField(key))
 
   /**
     * Returns `count` random field names from the hash at `key`; a negative `count` allows repeats.
     */
-  final def hRandField[K: KeyCodec, F0: KeyCodec](key: K, count: Long): F[Vector[F0]] = run(Hashes.hRandField(key, count))
+  final def hRandField[F0: KeyCodec](key: K, count: Long): F[Vector[F0]] = run(Hashes.hRandField(key, count))
 
   /**
     * Like [[hRandField]], but returns each field paired with its value.
     */
-  final def hRandFieldWithValues[K: KeyCodec, F0: KeyCodec, V: ValueCodec](key: K, count: Long): F[Vector[(F0, V)]] =
+  final def hRandFieldWithValues[F0: KeyCodec, V: ValueCodec](key: K, count: Long): F[Vector[(F0, V)]] =
     run(Hashes.hRandFieldWithValues(key, count))
 
   /**
     * One `HSCAN` page of field/value pairs over the hash at `key`; see [[sage.commands.ScanPage]].
     */
-  final def hScan[K: KeyCodec, F0: KeyCodec, V: ValueCodec](
+  final def hScan[F0: KeyCodec, V: ValueCodec](
     key: K,
     cursor: ScanCursor,
     pattern: Option[String] = None,
@@ -484,7 +497,7 @@ trait CommandRunner[F[_]] {
   /**
     * Like [[hScan]], but returns field names only (`HSCAN … NOVALUES`).
     */
-  final def hScanNoValues[K: KeyCodec, F0: KeyCodec](
+  final def hScanNoValues[F0: KeyCodec](
     key: K,
     cursor: ScanCursor,
     pattern: Option[String] = None,
@@ -494,7 +507,7 @@ trait CommandRunner[F[_]] {
   /**
     * Sets a TTL on the given hash fields, guarded by `condition`; one [[sage.commands.FieldExpiry]] per field, in request order.
     */
-  final def hExpire[K: KeyCodec, F0: KeyCodec](key: K, ttl: FiniteDuration, condition: ExpireCondition = ExpireCondition.Always)(
+  final def hExpire[F0: KeyCodec](key: K, ttl: FiniteDuration, condition: ExpireCondition = ExpireCondition.Always)(
     first: F0,
     rest: F0*
   ): F[Vector[FieldExpiry]] = run(Hashes.hExpire(key, ttl, condition)(first, rest*))
@@ -502,7 +515,7 @@ trait CommandRunner[F[_]] {
   /**
     * Like [[hExpire]], but at the absolute instant `at`.
     */
-  final def hExpireAt[K: KeyCodec, F0: KeyCodec](key: K, at: Instant, condition: ExpireCondition = ExpireCondition.Always)(
+  final def hExpireAt[F0: KeyCodec](key: K, at: Instant, condition: ExpireCondition = ExpireCondition.Always)(
     first: F0,
     rest: F0*
   ): F[Vector[FieldExpiry]] = run(Hashes.hExpireAt(key, at, condition)(first, rest*))
@@ -510,43 +523,43 @@ trait CommandRunner[F[_]] {
   /**
     * Returns when each given hash field expires; one [[sage.commands.FieldExpiryTime]] per field.
     */
-  final def hExpireTime[K: KeyCodec, F0: KeyCodec](key: K)(first: F0, rest: F0*): F[Vector[FieldExpiryTime]] =
+  final def hExpireTime[F0: KeyCodec](key: K)(first: F0, rest: F0*): F[Vector[FieldExpiryTime]] =
     run(Hashes.hExpireTime(key)(first, rest*))
 
   /**
     * Like [[hExpireTime]], in milliseconds (`HPEXPIRETIME`).
     */
-  final def hpExpireTime[K: KeyCodec, F0: KeyCodec](key: K)(first: F0, rest: F0*): F[Vector[FieldExpiryTime]] =
+  final def hpExpireTime[F0: KeyCodec](key: K)(first: F0, rest: F0*): F[Vector[FieldExpiryTime]] =
     run(Hashes.hpExpireTime(key)(first, rest*))
 
   /**
     * Returns the remaining TTL of each given hash field in seconds; one [[sage.commands.FieldTtl]] per field.
     */
-  final def hTtl[K: KeyCodec, F0: KeyCodec](key: K)(first: F0, rest: F0*): F[Vector[FieldTtl]] =
+  final def hTtl[F0: KeyCodec](key: K)(first: F0, rest: F0*): F[Vector[FieldTtl]] =
     run(Hashes.hTtl(key)(first, rest*))
 
   /**
     * Like [[hTtl]], in milliseconds (`HPTTL`).
     */
-  final def hpTtl[K: KeyCodec, F0: KeyCodec](key: K)(first: F0, rest: F0*): F[Vector[FieldTtl]] =
+  final def hpTtl[F0: KeyCodec](key: K)(first: F0, rest: F0*): F[Vector[FieldTtl]] =
     run(Hashes.hpTtl(key)(first, rest*))
 
   /**
     * Removes any expiry from the given hash fields; one [[sage.commands.FieldPersist]] per field.
     */
-  final def hPersist[K: KeyCodec, F0: KeyCodec](key: K)(first: F0, rest: F0*): F[Vector[FieldPersist]] =
+  final def hPersist[F0: KeyCodec](key: K)(first: F0, rest: F0*): F[Vector[FieldPersist]] =
     run(Hashes.hPersist(key)(first, rest*))
 
   /**
     * Gets and deletes the given hash fields atomically (`HGETDEL`), each `None` if absent.
     */
-  final def hGetDel[K: KeyCodec, F0: KeyCodec, V: ValueCodec](key: K)(first: F0, rest: F0*): F[Vector[Option[V]]] =
+  final def hGetDel[F0: KeyCodec, V: ValueCodec](key: K)(first: F0, rest: F0*): F[Vector[Option[V]]] =
     run(Hashes.hGetDel(key)(first, rest*))
 
   /**
     * Gets the given hash fields, optionally updating their expiry (`HGETEX`), each `None` if absent.
     */
-  final def hGetEx[K: KeyCodec, F0: KeyCodec, V: ValueCodec](key: K, expiry: GetExpiry = GetExpiry.Keep)(
+  final def hGetEx[F0: KeyCodec, V: ValueCodec](key: K, expiry: GetExpiry = GetExpiry.Keep)(
     first: F0,
     rest: F0*
   ): F[Vector[Option[V]]] = run(Hashes.hGetEx(key, expiry)(first, rest*))
@@ -554,7 +567,7 @@ trait CommandRunner[F[_]] {
   /**
     * Sets hash fields with a shared expiry and a set `condition` (`HSETEX`), returning whether the write applied.
     */
-  final def hSetEx[K: KeyCodec, F0: KeyCodec, V: ValueCodec](
+  final def hSetEx[F0: KeyCodec, V: ValueCodec](
     key: K,
     expiry: SetExpiry = SetExpiry.Clear,
     condition: HSetExCondition = HSetExCondition.Always
@@ -563,89 +576,89 @@ trait CommandRunner[F[_]] {
   /**
     * Prepends the given values to the list at `key` (left), returning the new length.
     */
-  final def lPush[K: KeyCodec, V: ValueCodec](key: K, first: V, rest: V*): F[Long] = run(Lists.lPush(key, first, rest*))
+  final def lPush[V: ValueCodec](key: K, first: V, rest: V*): F[Long] = run(Lists.lPush(key, first, rest*))
 
   /**
     * Appends the given values to the list at `key` (right), returning the new length.
     */
-  final def rPush[K: KeyCodec, V: ValueCodec](key: K, first: V, rest: V*): F[Long] = run(Lists.rPush(key, first, rest*))
+  final def rPush[V: ValueCodec](key: K, first: V, rest: V*): F[Long] = run(Lists.rPush(key, first, rest*))
 
   /**
     * Like [[lPush]], but only if the list already exists.
     */
-  final def lPushX[K: KeyCodec, V: ValueCodec](key: K, first: V, rest: V*): F[Long] = run(Lists.lPushX(key, first, rest*))
+  final def lPushX[V: ValueCodec](key: K, first: V, rest: V*): F[Long] = run(Lists.lPushX(key, first, rest*))
 
   /**
     * Like [[rPush]], but only if the list already exists.
     */
-  final def rPushX[K: KeyCodec, V: ValueCodec](key: K, first: V, rest: V*): F[Long] = run(Lists.rPushX(key, first, rest*))
+  final def rPushX[V: ValueCodec](key: K, first: V, rest: V*): F[Long] = run(Lists.rPushX(key, first, rest*))
 
   /**
     * Removes and returns the first (leftmost) element of the list at `key`, or `None` if empty.
     */
-  final def lPop[K: KeyCodec, V: ValueCodec](key: K): F[Option[V]] = run(Lists.lPop(key))
+  final def lPop[V: ValueCodec](key: K): F[Option[V]] = run(Lists.lPop(key))
 
   /**
     * Removes and returns the last (rightmost) element of the list at `key`, or `None` if empty.
     */
-  final def rPop[K: KeyCodec, V: ValueCodec](key: K): F[Option[V]] = run(Lists.rPop(key))
+  final def rPop[V: ValueCodec](key: K): F[Option[V]] = run(Lists.rPop(key))
 
   /**
     * Removes and returns up to `count` elements from the left of the list at `key`.
     */
-  final def lPopCount[K: KeyCodec, V: ValueCodec](key: K, count: Long): F[Vector[V]] = run(Lists.lPopCount(key, count))
+  final def lPopCount[V: ValueCodec](key: K, count: Long): F[Vector[V]] = run(Lists.lPopCount(key, count))
 
   /**
     * Removes and returns up to `count` elements from the right of the list at `key`.
     */
-  final def rPopCount[K: KeyCodec, V: ValueCodec](key: K, count: Long): F[Vector[V]] = run(Lists.rPopCount(key, count))
+  final def rPopCount[V: ValueCodec](key: K, count: Long): F[Vector[V]] = run(Lists.rPopCount(key, count))
 
   /**
     * Returns the length of the list at `key`.
     */
-  final def lLen[K: KeyCodec](key: K): F[Long] = run(Lists.lLen(key))
+  final def lLen(key: K): F[Long] = run(Lists.lLen(key))
 
   /**
     * Returns the elements of the list at `key` between `start` and `stop`, inclusive; negative indices count from the end.
     */
-  final def lRange[K: KeyCodec, V: ValueCodec](key: K, start: Long, stop: Long): F[Vector[V]] = run(Lists.lRange(key, start, stop))
+  final def lRange[V: ValueCodec](key: K, start: Long, stop: Long): F[Vector[V]] = run(Lists.lRange(key, start, stop))
 
   /**
     * Returns the element at `index` in the list at `key` (negative counts from the end), or `None` if out of range.
     */
-  final def lIndex[K: KeyCodec, V: ValueCodec](key: K, index: Long): F[Option[V]] = run(Lists.lIndex(key, index))
+  final def lIndex[V: ValueCodec](key: K, index: Long): F[Option[V]] = run(Lists.lIndex(key, index))
 
   /**
     * Sets the element at `index` in the list at `key`; fails if the index is out of range.
     */
-  final def lSet[K: KeyCodec, V: ValueCodec](key: K, index: Long, value: V): F[Unit] = run(Lists.lSet(key, index, value))
+  final def lSet[V: ValueCodec](key: K, index: Long, value: V): F[Unit] = run(Lists.lSet(key, index, value))
 
   /**
     * Inserts `value` before or after the first occurrence of `pivot` in the list at `key`; returns the new length, or -1 if `pivot` is absent.
     */
-  final def lInsert[K: KeyCodec, V: ValueCodec](key: K, position: InsertPosition, pivot: V, value: V): F[Long] =
+  final def lInsert[V: ValueCodec](key: K, position: InsertPosition, pivot: V, value: V): F[Long] =
     run(Lists.lInsert(key, position, pivot, value))
 
   /**
     * Removes occurrences of `value` from the list at `key`; `count` > 0 from head, < 0 from tail, 0 all. Returns how many were removed.
     */
-  final def lRem[K: KeyCodec, V: ValueCodec](key: K, count: Long, value: V): F[Long] = run(Lists.lRem(key, count, value))
+  final def lRem[V: ValueCodec](key: K, count: Long, value: V): F[Long] = run(Lists.lRem(key, count, value))
 
   /**
     * Trims the list at `key` to the inclusive range `[start, stop]`, discarding the rest.
     */
-  final def lTrim[K: KeyCodec](key: K, start: Long, stop: Long): F[Unit] = run(Lists.lTrim(key, start, stop))
+  final def lTrim(key: K, start: Long, stop: Long): F[Unit] = run(Lists.lTrim(key, start, stop))
 
   /**
     * Returns the index of the first match of `element` in the list at `key`, honoring `rank`/`maxLen`, or `None`.
     */
-  final def lPos[K: KeyCodec, V: ValueCodec](key: K, element: V, rank: Option[Long] = None, maxLen: Option[Long] = None): F[Option[Long]] =
+  final def lPos[V: ValueCodec](key: K, element: V, rank: Option[Long] = None, maxLen: Option[Long] = None): F[Option[Long]] =
     run(Lists.lPos(key, element, rank, maxLen))
 
   /**
     * Like [[lPos]], but returns up to `count` matching indices (`count` 0 means all).
     */
-  final def lPosCount[K: KeyCodec, V: ValueCodec](
+  final def lPosCount[V: ValueCodec](
     key: K,
     element: V,
     count: Long,
@@ -656,37 +669,37 @@ trait CommandRunner[F[_]] {
   /**
     * Atomically pops an element from one end of `source` and pushes it to one end of `destination`, returning the moved element.
     */
-  final def lMove[K: KeyCodec, V: ValueCodec](source: K, destination: K, from: ListSide, to: ListSide): F[Option[V]] =
+  final def lMove[V: ValueCodec](source: K, destination: K, from: ListSide, to: ListSide): F[Option[V]] =
     run(Lists.lMove(source, destination, from, to))
 
   /**
     * Pops up to `count` elements from the given side of the first non-empty list among the keys, returning that key and the elements.
     */
-  final def lMpop[K: KeyCodec, V: ValueCodec](first: K, rest: K*)(side: ListSide, count: Option[Long] = None): F[Option[(K, Vector[V])]] =
+  final def lMpop[V: ValueCodec](first: K, rest: K*)(side: ListSide, count: Option[Long] = None): F[Option[(K, Vector[V])]] =
     run(Lists.lMpop(first, rest*)(side, count))
 
   /**
     * Blocking [[lPop]] over several keys: waits up to `timeout` for an element on the left of any key.
     */
-  final def blPop[K: KeyCodec, V: ValueCodec](first: K, rest: K*)(timeout: BlockTimeout): F[Option[(K, V)]] =
+  final def blPop[V: ValueCodec](first: K, rest: K*)(timeout: BlockTimeout): F[Option[(K, V)]] =
     run(Lists.blPop(first, rest*)(timeout))
 
   /**
     * Blocking [[rPop]] over several keys: waits up to `timeout` for an element on the right of any key.
     */
-  final def brPop[K: KeyCodec, V: ValueCodec](first: K, rest: K*)(timeout: BlockTimeout): F[Option[(K, V)]] =
+  final def brPop[V: ValueCodec](first: K, rest: K*)(timeout: BlockTimeout): F[Option[(K, V)]] =
     run(Lists.brPop(first, rest*)(timeout))
 
   /**
     * Blocking [[lMove]]: waits up to `timeout` for an element in `source` to move.
     */
-  final def blMove[K: KeyCodec, V: ValueCodec](source: K, destination: K, from: ListSide, to: ListSide, timeout: BlockTimeout): F[Option[V]] =
+  final def blMove[V: ValueCodec](source: K, destination: K, from: ListSide, to: ListSide, timeout: BlockTimeout): F[Option[V]] =
     run(Lists.blMove(source, destination, from, to, timeout))
 
   /**
     * Blocking [[lMpop]]: waits up to `timeout` for an element on any of the keys.
     */
-  final def blMpop[K: KeyCodec, V: ValueCodec](first: K, rest: K*)(
+  final def blMpop[V: ValueCodec](first: K, rest: K*)(
     side: ListSide,
     timeout: BlockTimeout,
     count: Option[Long] = None
@@ -695,99 +708,99 @@ trait CommandRunner[F[_]] {
   /**
     * Adds the given members to the set at `key`, returning how many were newly added.
     */
-  final def sAdd[K: KeyCodec, V: ValueCodec](key: K, first: V, rest: V*): F[Long] = run(Sets.sAdd(key, first, rest*))
+  final def sAdd[V: ValueCodec](key: K, first: V, rest: V*): F[Long] = run(Sets.sAdd(key, first, rest*))
 
   /**
     * Removes the given members from the set at `key`, returning how many were present.
     */
-  final def sRem[K: KeyCodec, V: ValueCodec](key: K, first: V, rest: V*): F[Long] = run(Sets.sRem(key, first, rest*))
+  final def sRem[V: ValueCodec](key: K, first: V, rest: V*): F[Long] = run(Sets.sRem(key, first, rest*))
 
   /**
     * Returns the number of members in the set at `key`.
     */
-  final def sCard[K: KeyCodec](key: K): F[Long] = run(Sets.sCard(key))
+  final def sCard(key: K): F[Long] = run(Sets.sCard(key))
 
   /**
     * Returns whether `member` is in the set at `key`.
     */
-  final def sIsMember[K: KeyCodec, V: ValueCodec](key: K, member: V): F[Boolean] = run(Sets.sIsMember(key, member))
+  final def sIsMember[V: ValueCodec](key: K, member: V): F[Boolean] = run(Sets.sIsMember(key, member))
 
   /**
     * Returns, for each given member, whether it is in the set at `key`, in request order.
     */
-  final def sMisMember[K: KeyCodec, V: ValueCodec](key: K, first: V, rest: V*): F[Vector[Boolean]] =
+  final def sMisMember[V: ValueCodec](key: K, first: V, rest: V*): F[Vector[Boolean]] =
     run(Sets.sMisMember(key, first, rest*))
 
   /**
     * Returns all members of the set at `key`.
     */
-  final def sMembers[K: KeyCodec, V: ValueCodec](key: K): F[Set[V]] = run(Sets.sMembers(key))
+  final def sMembers[V: ValueCodec](key: K): F[Set[V]] = run(Sets.sMembers(key))
 
   /**
     * Atomically moves `member` from the set at `source` to the set at `destination`, returning whether it was present.
     */
-  final def sMove[K: KeyCodec, V: ValueCodec](source: K, destination: K, member: V): F[Boolean] =
+  final def sMove[V: ValueCodec](source: K, destination: K, member: V): F[Boolean] =
     run(Sets.sMove(source, destination, member))
 
   /**
     * Removes and returns one random member of the set at `key`, or `None` if empty.
     */
-  final def sPop[K: KeyCodec, V: ValueCodec](key: K): F[Option[V]] = run(Sets.sPop(key))
+  final def sPop[V: ValueCodec](key: K): F[Option[V]] = run(Sets.sPop(key))
 
   /**
     * Removes and returns up to `count` random members of the set at `key`.
     */
-  final def sPopCount[K: KeyCodec, V: ValueCodec](key: K, count: Long): F[Set[V]] = run(Sets.sPopCount(key, count))
+  final def sPopCount[V: ValueCodec](key: K, count: Long): F[Set[V]] = run(Sets.sPopCount(key, count))
 
   /**
     * Returns one random member of the set at `key` without removing it, or `None` if empty.
     */
-  final def sRandMember[K: KeyCodec, V: ValueCodec](key: K): F[Option[V]] = run(Sets.sRandMember(key))
+  final def sRandMember[V: ValueCodec](key: K): F[Option[V]] = run(Sets.sRandMember(key))
 
   /**
     * Returns `count` random members of the set at `key` without removing them; a negative `count` allows repeats.
     */
-  final def sRandMemberCount[K: KeyCodec, V: ValueCodec](key: K, count: Long): F[Vector[V]] = run(Sets.sRandMemberCount(key, count))
+  final def sRandMemberCount[V: ValueCodec](key: K, count: Long): F[Vector[V]] = run(Sets.sRandMemberCount(key, count))
 
   /**
     * Returns the members in the first set that are not in any of the others.
     */
-  final def sDiff[K: KeyCodec, V: ValueCodec](first: K, rest: K*): F[Set[V]] = run(Sets.sDiff(first, rest*))
+  final def sDiff[V: ValueCodec](first: K, rest: K*): F[Set[V]] = run(Sets.sDiff(first, rest*))
 
   /**
     * Like [[sDiff]], but stores the result in `destination` and returns its cardinality.
     */
-  final def sDiffStore[K: KeyCodec](destination: K, first: K, rest: K*): F[Long] = run(Sets.sDiffStore(destination, first, rest*))
+  final def sDiffStore(destination: K, first: K, rest: K*): F[Long] = run(Sets.sDiffStore(destination, first, rest*))
 
   /**
     * Returns the members common to all the given sets.
     */
-  final def sInter[K: KeyCodec, V: ValueCodec](first: K, rest: K*): F[Set[V]] = run(Sets.sInter(first, rest*))
+  final def sInter[V: ValueCodec](first: K, rest: K*): F[Set[V]] = run(Sets.sInter(first, rest*))
 
   /**
     * Like [[sInter]], but stores the result in `destination` and returns its cardinality.
     */
-  final def sInterStore[K: KeyCodec](destination: K, first: K, rest: K*): F[Long] = run(Sets.sInterStore(destination, first, rest*))
+  final def sInterStore(destination: K, first: K, rest: K*): F[Long] = run(Sets.sInterStore(destination, first, rest*))
 
   /**
     * Returns the cardinality of the intersection of the given sets, capped at `limit` if set (`SINTERCARD`).
     */
-  final def sInterCard[K: KeyCodec](first: K, rest: K*)(limit: Option[Long] = None): F[Long] = run(Sets.sInterCard(first, rest*)(limit))
+  final def sInterCard(first: K, rest: K*)(limit: Option[Long] = None): F[Long] = run(Sets.sInterCard(first, rest*)(limit))
 
   /**
     * Returns the union of all the given sets.
     */
-  final def sUnion[K: KeyCodec, V: ValueCodec](first: K, rest: K*): F[Set[V]] = run(Sets.sUnion(first, rest*))
+  final def sUnion[V: ValueCodec](first: K, rest: K*): F[Set[V]] = run(Sets.sUnion(first, rest*))
 
   /**
     * Like [[sUnion]], but stores the result in `destination` and returns its cardinality.
     */
-  final def sUnionStore[K: KeyCodec](destination: K, first: K, rest: K*): F[Long] = run(Sets.sUnionStore(destination, first, rest*))
+  final def sUnionStore(destination: K, first: K, rest: K*): F[Long] = run(Sets.sUnionStore(destination, first, rest*))
 
   /**
     * One `SSCAN` page over the members of the set at `key`; see [[sage.commands.ScanPage]].
     */
-  final def sScan[K: KeyCodec, V: ValueCodec](
+  final def sScan[V: ValueCodec](
     key: K,
     cursor: ScanCursor,
     pattern: Option[String] = None,
@@ -797,7 +810,7 @@ trait CommandRunner[F[_]] {
   /**
     * Adds the given members with scores to the sorted set at `key`, guarded by `condition`; returns how many were added (or changed, if `changed`).
     */
-  final def zAdd[K: KeyCodec, V: ValueCodec](key: K, condition: ZAddCondition = ZAddCondition.Always, changed: Boolean = false)(
+  final def zAdd[V: ValueCodec](key: K, condition: ZAddCondition = ZAddCondition.Always, changed: Boolean = false)(
     first: (V, Double),
     rest: (V, Double)*
   ): F[Long] = run(SortedSets.zAdd(key, condition, changed)(first, rest*))
@@ -805,7 +818,7 @@ trait CommandRunner[F[_]] {
   /**
     * Adds or updates one member and returns its new score (`ZADD … INCR`), or `None` when `condition` blocks the write.
     */
-  final def zAddIncr[K: KeyCodec, V: ValueCodec](
+  final def zAddIncr[V: ValueCodec](
     key: K,
     condition: ZAddCondition = ZAddCondition.Always
   )(member: V, score: Double): F[Option[Double]] =
@@ -814,139 +827,139 @@ trait CommandRunner[F[_]] {
   /**
     * Returns the number of members in the sorted set at `key`.
     */
-  final def zCard[K: KeyCodec](key: K): F[Long] = run(SortedSets.zCard(key))
+  final def zCard(key: K): F[Long] = run(SortedSets.zCard(key))
 
   /**
     * Returns the score of `member` in the sorted set at `key`, or `None` if absent.
     */
-  final def zScore[K: KeyCodec, V: ValueCodec](key: K, member: V): F[Option[Double]] = run(SortedSets.zScore(key, member))
+  final def zScore[V: ValueCodec](key: K, member: V): F[Option[Double]] = run(SortedSets.zScore(key, member))
 
   /**
     * Returns the scores of several members in request order, each `None` if absent.
     */
-  final def zMScore[K: KeyCodec, V: ValueCodec](key: K, first: V, rest: V*): F[Vector[Option[Double]]] =
+  final def zMScore[V: ValueCodec](key: K, first: V, rest: V*): F[Vector[Option[Double]]] =
     run(SortedSets.zMScore(key, first, rest*))
 
   /**
     * Increments the score of `member` in the sorted set at `key` by `increment`, returning the new score.
     */
-  final def zIncrBy[K: KeyCodec, V: ValueCodec](key: K, member: V, increment: Double): F[Double] =
+  final def zIncrBy[V: ValueCodec](key: K, member: V, increment: Double): F[Double] =
     run(SortedSets.zIncrBy(key, member, increment))
 
   /**
     * Returns the rank of `member` (0-based, lowest score first), or `None` if absent.
     */
-  final def zRank[K: KeyCodec, V: ValueCodec](key: K, member: V): F[Option[Long]] = run(SortedSets.zRank(key, member))
+  final def zRank[V: ValueCodec](key: K, member: V): F[Option[Long]] = run(SortedSets.zRank(key, member))
 
   /**
     * Like [[zRank]], but also returns the member's score.
     */
-  final def zRankWithScore[K: KeyCodec, V: ValueCodec](key: K, member: V): F[Option[(Long, Double)]] =
+  final def zRankWithScore[V: ValueCodec](key: K, member: V): F[Option[(Long, Double)]] =
     run(SortedSets.zRankWithScore(key, member))
 
   /**
     * Returns the rank of `member` counting from the highest score (`ZREVRANK`), or `None` if absent.
     */
-  final def zRevRank[K: KeyCodec, V: ValueCodec](key: K, member: V): F[Option[Long]] = run(SortedSets.zRevRank(key, member))
+  final def zRevRank[V: ValueCodec](key: K, member: V): F[Option[Long]] = run(SortedSets.zRevRank(key, member))
 
   /**
     * Like [[zRevRank]], but also returns the member's score.
     */
-  final def zRevRankWithScore[K: KeyCodec, V: ValueCodec](key: K, member: V): F[Option[(Long, Double)]] =
+  final def zRevRankWithScore[V: ValueCodec](key: K, member: V): F[Option[(Long, Double)]] =
     run(SortedSets.zRevRankWithScore(key, member))
 
   /**
     * Counts members of the sorted set at `key` whose score is within `[min, max]`; see [[sage.commands.ScoreBoundary]].
     */
-  final def zCount[K: KeyCodec](key: K, min: ScoreBoundary, max: ScoreBoundary): F[Long] = run(SortedSets.zCount(key, min, max))
+  final def zCount(key: K, min: ScoreBoundary, max: ScoreBoundary): F[Long] = run(SortedSets.zCount(key, min, max))
 
   /**
     * Counts members within a lexicographic range (`ZLEXCOUNT`); meaningful only when all members share the same score.
     */
-  final def zLexCount[K: KeyCodec, V: ValueCodec](key: K, min: LexBoundary[V], max: LexBoundary[V]): F[Long] =
+  final def zLexCount[V: ValueCodec](key: K, min: LexBoundary[V], max: LexBoundary[V]): F[Long] =
     run(SortedSets.zLexCount(key, min, max))
 
   /**
     * Returns members of the sorted set at `key` for the given range (by index, score, or lex); see [[sage.commands.ZRange]].
     */
-  final def zRange[K: KeyCodec, V: ValueCodec](key: K, range: ZRange[V]): F[Vector[V]] = run(SortedSets.zRange(key, range))
+  final def zRange[V: ValueCodec](key: K, range: ZRange[V]): F[Vector[V]] = run(SortedSets.zRange(key, range))
 
   /**
     * Like [[zRange]], but returns each member paired with its score.
     */
-  final def zRangeWithScores[K: KeyCodec, V: ValueCodec](key: K, range: ZRange[V]): F[Vector[(V, Double)]] =
+  final def zRangeWithScores[V: ValueCodec](key: K, range: ZRange[V]): F[Vector[(V, Double)]] =
     run(SortedSets.zRangeWithScores(key, range))
 
   /**
     * Like [[zRange]], but stores the selected members in `destination` and returns its cardinality.
     */
-  final def zRangeStore[K: KeyCodec, V: ValueCodec](destination: K, source: K, range: ZRange[V]): F[Long] =
+  final def zRangeStore[V: ValueCodec](destination: K, source: K, range: ZRange[V]): F[Long] =
     run(SortedSets.zRangeStore(destination, source, range))
 
   /**
     * Removes the given members from the sorted set at `key`, returning how many were present.
     */
-  final def zRem[K: KeyCodec, V: ValueCodec](key: K, first: V, rest: V*): F[Long] = run(SortedSets.zRem(key, first, rest*))
+  final def zRem[V: ValueCodec](key: K, first: V, rest: V*): F[Long] = run(SortedSets.zRem(key, first, rest*))
 
   /**
     * Removes members of the sorted set at `key` whose rank is within `[start, stop]`, returning how many were removed.
     */
-  final def zRemRangeByRank[K: KeyCodec](key: K, start: Long, stop: Long): F[Long] = run(SortedSets.zRemRangeByRank(key, start, stop))
+  final def zRemRangeByRank(key: K, start: Long, stop: Long): F[Long] = run(SortedSets.zRemRangeByRank(key, start, stop))
 
   /**
     * Removes members whose score is within `[min, max]`, returning how many were removed.
     */
-  final def zRemRangeByScore[K: KeyCodec](key: K, min: ScoreBoundary, max: ScoreBoundary): F[Long] =
+  final def zRemRangeByScore(key: K, min: ScoreBoundary, max: ScoreBoundary): F[Long] =
     run(SortedSets.zRemRangeByScore(key, min, max))
 
   /**
     * Removes members within a lexicographic range, returning how many were removed.
     */
-  final def zRemRangeByLex[K: KeyCodec, V: ValueCodec](key: K, min: LexBoundary[V], max: LexBoundary[V]): F[Long] =
+  final def zRemRangeByLex[V: ValueCodec](key: K, min: LexBoundary[V], max: LexBoundary[V]): F[Long] =
     run(SortedSets.zRemRangeByLex(key, min, max))
 
   /**
     * Removes and returns the lowest-scored member of the sorted set at `key`, or `None` if empty.
     */
-  final def zPopMin[K: KeyCodec, V: ValueCodec](key: K): F[Option[(V, Double)]] = run(SortedSets.zPopMin(key))
+  final def zPopMin[V: ValueCodec](key: K): F[Option[(V, Double)]] = run(SortedSets.zPopMin(key))
 
   /**
     * Removes and returns the highest-scored member of the sorted set at `key`, or `None` if empty.
     */
-  final def zPopMax[K: KeyCodec, V: ValueCodec](key: K): F[Option[(V, Double)]] = run(SortedSets.zPopMax(key))
+  final def zPopMax[V: ValueCodec](key: K): F[Option[(V, Double)]] = run(SortedSets.zPopMax(key))
 
   /**
     * Removes and returns up to `count` lowest-scored members of the sorted set at `key`.
     */
-  final def zPopMinCount[K: KeyCodec, V: ValueCodec](key: K, count: Long): F[Vector[(V, Double)]] = run(SortedSets.zPopMinCount(key, count))
+  final def zPopMinCount[V: ValueCodec](key: K, count: Long): F[Vector[(V, Double)]] = run(SortedSets.zPopMinCount(key, count))
 
   /**
     * Removes and returns up to `count` highest-scored members of the sorted set at `key`.
     */
-  final def zPopMaxCount[K: KeyCodec, V: ValueCodec](key: K, count: Long): F[Vector[(V, Double)]] = run(SortedSets.zPopMaxCount(key, count))
+  final def zPopMaxCount[V: ValueCodec](key: K, count: Long): F[Vector[(V, Double)]] = run(SortedSets.zPopMaxCount(key, count))
 
   /**
     * Pops up to `count` members from the min or max end of the first non-empty sorted set among the keys; see [[sage.commands.MinMax]].
     */
-  final def zMpop[K: KeyCodec, V: ValueCodec](first: K, rest: K*)(minMax: MinMax, count: Option[Long] = None): F[Option[(K, Vector[(V, Double)])]] =
+  final def zMpop[V: ValueCodec](first: K, rest: K*)(minMax: MinMax, count: Option[Long] = None): F[Option[(K, Vector[(V, Double)])]] =
     run(SortedSets.zMpop(first, rest*)(minMax, count))
 
   /**
     * Blocking [[zPopMin]] over several keys: waits up to `timeout` for the lowest-scored member of any key.
     */
-  final def bzPopMin[K: KeyCodec, V: ValueCodec](first: K, rest: K*)(timeout: BlockTimeout): F[Option[(K, V, Double)]] =
+  final def bzPopMin[V: ValueCodec](first: K, rest: K*)(timeout: BlockTimeout): F[Option[(K, V, Double)]] =
     run(SortedSets.bzPopMin(first, rest*)(timeout))
 
   /**
     * Blocking [[zPopMax]] over several keys: waits up to `timeout` for the highest-scored member of any key.
     */
-  final def bzPopMax[K: KeyCodec, V: ValueCodec](first: K, rest: K*)(timeout: BlockTimeout): F[Option[(K, V, Double)]] =
+  final def bzPopMax[V: ValueCodec](first: K, rest: K*)(timeout: BlockTimeout): F[Option[(K, V, Double)]] =
     run(SortedSets.bzPopMax(first, rest*)(timeout))
 
   /**
     * Blocking [[zMpop]]: waits up to `timeout` for a member on any of the keys.
     */
-  final def bzMpop[K: KeyCodec, V: ValueCodec](first: K, rest: K*)(
+  final def bzMpop[V: ValueCodec](first: K, rest: K*)(
     minMax: MinMax,
     timeout: BlockTimeout,
     count: Option[Long] = None
@@ -955,23 +968,23 @@ trait CommandRunner[F[_]] {
   /**
     * Returns one random member of the sorted set at `key` without removing it, or `None` if empty.
     */
-  final def zRandMember[K: KeyCodec, V: ValueCodec](key: K): F[Option[V]] = run(SortedSets.zRandMember(key))
+  final def zRandMember[V: ValueCodec](key: K): F[Option[V]] = run(SortedSets.zRandMember(key))
 
   /**
     * Returns `count` random members of the sorted set at `key`; a negative `count` allows repeats.
     */
-  final def zRandMemberCount[K: KeyCodec, V: ValueCodec](key: K, count: Long): F[Vector[V]] = run(SortedSets.zRandMemberCount(key, count))
+  final def zRandMemberCount[V: ValueCodec](key: K, count: Long): F[Vector[V]] = run(SortedSets.zRandMemberCount(key, count))
 
   /**
     * Like [[zRandMemberCount]], but returns each member paired with its score.
     */
-  final def zRandMemberWithScores[K: KeyCodec, V: ValueCodec](key: K, count: Long): F[Vector[(V, Double)]] =
+  final def zRandMemberWithScores[V: ValueCodec](key: K, count: Long): F[Vector[(V, Double)]] =
     run(SortedSets.zRandMemberWithScores(key, count))
 
   /**
     * Returns the union of the given sorted sets, combining scores per `aggregate` (and optional `weights`); see [[sage.commands.Aggregate]].
     */
-  final def zUnion[K: KeyCodec, V: ValueCodec](first: K, rest: K*)(
+  final def zUnion[V: ValueCodec](first: K, rest: K*)(
     weights: Option[Vector[Double]] = None,
     aggregate: Aggregate = Aggregate.Sum
   ): F[Vector[V]] = run(SortedSets.zUnion(first, rest*)(weights, aggregate))
@@ -979,7 +992,7 @@ trait CommandRunner[F[_]] {
   /**
     * Like [[zUnion]], but returns each member paired with its combined score.
     */
-  final def zUnionWithScores[K: KeyCodec, V: ValueCodec](first: K, rest: K*)(
+  final def zUnionWithScores[V: ValueCodec](first: K, rest: K*)(
     weights: Option[Vector[Double]] = None,
     aggregate: Aggregate = Aggregate.Sum
   ): F[Vector[(V, Double)]] = run(SortedSets.zUnionWithScores(first, rest*)(weights, aggregate))
@@ -987,7 +1000,7 @@ trait CommandRunner[F[_]] {
   /**
     * Like [[zUnion]], but stores the result in `destination` and returns its cardinality.
     */
-  final def zUnionStore[K: KeyCodec](destination: K, first: K, rest: K*)(
+  final def zUnionStore(destination: K, first: K, rest: K*)(
     weights: Option[Vector[Double]] = None,
     aggregate: Aggregate = Aggregate.Sum
   ): F[Long] = run(SortedSets.zUnionStore(destination, first, rest*)(weights, aggregate))
@@ -995,7 +1008,7 @@ trait CommandRunner[F[_]] {
   /**
     * Returns the intersection of the given sorted sets, combining scores per `aggregate` (and optional `weights`).
     */
-  final def zInter[K: KeyCodec, V: ValueCodec](first: K, rest: K*)(
+  final def zInter[V: ValueCodec](first: K, rest: K*)(
     weights: Option[Vector[Double]] = None,
     aggregate: Aggregate = Aggregate.Sum
   ): F[Vector[V]] = run(SortedSets.zInter(first, rest*)(weights, aggregate))
@@ -1003,7 +1016,7 @@ trait CommandRunner[F[_]] {
   /**
     * Like [[zInter]], but returns each member paired with its combined score.
     */
-  final def zInterWithScores[K: KeyCodec, V: ValueCodec](first: K, rest: K*)(
+  final def zInterWithScores[V: ValueCodec](first: K, rest: K*)(
     weights: Option[Vector[Double]] = None,
     aggregate: Aggregate = Aggregate.Sum
   ): F[Vector[(V, Double)]] = run(SortedSets.zInterWithScores(first, rest*)(weights, aggregate))
@@ -1011,7 +1024,7 @@ trait CommandRunner[F[_]] {
   /**
     * Like [[zInter]], but stores the result in `destination` and returns its cardinality.
     */
-  final def zInterStore[K: KeyCodec](destination: K, first: K, rest: K*)(
+  final def zInterStore(destination: K, first: K, rest: K*)(
     weights: Option[Vector[Double]] = None,
     aggregate: Aggregate = Aggregate.Sum
   ): F[Long] = run(SortedSets.zInterStore(destination, first, rest*)(weights, aggregate))
@@ -1019,29 +1032,29 @@ trait CommandRunner[F[_]] {
   /**
     * Returns the cardinality of the intersection of the given sorted sets, capped at `limit` if set (`ZINTERCARD`).
     */
-  final def zInterCard[K: KeyCodec](first: K, rest: K*)(limit: Option[Long] = None): F[Long] =
+  final def zInterCard(first: K, rest: K*)(limit: Option[Long] = None): F[Long] =
     run(SortedSets.zInterCard(first, rest*)(limit))
 
   /**
     * Returns the members of the first sorted set that are not in any of the others.
     */
-  final def zDiff[K: KeyCodec, V: ValueCodec](first: K, rest: K*): F[Vector[V]] = run(SortedSets.zDiff(first, rest*))
+  final def zDiff[V: ValueCodec](first: K, rest: K*): F[Vector[V]] = run(SortedSets.zDiff(first, rest*))
 
   /**
     * Like [[zDiff]], but returns each member paired with its score.
     */
-  final def zDiffWithScores[K: KeyCodec, V: ValueCodec](first: K, rest: K*): F[Vector[(V, Double)]] =
+  final def zDiffWithScores[V: ValueCodec](first: K, rest: K*): F[Vector[(V, Double)]] =
     run(SortedSets.zDiffWithScores(first, rest*))
 
   /**
     * Like [[zDiff]], but stores the result in `destination` and returns its cardinality.
     */
-  final def zDiffStore[K: KeyCodec](destination: K, first: K, rest: K*): F[Long] = run(SortedSets.zDiffStore(destination, first, rest*))
+  final def zDiffStore(destination: K, first: K, rest: K*): F[Long] = run(SortedSets.zDiffStore(destination, first, rest*))
 
   /**
     * One `ZSCAN` page of member/score pairs over the sorted set at `key`; see [[sage.commands.ScanPage]].
     */
-  final def zScan[K: KeyCodec, V: ValueCodec](
+  final def zScan[V: ValueCodec](
     key: K,
     cursor: ScanCursor,
     pattern: Option[String] = None,
@@ -1086,7 +1099,7 @@ trait CommandRunner[F[_]] {
   /**
     * Adds the given members at their coordinates to the geo set at `key`; returns how many were added (or changed, if `changed`).
     */
-  final def geoAdd[K: KeyCodec, V: ValueCodec](key: K, condition: GeoAddCondition = GeoAddCondition.Always, changed: Boolean = false)(
+  final def geoAdd[V: ValueCodec](key: K, condition: GeoAddCondition = GeoAddCondition.Always, changed: Boolean = false)(
     first: (V, GeoCoordinates),
     rest: (V, GeoCoordinates)*
   ): F[Long] = run(Geo.geoAdd(key, condition, changed)(first, rest*))
@@ -1094,25 +1107,25 @@ trait CommandRunner[F[_]] {
   /**
     * Returns the distance between two members of the geo set at `key` in `unit`, or `None` if either is absent.
     */
-  final def geoDist[K: KeyCodec, V: ValueCodec](key: K, member1: V, member2: V, unit: GeoUnit = GeoUnit.Meters): F[Option[Double]] =
+  final def geoDist[V: ValueCodec](key: K, member1: V, member2: V, unit: GeoUnit = GeoUnit.Meters): F[Option[Double]] =
     run(Geo.geoDist(key, member1, member2, unit))
 
   /**
     * Returns the Geohash string of each given member, or `None` if absent.
     */
-  final def geoHash[K: KeyCodec, V: ValueCodec](key: K, first: V, rest: V*): F[Vector[Option[String]]] =
+  final def geoHash[V: ValueCodec](key: K, first: V, rest: V*): F[Vector[Option[String]]] =
     run(Geo.geoHash(key, first, rest*))
 
   /**
     * Returns the coordinates of each given member, or `None` if absent.
     */
-  final def geoPos[K: KeyCodec, V: ValueCodec](key: K, first: V, rest: V*): F[Vector[Option[GeoCoordinates]]] =
+  final def geoPos[V: ValueCodec](key: K, first: V, rest: V*): F[Vector[Option[GeoCoordinates]]] =
     run(Geo.geoPos(key, first, rest*))
 
   /**
     * Returns members within `shape` of `origin`; see [[sage.commands.GeoOrigin]]/[[sage.commands.GeoShape]].
     */
-  final def geoSearch[K: KeyCodec, V: ValueCodec](
+  final def geoSearch[V: ValueCodec](
     key: K,
     origin: GeoOrigin[V],
     shape: GeoShape,
@@ -1123,7 +1136,7 @@ trait CommandRunner[F[_]] {
   /**
     * Like [[geoSearch]], but also returns the requested projections (distance/coordinates/hash); see [[sage.commands.GeoSearchResult]].
     */
-  final def geoSearchWith[K: KeyCodec, V: ValueCodec](
+  final def geoSearchWith[V: ValueCodec](
     key: K,
     origin: GeoOrigin[V],
     shape: GeoShape,
@@ -1137,7 +1150,7 @@ trait CommandRunner[F[_]] {
   /**
     * Like [[geoSearch]], but stores the matches in `destination` (or their distances, if `storeDist`) and returns the count.
     */
-  final def geoSearchStore[K: KeyCodec, V: ValueCodec](
+  final def geoSearchStore[V: ValueCodec](
     destination: K,
     source: K,
     origin: GeoOrigin[V],
@@ -1150,74 +1163,74 @@ trait CommandRunner[F[_]] {
   /**
     * Sets the bit at `offset` in the string at `key`, returning its previous value.
     */
-  final def setBit[K: KeyCodec](key: K, offset: Long, value: Boolean): F[Boolean] = run(Bitmaps.setBit(key, offset, value))
+  final def setBit(key: K, offset: Long, value: Boolean): F[Boolean] = run(Bitmaps.setBit(key, offset, value))
 
   /**
     * Returns the bit at `offset` in the string at `key`.
     */
-  final def getBit[K: KeyCodec](key: K, offset: Long): F[Boolean] = run(Bitmaps.getBit(key, offset))
+  final def getBit(key: K, offset: Long): F[Boolean] = run(Bitmaps.getBit(key, offset))
 
   /**
     * Counts the set bits in the string at `key`, optionally within a [[sage.commands.BitRange]].
     */
-  final def bitCount[K: KeyCodec](key: K, range: Option[BitRange] = None): F[Long] = run(Bitmaps.bitCount(key, range))
+  final def bitCount(key: K, range: Option[BitRange] = None): F[Long] = run(Bitmaps.bitCount(key, range))
 
   /**
     * Returns the position of the first `bit` (set/clear) in the string at `key`, optionally within a [[sage.commands.BitPosRange]].
     */
-  final def bitPos[K: KeyCodec](key: K, bit: Boolean, range: Option[BitPosRange] = None): F[Long] = run(Bitmaps.bitPos(key, bit, range))
+  final def bitPos(key: K, bit: Boolean, range: Option[BitPosRange] = None): F[Long] = run(Bitmaps.bitPos(key, bit, range))
 
   /**
     * Stores the bitwise AND of the source keys into `destination`, returning the result's byte length.
     */
-  final def bitOpAnd[K: KeyCodec](destination: K, first: K, rest: K*): F[Long] = run(Bitmaps.bitOpAnd(destination, first, rest*))
+  final def bitOpAnd(destination: K, first: K, rest: K*): F[Long] = run(Bitmaps.bitOpAnd(destination, first, rest*))
 
   /**
     * Stores the bitwise OR of the source keys into `destination`, returning the result's byte length.
     */
-  final def bitOpOr[K: KeyCodec](destination: K, first: K, rest: K*): F[Long] = run(Bitmaps.bitOpOr(destination, first, rest*))
+  final def bitOpOr(destination: K, first: K, rest: K*): F[Long] = run(Bitmaps.bitOpOr(destination, first, rest*))
 
   /**
     * Stores the bitwise XOR of the source keys into `destination`, returning the result's byte length.
     */
-  final def bitOpXor[K: KeyCodec](destination: K, first: K, rest: K*): F[Long] = run(Bitmaps.bitOpXor(destination, first, rest*))
+  final def bitOpXor(destination: K, first: K, rest: K*): F[Long] = run(Bitmaps.bitOpXor(destination, first, rest*))
 
   /**
     * Stores the bitwise NOT of `source` into `destination`, returning the result's byte length.
     */
-  final def bitOpNot[K: KeyCodec](destination: K, source: K): F[Long] = run(Bitmaps.bitOpNot(destination, source))
+  final def bitOpNot(destination: K, source: K): F[Long] = run(Bitmaps.bitOpNot(destination, source))
 
   /**
     * Runs a sequence of bitfield operations on `key`; one result per non-`Overflow` op. See [[sage.commands.BitFieldOp]].
     */
-  final def bitField[K: KeyCodec](key: K, first: BitFieldOp, rest: BitFieldOp*): F[Vector[Option[Long]]] =
+  final def bitField(key: K, first: BitFieldOp, rest: BitFieldOp*): F[Vector[Option[Long]]] =
     run(Bitmaps.bitField(key, first, rest*))
 
   /**
     * The read-only form of [[bitField]] (`BITFIELD_RO`), accepting only `Get` operations.
     */
-  final def bitFieldRo[K: KeyCodec](key: K, first: BitFieldOp.Get, rest: BitFieldOp.Get*): F[Vector[Long]] =
+  final def bitFieldRo(key: K, first: BitFieldOp.Get, rest: BitFieldOp.Get*): F[Vector[Long]] =
     run(Bitmaps.bitFieldRo(key, first, rest*))
 
   /**
     * Adds elements to the HyperLogLog at `key`, returning whether its estimate likely changed.
     */
-  final def pfAdd[K: KeyCodec, V: ValueCodec](key: K, elements: V*): F[Boolean] = run(HyperLogLog.pfAdd(key, elements*))
+  final def pfAdd[V: ValueCodec](key: K, elements: V*): F[Boolean] = run(HyperLogLog.pfAdd(key, elements*))
 
   /**
     * Returns the estimated cardinality of the union of the given HyperLogLogs.
     */
-  final def pfCount[K: KeyCodec](first: K, rest: K*): F[Long] = run(HyperLogLog.pfCount(first, rest*))
+  final def pfCount(first: K, rest: K*): F[Long] = run(HyperLogLog.pfCount(first, rest*))
 
   /**
     * Merges the source HyperLogLogs into `destination`.
     */
-  final def pfMerge[K: KeyCodec](destination: K, sources: K*): F[Unit] = run(HyperLogLog.pfMerge(destination, sources*))
+  final def pfMerge(destination: K, sources: K*): F[Unit] = run(HyperLogLog.pfMerge(destination, sources*))
 
   /**
     * Appends an entry of field/value pairs to the Stream at `key`, optionally trimming; returns the assigned ID. See [[sage.commands.XAddId]].
     */
-  final def xAdd[K: KeyCodec, F0: KeyCodec, V: ValueCodec](
+  final def xAdd[F0: KeyCodec, V: ValueCodec](
     key: K,
     id: XAddId = XAddId.Auto,
     trim: Option[Trimming] = None,
@@ -1227,7 +1240,7 @@ trait CommandRunner[F[_]] {
   /**
     * Like [[xAdd]], but does not create the Stream if it is absent (`XADD … NOMKSTREAM`); returns `None` in that case.
     */
-  final def xAddNoMkStream[K: KeyCodec, F0: KeyCodec, V: ValueCodec](
+  final def xAddNoMkStream[F0: KeyCodec, V: ValueCodec](
     key: K,
     id: XAddId = XAddId.Auto,
     trim: Option[Trimming] = None,
@@ -1237,35 +1250,35 @@ trait CommandRunner[F[_]] {
   /**
     * Returns the number of entries in the Stream at `key`.
     */
-  final def xLen[K: KeyCodec](key: K): F[Long] = run(Streams.xLen(key))
+  final def xLen(key: K): F[Long] = run(Streams.xLen(key))
 
   /**
     * Deletes the given entry IDs from the Stream at `key`, returning how many were removed.
     */
-  final def xDel[K: KeyCodec](key: K)(first: StreamId, rest: StreamId*): F[Long] = run(Streams.xDel(key)(first, rest*))
+  final def xDel(key: K)(first: StreamId, rest: StreamId*): F[Long] = run(Streams.xDel(key)(first, rest*))
 
   /**
     * Trims the Stream at `key` per `trim` (by max length or min ID); returns how many entries were removed. See [[sage.commands.Trimming]].
     */
-  final def xTrim[K: KeyCodec](key: K, trim: Trimming, policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef): F[Long] =
+  final def xTrim(key: K, trim: Trimming, policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef): F[Long] =
     run(Streams.xTrim(key, trim, policy))
 
   /**
     * Sets the Stream's last-generated ID and optional bookkeeping counters (`XSETID`).
     */
-  final def xSetId[K: KeyCodec](key: K, id: GroupStartId, entriesAdded: Option[Long] = None, maxDeletedId: Option[StreamId] = None): F[Unit] =
+  final def xSetId(key: K, id: GroupStartId, entriesAdded: Option[Long] = None, maxDeletedId: Option[StreamId] = None): F[Unit] =
     run(Streams.xSetId(key, id, entriesAdded, maxDeletedId))
 
   /**
     * Configures the Stream's idempotency window (`XCFGSET`).
     */
-  final def xCfgSet[K: KeyCodec](key: K, idmpDuration: Option[FiniteDuration] = None, idmpMaxSize: Option[Long] = None): F[Unit] =
+  final def xCfgSet(key: K, idmpDuration: Option[FiniteDuration] = None, idmpMaxSize: Option[Long] = None): F[Unit] =
     run(Streams.xCfgSet(key, idmpDuration, idmpMaxSize))
 
   /**
     * Returns Stream entries in the ID range `[start, end]`, up to `count`; see [[sage.commands.StreamRangeId]]/[[sage.commands.StreamEntry]].
     */
-  final def xRange[K: KeyCodec, F0: KeyCodec, V: ValueCodec](
+  final def xRange[F0: KeyCodec, V: ValueCodec](
     key: K,
     start: StreamRangeId = StreamRangeId.Min,
     end: StreamRangeId = StreamRangeId.Max,
@@ -1275,7 +1288,7 @@ trait CommandRunner[F[_]] {
   /**
     * Like [[xRange]], but in reverse order from `end` down to `start`.
     */
-  final def xRevRange[K: KeyCodec, F0: KeyCodec, V: ValueCodec](
+  final def xRevRange[F0: KeyCodec, V: ValueCodec](
     key: K,
     end: StreamRangeId = StreamRangeId.Max,
     start: StreamRangeId = StreamRangeId.Min,
@@ -1285,7 +1298,7 @@ trait CommandRunner[F[_]] {
   /**
     * Reads new entries from one or more Streams past each given [[sage.commands.ReadId]], optionally blocking up to `block`.
     */
-  final def xRead[K: KeyCodec, F0: KeyCodec, V: ValueCodec](first: (K, ReadId), rest: (K, ReadId)*)(
+  final def xRead[F0: KeyCodec, V: ValueCodec](first: (K, ReadId), rest: (K, ReadId)*)(
     count: Option[Long] = None,
     block: Option[BlockTimeout] = None
   ): F[Vector[(K, Vector[StreamEntry[F0, V]])]] = run(Streams.xRead(first, rest*)(count, block))
@@ -1293,7 +1306,7 @@ trait CommandRunner[F[_]] {
   /**
     * Reads entries for a Consumer Group as `consumer`, advancing the group on `>` or re-reading pending history otherwise; see [[sage.commands.GroupReadId]].
     */
-  final def xReadGroup[K: KeyCodec, F0: KeyCodec, V: ValueCodec](group: String, consumer: String)(first: (K, GroupReadId), rest: (K, GroupReadId)*)(
+  final def xReadGroup[F0: KeyCodec, V: ValueCodec](group: String, consumer: String)(first: (K, GroupReadId), rest: (K, GroupReadId)*)(
     count: Option[Long] = None,
     block: Option[BlockTimeout] = None,
     noAck: Boolean = false
@@ -1302,12 +1315,12 @@ trait CommandRunner[F[_]] {
   /**
     * Acknowledges the given entry IDs for a Consumer Group, removing them from its Pending Entries List; returns how many were acknowledged.
     */
-  final def xAck[K: KeyCodec](key: K, group: String)(first: StreamId, rest: StreamId*): F[Long] = run(Streams.xAck(key, group)(first, rest*))
+  final def xAck(key: K, group: String)(first: StreamId, rest: StreamId*): F[Long] = run(Streams.xAck(key, group)(first, rest*))
 
   /**
     * Creates a Consumer Group on the Stream at `key`, starting from `id`; `mkStream` creates the Stream if absent.
     */
-  final def xGroupCreate[K: KeyCodec](
+  final def xGroupCreate(
     key: K,
     group: String,
     id: GroupStartId = GroupStartId.Last,
@@ -1318,30 +1331,30 @@ trait CommandRunner[F[_]] {
   /**
     * Repositions a Consumer Group's last-delivered ID.
     */
-  final def xGroupSetId[K: KeyCodec](key: K, group: String, id: GroupStartId = GroupStartId.Last, entriesRead: Option[Long] = None): F[Unit] =
+  final def xGroupSetId(key: K, group: String, id: GroupStartId = GroupStartId.Last, entriesRead: Option[Long] = None): F[Unit] =
     run(Streams.xGroupSetId(key, group, id, entriesRead))
 
   /**
     * Destroys a Consumer Group and its pending state, returning whether it existed.
     */
-  final def xGroupDestroy[K: KeyCodec](key: K, group: String): F[Boolean] = run(Streams.xGroupDestroy(key, group))
+  final def xGroupDestroy(key: K, group: String): F[Boolean] = run(Streams.xGroupDestroy(key, group))
 
   /**
     * Explicitly creates a Consumer in a group, returning whether it was newly created.
     */
-  final def xGroupCreateConsumer[K: KeyCodec](key: K, group: String, consumer: String): F[Boolean] =
+  final def xGroupCreateConsumer(key: K, group: String, consumer: String): F[Boolean] =
     run(Streams.xGroupCreateConsumer(key, group, consumer))
 
   /**
     * Removes a Consumer from a group, returning how many pending entries it still owned.
     */
-  final def xGroupDelConsumer[K: KeyCodec](key: K, group: String, consumer: String): F[Long] =
+  final def xGroupDelConsumer(key: K, group: String, consumer: String): F[Long] =
     run(Streams.xGroupDelConsumer(key, group, consumer))
 
   /**
     * Transfers ownership of the given pending entries to `consumer`, if idle at least `minIdle`; returns the claimed entries.
     */
-  final def xClaim[K: KeyCodec, F0: KeyCodec, V: ValueCodec](key: K, group: String, consumer: String, minIdle: FiniteDuration)(
+  final def xClaim[F0: KeyCodec, V: ValueCodec](key: K, group: String, consumer: String, minIdle: FiniteDuration)(
     first: StreamId,
     rest: StreamId*
   )(idle: Option[ClaimIdle] = None, retryCount: Option[Long] = None, force: Boolean = false): F[Vector[StreamEntry[F0, V]]] =
@@ -1350,7 +1363,7 @@ trait CommandRunner[F[_]] {
   /**
     * Like [[xClaim]], but returns only the claimed entry IDs (`XCLAIM … JUSTID`).
     */
-  final def xClaimJustId[K: KeyCodec](key: K, group: String, consumer: String, minIdle: FiniteDuration)(first: StreamId, rest: StreamId*)(
+  final def xClaimJustId(key: K, group: String, consumer: String, minIdle: FiniteDuration)(first: StreamId, rest: StreamId*)(
     idle: Option[ClaimIdle] = None,
     retryCount: Option[Long] = None,
     force: Boolean = false
@@ -1359,7 +1372,7 @@ trait CommandRunner[F[_]] {
   /**
     * Scans a group's pending entries from `start`, claiming idle ones for `consumer`; see [[sage.commands.XAutoClaimResult]].
     */
-  final def xAutoClaim[K: KeyCodec, F0: KeyCodec, V: ValueCodec](
+  final def xAutoClaim[F0: KeyCodec, V: ValueCodec](
     key: K,
     group: String,
     consumer: String,
@@ -1371,7 +1384,7 @@ trait CommandRunner[F[_]] {
   /**
     * Like [[xAutoClaim]], but returns only the claimed entry IDs; see [[sage.commands.XAutoClaimJustIdResult]].
     */
-  final def xAutoClaimJustId[K: KeyCodec](
+  final def xAutoClaimJustId(
     key: K,
     group: String,
     consumer: String,
@@ -1383,12 +1396,12 @@ trait CommandRunner[F[_]] {
   /**
     * Returns a group-level summary of the Pending Entries List; see [[sage.commands.PendingSummary]].
     */
-  final def xPending[K: KeyCodec](key: K, group: String): F[PendingSummary] = run(Streams.xPending(key, group))
+  final def xPending(key: K, group: String): F[PendingSummary] = run(Streams.xPending(key, group))
 
   /**
     * Returns per-entry pending detail over an ID range, optionally filtered by `consumer`/`idle`; see [[sage.commands.PendingEntry]].
     */
-  final def xPendingExtended[K: KeyCodec](
+  final def xPendingExtended(
     key: K,
     group: String,
     start: StreamRangeId = StreamRangeId.Min,
@@ -1401,28 +1414,28 @@ trait CommandRunner[F[_]] {
   /**
     * Returns summary metadata about the Stream at `key`; see [[sage.commands.StreamInfo]].
     */
-  final def xInfoStream[K: KeyCodec, F0: KeyCodec, V: ValueCodec](key: K): F[StreamInfo[F0, V]] = run(StreamInfo.xInfoStream(key))
+  final def xInfoStream[F0: KeyCodec, V: ValueCodec](key: K): F[StreamInfo[F0, V]] = run(StreamInfo.xInfoStream(key))
 
   /**
     * Returns the full Stream introspection, including groups and PEL entries; see [[sage.commands.StreamInfoFull]].
     */
-  final def xInfoStreamFull[K: KeyCodec, F0: KeyCodec, V: ValueCodec](key: K, count: Option[Long] = None): F[StreamInfoFull[F0, V]] =
+  final def xInfoStreamFull[F0: KeyCodec, V: ValueCodec](key: K, count: Option[Long] = None): F[StreamInfoFull[F0, V]] =
     run(StreamInfo.xInfoStreamFull(key, count))
 
   /**
     * Returns one entry per Consumer Group on the Stream at `key`; see [[sage.commands.GroupInfo]].
     */
-  final def xInfoGroups[K: KeyCodec](key: K): F[Vector[GroupInfo]] = run(StreamInfo.xInfoGroups(key))
+  final def xInfoGroups(key: K): F[Vector[GroupInfo]] = run(StreamInfo.xInfoGroups(key))
 
   /**
     * Returns one entry per Consumer in a group; see [[sage.commands.ConsumerInfo]].
     */
-  final def xInfoConsumers[K: KeyCodec](key: K, group: String): F[Vector[ConsumerInfo]] = run(StreamInfo.xInfoConsumers(key, group))
+  final def xInfoConsumers(key: K, group: String): F[Vector[ConsumerInfo]] = run(StreamInfo.xInfoConsumers(key, group))
 
   /**
     * Deletes the given entries with an explicit deletion `policy`; one [[sage.commands.StreamEntryDeletion]] per ID (`XDELEX`).
     */
-  final def xDelEx[K: KeyCodec](key: K, policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef)(
+  final def xDelEx(key: K, policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef)(
     first: StreamId,
     rest: StreamId*
   ): F[Vector[StreamEntryDeletion]] =
@@ -1431,7 +1444,7 @@ trait CommandRunner[F[_]] {
   /**
     * Acknowledges and deletes the given entries in one step (`XACKDEL`); one [[sage.commands.StreamEntryDeletion]] per ID.
     */
-  final def xAckDel[K: KeyCodec](key: K, group: String, policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef)(
+  final def xAckDel(key: K, group: String, policy: StreamDeletionPolicy = StreamDeletionPolicy.KeepRef)(
     first: StreamId,
     rest: StreamId*
   ): F[Vector[StreamEntryDeletion]] = run(Streams.xAckDel(key, group, policy)(first, rest*))
@@ -1439,7 +1452,7 @@ trait CommandRunner[F[_]] {
   /**
     * Negatively-acknowledges the given pending entries (`XNACK`), per `mode`; returns how many were affected. See [[sage.commands.NackMode]].
     */
-  final def xNack[K: KeyCodec](key: K, group: String, mode: NackMode)(first: StreamId, rest: StreamId*)(
+  final def xNack(key: K, group: String, mode: NackMode)(first: StreamId, rest: StreamId*)(
     retryCount: Option[Long] = None,
     force: Boolean = false
   ): F[Long] = run(Streams.xNack(key, group, mode)(first, rest*)(retryCount, force))
@@ -1454,12 +1467,12 @@ trait CommandRunner[F[_]] {
   /**
     * Evaluates the Lua `script` with the given keys.
     */
-  final def eval[K: KeyCodec](script: String, keys: Seq[K]): F[Frame] = run(Scripting.eval(script, keys))
+  final def eval(script: String, keys: Seq[K]): F[Frame] = run(Scripting.eval(script, keys))
 
   /**
     * Evaluates the Lua `script` with the given keys and arguments.
     */
-  final def eval[K: KeyCodec, V: ValueCodec](script: String, keys: Seq[K], args: Seq[V]): F[Frame] =
+  final def eval[V: ValueCodec](script: String, keys: Seq[K], args: Seq[V]): F[Frame] =
     run(Scripting.eval(script, keys, args))
 
   /**
@@ -1470,12 +1483,12 @@ trait CommandRunner[F[_]] {
   /**
     * Read-only [[eval]] with the given keys (`EVAL_RO`).
     */
-  final def evalRo[K: KeyCodec](script: String, keys: Seq[K]): F[Frame] = run(Scripting.evalRo(script, keys))
+  final def evalRo(script: String, keys: Seq[K]): F[Frame] = run(Scripting.evalRo(script, keys))
 
   /**
     * Read-only [[eval]] with the given keys and arguments (`EVAL_RO`).
     */
-  final def evalRo[K: KeyCodec, V: ValueCodec](script: String, keys: Seq[K], args: Seq[V]): F[Frame] =
+  final def evalRo[V: ValueCodec](script: String, keys: Seq[K], args: Seq[V]): F[Frame] =
     run(Scripting.evalRo(script, keys, args))
 
   /**
@@ -1486,12 +1499,12 @@ trait CommandRunner[F[_]] {
   /**
     * Evaluates a cached script by `sha` with the given keys (`EVALSHA`).
     */
-  final def evalSha[K: KeyCodec](sha: String, keys: Seq[K]): F[Frame] = run(Scripting.evalSha(sha, keys))
+  final def evalSha(sha: String, keys: Seq[K]): F[Frame] = run(Scripting.evalSha(sha, keys))
 
   /**
     * Evaluates a cached script by `sha` with the given keys and arguments (`EVALSHA`).
     */
-  final def evalSha[K: KeyCodec, V: ValueCodec](sha: String, keys: Seq[K], args: Seq[V]): F[Frame] =
+  final def evalSha[V: ValueCodec](sha: String, keys: Seq[K], args: Seq[V]): F[Frame] =
     run(Scripting.evalSha(sha, keys, args))
 
   /**
@@ -1502,12 +1515,12 @@ trait CommandRunner[F[_]] {
   /**
     * Read-only [[evalSha]] with the given keys (`EVALSHA_RO`).
     */
-  final def evalShaRo[K: KeyCodec](sha: String, keys: Seq[K]): F[Frame] = run(Scripting.evalShaRo(sha, keys))
+  final def evalShaRo(sha: String, keys: Seq[K]): F[Frame] = run(Scripting.evalShaRo(sha, keys))
 
   /**
     * Read-only [[evalSha]] with the given keys and arguments (`EVALSHA_RO`).
     */
-  final def evalShaRo[K: KeyCodec, V: ValueCodec](sha: String, keys: Seq[K], args: Seq[V]): F[Frame] =
+  final def evalShaRo[V: ValueCodec](sha: String, keys: Seq[K], args: Seq[V]): F[Frame] =
     run(Scripting.evalShaRo(sha, keys, args))
 
   /**
@@ -1545,12 +1558,12 @@ trait CommandRunner[F[_]] {
   /**
     * Calls the named Function with the given keys (`FCALL`).
     */
-  final def fCall[K: KeyCodec](function: String, keys: Seq[K]): F[Frame] = run(Functions.fCall(function, keys))
+  final def fCall(function: String, keys: Seq[K]): F[Frame] = run(Functions.fCall(function, keys))
 
   /**
     * Calls the named Function with the given keys and arguments (`FCALL`).
     */
-  final def fCall[K: KeyCodec, V: ValueCodec](function: String, keys: Seq[K], args: Seq[V]): F[Frame] =
+  final def fCall[V: ValueCodec](function: String, keys: Seq[K], args: Seq[V]): F[Frame] =
     run(Functions.fCall(function, keys, args))
 
   /**
@@ -1561,12 +1574,12 @@ trait CommandRunner[F[_]] {
   /**
     * Read-only [[fCall]] with the given keys (`FCALL_RO`).
     */
-  final def fCallRo[K: KeyCodec](function: String, keys: Seq[K]): F[Frame] = run(Functions.fCallRo(function, keys))
+  final def fCallRo(function: String, keys: Seq[K]): F[Frame] = run(Functions.fCallRo(function, keys))
 
   /**
     * Read-only [[fCall]] with the given keys and arguments (`FCALL_RO`).
     */
-  final def fCallRo[K: KeyCodec, V: ValueCodec](function: String, keys: Seq[K], args: Seq[V]): F[Frame] =
+  final def fCallRo[V: ValueCodec](function: String, keys: Seq[K], args: Seq[V]): F[Frame] =
     run(Functions.fCallRo(function, keys, args))
 
   /**
@@ -1667,7 +1680,7 @@ trait CommandRunner[F[_]] {
   /**
     * Returns the approximate memory used by the value at `key` in bytes, or `None` if absent.
     */
-  final def memoryUsage[K: KeyCodec](key: K, samples: Option[Long] = None): F[Option[Long]] = run(Server.memoryUsage(key, samples))
+  final def memoryUsage(key: K, samples: Option[Long] = None): F[Option[Long]] = run(Server.memoryUsage(key, samples))
 
   /**
     * Asks the allocator to release memory back to the OS.
@@ -1844,85 +1857,85 @@ trait CommandRunner[F[_]] {
   /**
     * Writes the given values into the Array at `key` from `index` onward, returning the new used count.
     */
-  final def arSet[K: KeyCodec, V: ValueCodec](key: K, index: Long, first: V, rest: V*): F[Long] = run(Arrays.arSet(key, index, first, rest*))
+  final def arSet[V: ValueCodec](key: K, index: Long, first: V, rest: V*): F[Long] = run(Arrays.arSet(key, index, first, rest*))
 
   /**
     * Writes values at explicit indices in the Array at `key`, returning the new used count.
     */
-  final def arMSet[K: KeyCodec, V: ValueCodec](key: K, first: (Long, V), rest: (Long, V)*): F[Long] = run(Arrays.arMSet(key, first, rest*))
+  final def arMSet[V: ValueCodec](key: K, first: (Long, V), rest: (Long, V)*): F[Long] = run(Arrays.arMSet(key, first, rest*))
 
   /**
     * Returns the value at `index` in the Array at `key`, or `None` if that slot is empty.
     */
-  final def arGet[K: KeyCodec, V: ValueCodec](key: K, index: Long): F[Option[V]] = run(Arrays.arGet(key, index))
+  final def arGet[V: ValueCodec](key: K, index: Long): F[Option[V]] = run(Arrays.arGet(key, index))
 
   /**
     * Returns the values at the given indices in the Array at `key`, each `None` if its slot is empty.
     */
-  final def arMGet[K: KeyCodec, V: ValueCodec](key: K, first: Long, rest: Long*): F[Vector[Option[V]]] = run(Arrays.arMGet(key, first, rest*))
+  final def arMGet[V: ValueCodec](key: K, first: Long, rest: Long*): F[Vector[Option[V]]] = run(Arrays.arMGet(key, first, rest*))
 
   /**
     * Returns the logical length of the Array at `key` (highest index + 1).
     */
-  final def arLen[K: KeyCodec](key: K): F[Long] = run(Arrays.arLen(key))
+  final def arLen(key: K): F[Long] = run(Arrays.arLen(key))
 
   /**
     * Returns the number of populated slots in the Array at `key`.
     */
-  final def arCount[K: KeyCodec](key: K): F[Long] = run(Arrays.arCount(key))
+  final def arCount(key: K): F[Long] = run(Arrays.arCount(key))
 
   /**
     * Returns the values in the index range `[start, end]` of the Array at `key`, each `None` if its slot is empty.
     */
-  final def arGetRange[K: KeyCodec, V: ValueCodec](key: K, start: Long, end: Long): F[Vector[Option[V]]] =
+  final def arGetRange[V: ValueCodec](key: K, start: Long, end: Long): F[Vector[Option[V]]] =
     run(Arrays.arGetRange(key, start, end))
 
   /**
     * Appends values to the Array at `key` in ring-buffer mode of capacity `size`, overwriting the oldest; returns the new used count.
     */
-  final def arRing[K: KeyCodec, V: ValueCodec](key: K, size: Long, first: V, rest: V*): F[Long] = run(Arrays.arRing(key, size, first, rest*))
+  final def arRing[V: ValueCodec](key: K, size: Long, first: V, rest: V*): F[Long] = run(Arrays.arRing(key, size, first, rest*))
 
   /**
     * Returns the last `count` populated values of the Array at `key`, newest-first when `rev`.
     */
-  final def arLastItems[K: KeyCodec, V: ValueCodec](key: K, count: Long, rev: Boolean = false): F[Vector[V]] =
+  final def arLastItems[V: ValueCodec](key: K, count: Long, rev: Boolean = false): F[Vector[V]] =
     run(Arrays.arLastItems(key, count, rev))
 
   /**
     * Clears the given indices of the Array at `key`, returning how many were populated.
     */
-  final def arDel[K: KeyCodec](key: K, first: Long, rest: Long*): F[Long] = run(Arrays.arDel(key, first, rest*))
+  final def arDel(key: K, first: Long, rest: Long*): F[Long] = run(Arrays.arDel(key, first, rest*))
 
   /**
     * Clears the given inclusive index ranges of the Array at `key`, returning how many slots were cleared.
     */
-  final def arDelRange[K: KeyCodec](key: K, first: (Long, Long), rest: (Long, Long)*): F[Long] = run(Arrays.arDelRange(key, first, rest*))
+  final def arDelRange(key: K, first: (Long, Long), rest: (Long, Long)*): F[Long] = run(Arrays.arDelRange(key, first, rest*))
 
   /**
     * Writes the given values at the Array's write cursor and advances it, returning the new used count.
     */
-  final def arInsert[K: KeyCodec, V: ValueCodec](key: K, first: V, rest: V*): F[Long] = run(Arrays.arInsert(key, first, rest*))
+  final def arInsert[V: ValueCodec](key: K, first: V, rest: V*): F[Long] = run(Arrays.arInsert(key, first, rest*))
 
   /**
     * Returns the next populated index at or after the write cursor, or `None` if none.
     */
-  final def arNext[K: KeyCodec](key: K): F[Option[Long]] = run(Arrays.arNext(key))
+  final def arNext(key: K): F[Option[Long]] = run(Arrays.arNext(key))
 
   /**
     * Moves the Array's write cursor to `index`, returning whether it moved.
     */
-  final def arSeek[K: KeyCodec](key: K, index: Long): F[Boolean] = run(Arrays.arSeek(key, index))
+  final def arSeek(key: K, index: Long): F[Boolean] = run(Arrays.arSeek(key, index))
 
   /**
     * Returns populated (index, value) pairs in `[start, end]`, up to `limit`.
     */
-  final def arScan[K: KeyCodec, V: ValueCodec](key: K, start: Long, end: Long, limit: Option[Long] = None): F[Vector[(Long, V)]] =
+  final def arScan[V: ValueCodec](key: K, start: Long, end: Long, limit: Option[Long] = None): F[Vector[(Long, V)]] =
     run(Arrays.arScan(key, start, end, limit))
 
   /**
     * Returns the indices in `[start, end]` whose values match the given criteria, combined per `combine`; see [[sage.commands.ArMatch]].
     */
-  final def arGrep[K: KeyCodec](
+  final def arGrep(
     key: K,
     start: Long,
     end: Long,
@@ -1934,7 +1947,7 @@ trait CommandRunner[F[_]] {
   /**
     * Like [[arGrep]], but returns each matching index paired with its value.
     */
-  final def arGrepWithValues[K: KeyCodec, V: ValueCodec](
+  final def arGrepWithValues[V: ValueCodec](
     key: K,
     start: Long,
     end: Long,
@@ -1946,53 +1959,53 @@ trait CommandRunner[F[_]] {
   /**
     * Sums the values in `[start, end]` of the Array at `key`, or `None` if the range is empty.
     */
-  final def arOpSum[K: KeyCodec](key: K, start: Long, end: Long): F[Option[Double]] = run(Arrays.arOpSum(key, start, end))
+  final def arOpSum(key: K, start: Long, end: Long): F[Option[Double]] = run(Arrays.arOpSum(key, start, end))
 
   /**
     * Returns the minimum value in `[start, end]`, or `None` if the range is empty.
     */
-  final def arOpMin[K: KeyCodec](key: K, start: Long, end: Long): F[Option[Double]] = run(Arrays.arOpMin(key, start, end))
+  final def arOpMin(key: K, start: Long, end: Long): F[Option[Double]] = run(Arrays.arOpMin(key, start, end))
 
   /**
     * Returns the maximum value in `[start, end]`, or `None` if the range is empty.
     */
-  final def arOpMax[K: KeyCodec](key: K, start: Long, end: Long): F[Option[Double]] = run(Arrays.arOpMax(key, start, end))
+  final def arOpMax(key: K, start: Long, end: Long): F[Option[Double]] = run(Arrays.arOpMax(key, start, end))
 
   /**
     * Returns the bitwise AND of the integer values in `[start, end]`, or `None` if the range is empty.
     */
-  final def arOpAnd[K: KeyCodec](key: K, start: Long, end: Long): F[Option[Long]] = run(Arrays.arOpAnd(key, start, end))
+  final def arOpAnd(key: K, start: Long, end: Long): F[Option[Long]] = run(Arrays.arOpAnd(key, start, end))
 
   /**
     * Returns the bitwise OR of the integer values in `[start, end]`, or `None` if the range is empty.
     */
-  final def arOpOr[K: KeyCodec](key: K, start: Long, end: Long): F[Option[Long]] = run(Arrays.arOpOr(key, start, end))
+  final def arOpOr(key: K, start: Long, end: Long): F[Option[Long]] = run(Arrays.arOpOr(key, start, end))
 
   /**
     * Returns the bitwise XOR of the integer values in `[start, end]`, or `None` if the range is empty.
     */
-  final def arOpXor[K: KeyCodec](key: K, start: Long, end: Long): F[Option[Long]] = run(Arrays.arOpXor(key, start, end))
+  final def arOpXor(key: K, start: Long, end: Long): F[Option[Long]] = run(Arrays.arOpXor(key, start, end))
 
   /**
     * Returns how many slots in `[start, end]` are populated.
     */
-  final def arOpUsed[K: KeyCodec](key: K, start: Long, end: Long): F[Long] = run(Arrays.arOpUsed(key, start, end))
+  final def arOpUsed(key: K, start: Long, end: Long): F[Long] = run(Arrays.arOpUsed(key, start, end))
 
   /**
     * Returns how many slots in `[start, end]` hold `value`.
     */
-  final def arOpMatch[K: KeyCodec, V: ValueCodec](key: K, start: Long, end: Long, value: V): F[Long] =
+  final def arOpMatch[V: ValueCodec](key: K, start: Long, end: Long, value: V): F[Long] =
     run(Arrays.arOpMatch(key, start, end, value))
 
   /**
     * Returns summary metadata about the Array at `key`; see [[sage.commands.ArrayInfo]].
     */
-  final def arInfo[K: KeyCodec](key: K): F[ArrayInfo] = run(Arrays.arInfo(key))
+  final def arInfo(key: K): F[ArrayInfo] = run(Arrays.arInfo(key))
 
   /**
     * Returns the full introspection of the Array at `key`; see [[sage.commands.ArrayInfoFull]].
     */
-  final def arInfoFull[K: KeyCodec](key: K): F[ArrayInfoFull] = run(Arrays.arInfoFull(key))
+  final def arInfoFull(key: K): F[ArrayInfoFull] = run(Arrays.arInfoFull(key))
 }
 
 /**
@@ -2022,7 +2035,7 @@ private[sage] enum ScanStep {
   * blocking commands, and pub/sub acquire other connections, transparently. Constructed with a backend's `connect`/`scoped` and released with
   * [[close]].
   */
-trait Client[F[_]] extends CommandRunner[F] {
+trait Client[F[_], K] extends CommandRunner[F, K] {
 
   /**
     * Runs a read with client-side caching: served from the local cache until a server invalidation push or `ttl` evicts it. Only a
@@ -2046,7 +2059,7 @@ trait Client[F[_]] extends CommandRunner[F] {
   /**
     * Opens a [[TransactionScope]] on a leased Dedicated Connection for `MULTI`/`EXEC`, optionally guarded by `WATCH`.
     */
-  def transaction[A](body: TransactionScope[F] => F[A]): F[A]
+  def transaction[A](body: TransactionScope[F, K] => F[A]): F[A]
 
   /**
     * Subscribes to classic channels, returning a [[Subscription]] handle the backend wraps into its native stream of [[Message]]s.
@@ -2073,6 +2086,29 @@ trait Client[F[_]] extends CommandRunner[F] {
     * Releases all connections and the client's resources.
     */
   def close: F[Unit]
+
+  /**
+    * Re-types the whole client surface to another key type over the same connection — no new connection is opened. Everything but the command
+    * sugar is key-independent and simply forwards (`cached`, `pipeline`, `subscribe*`, `runOn`, `close`); `transaction` re-types its scope. This
+    * is what makes `client.as[Array[Byte]]` keep the full surface (and the backend `…All`/`subscribe` helpers, which extend `Client[F, K]`),
+    * not just the command methods.
+    */
+  override def as[K2](using KeyCodec[K2]): Client[F, K2] = {
+    val self = this
+    new Client[F, K2] {
+      def run[A](command: Command[A]): F[A]                                     = self.run(command)
+      def cached[A](command: Command[A], ttl: FiniteDuration): F[A]             = self.cached(command, ttl)
+      def pipeline[Out, R](p: Pipeline[Out, R]): F[Out]                         = self.pipeline(p)
+      def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R]                    = self.pipelineAttempt(p)
+      def transaction[A](body: TransactionScope[F, K2] => F[A]): F[A]           = self.transaction(scope => body(scope.as[K2]))
+      def subscribeChannels[V: ValueCodec](channel: String, rest: String*)      = self.subscribeChannels(channel, rest*)
+      def subscribePatterns[V: ValueCodec](pattern: String, rest: String*)      = self.subscribePatterns(pattern, rest*)
+      def subscribeShardChannels[V: ValueCodec](channel: String, rest: String*) = self.subscribeShardChannels(channel, rest*)
+      private[sage] def scanTargets: F[Vector[ScanTarget]]                      = self.scanTargets
+      private[sage] def runOn[A](target: ScanTarget, command: Command[A]): F[A] = self.runOn(target, command)
+      def close: F[Unit]                                                        = self.close
+    }
+  }
 }
 
 object Client {
@@ -2108,7 +2144,7 @@ object Client {
   /**
     * The construction seam each backend's `connect`/`scoped` builds on: validates `config`, then connects per its [[Topology]].
     */
-  def connect(config: SageConfig): CIO[Client[CIO]] =
+  def connect(config: SageConfig): CIO[Client[CIO, String]] =
     validate(config) match {
       case Some(problem) => CIO.fail(new IllegalArgumentException(problem))
       case None          =>
@@ -2174,7 +2210,7 @@ object Client {
   private def positiveOrInfinite(value: Duration, label: String): Option[String] =
     cond(value == Duration.Inf || (value.isFinite && value.toNanos > 0L), s"$label must be positive (or Inf)")
 
-  private def connectStandalone(config: SageConfig, endpoint: Endpoint): CIO[Client[CIO]] =
+  private def connectStandalone(config: SageConfig, endpoint: Endpoint): CIO[Client[CIO, String]] =
     // build the TLS context once (eager failure on bad trust material), then capture it in the reconnect factory so every connection — the
     // multiplexed one and each dedicated one — is upgraded identically
     CIO.blocking(Tls.buildUpgrade(config.tls, endpoint.host, endpoint.port)).flatMap { upgrade =>
@@ -2212,7 +2248,7 @@ object Client {
     events: Events = Events.disabled,
     database: Int = 0,
     clientName: Option[String] = None
-  ): CIO[Client[CIO]] = {
+  ): CIO[Client[CIO, String]] = {
     val bootstrap            = Bootstrap.commands(auth, database, clientName)
     // only the Multiplexed Connection caches reads, so only it enables tracking; the dedicated pool and subscription connection keep the
     // plain bootstrap. Tracking is skipped entirely when caching is disabled, so a server that denies CLIENT TRACKING still connects.
@@ -2258,7 +2294,7 @@ object Client {
     subscriptions: SubscriptionConnection,
     cachingEnabled: Boolean,
     events: Events
-  ) extends Client[CIO] {
+  ) extends Client[CIO, String] {
 
     def run[A](command: Command[A]): CIO[A] =
       command.execution match {
@@ -2284,7 +2320,7 @@ object Client {
     // The lease is bracketed: release runs on success, failure, and interruption (IO.bracket). A clean exit (exec/discard cleared the
     // connection's WATCH/MULTI state, no reply outstanding) recycles the connection; a scope left armed or interrupted mid-command is
     // discarded rather than handed to the next borrower dirty.
-    def transaction[A](body: TransactionScope[CIO] => CIO[A]): CIO[A] =
+    def transaction[A](body: TransactionScope[CIO, String] => CIO[A]): CIO[A] =
       CIO.acquireReleaseWith(acquireScope)(releaseScope)(scope => body(scope))
 
     private def acquireScope: CIO[TxScope] =
@@ -2353,7 +2389,7 @@ object Client {
       case Left(error)  => throw error
     }
 
-  final private[internal] class TxScope(val conn: DedicatedConnection, onFault: Throwable => Unit = _ => ()) extends TransactionScope[CIO] {
+  final private[internal] class TxScope(val conn: DedicatedConnection, onFault: Throwable => Unit = _ => ()) extends TransactionScope[CIO, String] {
 
     // tracks whether watched keys may still be armed on the connection; set as soon as WATCH is attempted, cleared by EXEC/UNWATCH
     val armed = new AtomicBoolean(false)

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -44,7 +44,7 @@ final private[client] class ClusterLive(
   seeds: Vector[Node],
   readFrom: ReadFrom = ReadFrom.Master,
   events: Events = Events.disabled
-) extends Client[CIO] {
+) extends Client[CIO, String] {
 
   private val topologyRef = new AtomicReference[ClusterTopology](ClusterTopology.from(Vector.empty))
 
@@ -141,7 +141,7 @@ final private[client] class ClusterLive(
   def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out]      = submitPipeline(p).flatMap(TxSupport.collapseStrict(_, p.toOut))
   def pipelineAttempt[Out, R](p: Pipeline[Out, R]): CIO[R] = submitPipeline(p).map(p.toResults)
 
-  def transaction[A](body: TransactionScope[CIO] => CIO[A]): CIO[A] =
+  def transaction[A](body: TransactionScope[CIO, String] => CIO[A]): CIO[A] =
     CIO.acquireReleaseWith(acquireScope)(releaseScope)(scope => body(scope))
 
   // classic subscriptions ride one connection pinned to an arbitrary master (classic PUBLISH broadcasts cluster-wide); the manager re-homes it
@@ -509,7 +509,7 @@ final private[client] class ClusterLive(
     * connection (or, before any key, an arbitrary master). Redirects and losses are never followed — they surface and refresh the topology
     * in the background — so the caller retries the whole block, as it already must for a `WATCH` abort.
     */
-  final private class ClusterTxScope extends TransactionScope[CIO] {
+  final private class ClusterTxScope extends TransactionScope[CIO, String] {
 
     private val lock                      = new ReentrantLock()
     private var released                  = false
@@ -842,8 +842,8 @@ private[client] object ClusterLive {
     cluster: ClusterConfig,
     scheduler: Scheduler,
     translate: Throwable => Throwable
-  ): CIO[Client[CIO]] =
-    CIO.blocking[Client[CIO]] {
+  ): CIO[Client[CIO, String]] =
+    CIO.blocking[Client[CIO, String]] {
       // cluster validation forces database 0, so this adds no SELECT
       val bootstrap                                               = Bootstrap.commands(config.auth, config.database, config.clientName)
       val factory: Node => MultiplexedConnection.TransportFactory = node => {

--- a/sage-client/shared/src/main/scala/sage/client/internal/LoweredClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LoweredClient.scala
@@ -14,7 +14,7 @@ import sage.commands.{Command, Pipeline}
   * expressed in terms of them. The native streaming sugar (`scanAll`, `subscribe`, …) stays per Backend, since it returns that ecosystem's
   * own stream type.
   */
-abstract class LoweredClient[F[_]](underlying: Client[CIO]) extends Client[F] {
+abstract class LoweredClient[F[_]](underlying: Client[CIO, String]) extends Client[F, String] {
 
   protected def lower[A](c: CIO[A]): F[A]
 
@@ -28,7 +28,7 @@ abstract class LoweredClient[F[_]](underlying: Client[CIO]) extends Client[F] {
 
   final def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R] = lower(underlying.pipelineAttempt(p))
 
-  final def transaction[A](body: TransactionScope[F] => F[A]): F[A] =
+  final def transaction[A](body: TransactionScope[F, String] => F[A]): F[A] =
     lower(underlying.transaction[A](scope => lift(body(lowerScope(scope)))))
 
   final def subscribeChannels[V: ValueCodec](channel: String, rest: String*): F[Subscription[F, Message[V]]] =
@@ -46,8 +46,8 @@ abstract class LoweredClient[F[_]](underlying: Client[CIO]) extends Client[F] {
 
   final def close: F[Unit] = lower(underlying.close)
 
-  private def lowerScope(scope: TransactionScope[CIO]): TransactionScope[F] =
-    new TransactionScope[F] {
+  private def lowerScope(scope: TransactionScope[CIO, String]): TransactionScope[F, String] =
+    new TransactionScope[F, String] {
       def watch[K: KeyCodec](key: K, rest: K*): F[Unit]          = lower(scope.watch(key, rest*))
       def run[A](command: Command[A]): F[A]                      = lower(scope.run(command))
       def exec[Out, R](p: Pipeline[Out, R]): F[Option[Out]]      = lower(scope.exec(p))

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -35,7 +35,7 @@ final private[client] class MasterReplicaLive(
   seeds: Vector[Node],
   minRefreshInterval: FiniteDuration,
   events: Events = Events.disabled
-) extends Client[CIO] {
+) extends Client[CIO, String] {
 
   private val readFrom       = config.readFrom
   private val cachingEnabled = config.clientCache.enabled
@@ -288,7 +288,7 @@ final private[client] class MasterReplicaLive(
 
   // --- transactions (always on the master) ---------------------------------------------------------------------------------------------
 
-  def transaction[A](body: TransactionScope[CIO] => CIO[A]): CIO[A] =
+  def transaction[A](body: TransactionScope[CIO, String] => CIO[A]): CIO[A] =
     CIO.acquireReleaseWith(acquireScope)(releaseScope)(lease => body(lease.scope))
 
   private def refreshOnTxFault(error: Throwable): Unit = if (isOwnershipFault(error)) triggerRefresh()
@@ -378,8 +378,8 @@ private[client] object MasterReplicaLive {
     masterReplica: sage.client.MasterReplicaConfig,
     scheduler: Scheduler,
     translate: Throwable => Throwable
-  ): CIO[Client[CIO]] =
-    CIO.blocking[Client[CIO]] {
+  ): CIO[Client[CIO, String]] =
+    CIO.blocking[Client[CIO, String]] {
       val bootstrap                                               = Bootstrap.commands(config.auth, config.database, config.clientName)
       val factory: Node => MultiplexedConnection.TransportFactory = node => {
         val upgrade = Tls.buildUpgrade(config.tls, node.host, node.port)

--- a/sage-client/shared/src/main/scala/sage/client/internal/TransactionScope.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/TransactionScope.scala
@@ -1,7 +1,7 @@
 package sage.client.internal
 
 import sage.codec.KeyCodec
-import sage.commands.Pipeline
+import sage.commands.{Command, Pipeline}
 
 /**
   * The handle opened by `transaction { tx => … }`: one leased Dedicated Connection, held for the whole block. Reads run immediately on that
@@ -10,7 +10,7 @@ import sage.commands.Pipeline
   * optimistic-concurrency attempt the caller retries, not a failure); `execAttempt` mirrors a Pipeline's per-position results. A queueing-phase
   * rejection fails the effect with `TransactionDiscarded` (nothing ran), distinct from an execution-phase error, which leaves the others committed.
   */
-trait TransactionScope[F[_]] extends CommandRunner[F] {
+trait TransactionScope[F[_], K] extends CommandRunner[F, K] {
 
   /**
     * Watches keys for the duration of the scope; a later `exec` aborts if any changed.
@@ -31,4 +31,19 @@ trait TransactionScope[F[_]] extends CommandRunner[F] {
     * Abandons the scope without committing, clearing any watched keys so the connection can be recycled (issues `UNWATCH`).
     */
   def discard: F[Unit]
+
+  /**
+    * Re-types the scope's command surface to another key type, keeping the leased connection and the transaction's `watch`/`exec`/`discard`.
+    * Lets a transaction read or write a different key type without leaving the scope (`tx.as[Array[Byte]].get(k)`).
+    */
+  override def as[K2](using KeyCodec[K2]): TransactionScope[F, K2] = {
+    val self = this
+    new TransactionScope[F, K2] {
+      def run[A](command: Command[A]): F[A]                             = self.run(command)
+      def watch[K0: KeyCodec](key: K0, rest: K0*): F[Unit]              = self.watch(key, rest*)
+      def exec[Out, R](pipeline: Pipeline[Out, R]): F[Option[Out]]      = self.exec(pipeline)
+      def execAttempt[Out, R](pipeline: Pipeline[Out, R]): F[Option[R]] = self.execAttempt(pipeline)
+      def discard: F[Unit]                                              = self.discard
+    }
+  }
 }

--- a/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
+++ b/sage-client/zio/src/main/scala/sage/zio/SageClient.scala
@@ -2,6 +2,7 @@ package sage.zio
 
 import java.util.concurrent.TimeUnit
 
+import scala.annotation.unused
 import scala.concurrent.duration.FiniteDuration
 
 import kyo.compat.*
@@ -17,9 +18,9 @@ import sage.commands.*
 /**
   * The ZIO-native surface: the same client, with every method returning `Task`.
   */
-type SageClient = Client[Task]
+type SageClient = Client[Task, String]
 
-extension (client: SageClient) {
+extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
 
   /**
     * Runs a read with client-side caching and a ZIO `Duration` TTL — the ZIO-native form of [[sage.client.internal.Client.cached]].
@@ -31,7 +32,7 @@ extension (client: SageClient) {
     * The full SCAN iteration: stops on the server's zero cursor, never on an empty page. SCAN may return a key more than once. In cluster
     * mode it walks every slot-owning master in turn, each with its own node-local cursor, so the sweep covers the whole keyspace.
     */
-  def scanAll[K: KeyCodec](
+  def scanAll(
     pattern: Option[String] = None,
     count: Option[Long] = None,
     ofType: Option[RedisType] = None
@@ -41,7 +42,7 @@ extension (client: SageClient) {
   /**
     * The full HSCAN iteration over field/value pairs: stops on the server's zero cursor, never on an empty page.
     */
-  def hScanAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def hScanAll[F: KeyCodec, V: ValueCodec](
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
@@ -51,7 +52,7 @@ extension (client: SageClient) {
   /**
     * The full SSCAN iteration over set members: stops on the server's zero cursor, never on an empty page.
     */
-  def sScanAll[K: KeyCodec, V: ValueCodec](
+  def sScanAll[V: ValueCodec](
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
@@ -61,7 +62,7 @@ extension (client: SageClient) {
   /**
     * The full ZSCAN iteration over member/score pairs: stops on the server's zero cursor, never on an empty page.
     */
-  def zScanAll[K: KeyCodec, V: ValueCodec](
+  def zScanAll[V: ValueCodec](
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
@@ -100,7 +101,7 @@ extension (client: SageClient) {
   /**
     * Lazily pages an entire stream by range, batching `XRANGE` and advancing past the last id each page. Stops when a page comes back empty.
     */
-  def xRangeAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def xRangeAll[F: KeyCodec, V: ValueCodec](
     key: K,
     start: StreamRangeId = StreamRangeId.Min,
     end: StreamRangeId = StreamRangeId.Max,
@@ -123,7 +124,7 @@ extension (client: SageClient) {
     * entries — claimed ids whose data was already deleted, which the decoder surfaces with no fields — are skipped, so every emitted entry
     * carries data.
     */
-  def xAutoClaimAll[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def xAutoClaimAll[F: KeyCodec, V: ValueCodec](
     key: K,
     group: String,
     consumer: String,
@@ -147,7 +148,7 @@ extension (client: SageClient) {
     * last id each round. Blocking on an explicit id (never `$`) leaves no gap for entries arriving mid-loop. No acknowledgement, unlike
     * [[xConsume]]. `from` defaults to the start; pass a later id to tail from there.
     */
-  def xTail[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def xTail[F: KeyCodec, V: ValueCodec](
     key: K,
     from: StreamId = StreamId.Zero,
     count: Option[Long] = None,
@@ -168,18 +169,18 @@ extension (client: SageClient) {
     * entries forever. `handle` runs per entry; the entry is acknowledged only after `handle` succeeds, so a failure leaves it in the PEL for
     * recovery.
     */
-  def xConsume[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  def xConsume[F: KeyCodec, V: ValueCodec](
     group: String,
     consumer: String,
     key: K,
     count: Option[Long] = None,
     block: BlockTimeout = SageClient.defaultPoll
   )(handle: StreamEntry[F, V] => Task[Unit]): Task[Unit] =
-    consumeStream[K, F, V](group, consumer, key, count, block)
+    consumeStream[F, V](group, consumer, key, count, block)
       .mapZIO(entry => handle(entry) *> client.run(Streams.xAck(key, group)(entry.id)).unit)
       .runDrain
 
-  private def consumeStream[K: KeyCodec, F: KeyCodec, V: ValueCodec](
+  private def consumeStream[F: KeyCodec, V: ValueCodec](
     group: String,
     consumer: String,
     key: K,
@@ -256,6 +257,12 @@ extension (client: SageClient) {
 
 object SageClient {
 
+  /**
+    * A command surface re-typed to a non-String key, as returned by `client.as[K]`. The unqualified [[SageClient]] is String-keyed;
+    * use `as` to reach any other key type over the same connection.
+    */
+  type Keyed[K] = Client[Task, K]
+
   // bounded poll so xConsume's blocking read returns periodically, keeping cancellation responsive
   private[zio] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, TimeUnit.SECONDS))
 
@@ -268,7 +275,7 @@ object SageClient {
   def layer(config: SageConfig): ZLayer[Any, Throwable, SageClient] =
     ZLayer.scoped(scoped(config))
 
-  final private class Lowered(underlying: Client[CIO]) extends LoweredClient[Task](underlying) {
+  final private class Lowered(underlying: Client[CIO, String]) extends LoweredClient[Task](underlying) {
     protected def lower[A](c: CIO[A]): Task[A] = c.lower
     protected def lift[A](fa: Task[A]): CIO[A] = CIO.lift(fa)
   }


### PR DESCRIPTION
## What

Moves the key type `K` from a per-method type parameter to the command surface itself:

```scala
// before
client.get[String, User]("u:1")
// after
client.get[User]("u:1")
```

`K` now lives on `CommandRunner[F[_], K]` / `Client[F[_], K]` / `TransactionScope[F[_], K]`. The value type still can't be inferred (it's the return), and Scala can't bind only the second type argument, so the redundant key type had to go somewhere: the client.

## Key points

- **No breakage for the common case.** `SageClient` is now `Client[F, String]`, so existing String-keyed code is unchanged; the only call-site edits are dropping the now-redundant leading key type argument.
- **`KeyCodec` is retained.** Redis keys are binary-safe, so `Array[Byte]`/`Int`/tagged keys stay first-class. Deleting it to force `String` was considered and rejected.
- **Non-String keys via `as[K]`.** `client.as[Array[Byte]]` re-types the client over the same connection (no new connection opened) and returns a **full** re-typed client, so its whole surface follows the new key type: commands, pipelines, transactions, subscriptions, and the `scanAll`/`hScanAll`/… helpers. It composes inside a transaction too (`tx.as[Array[Byte]].get(k)`).
- **Backend extensions are generic over the key** (`extension [K](client: Client[F, K])`), with the streaming/scan helpers tied to the client's key.
- **`Commands.*` builder facade keeps `[K, V]`** (it's a keyless object used for pipelines/reuse) — a deliberate asymmetry with the effectful sugar.
- **`watch` stays generic per-method** — its key is argument-inferred (no call-site cost) and it's the only public path to `WATCH`.

Key-returning commands improve incidentally: `keys`, `randomKey`, and the `scan` page now infer their element type from the client's `K`.

## Verification

- Compiles across all backends (zio, ce, ox, kyo, future), examples, integration tests, and benchmarks.
- `core` (693) and `clientZio` (158) unit test suites pass.