### PR TITLE
Add master-replica and cluster failover integration tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,8 +109,9 @@ lazy val client = (projectMatrix in file("sage-client"))
   .compatLibrary(ZioLib, CeLib, OxLib)(VirtualAxis.jvm)(Seq(scala3Version))
 
 // the shared testcontainers suite runs once per backend cell, catching backend-specific lowering bugs against real servers;
-// command-behavior (sage.integration.commands), security (sage.integration.security), and cluster (sage.integration.cluster) suites run on
-// one designated cell only — none of per-command behavior, TLS/auth, nor cluster routing (all in the shared layer) can differ per backend
+// command-behavior (sage.integration.commands), security (sage.integration.security), cluster (sage.integration.cluster), and master-replica
+// (sage.integration.masterreplica) suites run on one designated cell only — none of per-command behavior, TLS/auth, cluster routing, nor
+// master-replica routing (all in the shared layer) can differ per backend
 lazy val integrationTests = (projectMatrix in file("integration-tests"))
   .dependsOn(client, core % "test->test")
   .settings(name := "integration-tests")
@@ -122,7 +123,7 @@ lazy val integrationTests = (projectMatrix in file("integration-tests"))
     Test / testOptions += {
       val isAnchor     = moduleName.value.endsWith("-future")
       val isDesignated = moduleName.value.endsWith("-zio")
-      val onceOnly     = Set("sage.integration.commands.", "sage.integration.security.", "sage.integration.cluster.")
+      val onceOnly     = Set("sage.integration.commands.", "sage.integration.security.", "sage.integration.cluster.", "sage.integration.masterreplica.")
       Tests.Filter(name => !isAnchor && (isDesignated || !onceOnly.exists(name.startsWith)))
     }
   )

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterFailoverSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterFailoverSuite.scala
@@ -1,0 +1,164 @@
+package sage.integration.cluster
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.*
+import scala.util.Try
+
+import com.dimafeng.testcontainers.FixedHostPortGenericContainer
+import com.dimafeng.testcontainers.munit.TestContainerForAll
+import kyo.compat.*
+
+import sage.client.{ClusterConfig, Endpoint, SageConfig, Topology}
+import sage.client.internal.Client
+import sage.integration.{ContainerClient, Images}
+
+/**
+  * Drives cluster failover recovery against a real multi-node cluster: three masters and their replicas in one container. When a master
+  * crashes, the cluster promotes its replica automatically, and the client re-homes on its own — on the connection loss it force-refreshes
+  * `CLUSTER SLOTS` and re-dispatches, bounded by `maxRedirects`. That bound is shorter than an election, so, as with a real application, the
+  * caller retries across the failover window while the client refreshes the topology underneath.
+  *
+  * A cluster node announces a single address used for both gossip and clients, so the testcontainers-mapped random ports the other suites use
+  * cannot work here: gossip needs an address the nodes reach each other on. The escape is a fixed 1:1 host-port mapping plus
+  * `cluster-announce-ip 127.0.0.1`, so `127.0.0.1:<port>` resolves to the same node inside the container (gossip) and from the host (the test).
+  * The cost is fixed host ports (7100-7105), which must be free on the host — the only single-host scheme a multi-node cluster admits short of
+  * Linux-only host networking.
+  */
+abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends munit.FunSuite with TestContainerForAll with ContainerClient {
+
+  private val ports  = 7100 to 7105
+  private val victim = 7100 // redis-cli --cluster-create makes the first nodes masters, so 7100 is a master with a replica to promote
+
+  // each node needs its own cluster-config-file (they otherwise collide on nodes.conf); a low node-timeout keeps the failover election short
+  override val containerDef: FixedHostPortGenericContainer.Def = {
+    val starts = ports
+      .map(p =>
+        s"$serverBinary --port $p --cluster-enabled yes --cluster-config-file nodes-$p.conf --cluster-node-timeout 2000 " +
+          // --repl-diskless-sync-delay 0: start the replica's initial sync immediately, not after the default 5s window, so it is a live copy
+          // before the failover rather than still in wait_bgsave
+          s"--cluster-announce-ip 127.0.0.1 --repl-diskless-sync-delay 0 --save '' --appendonly no --protected-mode no --daemonize yes"
+      )
+      .mkString("; ")
+    FixedHostPortGenericContainer.Def(
+      image,
+      command = Seq("sh", "-c", s"$starts; tail -f /dev/null"),
+      portBindings = ports.map(p => (p, p)).toSeq
+    )
+  }
+
+  given ExecutionContext = munitExecutionContext
+
+  // forming a six-node cluster and waiting out an election runs past munit's 30s default on a loaded CI box
+  override def munitTimeout: Duration = 120.seconds
+
+  private def exec(container: FixedHostPortGenericContainer, args: String*): String = {
+    val result = container.execInContainer(args*)
+    result.getStdout + result.getStderr
+  }
+
+  private def cli(container: FixedHostPortGenericContainer, port: Int, args: String*): String =
+    exec(container, ("redis-cli" +: "-p" +: port.toString +: args)*)
+
+  private def parseKeys(out: String): Vector[String] =
+    out.split("\n").iterator.map(_.trim).filter(_.nonEmpty).toVector
+
+  // the victim master's own replica, parsed from CLUSTER NODES (a `slave` line whose master id is the victim's own id)
+  private def victimReplicaPort(container: FixedHostPortGenericContainer): Int = {
+    val myId  = cli(container, victim, "cluster", "myid").trim
+    val nodes = cli(container, victim, "cluster", "nodes")
+    parseKeys(nodes).iterator
+      .map(_.split("\\s+"))
+      .collectFirst { case f if f.length > 3 && f(2).contains("slave") && f(3) == myId => f(1).split("@")(0).split(":")(1).toInt }
+      .getOrElse(throw new RuntimeException(s"no replica found for victim $victim:\n$nodes"))
+  }
+
+  // the replication barrier: poll the victim's own replica until it holds every victim-owned key. WAIT keys off the calling connection's last
+  // write, so it would not cover writes the cluster client sent on its own routed connections; reading the replica directly proves recovery.
+  private def awaitReplicated(container: FixedHostPortGenericContainer, replicaPort: Int, expected: Set[String], attempts: Int): CIO[Unit] =
+    CIO.blocking(parseKeys(cli(container, replicaPort, "keys", "*")).toSet).flatMap { have =>
+      if (expected.subsetOf(have)) CIO.value(())
+      else if (attempts <= 0) CIO.fail(new RuntimeException(s"victim's replica did not catch up; missing ${(expected -- have).take(5)}"))
+      else CIO.sleep(100.millis).flatMap(_ => awaitReplicated(container, replicaPort, expected, attempts - 1))
+    }
+
+  // wait for every node to answer, form the cluster (idempotent across a re-run sharing the container), and wait for it to converge
+  private def formCluster(container: FixedHostPortGenericContainer): CIO[Unit] =
+    awaitPortsUp(container, 60).flatMap { _ =>
+      CIO.blocking(cli(container, victim, "cluster", "info").contains("cluster_state:ok")).flatMap { ok =>
+        if (ok) CIO.value(())
+        else
+          CIO
+            .blocking {
+              val create = Vector("redis-cli", "--cluster", "create") ++ ports.map(p => s"127.0.0.1:$p") ++
+                Vector("--cluster-replicas", "1", "--cluster-yes")
+              exec(container, create*)
+            }
+            .flatMap(_ => awaitClusterOk(container, 60))
+      }
+    }
+
+  private def awaitPortsUp(container: FixedHostPortGenericContainer, attempts: Int): CIO[Unit] =
+    CIO.blocking(ports.forall(p => cli(container, p, "ping").contains("PONG"))).flatMap { up =>
+      if (up) CIO.value(())
+      else if (attempts <= 0) CIO.fail(new RuntimeException("cluster nodes did not start"))
+      else CIO.sleep(300.millis).flatMap(_ => awaitPortsUp(container, attempts - 1))
+    }
+
+  private def awaitClusterOk(container: FixedHostPortGenericContainer, attempts: Int): CIO[Unit] =
+    CIO.blocking(cli(container, victim, "cluster", "info").contains("cluster_state:ok")).flatMap { ok =>
+      if (ok) CIO.value(())
+      else if (attempts <= 0) CIO.fail(new RuntimeException("cluster did not converge"))
+      else CIO.sleep(500.millis).flatMap(_ => awaitClusterOk(container, attempts - 1))
+    }
+
+  private def writeAll(client: Client[CIO, String], keys: Vector[String]): CIO[Unit] =
+    keys.foldLeft(CIO.value(()))((acc, key) => acc.flatMap(_ => client.set(key, key).map(_ => ())))
+
+  // retry a read across the failover window until the client refreshes onto the promoted master; each key stores its own name
+  private def recoverKey(client: Client[CIO, String], key: String, attempts: Int): CIO[Boolean] =
+    client
+      .get[String](key)
+      .fold(
+        {
+          case Some(v) if v == key => CIO.value(true)
+          case _ if attempts <= 0  => CIO.value(false)
+          case _                   => CIO.sleep(200.millis).flatMap(_ => recoverKey(client, key, attempts - 1))
+        },
+        _ => if (attempts <= 0) CIO.value(false) else CIO.sleep(200.millis).flatMap(_ => recoverKey(client, key, attempts - 1))
+      )
+
+  private def recoverAll(client: Client[CIO, String], keys: Vector[String]): CIO[Boolean] =
+    keys.foldLeft(CIO.value(true))((acc, key) => acc.flatMap(ok => if (!ok) CIO.value(false) else recoverKey(client, key, 150)))
+
+  test("the client recovers reads after a master crashes and its replica is promoted") {
+    withContainers { container =>
+      val seeds  = ports.map(p => Endpoint("127.0.0.1", p)).toVector
+      // short refresh interval so the topology refresh keeps pace with the caller's retries during the election
+      val config = SageConfig(topology = Topology.Cluster(seeds, ClusterConfig(minRefreshInterval = 500.millis)))
+      val keys   = (1 to 30).map(i => s"failover:$i").toVector
+
+      val program =
+        formCluster(container).flatMap { _ =>
+          connectAndUse(config) { client =>
+            for {
+              _           <- writeAll(client, keys)
+              // recovering exactly the victim's keys proves the client re-homed onto the promoted replica
+              onVictim    <- CIO.blocking(parseKeys(cli(container, victim, "keys", "*")))
+              replicaPort <- CIO.blocking(victimReplicaPort(container))
+              _           <- awaitReplicated(container, replicaPort, onVictim.toSet, 100)
+              _           <- CIO.blocking(Try(cli(container, victim, "shutdown", "nosave")))
+              recovered   <- recoverAll(client, onVictim)
+            } yield {
+              assert(onVictim.nonEmpty, "no keys landed on the victim master; cannot prove failover recovery")
+              assert(recovered, "client did not recover the victim master's keys after its replica was promoted")
+            }
+          }
+        }
+      program.unsafeRun
+    }
+  }
+}
+
+class RedisClusterFailoverSuite extends ClusterFailoverSuite(Images.redis, "redis-server")
+
+class ValkeyClusterFailoverSuite extends ClusterFailoverSuite(Images.valkey, "valkey-server")

