### PR TITLE
Update kyo to 1.0.0-RC4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val munitVersion          = "1.3.2"
 val testcontainersVersion = "0.44.1"
 
 // backend effect libraries, declared explicitly so Scala Steward keeps them current
-val kyoVersion        = "1.0.0-RC2+99-6f012d83-SNAPSHOT"
+val kyoVersion        = "1.0.0-RC4"
 val zioVersion        = "2.1.26"
 val catsEffectVersion = "3.7.0"
 val fs2Version        = "3.13.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,4 @@
-resolvers += Resolver.sonatypeCentralSnapshots
-
-addSbtPlugin("io.getkyo"          % "kyo-compat-plugin" % "1.0.0-RC2+64-9487771b-SNAPSHOT")
+addSbtPlugin("io.getkyo"          % "kyo-compat-plugin" % "1.0.0-RC4")
 addSbtPlugin("com.eed3si9n"       % "sbt-projectmatrix" % "0.10.1")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"     % "0.13.1")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"      % "2.6.1")


### PR DESCRIPTION
Pin kyo to the released `1.0.0-RC4` instead of the prior `1.0.0-RC2+...-SNAPSHOT` builds.

## Changes
- `build.sbt`: `kyoVersion` → `1.0.0-RC4` (`compatKyoVersion` tracks it automatically)
- `project/plugins.sbt`: `kyo-compat-plugin` → `1.0.0-RC4`, and dropped `resolvers += Resolver.sonatypeCentralSnapshots` since RC4 resolves from Maven Central

## Verification
Client, examples, benchmarks, and integration-test sources all compile against RC4. No API breakage.

Note: `build.sbt` still keeps `Resolver.sonatypeCentralSnapshots` in `inThisBuild`. Left it in place for now; happy to remove if no other snapshot deps remain.