### PR TITLE
Share fault categorization across the cluster and master-replica runtimes

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -234,24 +234,21 @@ final private[client] class ClusterLive(
     redirectsLeft: Int,
     complete: Try[A] => Unit
   ): Unit =
-    classify(error) match {
-      case ClusterLive.Disposition.Reroute             =>
-        error match {
-          case e: ServerError =>
-            Redirect.parse(e.getMessage).get match {
-              // strict Replica must not follow ASK onto the importing master (the migrating key is on no replica); MOVED refreshes and re-dispatches
-              case ask if ask.kind == RedirectKind.Ask =>
-                if (readFrom == ReadFrom.Replica) complete(Failure(NotConnected()))
-                else onRedirect(node, ask, command, redirectsLeft, complete)
-              case _ if redirectsLeft <= 0             =>
-                complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
-              case _                                   => refresh(force = true); offload(dispatch(command, redirectsLeft - 1, complete))
-            }
-          case _              =>
-            if (rest.nonEmpty) tryReadCandidates(command, rest, master, redirectsLeft, complete) else onUnreachable(command, redirectsLeft, complete)
+    Fault.categorize(error) match {
+      case Fault.Redirected(redirect)       =>
+        redirect.kind match {
+          // strict Replica must not follow ASK onto the importing master (the migrating key is on no replica); MOVED refreshes and re-dispatches
+          case RedirectKind.Ask                         =>
+            if (readFrom == ReadFrom.Replica) complete(Failure(NotConnected()))
+            else onRedirect(node, redirect, command, redirectsLeft, complete)
+          case RedirectKind.Moved if redirectsLeft <= 0 =>
+            complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
+          case RedirectKind.Moved                       => refresh(force = true); offload(dispatch(command, redirectsLeft - 1, complete))
         }
-      case ClusterLive.Disposition.RefreshThenTerminal => triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error))
-      case ClusterLive.Disposition.Terminal            => Events.attributeNode(complete, node); complete(Failure(error))
+      case Fault.Lost(false)                =>
+        if (rest.nonEmpty) tryReadCandidates(command, rest, master, redirectsLeft, complete) else onUnreachable(command, redirectsLeft, complete)
+      case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error))
+      case Fault.Fatal                      => Events.attributeNode(complete, node); complete(Failure(error))
     }
 
   // a broadcast command (SCRIPT LOAD, FUNCTION LOAD, …) runs on every slot-owning master, since a cluster replicates no script/function
@@ -355,31 +352,11 @@ final private[client] class ClusterLive(
   }
 
   private def onFailure[A](node: Node, command: Command[A], error: Throwable, redirectsLeft: Int, complete: Try[A] => Unit): Unit =