--- a/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
@@ -1,0 +1,306 @@
+package sage.integration.masterreplica
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.*
+
+import com.dimafeng.testcontainers.GenericContainer
+import com.dimafeng.testcontainers.munit.TestContainerForAll
+import kyo.compat.*
+
+import sage.{Bytes, Message}
+import sage.SageException.DecodeError
+import sage.client.{Endpoint, MasterReplicaConfig, ReadFrom, SageConfig, Topology}
+import sage.client.internal.Client
+import sage.commands.{Command, Commands, Pipeline}
+import sage.integration.{ContainerClient, Images}
+import sage.protocol.Frame
+
+/**
+  * Shared scaffolding for the master-replica suites. One container runs two server processes — a master on 6379 and a replica on 6380 — kept
+  * single-container like [[sage.integration.cluster.ClusterSuite]] while still exercising the runtime end to end: `ROLE` discovery, a distinct
+  * replica-pool endpoint, [[ReadFrom]] routing, and genuine replication between two processes. The replica announces its testcontainers-mapped
+  * host port (via `replica-announce-ip`/`-port`) so the address the master reports in `ROLE` is reachable from the test.
+  */
+abstract class MasterReplicaSuiteBase(image: String, serverBinary: String) extends munit.FunSuite with TestContainerForAll with ContainerClient {
+
+  // the fault that kills the master keeps the replica in the foreground (and vice versa) so the container survives — the exec'd process owns it
+  protected def masterRunsInForeground: Boolean = false
+
+  // --protected-mode no admits the testcontainers-mapped (non-loopback) connection; --save '' / --appendonly no keep the nodes in-memory
+  override val containerDef: GenericContainer.Def[GenericContainer] = {
+    val master                   = s"$serverBinary --port 6379 --save '' --appendonly no --protected-mode no"
+    val replica                  = s"$serverBinary --port 6380 --save '' --appendonly no --protected-mode no"
+    val (background, foreground) = if (masterRunsInForeground) (replica, master) else (master, replica)
+    GenericContainer.Def(image, exposedPorts = Seq(6379, 6380), command = Seq("sh", "-c", s"$background & exec $foreground"))
+  }
+
+  given ExecutionContext = munitExecutionContext
+
+  protected val masterPort  = 6379
+  protected val replicaPort = 6380
+  protected val marker      = "mr:replica-only-marker"
+
+  protected def admin(name: String, args: String*): Command[Unit] =
+    Command(name, Command.NoKeys, args.toVector.map(Bytes.utf8), _ => Right(()))
+
+  protected val infoReplication: Command[String] =
+    Command(
+      "INFO",
+      Command.NoKeys,
+      Vector(Bytes.utf8("replication")),
+      {
+        case Frame.BulkString(bytes)        => Right(bytes.asUtf8String)
+        case Frame.VerbatimString(_, bytes) => Right(bytes.asUtf8String)
+        case other                          => Left(DecodeError("bulk or verbatim string", Frame.describe(other)))
+      }
+    )
+
+  // follow the master and announce the host-mapped port, then write a marker key the master never has, so a read's origin is observable. The
+  // marker goes in after the link is up, since REPLICAOF triggers a full resync that would wipe an earlier write. Idempotent across a suite's tests.
+  protected def ensureReplicating(replica: Client[CIO, String], announceHost: String, announcePort: Int): CIO[Unit] =
+    replica.run(infoReplication).flatMap { info =>
+      if (info.contains("master_link_status:up")) CIO.value(())
+      else
+        for {
+          _ <- replica.run(admin("CONFIG", "SET", "replica-announce-ip", announceHost))
+          _ <- replica.run(admin("CONFIG", "SET", "replica-announce-port", announcePort.toString))
+          _ <- replica.run(admin("REPLICAOF", "127.0.0.1", masterPort.toString))
+          // Valkey's async full-sync takes a few seconds even for an empty dataset, so budget generously under CI load
+          _ <- awaitLinkUp(replica, 150)
+          _ <- replica.run(admin("CONFIG", "SET", "replica-read-only", "no"))
+          _ <- replica.run(admin("SET", marker, "from-replica"))
+          // restore read-only so a misrouted write to the replica fails loudly; replication still applies (it bypasses read-only) and the marker persists
+          _ <- replica.run(admin("CONFIG", "SET", "replica-read-only", "yes"))
+        } yield ()
+    }
+
+  protected def awaitLinkUp(replica: Client[CIO, String], attempts: Int): CIO[Unit] =
+    replica.run(infoReplication).flatMap { info =>
+      if (info.contains("master_link_status:up")) CIO.value(())
+      else if (attempts <= 0) CIO.fail(new RuntimeException(s"replica did not sync: $info"))
+      else CIO.sleep(100.millis).flatMap(_ => awaitLinkUp(replica, attempts - 1))
+    }
+
+  // replication is async; poll until the replica catches up
+  protected def awaitValue(client: Client[CIO, String], key: String, expected: String, attempts: Int): CIO[Option[String]] =
+    client.get[String](key).flatMap {
+      case Some(v) if v == expected => CIO.value(Some(v))
+      case _ if attempts <= 0       => CIO.value(None)
+      case _                        => CIO.sleep(100.millis).flatMap(_ => awaitValue(client, key, expected, attempts - 1))
+    }
+
+  // run for effect, discarding failure — for commands the server answers by closing the socket (SHUTDOWN), observed by what follows
+  protected def ignoreFailure(action: CIO[Unit]): CIO[Unit] =
+    action.fold(_ => CIO.value(()), _ => CIO.value(()))
+
+  protected def standalone(host: String, port: Int): SageConfig =
+    SageConfig(topology = Topology.Standalone(Endpoint(host, port)))
+
+  protected def masterReplica(host: String, masterMappedPort: Int, policy: ReadFrom, minRefreshInterval: FiniteDuration = 5.seconds): SageConfig =
+    SageConfig(
+      topology = Topology.MasterReplica(Vector(Endpoint(host, masterMappedPort)), MasterReplicaConfig(minRefreshInterval = minRefreshInterval)),
+      readFrom = policy
+    )
+}
+
+/**
+  * Read routing and master-pinned operations against a real master-replica deployment. Routing is proven with a marker key that lives only on
+  * the replica: a read that sees it was served by the replica, and one that does not was served by the master, which never has it.
+  */
+abstract class MasterReplicaSuite(image: String, serverBinary: String) extends MasterReplicaSuiteBase(image, serverBinary) {
+
+  test("reads honor the ReadFrom policy and writes always reach the master") {
+    withContainers { server =>
+      val host       = server.host
+      val pm         = server.mappedPort(masterPort)
+      val pr         = server.mappedPort(replicaPort)
+      val replicaCfg = standalone(host, pr)
+
+      val program =
+        connectAndUse(replicaCfg)(ensureReplicating(_, host, pr))
+          .flatMap { _ =>
+            connectAndUse(masterReplica(host, pm, ReadFrom.Replica)) { client =>
+              for {
+                fromReplica <- client.get[String](marker)
+                // the write always goes to the master; reading it back off the replica proves both replication and replica routing
+                _           <- client.set("mr:k", "v")
+                replicated  <- awaitValue(client, "mr:k", "v", 50)
+              } yield {
+                assertEquals(fromReplica, Some("from-replica"))
+                assertEquals(replicated, Some("v"))
+              }
+            }
+          }
+          .flatMap(_ => connectAndUse(masterReplica(host, pm, ReadFrom.Master))(_.get[String](marker).map(assertEquals(_, None))))
+          .flatMap(_ =>
+            connectAndUse(masterReplica(host, pm, ReadFrom.ReplicaPreferred))(_.get[String](marker).map(assertEquals(_, Some("from-replica"))))
+          )
+          .flatMap(_ => connectAndUse(masterReplica(host, pm, ReadFrom.MasterPreferred))(_.get[String](marker).map(assertEquals(_, None))))
+      program.unsafeRun
+    }
+  }
+
+  test("transactions and pub/sub run on the master under the master-replica runtime") {
+    withContainers { server =>
+      val host       = server.host
+      val pm         = server.mappedPort(masterPort)
+      val pr         = server.mappedPort(replicaPort)
+      val replicaCfg = standalone(host, pr)
+
+      val program =
+        connectAndUse(replicaCfg)(ensureReplicating(_, host, pr)).flatMap { _ =>
+          connectAndUse(masterReplica(host, pm, ReadFrom.ReplicaPreferred)) { client =>
+            for {
+              commit  <- client.transaction(tx => tx.exec(Pipeline.sequence(Vector(Commands.incr[String]("mr:c"), Commands.incr[String]("mr:c")))))
+              sub     <- client.subscribeChannels[String]("mr:news")
+              count   <- client.publish("mr:news", "hello")
+              message <- sub.next
+              _       <- sub.close
+            } yield {
+              assertEquals(commit, Some(Vector(1L, 2L)))
+              assertEquals(count, 1L)
+              assertEquals(message, Some(Message("mr:news", "hello")))
+            }
+          }
+        }
+      program.unsafeRun
+    }
+  }
+}
+
+/**
+  * Failover recovery: the replica is promoted and the old master taken out of write service, and the client re-discovers and re-homes on its
+  * own. Roles refresh only on events, so the first write meets the old master, fails fast, and trips a re-discovery; the caller's retry then
+  * lands on the promoted node. [[induceFailover]] supplies the fault, so the contract is checked against both the `READONLY` (demotion) and
+  * connection-loss (crash) branches. Its own container, since the promotion permanently rewrites the topology.
+  */
+abstract class MasterReplicaFailoverSuite(image: String, serverBinary: String, fault: String) extends MasterReplicaSuiteBase(image, serverBinary) {
+
+  // promote the replica, then take the old master out of write service in a fault-specific way; the client is told nothing
+  protected def induceFailover(replicaCfg: SageConfig, masterCfg: SageConfig): CIO[Unit]
+
+  // retry the write until it succeeds: the first attempt meets the old master and trips re-discovery, a later retry lands on the promoted master
+  private def writeUntilAccepted(client: Client[CIO, String], key: String, value: String, attempts: Int): CIO[Boolean] =
+    client
+      .set(key, value)
+      .fold(
+        _ => CIO.value(true),
+        _ => if (attempts <= 0) CIO.value(false) else CIO.sleep(100.millis).flatMap(_ => writeUntilAccepted(client, key, value, attempts - 1))
+      )
+
+  test(s"the client recovers writes after the replica is promoted to master ($fault)") {
+    withContainers { server =>
+      val host       = server.host
+      val pm         = server.mappedPort(masterPort)
+      val pr         = server.mappedPort(replicaPort)
+      val replicaCfg = standalone(host, pr)
+      val masterCfg  = standalone(host, pm)
+      // short refresh interval so the event-driven re-discovery is not throttled away during the retry window
+      val mrCfg      = masterReplica(host, pm, ReadFrom.Master, minRefreshInterval = 100.millis)
+
+      val program =
+        connectAndUse(replicaCfg)(ensureReplicating(_, host, pr)).flatMap { _ =>
+          connectAndUse(mrCfg) { client =>
+            for {
+              _         <- client.set("fo:before", "v1")
+              before    <- client.get[String]("fo:before")
+              _         <- induceFailover(replicaCfg, masterCfg)
+              recovered <- writeUntilAccepted(client, "fo:after", "v2", 50)
+              after     <- client.get[String]("fo:after")
+            } yield {
+              assertEquals(before, Some("v1"))
+              assert(recovered, "write never recovered after promotion")
+              assertEquals(after, Some("v2"))
+            }
+          }
+        }
+      program.unsafeRun
+    }
+  }
+}
+
+/**
+  * Failover where the old master is demoted to follow the new one — it stays reachable but answers writes with `READONLY`, exercising the
+  * ownership-fault branch of the runtime's re-discovery.
+  */
+abstract class MasterReplicaDemotionFailoverSuite(image: String, serverBinary: String)
+  extends MasterReplicaFailoverSuite(image, serverBinary, "demoted master") {
+
+  protected def induceFailover(replicaCfg: SageConfig, masterCfg: SageConfig): CIO[Unit] =
+    for {
+      _ <- connectAndUse(replicaCfg)(_.run(admin("REPLICAOF", "NO", "ONE")))
+      _ <- connectAndUse(masterCfg)(_.run(admin("REPLICAOF", "127.0.0.1", replicaPort.toString)))
+    } yield ()
+}
+
+/**
+  * Failover where the old master crashes outright (`SHUTDOWN`) — the next write meets a refused connection, exercising the connection-loss
+  * branch of the runtime's re-discovery. The master is backgrounded (the suite default), so the foreground replica keeps the container alive.
+  */
+abstract class MasterReplicaConnectionLossFailoverSuite(image: String, serverBinary: String)
+  extends MasterReplicaFailoverSuite(image, serverBinary, "master down") {
+
+  protected def induceFailover(replicaCfg: SageConfig, masterCfg: SageConfig): CIO[Unit] =
+    for {
+      _ <- connectAndUse(replicaCfg)(_.run(admin("REPLICAOF", "NO", "ONE")))
+      _ <- ignoreFailure(connectAndUse(masterCfg)(_.run(admin("SHUTDOWN", "NOSAVE"))))
+    } yield ()
+}
+
+/**
+  * A replica going down. The replica runs in the foreground so `SHUTDOWN`-ing it leaves the foreground master (and the container) alive. A
+  * strict `Replica` read then has no node to reach and fails, while `ReplicaPreferred` falls back to the master. Both clients connect before
+  * the replica dies, so they actually attempt the now-dead replica rather than simply never discovering it.
+  */
+abstract class MasterReplicaReplicaDownSuite(image: String, serverBinary: String) extends MasterReplicaSuiteBase(image, serverBinary) {
+
+  override protected def masterRunsInForeground: Boolean = true
+
+  test("a strict Replica read fails when the replica is down, while ReplicaPreferred falls back to the master") {
+    withContainers { server =>
+      val host       = server.host
+      val pm         = server.mappedPort(masterPort)
+      val pr         = server.mappedPort(replicaPort)
+      val replicaCfg = standalone(host, pr)
+
+      val program =
+        connectAndUse(replicaCfg)(ensureReplicating(_, host, pr)).flatMap { _ =>
+          connectAndUse(masterReplica(host, pm, ReadFrom.Replica)) { strict =>
+            connectAndUse(masterReplica(host, pm, ReadFrom.ReplicaPreferred)) { preferred =>
+              for {
+                // a master-backed key for the fallback read; the replica-only marker for the warm-up reads
+                _             <- preferred.set("rd:k", "v")
+                warmStrict    <- strict.get[String](marker)
+                warmPreferred <- preferred.get[String](marker)
+                _             <- ignoreFailure(connectAndUse(replicaCfg)(_.run(admin("SHUTDOWN", "NOSAVE"))))
+                strictFailed  <- strict.get[String]("rd:k").fold(_ => CIO.value(false), _ => CIO.value(true))
+                fallback      <- awaitValue(preferred, "rd:k", "v", 50)
+              } yield {
+                assertEquals(warmStrict, Some("from-replica"))
+                assertEquals(warmPreferred, Some("from-replica"))
+                assert(strictFailed, "strict Replica read should fail when no replica is reachable")
+                assertEquals(fallback, Some("v"))
+              }
+            }
+          }
+        }
+      program.unsafeRun
+    }
+  }
+}
+
+class RedisMasterReplicaSuite extends MasterReplicaSuite(Images.redis, "redis-server")
+
+class ValkeyMasterReplicaSuite extends MasterReplicaSuite(Images.valkey, "valkey-server")
+
+class RedisMasterReplicaDemotionFailoverSuite extends MasterReplicaDemotionFailoverSuite(Images.redis, "redis-server")
+
+class ValkeyMasterReplicaDemotionFailoverSuite extends MasterReplicaDemotionFailoverSuite(Images.valkey, "valkey-server")
+
+class RedisMasterReplicaConnectionLossFailoverSuite extends MasterReplicaConnectionLossFailoverSuite(Images.redis, "redis-server")
+
+class ValkeyMasterReplicaConnectionLossFailoverSuite extends MasterReplicaConnectionLossFailoverSuite(Images.valkey, "valkey-server")
+
+class RedisMasterReplicaReplicaDownSuite extends MasterReplicaReplicaDownSuite(Images.redis, "redis-server")
+
+class ValkeyMasterReplicaReplicaDownSuite extends MasterReplicaReplicaDownSuite(Images.valkey, "valkey-server")


