### PR TITLE
Tolerate CLIENT SETINFO rejection during bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,12 +93,12 @@ jobs:
         with:
           path: ~/.docker-images
           # keep the tags here in sync with integration-tests Images.scala; bump the key when they change
-          key: docker-images-v2-redis8.8.0-valkey9.1.0
+          key: docker-images-v2-redis8.8.0-valkey9.1.0-redis6.2
       - name: Pull and save server images
         if: steps.images.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/.docker-images
-          for img in redis:8.8.0 valkey/valkey:9.1.0; do
+          for img in redis:8.8.0 valkey/valkey:9.1.0 redis:6.2; do
             docker pull "$img"
             docker save "$img" -o ~/.docker-images/"${img//[\/:]/_}".tar
           done

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -27,7 +27,7 @@ No. Ordinary commands are auto-pipelined onto one multiplexed connection per nod
 
 ## Redis or Valkey? Which versions?
 
-Both. Sage targets RESP3 and modern Redis 8+ and Valkey 8+.
+Both. Sage targets RESP3 and modern Redis 8+ and Valkey 8+, where every command it exposes is available. It connects to any RESP3-capable server (Redis 6.0+), so an older server works for the subset of commands that version supports; commands added later (hash-field TTL in 7.4, `HGETEX`/`HGETDEL`/`HSETEX` in 8.0) simply error on a server that predates them.
 
 ## What Scala and JDK versions are required?
 

--- a/integration-tests/shared/src/test/scala/sage/integration/Images.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/Images.scala
@@ -9,4 +9,7 @@ object Images {
   val redis: String = "redis:8.8.0"
 
   val valkey: String = "valkey/valkey:9.1.0"
+
+  // a pre-7.2 server (lacks `CLIENT SETINFO`), used only by the bootstrap version-floor test, not by command coverage
+  val legacyRedis: String = "redis:6.2"
 }

--- a/integration-tests/shared/src/test/scala/sage/integration/LegacyServerConnectSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/LegacyServerConnectSuite.scala
@@ -1,0 +1,18 @@
+package sage.integration
+
+import kyo.compat.*
+
+/**
+  * Bootstrap must come up against a pre-7.2 server that rejects `CLIENT SETINFO`. Redis-only by design: Valkey has no pre-7.2 release.
+  */
+class LegacyServerConnectSuite extends ServerSuite(Images.legacyRedis) {
+
+  test("connects and round-trips against a pre-7.2 server that lacks CLIENT SETINFO") {
+    withClient { client =>
+      for {
+        _     <- client.set("legacy", "ok")
+        value <- client.get[String]("legacy")
+      } yield assertEquals(value, Some("ok"))
+    }
+  }
+}

--- a/sage-client/shared/src/main/scala/sage/client/internal/Bootstrap.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Bootstrap.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import scala.util.{Failure, Success, Try}
 
-import sage.SageException.ConnectionLost
+import sage.SageException.{ConnectionLost, ServerError}
 import sage.client.{AuthConfig, BuildInfo}
 import sage.commands.{Command, Connection}
 
