### PR TITLE
Share pagination steppers across backends behind the lowering seam

### DIFF
--- a/sage-client/ce/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/ce/src/main/scala/sage/backend/SageClient.scala
@@ -10,7 +10,7 @@ import kyo.compat.*
 
 import sage.{Message, PatternMessage}
 import sage.client.SageConfig
-import sage.client.internal.{Client, LoweredClient, ScanStep, ScanTarget, Subscription}
+import sage.client.internal.{Client, LoweredClient, Paged, ScanStep, ScanTarget, Subscription}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
 
@@ -64,30 +64,16 @@ extension [K](client: Client[IO, K])(using @unused ev: KeyCodec[K]) {
 
   private def scanStream[A](fetch: ScanCursor => IO[ScanPage[A]]): fs2.Stream[IO, A] =
     CStream
-      .unfold[Option[ScanCursor], Vector[A]](Some(ScanCursor.start)) {
-        case None         => CIO.value(None)
-        case Some(cursor) => CIO.lift(fetch(cursor)).map(page => Some((page.items, page.next)))
-      }
+      .unfold[Option[ScanCursor], Vector[A]](Some(ScanCursor.start))(Paged.byCursor(cursor => CIO.lift(fetch(cursor))))
       .flatMap(items => CStream.init(items))
       .lower
 
   // walks every scan target in turn, each with its own node-local cursor, so a cluster SCAN sweeps all masters instead of one
   private def scanStreamAll[A](fetch: ScanTarget => ScanCursor => IO[ScanPage[A]]): fs2.Stream[IO, A] =
     CStream
-      .unfold[ScanStep, Vector[A]](ScanStep.Begin) {
-        case ScanStep.Begin                 =>
-          CIO
-            .lift(client.scanTargets)
-            .map(targets => if (targets.isEmpty) None else Some((Vector.empty[A], ScanStep.Visit(ScanCursor.start, targets))))
-        case ScanStep.Visit(cursor, remain) =>
-          CIO.lift(fetch(remain.head)(cursor)).map { page =>
-            page.next match {
-              case Some(next) => Some((page.items, ScanStep.Visit(next, remain)))
-              case None       => Some((page.items, if (remain.tail.isEmpty) ScanStep.End else ScanStep.Visit(ScanCursor.start, remain.tail)))
-            }
-          }
-        case ScanStep.End                   => CIO.value(None)
-      }
+      .unfold[ScanStep, Vector[A]](ScanStep.Begin)(
+        Paged.acrossTargets(CIO.lift(client.scanTargets))(target => cursor => CIO.lift(fetch(target)(cursor)))
+      )
       .flatMap(items => CStream.init(items))
       .lower
 
@@ -101,14 +87,9 @@ extension [K](client: Client[IO, K])(using @unused ev: KeyCodec[K]) {
     batch: Long = 100L
   ): fs2.Stream[IO, StreamEntry[F, V]] =
     CStream
-      .unfold[Option[StreamRangeId], Vector[StreamEntry[F, V]]](Some(start)) {
-        case None       => CIO.value(None)
-        case Some(from) =>
-          CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))).map { entries =>
-            if (entries.isEmpty) None
-            else Some((entries, if (entries.length < batch) None else Some(StreamRangeId.Exclusive(entries.last.id))))
-          }
-      }
+      .unfold[Option[StreamRangeId], Vector[StreamEntry[F, V]]](Some(start))(
+        Paged.byRange(batch)(from => CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))))
+      )
       .flatMap(items => CStream.init(items))
       .lower
 
@@ -126,13 +107,9 @@ extension [K](client: Client[IO, K])(using @unused ev: KeyCodec[K]) {
     count: Option[Long] = None
   ): fs2.Stream[IO, StreamEntry[F, V]] =
     CStream
-      .unfold[Option[StreamId], Vector[StreamEntry[F, V]]](Some(start)) {
-        case None       => CIO.value(None)
-        case Some(from) =>
-          CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))).map { result =>
-            Some((result.entries.filter(_.fields.nonEmpty), if (result.cursor == StreamId.Zero) None else Some(result.cursor)))
-          }
-      }
+      .unfold[Option[StreamId], Vector[StreamEntry[F, V]]](Some(start))(
+        Paged.byAutoClaim(from => CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))))
+      )
       .flatMap(items => CStream.init(items))
       .lower
 
@@ -148,12 +125,11 @@ extension [K](client: Client[IO, K])(using @unused ev: KeyCodec[K]) {
     block: BlockTimeout = SageClient.defaultPoll
   ): fs2.Stream[IO, StreamEntry[F, V]] =
     CStream
-      .unfold[StreamId, Vector[StreamEntry[F, V]]](from) { last =>
-        CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map { result =>
-          val entries = result.flatMap(_._2)
-          Some((entries, if (entries.isEmpty) last else entries.last.id))
-        }
-      }
+      .unfold[StreamId, Vector[StreamEntry[F, V]]](from)(
+        Paged.tail(last =>
+          CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map(_.flatMap(_._2))
+        )
+      )
       .flatMap(items => CStream.init(items))
       .lower
 
