### PR TITLE
Remove public Pipeline type in favor of direct-command overloads

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -179,7 +179,7 @@ val tuple = client.pipeline(
   (
     Commands.get[String, String]("pipe:a"),
     Commands.incrBy("pipe:n", 5)
-  ).pipeline
+  )
 )
 ```
 
@@ -191,7 +191,7 @@ for {
              (
                Commands.get[String, String]("pipe:a"),
                Commands.incrBy("pipe:n", 5)
-             ).pipeline
+             )
            )
 } yield tuple
 ```
@@ -208,7 +208,7 @@ val result = client.transaction { tx =>
   tx.watch("tx:n")
   tx.get[Int]("tx:n")
   tx.exec(
-    (Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)).pipeline
+    (Commands.incr("tx:n"), Commands.incrBy("tx:n", 4))
   )
 }
 ```
@@ -224,7 +224,7 @@ for {
                          (
                            Commands.incr("tx:n"),
                            Commands.incrBy("tx:n", 4)
-                         ).pipeline
+                         )
                        )
               } yield res
             }

--- a/docs/pipelines-transactions.md
+++ b/docs/pipelines-transactions.md
@@ -15,7 +15,7 @@ val tuple = client.pipeline(
   (
     Commands.get[String, String]("pipe:a"),
     Commands.incrBy("pipe:n", 5)
-  ).pipeline
+  )
 )
 // tuple: (Option[String], Long)
 ```
@@ -28,12 +28,19 @@ for {
              (
                Commands.get[String, String]("pipe:a"),
                Commands.incrBy("pipe:n", 5)
-             ).pipeline
+             )
            )
 } yield tuple // (Option[String], Long)
 ```
 
 :::
+
+A tuple gives a fixed-arity, heterogeneous result. When the commands are built dynamically and share a result type, pass a `Seq[Command[A]]` instead and get back a `Vector[A]` in the same order (an empty `Seq` is a no-op that never touches the socket):
+
+```scala
+val ids = List("a", "b", "c")
+client.pipeline(ids.map(id => Commands.get[String, String](id))) // F[Vector[Option[String]]]
+```
 
 By default a pipeline fails as a whole if any position fails. Use `pipelineAttempt` to keep each position's outcome separate, so one failing command does not sink the others:
 
@@ -47,7 +54,7 @@ val attempt = client.pipelineAttempt(
   (
     Commands.get[String, String]("pipe:str"),
     Commands.incr("pipe:str")
-  ).pipeline
+  )
 )
 ```
 