-    classify(error) match {
-      case ClusterLive.Disposition.Reroute             =>
-        error match {
-          // classify only reroutes a ServerError when it parses as a redirect, so `.get` is safe here
-          case e: ServerError => onRedirect(node, Redirect.parse(e.getMessage).get, command, redirectsLeft, complete)
-          case _              => onUnreachable(command, redirectsLeft, complete)
-        }
-      case ClusterLive.Disposition.RefreshThenTerminal =>
-        triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error))
-      case ClusterLive.Disposition.Terminal            => Events.attributeNode(complete, node); complete(Failure(error))
-    }
-
-  // the single failure taxonomy a routed command can meet, shared by single-command and Pipeline-batch paths so they cannot drift: a redirect
-  // or a provably-unexecuted loss re-routes; a demoted master (`READONLY`) or a may-have-executed loss refreshes but still fails this command;
-  // anything else fails fast in place
-  private def classify(error: Throwable): ClusterLive.Disposition =
-    error match {
-      case e: ServerError        =>
-        if (Redirect.parse(e.getMessage).isDefined) ClusterLive.Disposition.Reroute
-        else if (e.code == "READONLY") ClusterLive.Disposition.RefreshThenTerminal
-        else ClusterLive.Disposition.Terminal
-      case NotConnected()        => ClusterLive.Disposition.Reroute
-      case ConnectionLost(false) => ClusterLive.Disposition.Reroute
-      case ConnectionLost(true)  => ClusterLive.Disposition.RefreshThenTerminal
-      case _                     => ClusterLive.Disposition.Terminal
+    Fault.categorize(error) match {
+      case Fault.Redirected(redirect)       => onRedirect(node, redirect, command, redirectsLeft, complete)
+      case Fault.Lost(false)                => onUnreachable(command, redirectsLeft, complete)
+      case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error))
+      case Fault.Fatal                      => Events.attributeNode(complete, node); complete(Failure(error))
     }
 
   private def onRedirect[A](from: Node, redirect: Redirect, command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit =
@@ -524,24 +501,20 @@ final private[client] class ClusterLive(
       result match {
         case Success(_)     => settle(index, result)
         case Failure(error) =>
-          classify(error) match {
-            case ClusterLive.Disposition.Reroute             =>
-              error match {
-                // ASK keeps the slot's owner, so re-routing by topology bounces off the exporting node and burns a redirect; follow it straight
-                // to the importing node with ASKING. MOVED and connection loss re-route normally.
-                case e: ServerError =>
-                  val redirect = Redirect.parse(e.getMessage).get // classify only reroutes a ServerError that parses as a redirect
-                  redirect.kind match {
-                    // strict Replica must not follow ASK onto the importing master (mirrors the single-read path at onReadFailure)
-                    case RedirectKind.Ask if useReplica && readFrom == ReadFrom.Replica => settle(index, Failure(NotConnected()))
-                    case RedirectKind.Ask                                               =>
-                      onRedirect(target, redirect, p.commands(index), cluster.maxRedirects, emits(index))
-                    case RedirectKind.Moved                                             => reroute(index)
-                  }
-                case _              => reroute(index)
+          Fault.categorize(error) match {
+            // ASK keeps the slot's owner, so re-routing by topology bounces off the exporting node and burns a redirect; follow it straight
+            // to the importing node with ASKING. MOVED and connection loss re-route normally.
+            case Fault.Redirected(redirect)       =>
+              redirect.kind match {
+                // strict Replica must not follow ASK onto the importing master (mirrors the single-read path at onReadFailure)
+                case RedirectKind.Ask if useReplica && readFrom == ReadFrom.Replica => settle(index, Failure(NotConnected()))
+                case RedirectKind.Ask                                               =>
+                  onRedirect(target, redirect, p.commands(index), cluster.maxRedirects, emits(index))
+                case RedirectKind.Moved                                             => reroute(index)
               }
-            case ClusterLive.Disposition.RefreshThenTerminal => triggerRefresh(); settle(index, result)
-            case ClusterLive.Disposition.Terminal            => settle(index, result)
+            case Fault.Lost(false)                => reroute(index)
+            case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); settle(index, result)
+            case Fault.Fatal                      => settle(index, result)
           }
       }
     }
@@ -598,9 +571,9 @@ final private[client] class ClusterLive(
     // a transaction never follows a redirect (that would break MULTI/EXEC atomicity), but on any ownership/connection fault it refreshes in the
     // background so the caller's retry re-pins to the new owner instead of looping on the stale node; a data error refreshes nothing
     private def refreshOnFault(error: Throwable): Unit =
-      classify(error) match {
-        case ClusterLive.Disposition.Terminal => ()
-        case _                                => forceRefresh()
+      Fault.categorize(error) match {
+        case Fault.Fatal => ()
+        case _           => forceRefresh()
       }
 
     private def faulting[A](complete: Try[A] => Unit): Try[A] => Unit = {
@@ -612,7 +585,7 @@ final private[client] class ClusterLive(
     // level and the EXEC array and refresh on any non-terminal one so the caller's retry re-pins
     private def refreshOnExecFault(frames: Vector[Frame]): Unit = {
       val nested = frames.lastOption match { case Some(Frame.Array(elems)) => elems.iterator; case _ => Iterator.empty[Frame] }
-      val fault  = (frames.iterator ++ nested).flatMap(TxSupport.errorOf).exists(m => classify(ServerError.of(m)) != ClusterLive.Disposition.Terminal)
+      val fault  = (frames.iterator ++ nested).flatMap(TxSupport.errorOf).exists(m => Fault.categorize(ServerError.of(m)) != Fault.Fatal)
       if (fault) forceRefresh()
     }
 
@@ -876,10 +849,6 @@ final private[client] class ClusterLive(
 }
 
 private[client] object ClusterLive {
-
-  private enum Disposition {
-    case Reroute, RefreshThenTerminal, Terminal
-  }
 
   // one-shot single-flight cell: the establisher fills it, concurrent callers block on `get`. First settle wins, so a `close` that
   // fails the waiters cannot be overwritten by a late establisher.

--- a/sage-client/shared/src/main/scala/sage/client/internal/Fault.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Fault.scala
@@ -1,0 +1,30 @@
+package sage.client.internal
+
+import sage.SageException.{ConnectionLost, NotConnected, ServerError}
+import sage.cluster.Redirect
+
+/**
+  * The shared categorization of a failed command: both runtimes read a [[Throwable]] the same way, so they cannot drift on what a fault is.
+  */
+private[client] enum Fault {
+  case Redirected(redirect: Redirect)
+  case Demoted
+  case Lost(mayHaveExecuted: Boolean)
+  case Fatal
+}
+
+private[client] object Fault {
+
+  def categorize(error: Throwable): Fault =
+    error match {
+      case e: ServerError           =>
+        Redirect.parse(e.getMessage) match {
+          case Some(redirect)               => Fault.Redirected(redirect)
+          case None if e.code == "READONLY" => Fault.Demoted
+          case None                         => Fault.Fatal
+        }
+      case NotConnected()           => Fault.Lost(mayHaveExecuted = false)
+      case ConnectionLost(executed) => Fault.Lost(executed)
+      case _                        => Fault.Fatal
+    }
+}

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -11,7 +11,7 @@ import scala.util.control.NonFatal
 import kyo.compat.*
 
 import sage.{Message, PatternMessage, SageException}
-import sage.SageException.{ConnectionLost, NotConnected, ServerError, TimedOut}
+import sage.SageException.{ConnectionLost, NotConnected, TimedOut}
 import sage.client.{ReadFrom, SageConfig}
 import sage.cluster.Node
 import sage.codec.ValueCodec
@@ -232,17 +232,14 @@ final private[client] class MasterReplicaLive(
     } else { Events.attributeNode(complete, node); complete(Failure(error)) }
   }
 
-  private def isOwnershipFault(error: Throwable): Boolean = error match {
-    case e: ServerError    => e.code == "READONLY"
-    case NotConnected()    => true
-    case ConnectionLost(_) => true
-    case _                 => false
+  private def isOwnershipFault(error: Throwable): Boolean = Fault.categorize(error) match {
+    case Fault.Demoted | Fault.Lost(_) => true
+    case _                             => false
   }
 
-  private def isConnLoss(error: Throwable): Boolean = error match {
-    case NotConnected()    => true
-    case ConnectionLost(_) => true
-    case _                 => false
+  private def isConnLoss(error: Throwable): Boolean = Fault.categorize(error) match {
+    case Fault.Lost(_) => true
+    case _             => false
   }
 
   // --- pipelines -----------------------------------------------------------------------------------------------------------------------

--- a/sage-client/shared/src/test/scala/sage/client/internal/FaultSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/FaultSpec.scala
@@ -1,0 +1,46 @@
+package sage.client.internal
+
+import sage.SageException.{ConnectionLost, NotConnected, ServerError}
+import sage.cluster.{Node, Redirect, RedirectKind, Slot}
+
+class FaultSpec extends munit.FunSuite {
+
+  test("a MOVED reply categorizes as Redirected carrying the parsed redirect") {
+    assertEquals(
+      Fault.categorize(ServerError("MOVED", "3999 127.0.0.1:6379")),
+      Fault.Redirected(Redirect(RedirectKind.Moved, Slot.at(3999).get, Node("127.0.0.1", 6379)))
+    )
+  }
+
+  test("an ASK reply categorizes as Redirected") {
+    assertEquals(
+      Fault.categorize(ServerError("ASK", "42 127.0.0.1:7000")),
+      Fault.Redirected(Redirect(RedirectKind.Ask, Slot.at(42).get, Node("127.0.0.1", 7000)))
+    )
+  }
+
+  test("a READONLY reply categorizes as Demoted") {
+    assertEquals(Fault.categorize(ServerError("READONLY", "You can't write against a read only replica.")), Fault.Demoted)
+  }
+
+  test("any other ServerError categorizes as Fatal") {
+    assertEquals(Fault.categorize(ServerError("WRONGTYPE", "Operation against a key holding the wrong kind of value")), Fault.Fatal)
+    assertEquals(Fault.categorize(ServerError("ERR", "foo bar")), Fault.Fatal)
+    assertEquals(Fault.categorize(ServerError("ERR", "")), Fault.Fatal)
+    // a redirect-shaped triple whose first token is not exactly MOVED/ASK is not a redirect
+    assertEquals(Fault.categorize(ServerError("MOVE", "3999 127.0.0.1:6379")), Fault.Fatal)
+  }
+
+  test("NotConnected categorizes as a provably-unexecuted loss") {
+    assertEquals(Fault.categorize(NotConnected()), Fault.Lost(mayHaveExecuted = false))
+  }
+
+  test("ConnectionLost carries through its mayHaveExecuted flag") {
+    assertEquals(Fault.categorize(ConnectionLost(mayHaveExecuted = false)), Fault.Lost(mayHaveExecuted = false))
+    assertEquals(Fault.categorize(ConnectionLost(mayHaveExecuted = true)), Fault.Lost(mayHaveExecuted = true))
+  }
+
+  test("an unrelated throwable categorizes as Fatal") {
+    assertEquals(Fault.categorize(new RuntimeException("boom")), Fault.Fatal)
+  }
+}


### PR DESCRIPTION
## What

`ClusterLive` carried a private `Disposition` enum plus `classify(error): Disposition`, while `MasterReplicaLive` re-derived the same `READONLY`/connection-loss vocabulary in two ad-hoc predicates (`isOwnershipFault`, `isConnLoss`). The two runtimes could drift on what a fault *is*, and the cluster classifier was reachable only through a live cluster.

This extracts a pure `Fault` categorization shared by both:

```scala
enum Fault:
  case Redirected(redirect: Redirect)
  case Demoted
  case Lost(mayHaveExecuted: Boolean)
  case Fatal

def categorize(error: Throwable): Fault
```

## Why categorization, not disposition

The architecture review proposed sharing `classify`/`Disposition` wholesale, but reading the code showed the two runtimes apply **different policies** to the same fault vocabulary — a cluster follows redirects and reroutes writes across owners; a master-replica has one master and reroutes only reads across replicas, and it ignores `ConnectionLost`'s `mayHaveExecuted` flag where the cluster distinguishes it. Sharing the action would have **changed master-replica's retry semantics**. So only the *categorization* (the bug-prone reading of a `Throwable`) is shared; what to *do* with each category stays per-runtime.

## How

`categorize` owns, in one place, the parsing of a `MOVED`/`ASK` redirect, the `READONLY` demotion check, and the `mayHaveExecuted` extraction. ClusterLive's five fault sites (`onReadFailure`, `onFailure`, the pipeline-batch callback, `refreshOnFault`, `refreshOnExecFault`) and MasterReplica's two predicates now match `Fault` directly. Because `Redirected` carries the parsed redirect, **both unsafe `Redirect.parse(...).get` calls and the nested `error match` blocks are gone**, and `sealed Fault` + exhaustive matching gives the no-drift guarantee the old `classify` comment wanted.

## Why it matters

The fault categorization previously had **no unit coverage** — the cluster classifier was reachable only through a live-cluster integration suite. It is now pinned directly in `FaultSpec`: MOVED/ASK→Redirected (against literal redirects), READONLY→Demoted, other ServerError→Fatal (incl. a near-miss `kind`), NotConnected→Lost(false), ConnectionLost(f)→Lost(f), arbitrary→Fatal.

## Tests

Behavior-preserving on both runtimes (verified case-by-case, including the impossible-in-master-replica `Redirected` edge). Existing `ClusterClientSpec` / `TxScopeFaultSpec` stay green.

- `clientZio/test` — 176 ✅
- `clientCe/test` — 127 ✅
- `clientOx/test` — 127 ✅
- `clientKyo3_8_3/test` (Scala 3.8.3 Next) — 127 ✅
- `scalafmtCheck` clean across all cells