@@ -182,17 +158,15 @@ extension [K](client: Client[IO, K])(using @unused ev: KeyCodec[K]) {
     block: BlockTimeout
   ): fs2.Stream[IO, StreamEntry[F, V]] =
     CStream
-      .unfold[Either[StreamId, Unit], Vector[StreamEntry[F, V]]](Left(StreamId.Zero)) {
-        case Left(after) =>
-          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map { result =>
-            val entries = result.flatMap(_._2)
-            if (entries.isEmpty) Some((Vector.empty, Right(()))) else Some((entries, Left(entries.last.id)))
-          }
-        case Right(_)    =>
-          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block)))).map { result =>
-            Some((result.flatMap(_._2), Right(())))
-          }
-      }
+      .unfold[Either[StreamId, Unit], Vector[StreamEntry[F, V]]](Left(StreamId.Zero))(
+        Paged.consume(
+          drainPending = after =>
+            CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map(_.flatMap(_._2)),
+          tailNew = CIO
+            .lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block))))
+            .map(_.flatMap(_._2))
+        )
+      )
       .flatMap(items => CStream.init(items))
       .lower
 

--- a/sage-client/kyo/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/kyo/src/main/scala/sage/backend/SageClient.scala
@@ -9,7 +9,7 @@ import _root_.kyo.compat.*
 
 import sage.{Message, PatternMessage}
 import sage.client.SageConfig
-import sage.client.internal.{Client, LoweredClient, ScanStep, ScanTarget, Subscription}
+import sage.client.internal.{Client, LoweredClient, Paged, ScanStep, ScanTarget, Subscription}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
 
@@ -69,32 +69,19 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
   )(using Tag[V]): Stream[(V, Double), Abort[Throwable] & Async] =
     scanStream(cursor => client.run(SortedSets.zScan[K, V](key, cursor, pattern, count)))
 
-  // chunkSize = 1: emit each page as it arrives — the default rechunks to 4096, withholding an infinite tail (xTail/xConsume) until then
-  private def paged[S, A](start: S)(step: S => Maybe[(Vector[A], S)] < (Abort[Throwable] & Async))(
-    using Tag[A]
-  ): Stream[A, Abort[Throwable] & Async] =
-    Stream.unfold[S, Vector[A], Abort[Throwable] & Async](start, chunkSize = 1)(step).flatMap(items => Stream.init(items))
+  // chunkSize = 1: emit each page as it arrives — the default rechunks to 4096, withholding an infinite tail (xTail/xConsume) until then.
+  // The page-step logic itself is shared in `Paged`; here we only lower its `CIO` to Kyo and turn the `Option` end-signal into a `Maybe`.
+  private def paged[S, A](start: S)(step: Paged.Step[S, A])(using Tag[A]): Stream[A, Abort[Throwable] & Async] =
+    Stream
+      .unfold[S, Vector[A], Abort[Throwable] & Async](start, chunkSize = 1)(s => step(s).lower.map(Maybe.fromOption))
+      .flatMap(items => Stream.init(items))
 
   private def scanStream[A](fetch: ScanCursor => KyoEff[ScanPage[A]])(using Tag[A]): Stream[A, Abort[Throwable] & Async] =
-    paged[Option[ScanCursor], A](Some(ScanCursor.start)) {
-      case None         => Maybe.empty
-      case Some(cursor) => fetch(cursor).map(page => Maybe((page.items, page.next)))
-    }
+    paged[Option[ScanCursor], A](Some(ScanCursor.start))(Paged.byCursor(cursor => CIO.lift(fetch(cursor))))
 
   // walks every scan target in turn, each with its own node-local cursor, so a cluster SCAN sweeps all masters instead of one
   private def scanStreamAll[A](fetch: ScanTarget => ScanCursor => KyoEff[ScanPage[A]])(using Tag[A]): Stream[A, Abort[Throwable] & Async] =