### PR DESCRIPTION
Adds integration-test coverage for the master-replica and cluster runtimes, including failover recovery, on both Redis and Valkey.

## Master-replica (`sage.integration.masterreplica`)
One container runs a master (6379) and a replica (6380); the replica announces its testcontainers-mapped host port so the address the master reports in `ROLE` is reachable from the test. Suites:

- **routing**: all four `ReadFrom` policies plus transactions/pub-sub pinned to the master, proven with a marker key that lives only on the replica.
- **demotion failover**: old master demoted to follow the new one, exercising the `READONLY` re-discovery branch.
- **connection-loss failover**: old master crashed via `SHUTDOWN`, exercising the connection-loss re-discovery branch.
- **replica-down**: strict `Replica` reads fail while `ReplicaPreferred` falls back to the master.

## Cluster (`sage.integration.cluster`)
A new `ClusterFailoverSuite` forms a real six-node cluster (three masters plus replicas) in one container, crashes a master, and verifies the client re-homes onto the promoted replica after re-discovery. A replication barrier polls the victim's own replica until it holds the victim-owned keys before the kill, so the test is deterministic rather than timing-dependent.

The single-node `ClusterSuite` already covers routing/pipelines/transactions/pub-sub/scan; the cluster client's routing, redirects, and failover logic are unit-tested in `ClusterClientSpec`, so the new suite adds only what those cannot: a real multi-node election.

## Notes
- All suites run on both Redis and Valkey.
- `build.sbt`: the master-replica suites run once on the designated cell, matching the existing cluster/commands/security filter.
- The cluster failover suite uses fixed host ports (7100-7105): a cluster node announces a single address used for both gossip and clients, so it needs a fixed 1:1 mapping plus `cluster-announce-ip 127.0.0.1`. Those ports must be free on the host.