### PR TITLE
Fix cluster KEYS aggregation, RESP depth bound, and shutdown races

### DIFF
--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterFailoverSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterFailoverSuite.scala
@@ -111,8 +111,18 @@ abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends
       else CIO.sleep(500.millis).flatMap(_ => awaitClusterOk(container, attempts - 1))
     }
 
+  // `cluster_state:ok` flips before every node will actually serve writes, so a freshly formed cluster can briefly answer CLUSTERDOWN; retry
+  // each write across that warm-up window, as a real application would, so the failover the test means to exercise is not masked by a startup race
+  private def writeKey(client: Client[CIO, String], key: String, attempts: Int): CIO[Unit] =
+    client
+      .set(key, key)
+      .fold(
+        _ => CIO.value(()),
+        error => if (attempts <= 0) CIO.fail(error) else CIO.sleep(200.millis).flatMap(_ => writeKey(client, key, attempts - 1))
+      )
+
   private def writeAll(client: Client[CIO, String], keys: Vector[String]): CIO[Unit] =
-    keys.foldLeft(CIO.value(()))((acc, key) => acc.flatMap(_ => client.set(key, key).map(_ => ())))
+    keys.foldLeft(CIO.value(()))((acc, key) => acc.flatMap(_ => writeKey(client, key, 150)))
 
   // retry a read across the failover window until the client refreshes onto the promoted master; each key stores its own name
   private def recoverKey(client: Client[CIO, String], key: String, attempts: Int): CIO[Boolean] =

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
@@ -104,7 +104,8 @@ final private[client] class ClientCache(maxBytes: Long) {
 
   private def insert(key: Key, entry: Entry): Unit = {
     val previous = entries.put(key, entry)
-    if (previous != null) bytesUsed -= previous.sizeBytes
+    // drop the replaced entry before recording the new mappings, so a key shared by both is not removed right after being re-added
+    if (previous != null) dropAccounting(key, previous)
     entry.keys.foreach(k => reverse.getOrElseUpdate(k, mutable.HashSet.empty) += key)
     bytesUsed += entry.sizeBytes
     val it       = entries.entrySet().iterator()

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -16,7 +16,7 @@ import sage.SageException.{ConnectionLost, CrossSlot, NotConnected, ServerError}
 import sage.client.{BackoffConfig, ClusterConfig, DedicatedPoolConfig, ReadFrom, SageConfig, WatchdogConfig}
 import sage.cluster.{ClusterTopology, Node, NodeGroup, Redirect, RedirectKind, Rejected, Route, Shard, Slot}
 import sage.codec.{KeyCodec, ValueCodec}
-import sage.commands.{Cluster, Command, Connection, Pipeline}
+import sage.commands.{Cluster, Command, Connection, Pipeline, Reply}
 import sage.protocol.Frame
 
 /**
@@ -163,7 +163,9 @@ final private[client] class ClusterLive(
     if (closed) complete(Failure(NotConnected()))
     else {
       val topology = topologyRef.get()
-      if (command.allMasters) sendToAllMasters(topology, command, complete)
+      if (command.allMasters)
+        if (command.aggregate) sendToAllMastersAggregated(topology, command, complete)
+        else sendToAllMasters(topology, command, complete)
       else
         topology.route(command) match {
           case Route.ToNode(node, slot) =>
@@ -188,7 +190,7 @@ final private[client] class ClusterLive(
     tryReadCandidates(command, ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement()), master, redirectsLeft, complete)
   }
 
-  // a keyless eligible read (KEYS, RANDOMKEY): round-robin over every replica, falling back per policy, so strict Replica never hits a master
+  // a keyless eligible read (RANDOMKEY): round-robin over every replica, falling back per policy, so strict Replica never hits a master
   private def sendKeylessRead[A](topology: ClusterTopology, command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit =
     pickNode(topology) match {
       case Some(master) =>
@@ -278,6 +280,57 @@ final private[client] class ClusterLive(
       }
     }
   }
+
+  // an aggregating broadcast (KEYS): every slot-owning master returns its node-local slice, which we merge as raw frames and decode once,
+  // since no single node sees the whole keyspace; any node failing fails the command
+  private def sendToAllMastersAggregated[A](topology: ClusterTopology, command: Command[A], complete: Try[A] => Unit): Unit = {
+    val masters = slotOwningMasters(topology)
+    if (masters.isEmpty) sendToAny(topology, command, cluster.maxRedirects, complete)
+    else {
+      val raw                                       = command.rawFrame
+      val frames                                    = new java.util.concurrent.atomic.AtomicReferenceArray[Frame](masters.size)
+      val remaining                                 = new java.util.concurrent.atomic.AtomicInteger(masters.size)
+      val firstError                                = new java.util.concurrent.atomic.AtomicReference[Throwable](null)
+      def settle(index: Int, result: Try[Frame]): Unit = {
+        result match {
+          case Success(frame) => frames.set(index, frame)
+          case Failure(e)     => firstError.compareAndSet(null, e)
+        }
+        if (remaining.decrementAndGet() == 0)
+          Option(firstError.get()) match {
+            case Some(e) => complete(Failure(e))
+            case None    => complete(decodeMerged(command, mergeFrames(frames, masters.size)))
+          }
+      }
+      masters.iterator.zipWithIndex.foreach { case (node, index) =>
+        val nc =
+          try getOrEstablish(node)
+          catch { case NonFatal(_) => null }
+        if (nc == null) settle(index, Failure(NotConnected()))
+        else nc.submit[Frame](raw, asking = false, result => settle(index, result))
+      }
+    }
+  }
+
+  private def mergeFrames(frames: java.util.concurrent.atomic.AtomicReferenceArray[Frame], size: Int): Frame = {
+    val merged = Vector.newBuilder[Frame]
+    var i      = 0
+    while (i < size) {
+      frames.get(i) match {
+        case Frame.Array(elements) => merged ++= elements
+        case Frame.Set(elements)   => merged ++= elements
+        case other                 => merged += other
+      }
+      i += 1
+    }
+    Frame.Array(merged.result())
+  }
+
+  private def decodeMerged[A](command: Command[A], merged: Frame): Try[A] =
+    Reply.run(command, merged) match {
+      case Right(value) => Success(value)
+      case Left(error)  => Failure(error)
+    }
 
   private def sendToAny[A](topology: ClusterTopology, command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit =
     pickNode(topology) match {
@@ -393,12 +446,12 @@ final private[client] class ClusterLive(
     // a blocking command is a programmer error: fail the whole effect up front, never a single position
     else if (p.commands.exists(_.isBlocking))
       CIO.fail(new IllegalArgumentException("a Pipeline cannot carry blocking commands; run them individually on the client"))
-    // a Pipeline batches per node, so an all-masters command (SCRIPT LOAD, FUNCTION LOAD, …) would load one node only and break a later
-    // key-routed EVALSHA/FCALL; fail up front rather than partially apply it
+    // a Pipeline batches per node, so an all-masters command (SCRIPT LOAD, FUNCTION LOAD, KEYS, …) would touch one node only and either
+    // break a later key-routed EVALSHA/FCALL or return a partial keyspace; fail up front rather than partially apply it
     else if (p.commands.exists(_.allMasters))
       CIO.fail(
         new IllegalArgumentException(
-          "a Pipeline cannot carry an all-masters command (e.g. SCRIPT LOAD, FUNCTION LOAD); run it individually on the client"
+          "a Pipeline cannot carry an all-masters command (e.g. SCRIPT LOAD, FUNCTION LOAD, KEYS); run it individually on the client"
         )
       )
     else

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -287,10 +287,10 @@ final private[client] class ClusterLive(
     val masters = slotOwningMasters(topology)
     if (masters.isEmpty) sendToAny(topology, command, cluster.maxRedirects, complete)
     else {
-      val raw                                       = command.rawFrame
-      val frames                                    = new java.util.concurrent.atomic.AtomicReferenceArray[Frame](masters.size)
-      val remaining                                 = new java.util.concurrent.atomic.AtomicInteger(masters.size)
-      val firstError                                = new java.util.concurrent.atomic.AtomicReference[Throwable](null)
+      val raw                                          = command.rawFrame
+      val frames                                       = new java.util.concurrent.atomic.AtomicReferenceArray[Frame](masters.size)
+      val remaining                                    = new java.util.concurrent.atomic.AtomicInteger(masters.size)
+      val firstError                                   = new java.util.concurrent.atomic.AtomicReference[Throwable](null)
       def settle(index: Int, result: Try[Frame]): Unit = {
         result match {
           case Success(frame) => frames.set(index, frame)

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -101,20 +101,35 @@ final private[client] class NodePool(
   }
 
   def close(): Unit = {
-    val all = locked { closed = true; val snap = established.values.toVector; established.clear(); snap }
+    val (all, waiters) = locked {
+      closed = true
+      val snap    = established.values.toVector
+      val pending = pendingEstablish.values.toVector
+      established.clear()
+      pendingEstablish.clear()
+      (snap, pending)
+    }
+    // release callers blocked on an in-flight connect now, rather than stranding them for the connect timeout; the establisher still
+    // observes `closed` on return and closes the node it opened
+    waiters.foreach(_.fail(NotConnected()))
     all.foreach(_.close())
   }
 }
 
 private[client] object NodePool {
 
-  // one-shot single-flight cell: the establisher fills it, concurrent callers block on `get` and observe the same success or failure
+  // one-shot single-flight cell: the establisher fills it, concurrent callers block on `get` and observe the same success or failure. The
+  // first settle wins, so a `close` that fails the waiters cannot be overwritten by a late establisher.
   final private class Establish {
     private val latch                                           = new CountDownLatch(1)
+    private val settled                                         = new java.util.concurrent.atomic.AtomicBoolean(false)
     @volatile private var result: Either[Throwable, NodeClient] = null
 
-    def succeed(nc: NodeClient): Unit = { result = Right(nc); latch.countDown() }
-    def fail(error: Throwable): Unit  = { result = Left(error); latch.countDown() }
+    def succeed(nc: NodeClient): Unit = settle(Right(nc))
+    def fail(error: Throwable): Unit  = settle(Left(error))
+
+    private def settle(outcome: Either[Throwable, NodeClient]): Unit =
+      if (settled.compareAndSet(false, true)) { result = outcome; latch.countDown() }
 
     def get(): NodeClient = {
       latch.await()

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -10,7 +10,7 @@ import sage.Bytes
 import sage.SageException.{CrossSlot, NotConnected, ServerError}
 import sage.client.internal.{ClusterLive, FakeTransport, MultiplexedConnection, Scheduler}
 import sage.cluster.{Node, Slot}
-import sage.commands.{Command, Connection, Strings}
+import sage.commands.{Command, Connection, Keys, Strings}
 import sage.protocol.Frame
 
 class ClusterClientSpec extends munit.FunSuite {
@@ -127,6 +127,25 @@ class ClusterClientSpec extends munit.FunSuite {
       assertEquals(result, Some(owner.host))
       assert(fixture.written(owner).exists(_.contains("GET")), "owner did not receive GET")
       assert(!fixture.written(other).exists(_.contains("GET")), "non-owner received GET")
+    }
+  }
+
+  test("KEYS broadcasts to every slot-owning master and concatenates the per-node slices") {
+    // nodeA owns the lower half, nodeB the upper half; KEYS is node-local, so each returns only its own keys
+    val mid             = Slot.Count / 2
+    val aKeys           = Vector("a1", "a2")
+    val bKeys           = Vector("b1")
+    def bulk(s: String) = Frame.BulkString(Bytes.utf8(s))
+    val behaviour       = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else if (text.contains("KEYS")) Seq(Frame.Array((if (node == nodeA) aKeys else bKeys).map(bulk)))
+      else Seq(Frame.Null)
+    val fixture         = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Keys.keys[String]("*")).unsafeRun.map { result =>
+      assertEquals(result.toSet, (aKeys ++ bKeys).toSet)
+      assert(fixture.written(nodeA).exists(_.contains("KEYS")), "nodeA did not receive KEYS")
+      assert(fixture.written(nodeB).exists(_.contains("KEYS")), "nodeB did not receive KEYS")
     }
   }
 

--- a/sage-core/src/main/scala/sage/commands/Command.scala
+++ b/sage-core/src/main/scala/sage/commands/Command.scala
@@ -26,6 +26,12 @@ enum Execution {
   * slot-owning master rather than one (`SCRIPT LOAD`, `FUNCTION LOAD` and their `FLUSH`/`DELETE`/`RESTORE` mutations, and `FLUSHALL`/
   * `FLUSHDB`). Inert on a standalone server.
   *
+  * `aggregate` refines an `allMasters` command whose reply is a per-node *view* rather than an identical acknowledgement (`KEYS`): the
+  * cluster broadcasts it to every slot-owning master and concatenates the array replies into one, since no single node sees the whole
+  * keyspace. The broadcast always targets masters regardless of the `ReadFrom` policy (a single replica would only see one shard's slice).
+  * An `allMasters` command without `aggregate` keeps the first node's reply (every node returns the same `OK`/SHA). Inert on a standalone
+  * server.
+  *
   * `cursorBound` marks a command whose reply carries a continuation cursor valid only on the node that issued it (`SCAN`/`HSCAN`/`SSCAN`/
   * `ZSCAN`). Such a read is excluded from replica round-robin routing: iterating its pages across different replicas would feed a cursor to
   * a node that never minted it, skipping or duplicating entries.
@@ -39,14 +45,15 @@ final case class Command[+Out](
   isReadOnly: Boolean = false,
   cacheable: Boolean = false,
   allMasters: Boolean = false,
-  cursorBound: Boolean = false
+  cursorBound: Boolean = false,
+  aggregate: Boolean = false
 ) {
 
   /**
     * Transforms the decoded result, leaving the wire encoding and routing metadata untouched.
     */
   def map[B](f: Out => B): Command[B] =
-    Command(name, keyIndices, args, frame => decode(frame).map(f), execution, isReadOnly, cacheable, allMasters, cursorBound)
+    Command(name, keyIndices, args, frame => decode(frame).map(f), execution, isReadOnly, cacheable, allMasters, cursorBound, aggregate)
 
   /**
     * Whether this command blocks its connection and so needs a Dedicated Connection.
@@ -67,6 +74,13 @@ final case class Command[+Out](
     * The full RESP3 wire encoding of this command.
     */
   def encode: Bytes = RespWriter.writeCommand(name, args)
+
+  /**
+    * This command's wire form with decoding replaced by the raw reply frame, preserving routing metadata. The cluster runtime uses it to
+    * collect an `aggregate` broadcast's per-node replies and merge them before decoding once.
+    */
+  def rawFrame: Command[Frame] =
+    Command(name, keyIndices, args, frame => Right(frame), execution, isReadOnly, cacheable, allMasters, cursorBound, aggregate)
 }
 
 object Command {

--- a/sage-core/src/main/scala/sage/commands/Keys.scala
+++ b/sage-core/src/main/scala/sage/commands/Keys.scala
@@ -174,8 +174,17 @@ private[sage] object Keys {
   def pExpireTime[K](key: K)(using keyCodec: KeyCodec[K]): Command[ExpiryTime] =
     Command.readUncacheable("PEXPIRETIME", Command.FirstKey, Vector(keyCodec.encode(key)), expiryTimeDecode(Instant.ofEpochMilli))
 
+  // KEYS is node-local; `allMasters` + `aggregate` makes a cluster sweep every master and merge the slices. Prefer `scanAll` in production.
   def keys[K](pattern: String)(using keyCodec: KeyCodec[K]): Command[Vector[K]] =
-    Command.read("KEYS", Command.NoKeys, Vector(Bytes.utf8(pattern)), Decode.vector(Decode.key))
+    Command(
+      "KEYS",
+      Command.NoKeys,
+      Vector(Bytes.utf8(pattern)),
+      Decode.vector(Decode.key),
+      isReadOnly = true,
+      allMasters = true,
+      aggregate = true
+    )
 
   def persist[K](key: K)(using keyCodec: KeyCodec[K]): Command[Boolean] =
     Command("PERSIST", Command.FirstKey, Vector(keyCodec.encode(key)), Decode.flag)

--- a/sage-core/src/main/scala/sage/protocol/RespParser.scala
+++ b/sage-core/src/main/scala/sage/protocol/RespParser.scala
@@ -163,7 +163,6 @@ final private[sage] class RespParser {
   // or Invalid (`failMessage` set)
   private def produceValue(): Int =
     if (readPos >= writePos) Incomplete
-    else if (stackDepth > MaxDepth) fail(s"aggregate nesting exceeds $MaxDepth levels")
     else {
       val pos = readPos
       (buf(pos).toChar: @switch) match {
@@ -275,7 +274,6 @@ final private[sage] class RespParser {
       val agg = new Agg(kind, count)
       agg.elements = Vector.newBuilder[Frame]
       push(agg)
-      Opened
     }
   }
 
@@ -288,19 +286,22 @@ final private[sage] class RespParser {
       val agg = new Agg(kind, count)
       if (kind == Map) agg.pairs = Vector.newBuilder[(Frame, Frame)]
       push(agg)
-      Opened
     }
   }
 
-  private def push(agg: Agg): Unit = {
-    if (stackDepth == stack.length) {
-      val grown = new Array[Agg](math.min(stack.length * 2, MaxDepth + 1))
-      System.arraycopy(stack, 0, grown, 0, stackDepth)
-      stack = grown
+  // bounds nesting at open time (not on every value), so a leaf at the deepest allowed level is still accepted
+  private def push(agg: Agg): Int =
+    if (stackDepth >= MaxDepth) fail(s"aggregate nesting exceeds $MaxDepth levels")
+    else {
+      if (stackDepth == stack.length) {
+        val grown = new Array[Agg](math.min(stack.length * 2, MaxDepth))
+        System.arraycopy(stack, 0, grown, 0, stackDepth)
+        stack = grown
+      }
+      stack(stackDepth) = agg
+      stackDepth += 1
+      Opened
     }
-    stack(stackDepth) = agg
-    stackDepth += 1
-  }
 
   // -1 is the RESP2 null marker; '+' is signed-integer syntax that the length grammar does not permit
   private def readLength(pos: Int, allowNull: Boolean): Int = {

--- a/sage-core/src/test/scala/sage/commands/KeysSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/KeysSpec.scala
@@ -101,6 +101,15 @@ class KeysSpec extends munit.FunSuite {
     assertEquals(Keys.randomKey[String].keyIndices, Vector.empty[Int])
   }
 
+  test("KEYS is an aggregating all-masters read, so a cluster sweeps every master and merges the slices") {
+    val command = Keys.keys[String]("*")
+    assert(command.allMasters)
+    assert(command.aggregate)
+    assert(command.isReadOnly)
+    assertEquals(command.rawFrame.allMasters, true)
+    assertEquals(command.rawFrame.aggregate, true)
+  }
+
   test("expire picks the wire command from the duration's precision") {
     assertEquals(Keys.expire("k", 90.seconds).name, "EXPIRE")
     assertEquals(Keys.expire("k", 90500.millis).name, "PEXPIRE")

--- a/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
+++ b/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
@@ -163,6 +163,14 @@ class RespParserSpec extends munit.FunSuite {
     assert(parseError("*1\r\n" * 1000 + ":1\r\n").message.contains("aggregate nesting exceeds"))
   }
 
+  test("accepts nesting exactly at the depth bound and rejects one level past it") {
+    val maxDepth        = 512
+    var expected: Frame = Frame.Integer(1)
+    for (_ <- 1 to maxDepth) expected = Frame.Array(Vector(expected))
+    assertEquals(parseOne("*1\r\n" * maxDepth + ":1\r\n"), expected)
+    assert(parseError("*1\r\n" * (maxDepth + 1) + ":1\r\n").message.contains("aggregate nesting exceeds"))
+  }
+
   test("resumes a deeply nested aggregate fed one byte at a time") {
     val deep            = 50
     val wire            = ("*1\r\n" * deep + ":1\r\n").getBytes


### PR DESCRIPTION
Addresses four issues found during review.

## [P2] Cluster `client.keys` returned only one node's keys
`KEYS` is node-local in Redis Cluster, but it was routed as a keyless read to a single node, so `client.keys(pattern)` silently returned a partial keyspace. It now routes as an **aggregating all-masters broadcast**: the cluster fans `KEYS` out to every slot-owning master and concatenates the replies.

- Adds an `aggregate` flag and a `rawFrame` helper on `Command`. `aggregate` refines `allMasters`: replies are merged as raw frames and decoded once, rather than keeping the first node's reply (the existing `SCRIPT LOAD`/`FUNCTION LOAD` behavior, where every node returns the same value).
- The broadcast targets masters regardless of `ReadFrom` (a single replica only sees one shard's slice) — documented on `Command`.
- Standalone and master-replica runtimes are unaffected (both flags are inert outside cluster mode).
- `KEYS` in a *cluster* pipeline now fails fast, like other all-masters commands, instead of returning a partial keyspace.
- Matches Lettuce / redis-py behavior. Prefer `scanAll` in production (`KEYS` is O(N) and blocks the server).

## [P3] RESP aggregate depth bound off by one
The depth check ran on every value (`stackDepth > MaxDepth`) and the stack could grow to `MaxDepth + 1`, so the stated 512-level bound was effectively 513. The check now lives at open time in `push` (`>= MaxDepth`), making the bound exactly `MaxDepth` open aggregates while still accepting a leaf at the deepest level. Added exact-boundary tests.

## [P3] NodePool shutdown stranded in-flight establishment waiters
`close()` left callers blocked in `Establish.get()` until the in-flight connect finished or timed out. It now fails pending establishes immediately with `NotConnected`, and the `Establish` cell is first-settle-wins so a late establisher can't overwrite the shutdown result (it still observes `closed` on return and closes the node it opened).

## ClientCache stale reverse-map on live replacement
`insert` subtracted the replaced entry's size but never removed its reverse mappings, so a stale `oldKey -> cacheKey` mapping could trigger a spurious eviction. It now calls `dropAccounting` (size + reverse) before recording the new mappings.

## Tests
- `RespParserSpec`: accepts nesting exactly at the bound, rejects one past it.
- `KeysSpec`: `KEYS` is an aggregating all-masters read.
- `ClusterClientSpec`: `KEYS` broadcasts to every slot-owning master and concatenates per-node slices.
- Full `core` and `clientZio` suites pass.