-    paged[ScanStep, A](ScanStep.Begin) {
-      case ScanStep.Begin                 =>
-        client.scanTargets.map(targets => if (targets.isEmpty) Maybe.empty else Maybe((Vector.empty[A], ScanStep.Visit(ScanCursor.start, targets))))
-      case ScanStep.Visit(cursor, remain) =>
-        fetch(remain.head)(cursor).map { page =>
-          page.next match {
-            case Some(next) => Maybe((page.items, ScanStep.Visit(next, remain)))
-            case None       => Maybe((page.items, if (remain.tail.isEmpty) ScanStep.End else ScanStep.Visit(ScanCursor.start, remain.tail)))
-          }
-        }
-      case ScanStep.End                   => Maybe.empty
-    }
+    paged[ScanStep, A](ScanStep.Begin)(Paged.acrossTargets(CIO.lift(client.scanTargets))(target => cursor => CIO.lift(fetch(target)(cursor))))
 
   /**
     * Lazily pages an entire stream by range, batching `XRANGE` and advancing past the last id each page. Stops when a page comes back empty.
@@ -105,14 +92,9 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
     end: StreamRangeId = StreamRangeId.Max,
     batch: Long = 100L
   )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[Throwable] & Async] =
-    paged[Option[StreamRangeId], StreamEntry[F, V]](Some(start)) {
-      case None       => Maybe.empty
-      case Some(from) =>
-        client.run(Streams.xRange[K, F, V](key, from, end, Some(batch))).map { entries =>
-          if (entries.isEmpty) Maybe.empty
-          else Maybe((entries, if (entries.length < batch) None else Some(StreamRangeId.Exclusive(entries.last.id))))
-        }
-    }
+    paged[Option[StreamRangeId], StreamEntry[F, V]](Some(start))(
+      Paged.byRange(batch)(from => CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))))
+    )
 
   /**
     * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Tombstone
@@ -127,13 +109,9 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
     start: StreamId = StreamId.Zero,
     count: Option[Long] = None
   )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[Throwable] & Async] =
-    paged[Option[StreamId], StreamEntry[F, V]](Some(start)) {
-      case None       => Maybe.empty
-      case Some(from) =>
-        client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count)).map { result =>
-          Maybe((result.entries.filter(_.fields.nonEmpty), if (result.cursor == StreamId.Zero) None else Some(result.cursor)))
-        }
-    }
+    paged[Option[StreamId], StreamEntry[F, V]](Some(start))(
+      Paged.byAutoClaim(from => CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))))
+    )
 
   /**
     * Follows a stream without a consumer group: replays every entry after `from`, then blocks for new entries forever, advancing past the
@@ -146,12 +124,11 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
     count: Option[Long] = None,
     block: BlockTimeout = SageClient.defaultPoll
   )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[Throwable] & Async] =
-    paged[StreamId, StreamEntry[F, V]](from) { last =>
-      client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block))).map { result =>
-        val entries = result.flatMap(_._2)
-        Maybe((entries, if (entries.isEmpty) last else entries.last.id))
-      }
-    }
+    paged[StreamId, StreamEntry[F, V]](from)(
+      Paged.tail(last =>
+        CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map(_.flatMap(_._2))
+      )
+    )
 
   /**
     * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
@@ -175,17 +152,15 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
     count: Option[Long],
     block: BlockTimeout
   )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[Throwable] & Async] =
-    paged[Either[StreamId, Unit], StreamEntry[F, V]](Left(StreamId.Zero)) {
-      case Left(after) =>
-        client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count)).map { result =>
-          val entries = result.flatMap(_._2)
-          if (entries.isEmpty) Maybe((Vector.empty, Right(()))) else Maybe((entries, Left(entries.last.id)))
-        }
-      case Right(_)    =>
-        client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block))).map { result =>
-          Maybe((result.flatMap(_._2), Right(())))
-        }
-    }
+    paged[Either[StreamId, Unit], StreamEntry[F, V]](Left(StreamId.Zero))(
+      Paged.consume(
+        drainPending = after =>
+          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map(_.flatMap(_._2)),
+        tailNew = CIO
+          .lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block))))
+          .map(_.flatMap(_._2))
+      )
+    )
 
   /**
     * Subscribes to one or more channels; closing the enclosing `Scope` unsubscribes. Survives reconnects via auto-resubscribe, dropping

--- a/sage-client/ox/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/backend/SageClient.scala
@@ -12,7 +12,7 @@ import kyo.compat.*
 
 import sage.{Message, PatternMessage}
 import sage.client.SageConfig
-import sage.client.internal.{Client, LoweredClient, ScanStep, ScanTarget, Subscription}
+import sage.client.internal.{Client, LoweredClient, Paged, ScanStep, ScanTarget, Subscription}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
 
@@ -66,30 +66,16 @@ extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]
 
   private def scanStream[A](fetch: ScanCursor => (Ox ?=> ScanPage[A])): Ox ?=> Flow[A] =
     CStream
-      .unfold[Option[ScanCursor], Vector[A]](Some(ScanCursor.start)) {
-        case None         => CIO.value(None)
-        case Some(cursor) => CIO.lift(fetch(cursor)).map(page => Some((page.items, page.next)))
-      }
+      .unfold[Option[ScanCursor], Vector[A]](Some(ScanCursor.start))(Paged.byCursor(cursor => CIO.lift(fetch(cursor))))
       .flatMap(items => CStream.init(items))
       .lower
 
   // walks every scan target in turn, each with its own node-local cursor, so a cluster SCAN sweeps all masters instead of one
   private def scanStreamAll[A](fetch: ScanTarget => ScanCursor => (Ox ?=> ScanPage[A])): Ox ?=> Flow[A] =
     CStream
-      .unfold[ScanStep, Vector[A]](ScanStep.Begin) {
-        case ScanStep.Begin                 =>
-          CIO
-            .lift(client.scanTargets)
-            .map(targets => if (targets.isEmpty) None else Some((Vector.empty[A], ScanStep.Visit(ScanCursor.start, targets))))
-        case ScanStep.Visit(cursor, remain) =>
-          CIO.lift(fetch(remain.head)(cursor)).map { page =>
-            page.next match {
-              case Some(next) => Some((page.items, ScanStep.Visit(next, remain)))
-              case None       => Some((page.items, if (remain.tail.isEmpty) ScanStep.End else ScanStep.Visit(ScanCursor.start, remain.tail)))
-            }
-          }
-        case ScanStep.End                   => CIO.value(None)
-      }
+      .unfold[ScanStep, Vector[A]](ScanStep.Begin)(
+        Paged.acrossTargets(CIO.lift(client.scanTargets))(target => cursor => CIO.lift(fetch(target)(cursor)))
+      )
       .flatMap(items => CStream.init(items))
       .lower
 
@@ -103,14 +89,9 @@ extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]
     batch: Long = 100L
   ): Ox ?=> Flow[StreamEntry[F, V]] =
     CStream
-      .unfold[Option[StreamRangeId], Vector[StreamEntry[F, V]]](Some(start)) {
-        case None       => CIO.value(None)
-        case Some(from) =>
-          CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))).map { entries =>
-            if (entries.isEmpty) None
-            else Some((entries, if (entries.length < batch) None else Some(StreamRangeId.Exclusive(entries.last.id))))
-          }
-      }
+      .unfold[Option[StreamRangeId], Vector[StreamEntry[F, V]]](Some(start))(
+        Paged.byRange(batch)(from => CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))))
+      )
       .flatMap(items => CStream.init(items))
       .lower
 
@@ -128,13 +109,9 @@ extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]
     count: Option[Long] = None
   ): Ox ?=> Flow[StreamEntry[F, V]] =
     CStream
-      .unfold[Option[StreamId], Vector[StreamEntry[F, V]]](Some(start)) {
-        case None       => CIO.value(None)
-        case Some(from) =>
-          CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))).map { result =>
-            Some((result.entries.filter(_.fields.nonEmpty), if (result.cursor == StreamId.Zero) None else Some(result.cursor)))
-          }
-      }
+      .unfold[Option[StreamId], Vector[StreamEntry[F, V]]](Some(start))(
+        Paged.byAutoClaim(from => CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))))
+      )
       .flatMap(items => CStream.init(items))
       .lower
 
@@ -150,12 +127,11 @@ extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]
     block: BlockTimeout = SageClient.defaultPoll
   ): Ox ?=> Flow[StreamEntry[F, V]] =
     CStream
-      .unfold[StreamId, Vector[StreamEntry[F, V]]](from) { last =>
-        CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map { result =>
-          val entries = result.flatMap(_._2)
-          Some((entries, if (entries.isEmpty) last else entries.last.id))
-        }
-      }
+      .unfold[StreamId, Vector[StreamEntry[F, V]]](from)(
+        Paged.tail(last =>
+          CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map(_.flatMap(_._2))
+        )
+      )
       .flatMap(items => CStream.init(items))
       .lower
 
@@ -185,17 +161,15 @@ extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]
     block: BlockTimeout
   ): Ox ?=> Flow[StreamEntry[F, V]] =
     CStream
-      .unfold[Either[StreamId, Unit], Vector[StreamEntry[F, V]]](Left(StreamId.Zero)) {
-        case Left(after) =>
-          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map { result =>
-            val entries = result.flatMap(_._2)
-            if (entries.isEmpty) Some((Vector.empty, Right(()))) else Some((entries, Left(entries.last.id)))
-          }
-        case Right(_)    =>
-          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block)))).map { result =>
-            Some((result.flatMap(_._2), Right(())))
-          }
-      }
+      .unfold[Either[StreamId, Unit], Vector[StreamEntry[F, V]]](Left(StreamId.Zero))(
+        Paged.consume(
+          drainPending = after =>
+            CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map(_.flatMap(_._2)),
+          tailNew = CIO
+            .lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block))))
+            .map(_.flatMap(_._2))
+        )
+      )
       .flatMap(items => CStream.init(items))
       .lower
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/Paged.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Paged.scala
@@ -1,0 +1,89 @@
+package sage.client.internal
+
+import kyo.compat.*
+
+import sage.commands.{ScanCursor, ScanPage, StreamEntry, StreamId, StreamRangeId, XAutoClaimResult}
+
+/**
+  * The page-stepping state machines behind the per-backend `…All` streaming helpers (`scanAll`, `xRangeAll`, `xConsume`, …). Each builder
+  * takes a `fetch` that pulls one page in the `CIO` carrier and returns a step `S => CIO[Option[(page, nextState)]]` — the shape both
+  * `CStream.unfold` (zio/ce/ox) and the native `Stream.unfold` (kyo, which needs `chunkSize = 1` for its infinite tails) consume. The
+  * cursor-termination, tombstone-skipping and pending-then-tail logic lives here once; the backend keeps only its own stream construction and
+  * the `s => CIO.lift(client.run(…))` fetch. Pure given its `fetch`, so each step is driven directly in `PagedSpec` with a scripted fetch.
+  */
+private[sage] object Paged {
+
+  /**
+    * A page step: from state `S`, fetch the next page of `A`s and the state to resume from, or `None` to end the stream.
+    */
+  type Step[S, A] = S => CIO[Option[(Vector[A], S)]]
+
+  /**
+    * Cursor scan (HSCAN/SSCAN/ZSCAN, and a single SCAN target): page until the server returns no continuation cursor. Termination is on the
+    * zero cursor only, never on an empty page — a `MATCH`-filtered scan routinely returns empty intermediate pages with a non-zero cursor, so
+    * an `isEmpty => None` guard (as [[byRange]] and [[byAutoClaim]] carry) would end the sweep early and drop the rest of the keyspace.
+    */
+  def byCursor[A](fetch: ScanCursor => CIO[ScanPage[A]]): Step[Option[ScanCursor], A] = {
+    case None         => CIO.value(None)
+    case Some(cursor) => fetch(cursor).map(page => Some((page.items, page.next)))
+  }
+
+  /**
+    * Cluster-wide SCAN: walk every target in turn, scanning each to its node-local zero cursor before moving on, so the sweep never
+    * silently covers a single node. The `Begin` step discovers the targets; an empty set ends the stream immediately.
+    */
+  def acrossTargets[A](scanTargets: CIO[Vector[ScanTarget]])(fetch: ScanTarget => ScanCursor => CIO[ScanPage[A]]): Step[ScanStep, A] = {
+    case ScanStep.Begin                    =>
+      scanTargets.map(targets => if (targets.isEmpty) None else Some((Vector.empty[A], ScanStep.Visit(ScanCursor.start, targets))))
+    case ScanStep.Visit(cursor, remaining) =>
+      fetch(remaining.head)(cursor).map { page =>
+        page.next match {
+          case Some(next) => Some((page.items, ScanStep.Visit(next, remaining)))
+          case None       => Some((page.items, if (remaining.tail.isEmpty) ScanStep.End else ScanStep.Visit(ScanCursor.start, remaining.tail)))
+        }
+      }
+    case ScanStep.End                      => CIO.value(None)
+  }
+
+  /**
+    * XRANGE paging: advance past the last id each page; a short page (fewer than `batch`) or an empty page ends the stream.
+    */
+  def byRange[F, V](batch: Long)(fetch: StreamRangeId => CIO[Vector[StreamEntry[F, V]]]): Step[Option[StreamRangeId], StreamEntry[F, V]] = {
+    case None       => CIO.value(None)
+    case Some(from) =>
+      fetch(from).map { entries =>
+        if (entries.isEmpty) None
+        else Some((entries, if (entries.length < batch) None else Some(StreamRangeId.Exclusive(entries.last.id))))
+      }
+  }
+
+  /**
+    * XAUTOCLAIM paging: advance the cursor each call until it wraps back to the start (`StreamId.Zero`). Tombstone entries — claimed ids
+    * whose data was already deleted, surfaced with no fields — are dropped so every emitted entry carries data.
+    */
+  def byAutoClaim[F, V](fetch: StreamId => CIO[XAutoClaimResult[F, V]]): Step[Option[StreamId], StreamEntry[F, V]] = {
+    case None       => CIO.value(None)
+    case Some(from) =>
+      fetch(from).map(result => Some((result.entries.filter(_.fields.nonEmpty), if (result.cursor == StreamId.Zero) None else Some(result.cursor))))
+  }
+
+  /**
+    * XREAD tail: replay every entry after `from`, then block for new ones forever, advancing past the last id and never advancing on an empty round.
+    */
+  def tail[F, V](fetch: StreamId => CIO[Vector[StreamEntry[F, V]]]): Step[StreamId, StreamEntry[F, V]] =
+    last => fetch(last).map(entries => Some((entries, if (entries.isEmpty) last else entries.last.id)))
+
+  /**
+    * XREADGROUP consume: first drain this consumer's own pending history (`Left`, at-least-once recovery after a restart), then block for
+    * new entries forever (`Right`). The per-entry acknowledgement is the backend's, layered over the entries this step yields.
+    */
+  def consume[F, V](
+    drainPending: StreamId => CIO[Vector[StreamEntry[F, V]]],
+    tailNew: CIO[Vector[StreamEntry[F, V]]]
+  ): Step[Either[StreamId, Unit], StreamEntry[F, V]] = {
+    case Left(after) =>
+      drainPending(after).map(entries => if (entries.isEmpty) Some((Vector.empty, Right(()))) else Some((entries, Left(entries.last.id))))
+    case Right(_)    =>
+      tailNew.map(entries => Some((entries, Right(()))))
+  }
+}

