### PR TITLE
Fix classic subscription leak when no master is live

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
@@ -69,14 +69,15 @@ final private[client] class ClusterSubscriptions(
   private def classic(names: Vector[String], kind: Kind): RawSubscription = {
     val sink = new Sink(names, kind, bufferSize)
     val sub  = ClassicSub(sink, names, kind)
-    val conn =
-      locked {
-        if (closed) throw NotConnected()
-        classicSubs += sub
-        ensureClassicConn()
-      }
-    try conn.attach(sink, names, kind)
-    catch {
+    try {
+      val conn =
+        locked {
+          if (closed) throw NotConnected()
+          classicSubs += sub
+          ensureClassicConn()
+        }
+      conn.attach(sink, names, kind)
+    } catch {
       case e: Throwable => locked(classicSubs -= sub); sink.terminate(); throw e
     }
     new RawSubscription(sink, () => closeClassic(sub))


### PR DESCRIPTION
## Problem

`ClusterSubscriptions.classic` registers the sub and acquires the shared classic connection in one locked block:

```scala
val conn =
  locked {
    if (closed) throw NotConnected()
    classicSubs += sub
    ensureClassicConn()   // throws NotConnected() when no master is live
  }
try conn.attach(sink, names, kind)
catch { case e: Throwable => locked(classicSubs -= sub); sink.terminate(); throw e }
```

`ensureClassicConn()` throws `NotConnected()` when `pickMaster()` returns `None` (reachable before/around bootstrap or after a refresh yields an empty topology). That throw escapes the locked block **before `conn` is assigned**, and the rollback `try/catch` only wraps `conn.attach` — so it never runs. The result:

- `sub` stays registered in `classicSubs` forever, and its `sink` is never terminated.
- The caller receives the exception with no `RawSubscription`, so it can never close the orphan.
- When a master later appears, `rehomeClassic` snapshots `classicSubs` and attaches the orphan as a **phantom subscription**. Its bounded buffer has no reader, so once full, `offer` parks the shared classic connection's reader thread — stalling delivery to legitimate subscribers.

The shard path (`subscribeShard`) already gets this right: register under lock, then wrap the failure-prone placement in a rollback.

## Fix

Wrap both the locked acquisition (where `ensureClassicConn` can throw) and the `attach` in a single rollback, so any failure removes `sub` and terminates the sink. The atomic single-lock registration+acquisition semantics are unchanged; only the rollback's scope widens to cover acquisition — mirroring the shard path.

Compiles clean; `scalafmtCheckAll` passes.