### PR TITLE
Fix spurious NotConnected on shard subscribe under eviction race

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/Placement.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Placement.scala
@@ -14,9 +14,10 @@ import sage.cluster.Node
   * is the single place that keeps that record in step with the wire. A Node owning several slot ranges needs one `SSUBSCRIBE` per Slot (a
   * batched cross-slot subscribe returns `CROSSSLOT`), so a plan groups a Node's channels into the groups that each become one `SSUBSCRIBE`.
   *
-  * Two ways to apply a plan, differing only in their failure handling:
-  *   - [[place]] is fail-fast for the initial subscribe — an attach failure propagates so the caller can roll back — and records each group
-  *     as it lands, so a roll-back ([[reconcile]] to the empty plan) detaches exactly what was already placed.
+  * Two ways to apply a plan:
+  *   - [[place]] is the initial subscribe: it records each group as it lands and leaves a failed attach unplaced for the caller to retry
+  *     (see `fullyPlaced`), so a transient owner/connection failure converges instead of surfacing to the subscriber; `placedAt` still
+  *     reflects exactly what landed, so a roll-back ([[reconcile]] to the empty plan) detaches it.
   *   - [[reconcile]] is best-effort for re-homing — it detaches channels that left the plan, attaches the rest, records only what actually
   *     lands, and reports whether any attach failed so the caller can retry.
   */
@@ -35,8 +36,11 @@ final private[internal] class Placement(sink: Sink, requested: Vector[String]) {
     plan.foreach { case (node, groups) =>
       conns.ensure(node).foreach { conn =>
         groups.foreach { group =>
-          conn.attach(sink, group, Kind.Shard)
-          locked { placedAt = placedAt.updatedWith(node)(prev => Some(prev.getOrElse(Set.empty) ++ group)) }
+          // a concurrent eviction can close `conn` before attach; leave it unplaced to retry, don't propagate
+          try {
+            conn.attach(sink, group, Kind.Shard)
+            locked { placedAt = placedAt.updatedWith(node)(prev => Some(prev.getOrElse(Set.empty) ++ group)) }
+          } catch { case NonFatal(_) => () }
         }
       }
     }

--- a/sage-client/shared/src/test/scala/sage/client/internal/PlacementSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/PlacementSpec.scala
@@ -56,14 +56,15 @@ class PlacementSpec extends munit.FunSuite {
     assert(!placement.fullyPlaced, "b's owner was unavailable, so coverage is incomplete")
   }
 
-  test("place is fail-fast: an attach failure propagates, but what landed is recorded for roll-back") {
+  test("place leaves a failed attach unplaced instead of propagating, recording what landed for roll-back") {
     val pool      = new FakePool
     val placement = new Placement(sink("a", "b"), Vector("a", "b"))
     pool.byNode.getOrElseUpdate(n1, new FakeConn).failOn = Set("b")
 
-    intercept[RuntimeException](placement.place(Map(n1 -> groups(Vector("a"), Vector("b"))), pool))
+    placement.place(Map(n1 -> groups(Vector("a"), Vector("b"))), pool)
 
-    assertEquals(pool.byNode(n1).subscribed.toSet, Set("a"))
+    assertEquals(pool.byNode(n1).subscribed.toSet, Set("a"), "a landed; b's attach failed but did not propagate")
+    assert(!placement.fullyPlaced, "b is unplaced, so coverage is incomplete and the caller retries")
     // roll-back: reconcile to the empty plan detaches exactly what was placed
     placement.reconcile(Map.empty, pool)
     assert(pool.byNode(n1).subscribed.isEmpty, "the empty plan detaches the landed channel")


### PR DESCRIPTION
## Problem

`Placement.place` acquires the shard connection under the manager lock (`conns.ensure`) but calls `conn.attach` *after releasing it* (attach can block on the `SSUBSCRIBE` confirmation, so it deliberately runs outside the lock). In that window the connection is freshly created and has no sinks registered, so it looks "empty." A concurrent `evictEmptyShardConns` — triggered by closing an *unrelated* shard subscription or by a topology-change reconcile — can close it. The subsequent `attach` then runs against a closed connection and throws `NotConnected`.

On the initial-subscribe path that exception propagated to the caller, so a `subscribeShardChannels`/`sSubscribe` could fail with `NotConnected` under concurrent subscription churn or a topology change, even though a valid slot owner existed. (The reconcile path already caught-and-retried this; only the user-facing initial subscribe surfaced it.)

## Fix

Make `place` treat a failed attach as retriable, exactly as `reconcile` already does: record only what landed, and leave the rest for the caller's `fullyPlaced` check to retry via the existing `scheduleRetry`. This is also consistent with how an *unowned slot* already behaves at subscribe time (retry, not error) — so all transient placement issues now converge uniformly instead of one of them throwing.

`PlacementSpec`'s fail-fast test is updated to assert the new contract (a failed attach is left unplaced, not propagated); it now doubles as the regression guard. `PlacementSpec` + `SubscriptionConnectionSpec` pass; `scalafmtCheckAll` clean.

## Not included

The related `ClusterLive.adopt`-mid-`establish` finding is left as a follow-up: the obvious fix (reject a node absent from the current topology) would break bootstrap and MOVED-redirect establishment, where the node legitimately isn't in `topologyRef` yet; a correct fix needs a tombstone set, which is more than a trivial change. It is a bounded, self-healing leak.