--- a/sage-client/shared/src/test/scala/sage/client/internal/PagedSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/PagedSpec.scala
@@ -1,0 +1,135 @@
+package sage.client.internal
+
+import scala.concurrent.ExecutionContext
+
+import kyo.compat.*
+
+import sage.commands.{ScanCursor, ScanPage, StreamEntry, StreamId, StreamRangeId, XAutoClaimResult}
+
+/**
+  * Drives each [[Paged]] stepper directly with a scripted `CIO` fetch — the deterministic test surface the extraction unlocks. No server,
+  * no backend stream type: just the cursor-termination, tombstone-skipping and pending-then-tail logic the four backends share.
+  */
+class PagedSpec extends munit.FunSuite {
+
+  private given ExecutionContext = munitExecutionContext
+
+  private def entry(ms: Long): StreamEntry[String, String]     = StreamEntry(StreamId(ms, 0L), Vector("f" -> "v"))
+  private def tombstone(ms: Long): StreamEntry[String, String] = StreamEntry(StreamId(ms, 0L), Vector.empty)
+
+  test("byCursor emits the page, and stops when the server returns no continuation cursor") {
+    val more = Paged.byCursor[String](_ => CIO.value(ScanPage(Vector("a", "b"), Some(ScanCursor.start))))
+    val done = Paged.byCursor[String](_ => CIO.value(ScanPage(Vector("c"), None)))
+    for {
+      m   <- more(Some(ScanCursor.start)).unsafeRun
+      d   <- done(Some(ScanCursor.start)).unsafeRun
+      end <- done(None).unsafeRun
+    } yield {
+      assertEquals(m.map(_._1), Some(Vector("a", "b")))
+      assert(m.flatMap(_._2).isDefined, "a continuation cursor should keep the scan going")
+      assertEquals(d.map(_._1), Some(Vector("c")))
+      assert(d.get._2.isEmpty, "a zero cursor should end the scan")
+      assertEquals(end, None)
+    }
+  }
+
+  test("acrossTargets walks every target to its own zero cursor, then ends; empty targets end immediately") {
+    val fetch: ScanTarget => ScanCursor => CIO[ScanPage[String]] = _ => _ => CIO.value(ScanPage(Vector("x"), None))
+    val step                                                     = Paged.acrossTargets(CIO.value(Vector(ScanTarget.any, ScanTarget.any)))(fetch)
+    val none                                                     = Paged.acrossTargets[String](CIO.value(Vector.empty[ScanTarget]))(fetch)
+    for {
+      begin  <- step(ScanStep.Begin).unsafeRun
+      visit1 <- step(begin.get._2).unsafeRun
+      visit2 <- step(visit1.get._2).unsafeRun
+      end    <- step(ScanStep.End).unsafeRun
+      empty  <- none(ScanStep.Begin).unsafeRun
+    } yield {
+      assertEquals(begin.get._1, Vector.empty[String])
+      begin.get._2 match {
+        case ScanStep.Visit(_, remaining) => assertEquals(remaining.length, 2)
+        case other                        => fail(s"expected Visit over two targets, got $other")
+      }
+      assertEquals(visit1.get._1, Vector("x"))
+      visit1.get._2 match {
+        case ScanStep.Visit(_, remaining) => assertEquals(remaining.length, 1)
+        case other                        => fail(s"expected Visit over the last target, got $other")
+      }
+      assertEquals(visit2.get._1, Vector("x"))
+      assertEquals(visit2.get._2, ScanStep.End)
+      assertEquals(end, None)
+      assertEquals(empty, None)
+    }
+  }
+
+  test("byRange advances past the last id while pages are full, and ends on a short or empty page") {
+    val full  = Vector(entry(1), entry(2), entry(3))
+    val step  = Paged.byRange[String, String](batch = 3) {
+      case StreamRangeId.Min => CIO.value(full)
+      case _                 => CIO.value(Vector(entry(4)))
+    }
+    val drain = Paged.byRange[String, String](batch = 3)(_ => CIO.value(Vector.empty[StreamEntry[String, String]]))
+    for {
+      page1 <- step(Some(StreamRangeId.Min)).unsafeRun
+      page2 <- step(page1.get._2).unsafeRun
+      end   <- step(None).unsafeRun
+      empty <- drain(Some(StreamRangeId.Min)).unsafeRun
+    } yield {
+      assertEquals(page1, Some((full, Some(StreamRangeId.Exclusive(StreamId(3L, 0L))))))
+      assertEquals(page2, Some((Vector(entry(4)), None)))
+      assertEquals(end, None)
+      assertEquals(empty, None)
+    }
+  }
+
+  test("byAutoClaim skips tombstones and ends when the cursor wraps to Zero") {
+    val step = Paged.byAutoClaim[String, String] {
+      case StreamId.Zero => CIO.value(XAutoClaimResult(StreamId(5L, 0L), Vector(entry(1), tombstone(2), entry(3)), Vector.empty))
+      case _             => CIO.value(XAutoClaimResult(StreamId.Zero, Vector(entry(4)), Vector.empty))
+    }
+    for {
+      first <- step(Some(StreamId.Zero)).unsafeRun
+      last  <- step(first.get._2).unsafeRun
+      end   <- step(None).unsafeRun
+    } yield {
+      assertEquals(first, Some((Vector(entry(1), entry(3)), Some(StreamId(5L, 0L)))))
+      assertEquals(last, Some((Vector(entry(4)), None)))
+      assertEquals(end, None)
+    }
+  }
+
+  test("tail advances past the last id and holds position on an empty round") {
+    val step = Paged.tail[String, String] {
+      case StreamId.Zero => CIO.value(Vector(entry(1)))
+      case _             => CIO.value(Vector.empty[StreamEntry[String, String]])
+    }
+    for {
+      first <- step(StreamId.Zero).unsafeRun
+      empty <- step(first.get._2).unsafeRun
+    } yield {
+      assertEquals(first, Some((Vector(entry(1)), StreamId(1L, 0L))))
+      assertEquals(empty, Some((Vector.empty[StreamEntry[String, String]], StreamId(1L, 0L))))
+    }
+  }
+
+  test("consume drains this consumer's pending history (Left), then switches to tailing new entries (Right)") {
+    val step = Paged.consume[String, String](
+      drainPending = {
+        case StreamId.Zero => CIO.value(Vector(entry(1)))
+        case _             => CIO.value(Vector.empty[StreamEntry[String, String]])
+      },
+      tailNew = CIO.value(Vector(entry(2)))
+    )
+    for {
+      pending1 <- step(Left(StreamId.Zero)).unsafeRun
+      pending2 <- step(pending1.get._2).unsafeRun
+      tailing  <- step(pending2.get._2).unsafeRun
+      tailing2 <- step(tailing.get._2).unsafeRun
+    } yield {
+      assertEquals(pending1, Some((Vector(entry(1)), Left(StreamId(1L, 0L)))))
+      assertEquals(pending2, Some((Vector.empty[StreamEntry[String, String]], Right(()))))
+      assertEquals(tailing, Some((Vector(entry(2)), Right(()))))
+      // a second tail round re-issues XREADGROUP NEW: tailNew is a re-runnable CIO description, not consumed once
+      assertEquals(tailing2, Some((Vector(entry(2)), Right(()))))
+    }
+  }
+}

