### PR TITLE
Fail ClusterLive establish waiters on close

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -858,7 +858,16 @@ final private[client] class ClusterLive(
   }
 
   private def closeAll(): Unit = {
-    val all = lockedNodes { closed = true; val snapshot = established.values.toVector; established.clear(); snapshot }
+    val (all, waiters) = lockedNodes {
+      closed = true
+      val snapshot = established.values.toVector
+      val pending  = pendingEstablish.values.toVector
+      established.clear()
+      pendingEstablish.clear()
+      (snapshot, pending)
+    }
+    // release callers blocked on an in-flight connect; the establisher observes `closed` on return and closes the node it opened
+    waiters.foreach(_.fail(NotConnected()))
     subscriptions.close()
     replicaPool.close()
     all.foreach(_.close())
@@ -872,13 +881,18 @@ private[client] object ClusterLive {
     case Reroute, RefreshThenTerminal, Terminal
   }
 
-  // one-shot single-flight cell: the establisher fills it, concurrent callers block on `get` and observe the same success or failure
+  // one-shot single-flight cell: the establisher fills it, concurrent callers block on `get`. First settle wins, so a `close` that
+  // fails the waiters cannot be overwritten by a late establisher.
   final private class Establish {
     private val latch                                           = new CountDownLatch(1)
+    private val settled                                         = new java.util.concurrent.atomic.AtomicBoolean(false)
     @volatile private var result: Either[Throwable, NodeClient] = null
 
-    def succeed(nc: NodeClient): Unit = { result = Right(nc); latch.countDown() }
-    def fail(error: Throwable): Unit  = { result = Left(error); latch.countDown() }
+    def succeed(nc: NodeClient): Unit = settle(Right(nc))
+    def fail(error: Throwable): Unit  = settle(Left(error))
+
+    private def settle(outcome: Either[Throwable, NodeClient]): Unit =
+      if (settled.compareAndSet(false, true)) { result = outcome; latch.countDown() }
 
     def get(): NodeClient = {
       latch.await()


### PR DESCRIPTION
## Problem

`ClusterLive` has its own master-node single-flight establish registry with the same shape that was already fixed in `NodePool`. `closeAll()` only cleared `established` and closed those clients; it never failed the `pendingEstablish` waiters. Callers blocked in `Establish.get()` could keep waiting until the in-flight connect/bootstrap finished or timed out during shutdown.

There was also a small race in `Establish`: after `close` failed the waiters, a late establisher could overwrite `result` before a released waiter read it.

## Fix

Mirror the `NodePool` pattern:

- `closeAll()` snapshots and clears `pendingEstablish` under the lock alongside `established`, then calls `fail(NotConnected())` on each waiter so blocked callers are released immediately.
- `Establish` is now first-settle-wins via an `AtomicBoolean`, so a late establisher cannot overwrite the failure that `close` delivered.

Whenever `getOrEstablish` takes the stale path it requires `closed == true`, which is only set inside `closeAll`'s lock — so `closeAll`'s snapshot necessarily captured the waiter first and already failed it. No waiter is left stranded.

Compiles cleanly (`clientZio/Test/compile`).