@@ -29,7 +29,8 @@ private[client] object Bootstrap {
     * Runs the connection-setup handshake on a freshly opened connection: submits each command in turn and blocks for its reply up to
     * `connectTimeoutMillis`, then closes the half-built connection and throws on a timeout or a failed reply so the caller discards it.
     * `submit` enqueues one command and delivers its decoded reply; replies are FIFO, so each command is awaited before the next is sent.
-    * Used by the Multiplexed, Dedicated, and Subscription connections, which differ only in how a single command's reply is obtained.
+    * A [[bestEffort]] command whose reply is a `ServerError` is tolerated rather than fatal; a `ConnectionLost`/`DecodeError` stays fatal
+    * even for it. Used by the Multiplexed, Dedicated, and Subscription connections, which differ only in how a reply is obtained.
     */
   def run(
     commands: Vector[Command[?]],
@@ -46,8 +47,17 @@ private[client] object Bootstrap {
         throw ConnectionLost(mayHaveExecuted = false)
       }
       outcome.get() match {
-        case Failure(error) => close(); throw error
-        case Success(_)     => ()
+        case Failure(_: ServerError) if bestEffort(command) => ()
+        case Failure(error)                                 => close(); throw error
+        case Success(_)                                     => ()
       }
     }
+
+  /**
+    * Whether a server-error reply to this command may be tolerated during bootstrap. Only `CLIENT SETINFO` qualifies: it is library
+    * identification added in Redis 7.2, so an older server rejects it with an error every client ignores. Every other bootstrap command is
+    * load-bearing, so its failure stays fatal.
+    */
+  private def bestEffort(command: Command[?]): Boolean =
+    command.name == "CLIENT" && command.args.headOption.exists(_.asUtf8String == "SETINFO")
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/BootstrapSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/BootstrapSpec.scala
@@ -1,6 +1,10 @@
 package sage.client.internal
 
+import scala.util.{Failure, Success}
+
+import sage.SageException.{ConnectionLost, ServerError}
 import sage.client.AuthConfig
+import sage.commands.{Command, Connection}
 
 class BootstrapSpec extends munit.FunSuite {
 
@@ -29,5 +33,45 @@ class BootstrapSpec extends munit.FunSuite {
     val first = Bootstrap.commands(Some(AuthConfig("pw", "alice")), 0, None).head
     assertEquals(first.name, "HELLO")
     assert(first.args.map(_.asUtf8String).containsSlice(Vector("AUTH", "alice", "pw")))
+  }
+
+  test("a CLIENT SETINFO error does not abort setup, so a pre-7.2 server still connects") {
+    val unknown = Failure(ServerError("ERR", "Unknown subcommand or wrong number of arguments for 'SETINFO'."))
+    var closed  = false
+    Bootstrap.run(
+      Bootstrap.commands(None, 0, None),
+      connectTimeoutMillis = 1000,
+      submit = (c, cb) => cb(if (c.name == "CLIENT" && c.args.head.asUtf8String == "SETINFO") unknown else Success(())),
+      close = () => closed = true
+    )
+    assert(!closed, "connection must stay open when only library identification fails")
+  }
+
+  test("a CLIENT SETINFO connection loss is NOT tolerated: it closes and throws") {
+    var closed = false
+    val thrown = intercept[ConnectionLost] {
+      Bootstrap.run(
+        Bootstrap.commands(None, 0, None),
+        connectTimeoutMillis = 1000,
+        submit = (c, cb) =>
+          cb(
+            if (c.name == "CLIENT" && c.args.head.asUtf8String == "SETINFO") Failure(ConnectionLost(mayHaveExecuted = false))
+            else Success(())
+          ),
+        close = () => closed = true
+      )
+    }
+    assertEquals(thrown.mayHaveExecuted, false)
+    assert(closed, "a broken connection must be discarded even on a best-effort command")
+  }
+
+  test("a load-bearing command error aborts setup and closes the connection") {
+    val error  = ServerError("NOAUTH", "Authentication required.")
+    var closed = false
+    val thrown = intercept[ServerError] {
+      Bootstrap.run(Vector(Connection.hello(None)), 1000, (_, cb) => cb(Failure(error)), () => closed = true)
+    }
+    assertEquals(thrown, error)
+    assert(closed, "connection must be closed when a load-bearing command fails")
   }
 }


### PR DESCRIPTION
## Problem

`CLIENT SETINFO` (library identification) was added in Redis 7.2. The connection bootstrap sends it after `HELLO`, but `Bootstrap.run` treated **any** failed reply as fatal, so connecting to a server older than 7.2 (which answers `ERR Unknown subcommand ... for 'SETINFO'`) tore the connection down before a single command could run.

## Fix

Treat a `ServerError` reply to `CLIENT SETINFO` as best-effort and continue, matching every other client. A `ConnectionLost`/`DecodeError` stays fatal even for that command, so a genuinely broken or desynced connection is still discarded.

This drops the connectivity floor to the RESP3 floor (Redis 6.0). Commands added later still error per-call on older servers (hash-field TTL in 7.4, `HGETEX`/`HGETDEL`/`HSETEX` in 8.0); the documented target stays Redis 8+ / Valkey 8+ for full command coverage.

## Tests

- `BootstrapSpec`: `CLIENT SETINFO` server error is tolerated; a `ConnectionLost` on it still closes and throws; a load-bearing failure (`HELLO`) still closes and throws.
- `LegacyServerConnectSuite`: real connect + round-trip against `redis:6.2` (Redis-only by design; Valkey has no pre-7.2 release).
- CI pre-pulls `redis:6.2` alongside the existing images, with the cache key bumped.