--- a/sage-client/zio/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/zio/src/main/scala/sage/backend/SageClient.scala
@@ -11,7 +11,7 @@ import zio.stream.ZStream
 
 import sage.{Message, PatternMessage}
 import sage.client.SageConfig
-import sage.client.internal.{Client, LoweredClient, ScanStep, ScanTarget, Subscription}
+import sage.client.internal.{Client, LoweredClient, Paged, ScanStep, ScanTarget, Subscription}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
 
@@ -71,30 +71,16 @@ extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
 
   private def scanStream[A](fetch: ScanCursor => Task[ScanPage[A]]): ZStream[Any, Throwable, A] =
     CStream
-      .unfold[Option[ScanCursor], Vector[A]](Some(ScanCursor.start)) {
-        case None         => CIO.value(None)
-        case Some(cursor) => CIO.lift(fetch(cursor)).map(page => Some((page.items, page.next)))
-      }
+      .unfold[Option[ScanCursor], Vector[A]](Some(ScanCursor.start))(Paged.byCursor(cursor => CIO.lift(fetch(cursor))))
       .flatMap(items => CStream.init(items))
       .lower
 
   // walks every scan target in turn, each with its own node-local cursor, so a cluster SCAN sweeps all masters instead of one
   private def scanStreamAll[A](fetch: ScanTarget => ScanCursor => Task[ScanPage[A]]): ZStream[Any, Throwable, A] =
     CStream
