### PR TITLE
Fix subscription keepalive, lighten pool wakeups, and speed up int encoding

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
+++ b/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
@@ -53,11 +53,18 @@ object TrustSource {
 
   case object System extends TrustSource
 
+  /**
+    * Server-trust only: the trust store supplies the certificates the client verifies the server against, never client key material. A
+    * server that demands a client certificate (mutual TLS) fails the handshake under this source — use [[Custom]] to supply key managers.
+    */
   final case class TrustStore(path: Path, password: Option[String] = None) extends TrustSource {
     // keep the keystore password out of logs and error messages that print a SageConfig
     override def toString: String = s"TrustStore($path, password=${password.fold("None")(_ => "<redacted>")})"
   }
 
+  /**
+    * Server-trust only, like [[TrustStore]]: a PEM of trusted certificates, never client key material. Mutual TLS must go through [[Custom]].
+    */
   final case class Pem(path: Path) extends TrustSource
 
   // the escape hatch, and the path for mutual TLS via the caller's own key managers

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -100,7 +100,7 @@ final private[client] class DedicatedPool(
     else
       locked {
         discardLocked(connection)
-        available.signalAll()
+        available.signal()
       }
 
   private[internal] def wakeWaiters(): Unit = locked(available.signalAll())
@@ -146,7 +146,7 @@ final private[client] class DedicatedPool(
       try DedicatedConnection.establish(factory, bootstrap, connectTimeoutMillis)
       catch {
         case e: Throwable =>
-          locked { reserved -= 1; available.signalAll() }
+          locked { reserved -= 1; available.signal() }
           lock.lock() // re-take so acquire()'s `locked` block unlocks exactly once on exit
           throw e
       }
@@ -154,13 +154,13 @@ final private[client] class DedicatedPool(
     reserved -= 1
     // stamp with the epoch live the moment it joins the pool, so a connection built across a reconnect is born current, never stale
     if (closing) {
-      available.signalAll()
+      available.signal()
       scheduleClose(connection)
       throw NotConnected()
     }
     liveGeneration() match {
       case None      =>
-        available.signalAll()
+        available.signal()
         scheduleClose(connection)
         throw NotConnected()
       case Some(gen) =>
@@ -187,7 +187,7 @@ final private[client] class DedicatedPool(
     locked {
       if (closing || !healthyAndCurrent(connection)) discardLocked(connection)
       else idle.append(DedicatedPool.Idle(connection, scheduler.nowMillis))
-      available.signalAll()
+      available.signal()
     }
 
   private def sweepExpired(): Unit = {

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -302,10 +302,10 @@ final private[client] class SubscriptionConnection(
       if (reconnect) scheduleReconnect(0)
     }
 
-  private def onFrame(frame: Frame): Unit = {
-    lastReplyAtMillis = scheduler.nowMillis
+  private def onFrame(frame: Frame): Unit =
     frame match {
       case Frame.Push(elements) =>
+        // not touching lastReplyAtMillis: a push proves only the read path, so push-only traffic must still get the idle keepalive PING
         Pubsub.decode(elements) match {
           case Some(Pubsub.Event.Message(channel, payload))            => dispatch(channelSinks, channel, Delivery.Channel(channel, payload))
           case Some(Pubsub.Event.ShardMessage(channel, payload))       => dispatch(shardSinks, channel, Delivery.Channel(channel, payload))
@@ -314,10 +314,10 @@ final private[client] class SubscriptionConnection(
           case _                                                       => () // an Unsubscribed ack is informational; re-homing is disconnect-driven
         }
       case reply                => // a non-push reply is the bootstrap HELLO or the watchdog's PONG
+        lastReplyAtMillis = scheduler.nowMillis
         val waiter = bootstrapWaiter
         if (waiter != null) waiter(reply) else pingSentAtMillis = 0L
     }
-  }
 
   // snapshot the sinks under the lock, then deliver outside it: a blocking put (backpressure) must never hold the registry lock
   private def dispatch(map: mutable.HashMap[String, mutable.LinkedHashSet[Sink]], key: String, delivery: Delivery): Unit = {

--- a/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
@@ -202,6 +202,29 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
     assertChannel(nextBlocking(sub), "news", "after-reconnect")
   }
 
+  test("a steady stream of message pushes does not suppress the keepalive PING (push proves only the read path)") {
+    val silentToPing: Bytes => Seq[Frame]   = { payload =>
+      val s = payload.asUtf8String
+      if (s.contains("\r\nSELECT\r\n")) Seq(Frame.SimpleString("OK"))
+      else if (s.contains("\r\nSUBSCRIBE\r\n")) confirmations("subscribe", s)
+      else Nil // silent to PING, so a fired keepalive goes unanswered and the watchdog must eventually kill the socket
+    }
+    val watchdog                            = WatchdogConfig(pingInterval = 100.millis, pingTimeout = 50.millis, enabled = true)
+    val (connection, scheduler, transports) = make(watchdog = watchdog, respond = silentToPing, bootstrap = Vector(Connection.select(0)))
+    val _                                   = connection.subscribeChannels(Vector("news"))
+    assertEquals(transports.size, 1)
+
+    var iteration = 0
+    while (iteration < 3) {
+      transports.head.emit(message("news", "tick"))
+      scheduler.advance(90.millis)
+      iteration += 1
+    }
+
+    assertEquals(transports.head.closeCount, 1, "the watchdog killed the socket despite continuous inbound pushes")
+    assertEquals(transports.size, 2, "the killed connection reconnected")
+  }
+
   test("subscribing to multiple channels in one call delivers messages from any of them") {
     val (connection, _, transports) = make()
     val sub                         = connection.subscribeChannels(Vector("a", "b"))

--- a/sage-core/src/main/scala/sage/codec/KeyCodec.scala
+++ b/sage-core/src/main/scala/sage/codec/KeyCodec.scala
@@ -57,12 +57,12 @@ object KeyCodec {
   /**
     * Decimal `Int`; decoding rejects non-numeric or out-of-range input.
     */
-  given int: KeyCodec[Int] = instance(Primitives.encodeNumber, Primitives.decodeNumber("Int", Primitives.parseInt))
+  given int: KeyCodec[Int] = instance(Primitives.encodeInt, Primitives.decodeNumber("Int", Primitives.parseInt))
 
   /**
     * Decimal `Long`; decoding rejects non-numeric or out-of-range input.
     */
-  given long: KeyCodec[Long] = instance(Primitives.encodeNumber, Primitives.decodeNumber("Long", Primitives.parseLong))
+  given long: KeyCodec[Long] = instance(Primitives.encodeLong, Primitives.decodeNumber("Long", Primitives.parseLong))
 
   /**
     * Raw [[sage.Bytes]], passed through unchanged in both directions.

--- a/sage-core/src/main/scala/sage/codec/Primitives.scala
+++ b/sage-core/src/main/scala/sage/codec/Primitives.scala
@@ -11,9 +11,32 @@ private[codec] object Primitives {
 
   private val True       = Bytes.utf8("1")
   private val False      = Bytes.utf8("0")
+  private val Zero       = Bytes.utf8("0")
   private val MaxPreview = 64
 
-  def encodeNumber[A](value: A): Bytes = Bytes.utf8(value.toString)
+  def encodeInt(value: Int): Bytes = encodeLong(value.toLong)
+
+  // digits come from the negative magnitude (`value % 10` is <= 0), so Long.MinValue, which has no positive counterpart, is safe
+  def encodeLong(value: Long): Bytes =
+    if (value == 0L) Zero
+    else {
+      val negative  = value < 0
+      var counter   = value
+      var digits    = 0
+      while (counter != 0L) { counter /= 10; digits += 1 }
+      val start     = if (negative) 1 else 0
+      val out       = new Array[Byte](start + digits)
+      var i         = out.length - 1
+      var remaining = value
+      while (i >= start) {
+        val digit = if (negative) -(remaining % 10) else remaining % 10
+        out(i) = ('0' + digit).toByte
+        remaining /= 10
+        i -= 1
+      }
+      if (negative) out(0) = '-'
+      Bytes.wrap(IArray.unsafeFromArray(out))
+    }
 
   def encodeBoolean(value: Boolean): Bytes = if (value) True else False
 

--- a/sage-core/src/main/scala/sage/codec/ValueCodec.scala
+++ b/sage-core/src/main/scala/sage/codec/ValueCodec.scala
@@ -57,12 +57,12 @@ object ValueCodec {
   /**
     * Decimal `Int`; decoding rejects non-numeric or out-of-range input.
     */
-  given int: ValueCodec[Int] = instance(Primitives.encodeNumber, Primitives.decodeNumber("Int", Primitives.parseInt))
+  given int: ValueCodec[Int] = instance(Primitives.encodeInt, Primitives.decodeNumber("Int", Primitives.parseInt))
 
   /**
     * Decimal `Long`; decoding rejects non-numeric or out-of-range input.
     */
-  given long: ValueCodec[Long] = instance(Primitives.encodeNumber, Primitives.decodeNumber("Long", Primitives.parseLong))
+  given long: ValueCodec[Long] = instance(Primitives.encodeLong, Primitives.decodeNumber("Long", Primitives.parseLong))
 
   /**
     * `Double` in Redis's number format, including `inf`/`-inf`/`nan`.


### PR DESCRIPTION
Findings surfaced by a review sweep across the core and client runtime, verified and fixed.

## Bug — subscription keepalive defeated under message load
`SubscriptionConnection.onFrame` refreshed `lastReplyAtMillis` on every frame, including `Frame.Push`. The watchdog only PINGs when `now - lastReplyAtMillis >= pingInterval`, so a steady stream of pub/sub messages kept the clock fresh and the round-trip liveness probe never fired — a half-open socket (dead send path, live receive path) was never detected. The fix moves the clock update into the non-push `case reply` branch, mirroring the deliberate choice already documented in `MultiplexedConnection.onFrame`. A new regression test drives continuous pushes and asserts the watchdog still kills the socket (it fails against the old behavior).

## Perf — `DedicatedPool` thundering herd
Single-slot-freeing paths used `available.signalAll()`, waking every parked acquirer when only one can proceed; the rest re-check capacity and re-park. Switched those five sites to `signal()`, keeping `signalAll()` only in `close()` and `wakeWaiters()`, which genuinely invalidate the wait condition for all waiters. No lost-wakeup: `acquire()` re-evaluates authoritative state under the lock before parking, and the liveness-loss path still uses `signalAll()`.

## Perf — numeric encode boxing
`encodeNumber[A](value: A) = Bytes.utf8(value.toString)` boxed the `Int`/`Long`, allocated a `String`, then a byte array on every numeric key/value encode. Replaced with `encodeInt`/`encodeLong` that write ASCII digits straight into a right-sized array (digits accumulated from the negative magnitude, so `Long.MinValue` is safe). Existing codec round-trip tests cover `Int.MinValue`/`Long.MinValue`/`0`/negatives.

## Docs — TLS mTLS gap
`TrustStore`/`Pem` initialize the `SSLContext` with no key managers, so a server requiring a client certificate fails the handshake with an opaque error. Added scaladoc noting these are server-trust only and that mutual TLS must go through `Custom` (only `Custom` documented this before).

## Testing
`scalafmtCheckAll` clean; `core` and `clientOx` compile; codec, subscription, multiplexed, and dedicated-pool suites pass.