@@ -60,7 +67,7 @@ for {
                (
                  Commands.get[String, String]("pipe:str"),
                  Commands.incr("pipe:str")
-               ).pipeline
+               )
              )
 } yield attempt
 ```
@@ -81,7 +88,7 @@ val result = client.transaction { tx =>
   tx.watch("tx:n")
   tx.get[Int]("tx:n")
   tx.exec(
-    (Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)).pipeline
+    (Commands.incr("tx:n"), Commands.incrBy("tx:n", 4))
   )
 }
 // result: Some((2, 6)), or None if "tx:n" changed before EXEC
@@ -98,7 +105,7 @@ for {
                          (
                            Commands.incr("tx:n"),
                            Commands.incrBy("tx:n", 4)
-                         ).pipeline
+                         )
                        )
               } yield res
             }

--- a/examples/ce/src/main/scala/sage/examples/ce/PipelinesExample.scala
+++ b/examples/ce/src/main/scala/sage/examples/ce/PipelinesExample.scala
@@ -15,10 +15,10 @@ object PipelinesExample {
     for {
       _       <- client.set("pipe:a", "x")
       _       <- client.set("pipe:n", 10)
-      tuple   <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy("pipe:n", 5)).pipeline)
+      tuple   <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy("pipe:n", 5)))
       _       <- client.set("pipe:str", "hello")
       // INCR on a non-numeric string fails only at its own position; the GET still succeeds
-      attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr("pipe:str")).pipeline)
+      attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr("pipe:str")))
       _       <- IO.println(s"tuple=$tuple attempt=$attempt")
     } yield ()
 }

--- a/examples/ce/src/main/scala/sage/examples/ce/TransactionsExample.scala
+++ b/examples/ce/src/main/scala/sage/examples/ce/TransactionsExample.scala
@@ -18,7 +18,7 @@ object TransactionsExample {
                   for {
                     _   <- tx.watch("tx:n")
                     _   <- tx.get[Int]("tx:n")
-                    res <- tx.exec((Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)).pipeline)
+                    res <- tx.exec((Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)))
                   } yield res
                 }
       _      <- IO.println(s"transaction result=$result")

--- a/examples/kyo/src/main/scala/sage/examples/kyo/PipelinesExample.scala
+++ b/examples/kyo/src/main/scala/sage/examples/kyo/PipelinesExample.scala
@@ -15,10 +15,10 @@ object PipelinesExample {
     for {
       _       <- client.set("pipe:a", "x")
       _       <- client.set("pipe:n", 10)
-      tuple   <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy("pipe:n", 5)).pipeline)
+      tuple   <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy("pipe:n", 5)))
       _       <- client.set("pipe:str", "hello")
       // INCR on a non-numeric string fails only at its own position; the GET still succeeds
-      attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr("pipe:str")).pipeline)
+      attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr("pipe:str")))
       _       <- Console.printLine(s"tuple=$tuple attempt=$attempt")
     } yield ()
 }

--- a/examples/kyo/src/main/scala/sage/examples/kyo/TransactionsExample.scala
+++ b/examples/kyo/src/main/scala/sage/examples/kyo/TransactionsExample.scala
@@ -18,7 +18,7 @@ object TransactionsExample {
                   for {
                     _   <- tx.watch("tx:n")
                     _   <- tx.get[Int]("tx:n")
-                    res <- tx.exec((Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)).pipeline)
+                    res <- tx.exec((Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)))
                   } yield res
                 }
       _      <- Console.printLine(s"transaction result=$result")

--- a/examples/ox/src/main/scala/sage/examples/ox/PipelinesExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/PipelinesExample.scala
@@ -14,10 +14,10 @@ object PipelinesExample {
   def run(client: SageClient)(using Ox): Unit = {
     val _       = client.set("pipe:a", "x")
     val _       = client.set("pipe:n", 10)
-    val tuple   = client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy("pipe:n", 5)).pipeline)
+    val tuple   = client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy("pipe:n", 5)))
     val _       = client.set("pipe:str", "hello")
     // INCR on a non-numeric string fails only at its own position; the GET still succeeds
-    val attempt = client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr("pipe:str")).pipeline)
+    val attempt = client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr("pipe:str")))
     println(s"tuple=$tuple attempt=$attempt")
   }
 }

--- a/examples/ox/src/main/scala/sage/examples/ox/TransactionsExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/TransactionsExample.scala
@@ -16,7 +16,7 @@ object TransactionsExample {
     val result = client.transaction { tx =>
       val _ = tx.watch("tx:n")
       val _ = tx.get[Int]("tx:n")
-      tx.exec((Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)).pipeline)
+      tx.exec((Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)))
     }
     println(s"transaction result=$result")
   }

--- a/examples/zio/src/main/scala/sage/examples/zio/PipelinesExample.scala
+++ b/examples/zio/src/main/scala/sage/examples/zio/PipelinesExample.scala
@@ -16,10 +16,10 @@ object PipelinesExample {
       for {
         _       <- client.set("pipe:a", "x")
         _       <- client.set("pipe:n", 10)
-        tuple   <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy("pipe:n", 5)).pipeline)
+        tuple   <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy("pipe:n", 5)))
         _       <- client.set("pipe:str", "hello")
         // INCR on a non-numeric string fails only at its own position; the GET still succeeds
-        attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr("pipe:str")).pipeline)
+        attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr("pipe:str")))
         _       <- Console.printLine(s"tuple=$tuple attempt=$attempt")
       } yield ()
     }

--- a/examples/zio/src/main/scala/sage/examples/zio/TransactionsExample.scala
+++ b/examples/zio/src/main/scala/sage/examples/zio/TransactionsExample.scala
@@ -19,7 +19,7 @@ object TransactionsExample {
                     for {
                       _   <- tx.watch("tx:n")
                       _   <- tx.get[Int]("tx:n")
-                      res <- tx.exec((Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)).pipeline)
+                      res <- tx.exec((Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)))
                     } yield res
                   }
         _      <- Console.printLine(s"transaction result=$result")

--- a/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
+++ b/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
@@ -36,9 +36,9 @@ class CeSmokeSuite extends ServerSuite(Images.redis) {
           for {
             _       <- client.set("pipe:a", "x")
             _       <- client.set("pipe:n", 10)
-            out     <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)).pipeline)
+            out     <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)))
             _       <- client.set("pipe:str", "hello")
-            attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")).pipeline)
+            attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")))
           } yield {
             assertEquals(out, (Some("x"), 15L))
             assert(attempt._1 == Right(Some("hello")), attempt._1)
@@ -60,7 +60,7 @@ class CeSmokeSuite extends ServerSuite(Images.redis) {
                      for {
                        _   <- tx.watch("tx:n")
                        _   <- tx.get[Int]("tx:n")
-                       res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)).pipeline)
+                       res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)))
                      } yield res
                    }
           } yield assertEquals(out, Some((2L, 6L)))

--- a/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
+++ b/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
@@ -34,9 +34,9 @@ class KyoSmokeSuite extends ServerSuite(Images.redis) {
           client  <- SageClient.scoped(configOf(server))
           _       <- client.set("pipe:a", "x")
           _       <- client.set("pipe:n", 10)
-          out     <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)).pipeline)
+          out     <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)))
           _       <- client.set("pipe:str", "hello")
-          attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")).pipeline)
+          attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")))
         } yield {
           assertEquals(out, (Some("x"), 15L))
           assert(attempt._1 == Right(Some("hello")), attempt._1)
@@ -58,7 +58,7 @@ class KyoSmokeSuite extends ServerSuite(Images.redis) {
                       for {
                         _   <- tx.watch("tx:n")
                         _   <- tx.get[Int]("tx:n")
-                        res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)).pipeline)
+                        res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)))
                       } yield res
                     }
         } yield assertEquals(out, Some((2L, 6L)))

--- a/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
+++ b/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
@@ -32,10 +32,10 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
         val client  = SageClient.scoped(configOf(server))
         val _       = client.set("pipe:a", "x")
         val _       = client.set("pipe:n", 10)
-        val out     = client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)).pipeline)
+        val out     = client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)))
         assertEquals(out, (Some("x"), 15L))
         val _       = client.set("pipe:str", "hello")
-        val attempt = client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")).pipeline)
+        val attempt = client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")))
         assert(attempt._1 == Right(Some("hello")), attempt._1)
         assert(attempt._2.isLeft, attempt._2)
       }
@@ -50,7 +50,7 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
         val out    = client.transaction { tx =>
           val _ = tx.watch("tx:n")
           val _ = tx.get[Int]("tx:n")
-          tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)).pipeline)
+          tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)))
         }
         assertEquals(out, Some((2L, 6L)))
       }

--- a/integration-tests/shared/src/test/scala/sage/integration/RoundTripSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/RoundTripSuite.scala
@@ -7,8 +7,7 @@ import kyo.compat.*
 import sage.Bytes
 import sage.SageException.DecodeError
 import sage.client.internal.Client
-import sage.commands.{Command, Commands, Pipeline}
-import sage.commands.Pipeline.pipeline
+import sage.commands.{Command, Commands}
 import sage.protocol.Frame
 
 abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
@@ -75,7 +74,7 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
       for {
         _   <- client.set("p:a", "x")
         _   <- client.set("p:n", 10)
-        out <- client.pipeline((Commands.get[String, String]("p:a"), Commands.incrBy[String]("p:n", 5)).pipeline)
+        out <- client.pipeline((Commands.get[String, String]("p:a"), Commands.incrBy[String]("p:n", 5)))
       } yield assertEquals(out, (Some("x"), 15L))
     }
   }
@@ -89,7 +88,7 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
                        Commands.get[String, String]("p:str"),
                        Commands.incr[String]("p:str"),
                        Commands.get[String, String]("p:str")
-                     ).pipeline
+                     )
                    )
       } yield {
         val (a, b, c) = results
@@ -103,7 +102,7 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
   test("a large pipeline runs every command and returns one result per position") {
     withClient { client =>
       val n = 200
-      client.pipeline(Pipeline.sequence(Vector.fill(n)(Commands.incr[String]("p:rtt")))).flatMap { results =>
+      client.pipeline(Vector.fill(n)(Commands.incr[String]("p:rtt"))).flatMap { results =>
         client.get[Int]("p:rtt").map { stored =>
           assertEquals(results.length, n)
           assertEquals(results, (1 to n).map(_.toLong).toVector)
@@ -117,7 +116,7 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _   <- client.set("t:n", 10)
-        out <- client.transaction(tx => tx.exec((Commands.incr[String]("t:n"), Commands.incrBy[String]("t:n", 5)).pipeline))
+        out <- client.transaction(tx => tx.exec((Commands.incr[String]("t:n"), Commands.incrBy[String]("t:n", 5))))
       } yield assertEquals(out, Some((11L, 16L)))
     }
   }
@@ -130,7 +129,7 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
                     for {
                       _   <- tx.watch("t:rmw")
                       cur <- tx.get[Int]("t:rmw")
-                      res <- tx.exec(Pipeline.sequence(Vector(Commands.set[String, Int]("t:rmw", cur.getOrElse(0) + 1))))
+                      res <- tx.exec(Vector(Commands.set[String, Int]("t:rmw", cur.getOrElse(0) + 1)))
                     } yield res
                   }
         stored <- client.get[Int]("t:rmw")
@@ -152,7 +151,7 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
                         _   <- tx.watch("t:w")
                         _   <- tx.get[Int]("t:w")
                         _   <- other.set("t:w", 99) // a different connection changes the watched key before EXEC
-                        res <- tx.exec(Pipeline.sequence(Vector(Commands.incr[String]("t:w"))))
+                        res <- tx.exec(Vector(Commands.incr[String]("t:w")))
                       } yield res
                     }
           _      <- other.close
@@ -169,7 +168,7 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
     withClient { client =>
       for {
         _   <- client.set("t:str", "x")
-        res <- client.transaction(tx => tx.execAttempt((Commands.incr[String]("t:fresh"), Commands.incr[String]("t:str")).pipeline))
+        res <- client.transaction(tx => tx.execAttempt((Commands.incr[String]("t:fresh"), Commands.incr[String]("t:str"))))
         ok  <- client.get[Int]("t:fresh")
       } yield {
         val (a, b) = res.getOrElse(fail("expected a committed transaction"))

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
@@ -11,8 +11,7 @@ import sage.{Bytes, Message}
 import sage.SageException.DecodeError
 import sage.client.{Endpoint, SageConfig, Topology}
 import sage.client.internal.{Client, ScanTarget}
-import sage.commands.{Command, Commands, FlushMode, Pipeline, ScanCursor}
-import sage.commands.Pipeline.pipeline
+import sage.commands.{Command, Commands, FlushMode, ScanCursor}
 import sage.integration.{ContainerClient, Images}
 import sage.protocol.Frame
 
@@ -78,8 +77,8 @@ abstract class ClusterSuite(image: String, serverBinary: String) extends munit.F
               count  <- client.incr("counter")
               _      <- client.set("{t}a", "1")
               _      <- client.set("{t}b", "2")
-              piped  <- client.pipeline((Commands.get[String, String]("{t}a"), Commands.get[String, String]("{t}b")).pipeline)
-              commit <- client.transaction(tx => tx.exec(Pipeline.sequence(Vector(Commands.incr[String]("{t}c"), Commands.incr[String]("{t}c")))))
+              piped  <- client.pipeline((Commands.get[String, String]("{t}a"), Commands.get[String, String]("{t}b")))
+              commit <- client.transaction(tx => tx.exec(Vector(Commands.incr[String]("{t}c"), Commands.incr[String]("{t}c"))))
             } yield {
               assertEquals(value, Some("hello"))
               assertEquals(count, 1L)

--- a/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
@@ -11,7 +11,7 @@ import sage.{Bytes, Message}
 import sage.SageException.DecodeError
 import sage.client.{Endpoint, MasterReplicaConfig, ReadFrom, SageConfig, Topology}
 import sage.client.internal.Client
-import sage.commands.{Command, Commands, Pipeline}
+import sage.commands.{Command, Commands}
 import sage.integration.{ContainerClient, Images}
 import sage.protocol.Frame
 
@@ -151,7 +151,7 @@ abstract class MasterReplicaSuite(image: String, serverBinary: String) extends M
         connectAndUse(replicaCfg)(ensureReplicating(_, host, pr)).flatMap { _ =>
           connectAndUse(masterReplica(host, pm, ReadFrom.ReplicaPreferred)) { client =>
             for {
-              commit  <- client.transaction(tx => tx.exec(Pipeline.sequence(Vector(Commands.incr[String]("mr:c"), Commands.incr[String]("mr:c")))))
+              commit  <- client.transaction(tx => tx.exec(Vector(Commands.incr[String]("mr:c"), Commands.incr[String]("mr:c"))))
               sub     <- client.subscribeChannels[String]("mr:news")
               count   <- client.publish("mr:news", "hello")
               message <- sub.next

--- a/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
+++ b/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
@@ -36,9 +36,9 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
             client  <- SageClient.scoped(configOf(server))
             _       <- client.set("pipe:a", "x")
             _       <- client.set("pipe:n", 10)
-            out     <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)).pipeline)
+            out     <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)))
             _       <- client.set("pipe:str", "hello")
-            attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")).pipeline)
+            attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")))
           } yield {
             assertEquals(out, (Some("x"), 15L))
             assert(attempt._1 == Right(Some("hello")), attempt._1)
@@ -61,7 +61,7 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
                         for {
                           _   <- tx.watch("tx:n")
                           _   <- tx.get[Int]("tx:n")
-                          res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)).pipeline)
+                          res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)))
                         } yield res
                       }
           } yield assertEquals(out, Some((2L, 6L)))

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2009,8 +2009,8 @@ trait CommandRunner[F[_], K](using KeyCodec[K]) {
 }
 
 /**
-  * The user-facing handle owning all connections to one server: the command surface, plus pipelines and transactions. Commands compose into
-  * a [[Pipeline]] value (built from [[sage.commands.Commands]]) that `pipeline` sends in one round-trip, yielding a typed result per command.
+  * The user-facing handle owning all connections to one server: the command surface, plus pipelines and transactions. A batch of
+  * [[sage.commands.Commands]] handed to `pipeline` is sent in one round-trip, yielding a typed result per command.
   */
 // one independent keyspace a full SCAN sweep visits: a single node standalone, one per slot-owning master in cluster. `node` is None when
 // the backend has no node to pin to (standalone, or a not-yet-discovered cluster topology), in which case the command runs through normal routing.
@@ -2046,15 +2046,35 @@ trait Client[F[_], K] extends CommandRunner[F, K] {
     */
   def cached[A](command: Command[A], ttl: FiniteDuration): F[A]
 
-  /**
-    * Runs a [[sage.commands.Pipeline]] in one round-trip, yielding its typed result tuple. Fails if any position fails.
-    */
-  def pipeline[Out, R](p: Pipeline[Out, R]): F[Out]
+  private[sage] def pipeline[Out, R](p: Pipeline[Out, R]): F[Out]
+
+  private[sage] def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R]
 
   /**
-    * Like [[pipeline]], but yields the per-position results, each slot a `Right`/`Left`, instead of failing on the first error.
+    * Runs a fixed-arity batch of commands in one round-trip, yielding a result tuple that mirrors the argument tuple element-for-element
+    * (`pipeline((get, incr))` → `F[(Option[V], Long)]`). Fails if any position fails; use [[pipelineAttempt]] to keep per-position errors.
     */
-  def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R]
+  def pipeline[T <: NonEmptyTuple](commands: T)(using Tuple.IsMappedBy[Command][T]): F[Tuple.InverseMap[T, Command]] =
+    pipeline(Pipeline.fromTuple(commands))
+
+  /**
+    * Runs a dynamic, homogeneous batch of commands in one round-trip, yielding one result per command in order. An empty batch is a no-op
+    * that yields an empty `Vector` without touching the socket.
+    */
+  def pipeline[A](commands: Seq[Command[A]]): F[Vector[A]] =
+    pipeline(Pipeline.sequence(commands))
+
+  /**
+    * Like the tuple [[pipeline]], but yields the per-position results, each slot a `Right`/`Left`, instead of failing on the first error.
+    */
+  def pipelineAttempt[T <: NonEmptyTuple](commands: T)(using Tuple.IsMappedBy[Command][T]): F[Tuple.Map[Tuple.InverseMap[T, Command], Attempt]] =
+    pipelineAttempt(Pipeline.fromTuple(commands))
+
+  /**
+    * Like the `Seq` [[pipeline]], but yields the per-position results, each slot a `Right`/`Left`, instead of failing on the first error.
+    */
+  def pipelineAttempt[A](commands: Seq[Command[A]]): F[Vector[Attempt[A]]] =
+    pipelineAttempt(Pipeline.sequence(commands))
 
   /**
     * Opens a [[TransactionScope]] on a leased Dedicated Connection for `MULTI`/`EXEC`, optionally guarded by `WATCH`.
@@ -2098,8 +2118,8 @@ trait Client[F[_], K] extends CommandRunner[F, K] {
     new Client[F, K2] {
       def run[A](command: Command[A]): F[A]                                     = self.run(command)
       def cached[A](command: Command[A], ttl: FiniteDuration): F[A]             = self.cached(command, ttl)
-      def pipeline[Out, R](p: Pipeline[Out, R]): F[Out]                         = self.pipeline(p)
-      def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R]                    = self.pipelineAttempt(p)
+      private[sage] def pipeline[Out, R](p: Pipeline[Out, R]): F[Out]           = self.pipeline(p)
+      private[sage] def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R]      = self.pipelineAttempt(p)
       def transaction[A](body: TransactionScope[F, K2] => F[A]): F[A]           = self.transaction(scope => body(scope.as[K2]))
       def subscribeChannels[V: ValueCodec](channel: String, rest: String*)      = self.subscribeChannels(channel, rest*)
       def subscribePatterns[V: ValueCodec](pattern: String, rest: String*)      = self.subscribePatterns(pattern, rest*)
@@ -2311,10 +2331,10 @@ object Client {
 
     def runOn[A](target: ScanTarget, command: Command[A]): CIO[A] = run(command)
 
-    def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out] =
+    private[sage] def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out] =
       submitPipeline(p).flatMap(TxSupport.collapseStrict(_, p.toOut))
 
-    def pipelineAttempt[Out, R](p: Pipeline[Out, R]): CIO[R] =
+    private[sage] def pipelineAttempt[Out, R](p: Pipeline[Out, R]): CIO[R] =
       submitPipeline(p).map(p.toResults)
 
     // The lease is bracketed: release runs on success, failure, and interruption (IO.bracket). A clean exit (exec/discard cleared the
@@ -2456,13 +2476,13 @@ object Client {
         }
       }
 
-    def exec[Out, R](p: Pipeline[Out, R]): CIO[Option[Out]] =
+    private[sage] def exec[Out, R](p: Pipeline[Out, R]): CIO[Option[Out]] =
       runExec(p).flatMap {
         case None          => CIO.value(None)
         case Some(results) => TxSupport.collapseStrict(results, p.toOut).map(Some(_))
       }
 
-    def execAttempt[Out, R](p: Pipeline[Out, R]): CIO[Option[R]] =
+    private[sage] def execAttempt[Out, R](p: Pipeline[Out, R]): CIO[Option[R]] =
       runExec(p).map(_.map(p.toResults))
 
     // None = WATCH abort; Some = the per-position decoded results. A queueing-phase error fails the effect (nothing ran).

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -138,8 +138,8 @@ final private[client] class ClusterLive(
       case None       => run(command)
     }
 
-  def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out]      = submitPipeline(p).flatMap(TxSupport.collapseStrict(_, p.toOut))
-  def pipelineAttempt[Out, R](p: Pipeline[Out, R]): CIO[R] = submitPipeline(p).map(p.toResults)
+  private[sage] def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out]      = submitPipeline(p).flatMap(TxSupport.collapseStrict(_, p.toOut))
+  private[sage] def pipelineAttempt[Out, R](p: Pipeline[Out, R]): CIO[R] = submitPipeline(p).map(p.toResults)
 
   def transaction[A](body: TransactionScope[CIO, String] => CIO[A]): CIO[A] =
     CIO.acquireReleaseWith(acquireScope)(releaseScope)(scope => body(scope))
@@ -563,13 +563,13 @@ final private[client] class ClusterLive(
       if (fault) forceRefresh()
     }
 
-    def exec[Out, R](p: Pipeline[Out, R]): CIO[Option[Out]] =
+    private[sage] def exec[Out, R](p: Pipeline[Out, R]): CIO[Option[Out]] =
       runExec(p).flatMap {
         case None          => CIO.value(None)
         case Some(results) => TxSupport.collapseStrict(results, p.toOut).map(Some(_))
       }
 
-    def execAttempt[Out, R](p: Pipeline[Out, R]): CIO[Option[R]] =
+    private[sage] def execAttempt[Out, R](p: Pipeline[Out, R]): CIO[Option[R]] =
       runExec(p).map(_.map(p.toResults))
 
     private def runExec[Out, R](p: Pipeline[Out, R]): CIO[Option[Vector[Either[SageException, Any]]]] =

--- a/sage-client/shared/src/main/scala/sage/client/internal/LoweredClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LoweredClient.scala
@@ -24,9 +24,9 @@ abstract class LoweredClient[F[_]](underlying: Client[CIO, String]) extends Clie
 
   final def cached[A](command: Command[A], ttl: FiniteDuration): F[A] = lower(underlying.cached(command, ttl))
 
-  final def pipeline[Out, R](p: Pipeline[Out, R]): F[Out] = lower(underlying.pipeline(p))
+  final private[sage] def pipeline[Out, R](p: Pipeline[Out, R]): F[Out] = lower(underlying.pipeline(p))
 
-  final def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R] = lower(underlying.pipelineAttempt(p))
+  final private[sage] def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R] = lower(underlying.pipelineAttempt(p))
 
   final def transaction[A](body: TransactionScope[F, String] => F[A]): F[A] =
     lower(underlying.transaction[A](scope => lift(body(lowerScope(scope)))))
@@ -48,11 +48,11 @@ abstract class LoweredClient[F[_]](underlying: Client[CIO, String]) extends Clie
 
   private def lowerScope(scope: TransactionScope[CIO, String]): TransactionScope[F, String] =
     new TransactionScope[F, String] {
-      def watch[K: KeyCodec](key: K, rest: K*): F[Unit]          = lower(scope.watch(key, rest*))
-      def run[A](command: Command[A]): F[A]                      = lower(scope.run(command))
-      def exec[Out, R](p: Pipeline[Out, R]): F[Option[Out]]      = lower(scope.exec(p))
-      def execAttempt[Out, R](p: Pipeline[Out, R]): F[Option[R]] = lower(scope.execAttempt(p))
-      def discard: F[Unit]                                       = lower(scope.discard)
+      def watch[K: KeyCodec](key: K, rest: K*): F[Unit]                        = lower(scope.watch(key, rest*))
+      def run[A](command: Command[A]): F[A]                                    = lower(scope.run(command))
+      private[sage] def exec[Out, R](p: Pipeline[Out, R]): F[Option[Out]]      = lower(scope.exec(p))
+      private[sage] def execAttempt[Out, R](p: Pipeline[Out, R]): F[Option[R]] = lower(scope.execAttempt(p))
+      def discard: F[Unit]                                                     = lower(scope.discard)
     }
 
   private def lowerSub[A](sub: Subscription[CIO, A]): Subscription[F, A] =

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -247,8 +247,8 @@ final private[client] class MasterReplicaLive(
 
   // --- pipelines -----------------------------------------------------------------------------------------------------------------------
 
-  def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out]      = submitPipeline(p).flatMap(TxSupport.collapseStrict(_, p.toOut))
-  def pipelineAttempt[Out, R](p: Pipeline[Out, R]): CIO[R] = submitPipeline(p).map(p.toResults)
+  private[sage] def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out]      = submitPipeline(p).flatMap(TxSupport.collapseStrict(_, p.toOut))
+  private[sage] def pipelineAttempt[Out, R](p: Pipeline[Out, R]): CIO[R] = submitPipeline(p).map(p.toResults)
 
   private def submitPipeline[Out, R](p: Pipeline[Out, R]): CIO[Vector[Either[SageException, Any]]] =
     if (p.commands.isEmpty) CIO.value(Vector.empty)

--- a/sage-client/shared/src/main/scala/sage/client/internal/TransactionScope.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/TransactionScope.scala
@@ -1,7 +1,7 @@
 package sage.client.internal
 
 import sage.codec.KeyCodec
-import sage.commands.{Command, Pipeline}
+import sage.commands.{Attempt, Command, Pipeline}
 
 /**
   * The handle opened by `transaction { tx => … }`: one leased Dedicated Connection, held for the whole block. Reads run immediately on that
@@ -17,15 +17,35 @@ trait TransactionScope[F[_], K] extends CommandRunner[F, K] {
     */
   def watch[K: KeyCodec](key: K, rest: K*): F[Unit]
 
-  /**
-    * Executes the Pipeline atomically. `None` means a watched key changed and the transaction aborted.
-    */
-  def exec[Out, R](pipeline: Pipeline[Out, R]): F[Option[Out]]
+  private[sage] def exec[Out, R](pipeline: Pipeline[Out, R]): F[Option[Out]]
+
+  private[sage] def execAttempt[Out, R](pipeline: Pipeline[Out, R]): F[Option[R]]
 
   /**
-    * Like `exec`, but yields the per-position results (each slot a `Right`/`Left`) on commit. `None` still means aborted.
+    * Executes a fixed-arity batch of commands atomically (`MULTI`/`EXEC`), yielding a result tuple that mirrors the argument tuple
+    * element-for-element. `None` means a watched key changed and the transaction aborted.
     */
-  def execAttempt[Out, R](pipeline: Pipeline[Out, R]): F[Option[R]]
+  def exec[T <: NonEmptyTuple](commands: T)(using Tuple.IsMappedBy[Command][T]): F[Option[Tuple.InverseMap[T, Command]]] =
+    exec(Pipeline.fromTuple(commands))
+
+  /**
+    * Executes a dynamic, homogeneous batch of commands atomically (`MULTI`/`EXEC`), yielding one result per command in order. `None` means
+    * a watched key changed and the transaction aborted.
+    */
+  def exec[A](commands: Seq[Command[A]]): F[Option[Vector[A]]] =
+    exec(Pipeline.sequence(commands))
+
+  /**
+    * Like the tuple [[exec]], but yields the per-position results (each slot a `Right`/`Left`) on commit. `None` still means aborted.
+    */
+  def execAttempt[T <: NonEmptyTuple](commands: T)(using Tuple.IsMappedBy[Command][T]): F[Option[Tuple.Map[Tuple.InverseMap[T, Command], Attempt]]] =
+    execAttempt(Pipeline.fromTuple(commands))
+
+  /**
+    * Like the `Seq` [[exec]], but yields the per-position results (each slot a `Right`/`Left`) on commit. `None` still means aborted.
+    */
+  def execAttempt[A](commands: Seq[Command[A]]): F[Option[Vector[Attempt[A]]]] =
+    execAttempt(Pipeline.sequence(commands))
 
   /**
     * Abandons the scope without committing, clearing any watched keys so the connection can be recycled (issues `UNWATCH`).
@@ -39,11 +59,11 @@ trait TransactionScope[F[_], K] extends CommandRunner[F, K] {
   override def as[K2](using KeyCodec[K2]): TransactionScope[F, K2] = {
     val self = this
     new TransactionScope[F, K2] {
-      def run[A](command: Command[A]): F[A]                             = self.run(command)
-      def watch[K0: KeyCodec](key: K0, rest: K0*): F[Unit]              = self.watch(key, rest*)
-      def exec[Out, R](pipeline: Pipeline[Out, R]): F[Option[Out]]      = self.exec(pipeline)
-      def execAttempt[Out, R](pipeline: Pipeline[Out, R]): F[Option[R]] = self.execAttempt(pipeline)
-      def discard: F[Unit]                                              = self.discard
+      def run[A](command: Command[A]): F[A]                                           = self.run(command)
+      def watch[K0: KeyCodec](key: K0, rest: K0*): F[Unit]                            = self.watch(key, rest*)
+      private[sage] def exec[Out, R](pipeline: Pipeline[Out, R]): F[Option[Out]]      = self.exec(pipeline)
+      private[sage] def execAttempt[Out, R](pipeline: Pipeline[Out, R]): F[Option[R]] = self.execAttempt(pipeline)
+      def discard: F[Unit]                                                            = self.discard
     }
   }
 }

--- a/sage-client/shared/src/main/scala/sage/exports.scala
+++ b/sage-client/shared/src/main/scala/sage/exports.scala
@@ -129,7 +129,6 @@ export sage.commands.{
   ZRange
 }
 export sage.commands.{as, asArray, asArrayOf, asLong, asString}
-export sage.commands.{Command, Commands, Execution, Pipeline}
-export sage.commands.Pipeline.pipeline
+export sage.commands.{Attempt, Command, Commands, Execution}
 // raw-Frame escape hatch for eval/fcall replies
 export sage.protocol.Frame

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -10,8 +10,7 @@ import sage.Bytes
 import sage.SageException.{CrossSlot, NotConnected, ServerError}
 import sage.client.internal.{ClusterLive, FakeTransport, MultiplexedConnection, Scheduler}
 import sage.cluster.{Node, Slot}
-import sage.commands.{Command, Connection, Pipeline, Strings}
-import sage.commands.Pipeline.pipeline
+import sage.commands.{Command, Connection, Strings}
 import sage.protocol.Frame
 
 class ClusterClientSpec extends munit.FunSuite {
@@ -250,7 +249,7 @@ class ClusterClientSpec extends munit.FunSuite {
       (node: Node, text: String) => if (text.contains("CLUSTER")) Seq(splitOn(slotB)) else Seq(Frame.BulkString(Bytes.utf8(node.host)))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
-    fixture.live.pipelineAttempt((Strings.get[String, String](keyA), Strings.get[String, String](keyB)).pipeline).unsafeRun.map { result =>
+    fixture.live.pipelineAttempt((Strings.get[String, String](keyA), Strings.get[String, String](keyB))).unsafeRun.map { result =>
       assertEquals(result, (Right(Some(nodeA.host)), Right(Some(nodeB.host))))
       assert(fixture.written(nodeA).exists(_.contains("GET")), "nodeA did not receive its GET")
       assert(fixture.written(nodeB).exists(_.contains("GET")), "nodeB did not receive its GET")
@@ -264,10 +263,9 @@ class ClusterClientSpec extends munit.FunSuite {
       else Seq(Frame.BulkString(Bytes.utf8("ok")))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
-    fixture.live.pipelineAttempt((Strings.get[String, String](keyA), Strings.get[String, String](keyB)).pipeline).unsafeRun.map {
-      case (first, second) =>
-        assertEquals(first, Right(Some("ok")))
-        assert(second.fold(_.isInstanceOf[ServerError], _ => false), s"second position should be a ServerError: $second")
+    fixture.live.pipelineAttempt((Strings.get[String, String](keyA), Strings.get[String, String](keyB))).unsafeRun.map { case (first, second) =>
+      assertEquals(first, Right(Some("ok")))
+      assert(second.fold(_.isInstanceOf[ServerError], _ => false), s"second position should be a ServerError: $second")
     }
   }
 
@@ -277,7 +275,7 @@ class ClusterClientSpec extends munit.FunSuite {
       else Seq(Frame.BulkString(Bytes.utf8("v1")), Frame.BulkString(Bytes.utf8("v2")))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
-    fixture.live.pipeline((Strings.get[String, String]("{x}1"), Strings.get[String, String]("{x}2")).pipeline).unsafeRun.map { result =>
+    fixture.live.pipeline((Strings.get[String, String]("{x}1"), Strings.get[String, String]("{x}2"))).unsafeRun.map { result =>
       assertEquals(result, (Some("v1"), Some("v2")))
     }
   }
@@ -304,7 +302,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live
-      .pipeline((Strings.get[String, String]("{a}1"), Connection.ping(None), Strings.get[String, String]("{a}2")).pipeline)
+      .pipeline((Strings.get[String, String]("{a}1"), Connection.ping(None), Strings.get[String, String]("{a}2")))
       .unsafeRun
       .map { result =>
         assertEquals(result, (Some("v1"), "PONG", Some("v2")))
@@ -326,7 +324,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live
-      .transaction(_.exec(Pipeline.sequence(Vector(Strings.get[String, String]("{a}1")))))
+      .transaction(_.exec(Vector(Strings.get[String, String]("{a}1"))))
       .unsafeRun
       .failed
       .map { _ =>
@@ -346,7 +344,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val fixture   = new Fixture(behaviour, Vector(nodeA)) // default minRefreshInterval (5s) far exceeds this test's duration
 
     // two faults within the throttle window: a throttled refresh would run only once (CLUSTER stays at 2), a forced one runs on each
-    val tx = fixture.live.transaction(_.exec(Pipeline.sequence(Vector(Strings.get[String, String]("{a}1")))))
+    val tx = fixture.live.transaction(_.exec(Vector(Strings.get[String, String]("{a}1"))))
     for {
       _ <- tx.unsafeRun.failed
       _  = Thread.sleep(150) // let the first forced refresh complete and stamp the throttle window
@@ -368,7 +366,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live
-      .transaction(tx => tx.watch(key).flatMap(_ => tx.exec(Pipeline.sequence(Vector(Strings.get[String, String](key))))))
+      .transaction(tx => tx.watch(key).flatMap(_ => tx.exec(Vector(Strings.get[String, String](key)))))
       .unsafeRun
       .map(result => assertEquals(result, Some(Vector(Some("v")))))
   }

--- a/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
@@ -11,7 +11,7 @@ import kyo.compat.*
 import sage.{Bytes, Outcome, SageEvent, SageListener}
 import sage.SageException.{NotConnected, UnsupportedServer}
 import sage.client.internal.{Client, Events, FakeTransport, ManualScheduler, MultiplexedConnection}
-import sage.commands.{Command, Execution, Pipeline}
+import sage.commands.{Command, Execution}
 import sage.protocol.Frame
 
 class ConnectSpec extends munit.FunSuite {
@@ -115,7 +115,7 @@ class ConnectSpec extends munit.FunSuite {
 
   test("a pipeline carrying a blocking command fails fast without reaching the socket") {
     val (factory, transport) = scripted(helloThenPong)
-    val blocking             = Pipeline.sequence(Vector(Command("BLPOP", Command.NoKeys, Vector.empty, _ => Right(()), Execution.Blocking)))
+    val blocking             = Vector(Command("BLPOP", Command.NoKeys, Vector.empty, _ => Right(()), Execution.Blocking))
     Client.connectWith(factory).flatMap(_.pipeline(blocking)).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
       assertEquals(transport().written.count(_.asUtf8String.contains("BLPOP")), 0)
@@ -134,7 +134,7 @@ class ConnectSpec extends munit.FunSuite {
       }
     }
     val get                  = Command("GET", Command.NoKeys, Vector.empty, (_: Frame) => Right(0L))
-    val twoGets              = Pipeline.sequence(Vector(get, get))
+    val twoGets              = Vector(get, get)
     Client
       .connectWith(factory, scheduler, events = Events(Vector(listener)))
       .flatMap { client =>
@@ -154,7 +154,7 @@ class ConnectSpec extends munit.FunSuite {
 
   test("an empty pipeline succeeds without a round-trip") {
     val (factory, transport) = scripted(helloThenPong)
-    val empty                = Pipeline.sequence(Vector.empty[Command[Long]])
+    val empty                = Vector.empty[Command[Long]]
     Client.connectWith(factory).flatMap(_.pipeline(empty)).unsafeRun.map { result =>
       assertEquals(result, Vector.empty[Long])
       // exclude the bootstrap commands (HELLO, CLIENT SETINFO/TRACKING); the empty pipeline itself causes no write

--- a/sage-client/zio/src/test/scala/sage/client/TransactionSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/TransactionSpec.scala
@@ -7,8 +7,7 @@ import kyo.compat.*
 import sage.Bytes
 import sage.SageException.{ServerError, TransactionDiscarded}
 import sage.client.internal.{Client, FakeTransport, MultiplexedConnection}
-import sage.commands.{Command, Commands, Execution, Pipeline}
-import sage.commands.Pipeline.pipeline
+import sage.commands.{Command, Commands, Execution}
 import sage.protocol.Frame
 
 class TransactionSpec extends munit.FunSuite {
@@ -56,9 +55,9 @@ class TransactionSpec extends munit.FunSuite {
     (wrapped, () => last)
   }
 
-  private val twoIncrements = (Commands.incr[String]("a"), Commands.incr[String]("b")).pipeline
+  private val twoIncrements = (Commands.incr[String]("a"), Commands.incr[String]("b"))
 
-  private val emptyPipeline = Pipeline.sequence(Vector.empty[Command[Long]])
+  private val noCommands = Vector.empty[Command[Long]]
 
   test("a transaction commits and returns the typed tuple") {
     val factory = scripted(Seq(ok, queued, queued, Frame.Array(Vector(Frame.Integer(1), Frame.Integer(2)))))
@@ -80,7 +79,7 @@ class TransactionSpec extends munit.FunSuite {
     val factory = scripted(
       Seq(ok, Frame.SimpleError("ERR unknown command 'FOO'"), Frame.SimpleError("EXECABORT Transaction discarded because of previous errors"))
     )
-    val single  = Pipeline.sequence(Vector(Commands.incr[String]("a")))
+    val single  = Vector(Commands.incr[String]("a"))
     Client.connectWith(factory).flatMap(_.transaction(_.exec(single))).unsafeRun.failed.map { error =>
       assertEquals(error, TransactionDiscarded("ERR unknown command 'FOO'"))
     }
@@ -128,7 +127,7 @@ class TransactionSpec extends munit.FunSuite {
     val factory = scripted(Seq(ok))
     Client
       .connectWith(factory)
-      .flatMap(client => client.transaction(tx => CIO.value(tx)).flatMap(escaped => escaped.exec(emptyPipeline)))
+      .flatMap(client => client.transaction(tx => CIO.value(tx)).flatMap(escaped => escaped.exec(noCommands)))
       .unsafeRun
       .failed
       .map(error => assert(error.isInstanceOf[IllegalStateException], s"unexpected error: $error"))
@@ -138,7 +137,7 @@ class TransactionSpec extends munit.FunSuite {
     val (factory, transport) = capturing(scripted(Seq(ok, Frame.Null))) // MULTI ok, EXEC null = watched key changed
     Client
       .connectWith(factory)
-      .flatMap(client => client.transaction(tx => tx.watch("a").flatMap(_ => tx.exec(emptyPipeline))))
+      .flatMap(client => client.transaction(tx => tx.watch("a").flatMap(_ => tx.exec(noCommands))))
       .unsafeRun
       .map { result =>
         assertEquals(result, None)
@@ -150,7 +149,7 @@ class TransactionSpec extends munit.FunSuite {
     val (factory, transport) = capturing(scripted(Seq(ok)))
     Client
       .connectWith(factory)
-      .flatMap(_.transaction(_.exec(emptyPipeline)))
+      .flatMap(_.transaction(_.exec(noCommands)))
       .unsafeRun
       .map { result =>
         assertEquals(result, Some(Vector.empty[Long]))
@@ -160,7 +159,7 @@ class TransactionSpec extends munit.FunSuite {
 
   test("a transaction carrying a blocking command fails fast without reaching the socket") {
     val factory  = scripted(Seq(ok))
-    val blocking = Pipeline.sequence(Vector(Command("BLPOP", Command.NoKeys, Vector.empty, _ => Right(()), Execution.Blocking)))
+    val blocking = Vector(Command("BLPOP", Command.NoKeys, Vector.empty, _ => Right(()), Execution.Blocking))
     Client.connectWith(factory).flatMap(_.transaction(_.exec(blocking))).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
     }

--- a/sage-client/zio/src/test/scala/sage/client/internal/TxScopeFaultSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/internal/TxScopeFaultSpec.scala
@@ -8,7 +8,7 @@ import kyo.compat.*
 import sage.Bytes
 import sage.SageException.{ConnectionLost, ServerError}
 import sage.client.DedicatedPoolConfig
-import sage.commands.{Connection, Pipeline, Strings}
+import sage.commands.{Connection, Strings}
 import sage.protocol.Frame
 
 class TxScopeFaultSpec extends munit.FunSuite {
@@ -56,7 +56,7 @@ class TxScopeFaultSpec extends munit.FunSuite {
       else if (p.asUtf8String.contains("MULTI")) Seq(Frame.SimpleString("OK"), readonly, Frame.SimpleError("EXECABORT discarded"))
       else Seq(Frame.SimpleString("OK"))
     val (scope, faults)              = txScope(respond)
-    scope.exec(Pipeline.sequence(Vector(Strings.set("k", "v")))).unsafeRun.failed.map { _ =>
+    scope.exec(Vector(Strings.set("k", "v"))).unsafeRun.failed.map { _ =>
       assert(faults.exists(isOwnershipFault), s"expected an ownership fault, got $faults")
     }
   }

--- a/sage-core/src/main/scala/sage/commands/Pipeline.scala
+++ b/sage-core/src/main/scala/sage/commands/Pipeline.scala
@@ -3,12 +3,20 @@ package sage.commands
 import sage.SageException
 
 /**
-  * An applicative composition of Commands sent in one round-trip, yielding one typed result per command. Not a transaction — no
-  * atomicity. `Out` is the all-success shape; `Results` is the per-position shape, each slot an `Either[SageException, _]`. The runtime
-  * decodes every position independently into a `Vector[Either[SageException, Any]]`, then either collapses it to `Out` (strict) or shapes
-  * it to `Results` (attempt); the `Any` is confined to the assemblers below and never reaches a caller.
+  * One pipeline (or transaction) position's outcome: `Right` on success, `Left` carrying the per-position error. This is the element type of
+  * the `*Attempt` result shapes (`Vector[Attempt[A]]` for a homogeneous batch, a tuple of `Attempt`s for a fixed-arity one).
   */
-final class Pipeline[Out, Results] private[commands] (
+type Attempt[A] = Either[SageException, A]
+
+/**
+  * The internal assembler behind the `pipeline`/`exec` command-batch sugar: an applicative composition of Commands sent in one round-trip,
+  * yielding one typed result per command. Not a transaction, so no atomicity. Callers never name this type; they hand `pipeline`/`exec` a tuple
+  * of Commands (fixed arity, heterogeneous results) or a `Seq[Command[A]]` (dynamic arity, homogeneous), and the runtime builds one of these.
+  * `Out` is the all-success shape; `Results` is the per-position shape, each slot an [[Attempt]]. The runtime decodes every position
+  * independently into a `Vector[Either[SageException, Any]]`, then either collapses it to `Out` (strict) or shapes it to `Results` (attempt);
+  * the `Any` is confined to the assemblers below and never reaches a caller.
+  */
+final private[sage] class Pipeline[Out, Results] private[commands] (
   /**
     * The composed commands, in send order.
     */
@@ -17,12 +25,7 @@ final class Pipeline[Out, Results] private[commands] (
   private[sage] val toResults: Vector[Either[SageException, Any]] => Results
 )
 
-object Pipeline {
-
-  /**
-    * One pipeline position's outcome: `Right` on success, `Left` carrying the per-position error.
-    */
-  type Attempt[A] = Either[SageException, A]
+private[sage] object Pipeline {
 
   /**
     * A dynamic, homogeneous pipeline. An empty sequence is a no-op that yields an empty result without touching the socket.
@@ -35,17 +38,17 @@ object Pipeline {
     )
 
   /**
-    * Tuple syntax: a tuple of `Command`s composes into a pipeline whose result tuple mirrors it element-for-element. `(get, incr).pipeline`
-    * yields `Pipeline[(Option[V], Long), (Attempt[Option[V]], Attempt[Long])]`.
+    * A fixed-arity pipeline from a tuple of `Command`s, whose result tuple mirrors it element-for-element. `(get, incr)` yields
+    * `Pipeline[(Option[V], Long), (Attempt[Option[V]], Attempt[Long])]`.
     */
-  extension [T <: NonEmptyTuple](commands: T) {
-    def pipeline(using Tuple.IsMappedBy[Command][T]): Pipeline[Tuple.InverseMap[T, Command], Tuple.Map[Tuple.InverseMap[T, Command], Attempt]] = {
-      val cmds = commands.toList.asInstanceOf[List[Command[?]]].toVector
-      new Pipeline(
-        cmds,
-        values => Tuple.fromArray(values.toArray).asInstanceOf[Tuple.InverseMap[T, Command]],
-        results => Tuple.fromArray(results.toArray).asInstanceOf[Tuple.Map[Tuple.InverseMap[T, Command], Attempt]]
-      )
-    }
+  def fromTuple[T <: NonEmptyTuple](
+    commands: T
+  )(using Tuple.IsMappedBy[Command][T]): Pipeline[Tuple.InverseMap[T, Command], Tuple.Map[Tuple.InverseMap[T, Command], Attempt]] = {
+    val cmds = commands.toList.asInstanceOf[List[Command[?]]].toVector
+    new Pipeline(
+      cmds,
+      values => Tuple.fromArray(values.toArray).asInstanceOf[Tuple.InverseMap[T, Command]],
+      results => Tuple.fromArray(results.toArray).asInstanceOf[Tuple.Map[Tuple.InverseMap[T, Command], Attempt]]
+    )
   }
 }

--- a/sage-core/src/test/scala/sage/commands/PipelineSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/PipelineSpec.scala
@@ -1,23 +1,22 @@
 package sage.commands
 
 import sage.SageException.{DecodeError, ServerError}
-import sage.commands.Pipeline.pipeline
 
 class PipelineSpec extends munit.FunSuite {
 
   test("tuple syntax preserves command order and arity") {
-    val p = (Connection.ping(), Strings.get[String, String]("k"), Strings.incr[String]("n")).pipeline
+    val p = Pipeline.fromTuple((Connection.ping(), Strings.get[String, String]("k"), Strings.incr[String]("n")))
     assertEquals(p.commands.map(_.name), Vector("PING", "GET", "INCR"))
   }
 
   test("tuple pipeline assembles the all-success tuple") {
-    val p   = (Connection.ping(), Strings.get[String, String]("k")).pipeline
+    val p   = Pipeline.fromTuple((Connection.ping(), Strings.get[String, String]("k")))
     val out = p.toOut(Vector("PONG", Some("v")))
     assertEquals(out, ("PONG", Some("v")))
   }
 
   test("tuple pipeline shapes per-position results, mixing success and failure") {
-    val p       = (Connection.ping(), Strings.incr[String]("n")).pipeline
+    val p       = Pipeline.fromTuple((Connection.ping(), Strings.incr[String]("n")))
     val results = p.toResults(Vector(Right("PONG"), Left(ServerError("WRONGTYPE", ""))))
     assertEquals(results, (Right("PONG"), Left(ServerError("WRONGTYPE", ""))))
   }


### PR DESCRIPTION
## What

Pipelining previously required naming `Pipeline`: `Pipeline.sequence(xs)` for a homogeneous batch or `(a, b).pipeline` for a fixed-arity one, then handing the result to `client.pipeline` / `tx.exec`. That doubled the vocabulary and forced a wrapper:

```scala
client.pipeline((Commands.zRem(viewKey, id), Commands.zRem(reportedKey, id)).pipeline)
client.pipeline(Pipeline.sequence(ids.map(Commands.get(_))))
```

`Pipeline` carried no unique public capability. The two public constructors (`Pipeline.sequence` and the `.pipeline` tuple extension) covered every case, and a tuple or a `Seq[Command]` already **is** the reusable, fully-typed batch value, so the intermediate could be inlined.

## Change

`Pipeline` (class + object) is now `private[sage]`. The public API is a pair of overloads on both `Client` and `TransactionScope` that take the commands directly:

```scala
client.pipeline((Commands.zRem(viewKey, id), Commands.zRem(reportedKey, id)))  // F[(Long, Long)]
client.pipeline(ids.map(id => Commands.get[String, String](id)))               // F[Vector[Option[String]]]
client.pipelineAttempt(...)                                                    // per-position Either results
tx.exec((Commands.incr("n"), Commands.incrBy("n", 4)))
tx.exec(Vector(Commands.incr("a"), Commands.incr("b")))
```

- The `Pipeline`-typed methods stay as `private[sage]` primitives; the public overloads build the internal value (`Pipeline.fromTuple` / `Pipeline.sequence`) and delegate. Backends only gained the modifier, so no renaming.
- Overload resolution is unambiguous: a tuple is `NonEmptyTuple`, a `Vector`/`List` is `Seq`, the internal `Pipeline` is neither.
- `Attempt[A] = Either[SageException, A]` moves from `Pipeline.Attempt` to a public top-level alias in `sage.commands` (exported), since the `*Attempt` return types still name it.
- `Pipeline` and the `.pipeline` extension dropped from `exports.scala`.
- Tests, examples, and the two docs pages migrated to the new API. Core `PipelineSpec`/`SplitPlanSpec` still test the internal assembler directly via `Pipeline.fromTuple`/`sequence`.

Note: the tuple form is `client.pipeline((a, b))` (the tuple is a single argument) — the cost of preserving per-position types.

## Testing

`sbt testUnit` green (693 core + ce/ox/kyo/zio backend suites); all backends, integration `Test/compile`, examples, and benchmarks compile.