-      .unfold[ScanStep, Vector[A]](ScanStep.Begin) {
-        case ScanStep.Begin                 =>
-          CIO
-            .lift(client.scanTargets)
-            .map(targets => if (targets.isEmpty) None else Some((Vector.empty[A], ScanStep.Visit(ScanCursor.start, targets))))
-        case ScanStep.Visit(cursor, remain) =>
-          CIO.lift(fetch(remain.head)(cursor)).map { page =>
-            page.next match {
-              case Some(next) => Some((page.items, ScanStep.Visit(next, remain)))
-              case None       => Some((page.items, if (remain.tail.isEmpty) ScanStep.End else ScanStep.Visit(ScanCursor.start, remain.tail)))
-            }
-          }
-        case ScanStep.End                   => CIO.value(None)
-      }
+      .unfold[ScanStep, Vector[A]](ScanStep.Begin)(
+        Paged.acrossTargets(CIO.lift(client.scanTargets))(target => cursor => CIO.lift(fetch(target)(cursor)))
+      )
       .flatMap(items => CStream.init(items))
       .lower
 
@@ -108,14 +94,9 @@ extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
     batch: Long = 100L
   ): ZStream[Any, Throwable, StreamEntry[F, V]] =
     CStream
-      .unfold[Option[StreamRangeId], Vector[StreamEntry[F, V]]](Some(start)) {
-        case None       => CIO.value(None)
-        case Some(from) =>
-          CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))).map { entries =>
-            if (entries.isEmpty) None
-            else Some((entries, if (entries.length < batch) None else Some(StreamRangeId.Exclusive(entries.last.id))))
-          }
-      }
+      .unfold[Option[StreamRangeId], Vector[StreamEntry[F, V]]](Some(start))(
+        Paged.byRange(batch)(from => CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))))
+      )
       .flatMap(items => CStream.init(items))
       .lower
 
@@ -133,13 +114,9 @@ extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
     count: Option[Long] = None
   ): ZStream[Any, Throwable, StreamEntry[F, V]] =
     CStream
-      .unfold[Option[StreamId], Vector[StreamEntry[F, V]]](Some(start)) {
-        case None       => CIO.value(None)
-        case Some(from) =>
-          CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))).map { result =>
-            Some((result.entries.filter(_.fields.nonEmpty), if (result.cursor == StreamId.Zero) None else Some(result.cursor)))
-          }
-      }
+      .unfold[Option[StreamId], Vector[StreamEntry[F, V]]](Some(start))(
+        Paged.byAutoClaim(from => CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))))
+      )
       .flatMap(items => CStream.init(items))
       .lower
 
@@ -155,12 +132,11 @@ extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
     block: BlockTimeout = SageClient.defaultPoll
   ): ZStream[Any, Throwable, StreamEntry[F, V]] =
     CStream
-      .unfold[StreamId, Vector[StreamEntry[F, V]]](from) { last =>
-        CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map { result =>
-          val entries = result.flatMap(_._2)
-          Some((entries, if (entries.isEmpty) last else entries.last.id))
-        }
-      }
+      .unfold[StreamId, Vector[StreamEntry[F, V]]](from)(
+        Paged.tail(last =>
+          CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map(_.flatMap(_._2))
+        )
+      )
       .flatMap(items => CStream.init(items))
       .lower
 
@@ -188,17 +164,15 @@ extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
     block: BlockTimeout
   ): ZStream[Any, Throwable, StreamEntry[F, V]] =
     CStream
-      .unfold[Either[StreamId, Unit], Vector[StreamEntry[F, V]]](Left(StreamId.Zero)) {
-        case Left(after) =>
-          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map { result =>
-            val entries = result.flatMap(_._2)
-            if (entries.isEmpty) Some((Vector.empty, Right(()))) else Some((entries, Left(entries.last.id)))
-          }
-        case Right(_)    =>
-          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block)))).map { result =>
-            Some((result.flatMap(_._2), Right(())))
-          }
-      }
+      .unfold[Either[StreamId, Unit], Vector[StreamEntry[F, V]]](Left(StreamId.Zero))(
+        Paged.consume(
+          drainPending = after =>
+            CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map(_.flatMap(_._2)),
+          tailNew = CIO
+            .lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block))))
+            .map(_.flatMap(_._2))
+        )
+      )
       .flatMap(items => CStream.init(items))
       .lower
 


### PR DESCRIPTION
## What

The per-backend `…All` streaming helpers (`scanAll`, `hScanAll`, `sScanAll`, `zScanAll`, `xRangeAll`, `xAutoClaimAll`, `xTail`, `xConsume`) re-derived the same page-stepping state machines — cursor termination, the cluster scan-target walk, tombstone skipping, the `xRange` short-page end, and the `xConsume` pending-then-tail transition — **once in each of the four backend `SageClient.scala` files**.

This extracts that logic into a single `private[sage]` `Paged` object of `CIO` step builders in the shared layer.

## How

Each stepper takes a `fetch: S => CIO[Page]` and owns only the bespoke next-state logic. The backends keep what is genuinely per-backend:

- **stream construction** — zio/ce/ox feed the steppers to `CStream.unfold`; kyo keeps its native `Stream.unfold(chunkSize = 1)` (the compat `CStream` lowering rechunks to 4096, which would withhold the infinite `xTail`/`xConsume` tails) and bridges once via `.lower.map(Maybe.fromOption)`.
- **the fetch** — uniformly `s => CIO.lift(client.run(...))`.
- **`xConsume`'s handle-then-ack drain** and the **`subscribe`/`streamOf`** wrappers, which aren't pagination.

No change to `LoweredClient`. The net is ~200 fewer lines and one place to fix a cursor/termination bug instead of four.

## Why it matters

The paging state machines previously had **no unit coverage** — they were reachable only through per-backend integration suites against a live server. They are now driven directly in `PagedSpec` with scripted `CIO` fetches: termination, tombstone skip, cursor advance, and the consume `Left`→`Right` transition, deterministically and without a server.

## Tests

Behavior-preserving on all four backends; Kyo's logic was line-for-line identical to ZIO's (only `Maybe`/`Option`), so the extraction is faithful.

- `clientZio/test` — 169 ✅
- `clientCe/test` — 120 ✅
- `clientOx/test` — 120 ✅
- `clientKyo3_8_3/test` (Scala 3.8.3 Next) — 120 ✅
- `scalafmtCheck` clean across all cells