### PR TITLE
Update scala3-library to 3.8.4 and derive Kyo project suffix from the version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Build API docs (no Scaladoc warnings)
         run: |
           set -o pipefail
-          sbt -batch core/doc clientZio/doc clientCe/doc clientOx/doc clientKyo3_8_3/doc 2>&1 | tee doc.log
+          sbt -batch docAll 2>&1 | tee doc.log
           if grep -E "Couldn't resolve|-- (\[E\] )?(Warning|Error)" doc.log; then
             echo "::error::Scaladoc emitted warnings; see the log above"
             exit 1

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -25,7 +25,7 @@ different Scala version), so the harness is one `projectMatrix` cell per backend
 | `sage-zio` / `zio-redis` | `benchmarksZio` | zio-redis is native ZIO. |
 | `sage-ce` / `redis4cats` | `benchmarksCe` | redis4cats wraps Lettuce. |
 | `sage-ox` / `lettuce` | `benchmarksOx` | `lettuce` is the async/auto-pipelined Lettuce client — the JVM ceiling. |
-| `sage-kyo` | `benchmarksKyo3_8_4` | no native Kyo competitor exists. |
+| `sage-kyo` | `benchmarksKyo<scala-next>` | suffix tracks the Next Scala version; no native Kyo competitor exists. |
 
 Dropped after review: Jedis (sync Java), laserdisc (Scala 2.13 + RESP2), rediculous (RESP2, dormant) — none are Scala-3 + RESP3 peers.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -25,7 +25,7 @@ different Scala version), so the harness is one `projectMatrix` cell per backend
 | `sage-zio` / `zio-redis` | `benchmarksZio` | zio-redis is native ZIO. |
 | `sage-ce` / `redis4cats` | `benchmarksCe` | redis4cats wraps Lettuce. |
 | `sage-ox` / `lettuce` | `benchmarksOx` | `lettuce` is the async/auto-pipelined Lettuce client — the JVM ceiling. |
-| `sage-kyo` | `benchmarksKyo3_8_3` | no native Kyo competitor exists. |
+| `sage-kyo` | `benchmarksKyo3_8_4` | no native Kyo competitor exists. |
 
 Dropped after review: Jedis (sync Java), laserdisc (Scala 2.13 + RESP2), rediculous (RESP2, dormant) — none are Scala-3 + RESP3 peers.
 

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -14,7 +14,9 @@ root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$root"
 
 args="$*"
-cells=(benchmarksZio:zio benchmarksCe:ce benchmarksOx:ox benchmarksKyo3_8_3:kyo)
+# the Kyo cell's project id embeds the Next Scala version; read it from build.sbt so bumps need no edit here
+kyoSuffix="$(grep -E '^val scala3NextVersion' build.sbt | sed -E 's/.*"([0-9.]+)".*/\1/' | tr '.' '_')"
+cells=(benchmarksZio:zio benchmarksCe:ce benchmarksOx:ox "benchmarksKyo${kyoSuffix}:kyo")
 failed=0
 
 rm -f benchmarks/results/*.json

--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,11 @@ addCommandAlias("itCe", "integrationTestsCe/test")
 addCommandAlias("itOx", "integrationTestsOx/test")
 addCommandAlias("itKyo", s"integrationTestsKyo$scala3NextSuffix/test")
 
+addCommandAlias(
+  "docAll",
+  s"all core/doc clientZio/doc clientCe/doc clientOx/doc clientKyo$scala3NextSuffix/doc"
+)
+
 lazy val root = project
   .in(file("."))
   .settings(publish / skip := true)

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
 import sbt.VirtualAxis
 
 val scala3Version     = "3.3.8"
-val scala3NextVersion = "3.8.3" // Kyo requires Scala 3.8.x (Next)
+val scala3NextVersion = "3.8.4"                             // Kyo requires Scala 3.8.x (Next)
+val scala3NextSuffix  = scala3NextVersion.replace('.', '_') // Kyo cells embed the Next Scala version in their project id
 
 val munitVersion          = "1.3.3"
 val testcontainersVersion = "0.44.1"
@@ -37,26 +38,26 @@ name := "sage"
 addCommandAlias(
   "fmt",
   "all scalafmtSbt scalafmt test:scalafmt " +
-    "benchmarksZio/scalafmt benchmarksCe/scalafmt benchmarksOx/scalafmt benchmarksKyo3_8_3/scalafmt"
+    s"benchmarksZio/scalafmt benchmarksCe/scalafmt benchmarksOx/scalafmt benchmarksKyo$scala3NextSuffix/scalafmt"
 )
 addCommandAlias(
   "check",
   "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck " +
-    "benchmarksZio/scalafmtCheck benchmarksCe/scalafmtCheck benchmarksOx/scalafmtCheck benchmarksKyo3_8_3/scalafmtCheck"
+    s"benchmarksZio/scalafmtCheck benchmarksCe/scalafmtCheck benchmarksOx/scalafmtCheck benchmarksKyo$scala3NextSuffix/scalafmtCheck"
 )
 
 addCommandAlias(
   "testUnit",
-  "all core/test clientZio/test clientCe/test clientOx/test clientKyo3_8_3/test " +
+  s"all core/test clientZio/test clientCe/test clientOx/test clientKyo$scala3NextSuffix/test " +
     "clientFuture/Test/compile integrationTestsFuture/Test/compile " +
-    "benchmarksZio/compile benchmarksCe/compile benchmarksOx/compile benchmarksKyo3_8_3/compile " +
+    s"benchmarksZio/compile benchmarksCe/compile benchmarksOx/compile benchmarksKyo$scala3NextSuffix/compile " +
     "examplesZio/Compile/compile examplesCe/Compile/compile examplesOx/Compile/compile " +
-    "examplesKyo3_8_3/Compile/compile examplesFuture/Compile/compile"
+    s"examplesKyo$scala3NextSuffix/Compile/compile examplesFuture/Compile/compile"
 )
 addCommandAlias("itZio", "integrationTestsZio/test")
 addCommandAlias("itCe", "integrationTestsCe/test")
 addCommandAlias("itOx", "integrationTestsOx/test")
-addCommandAlias("itKyo", "integrationTestsKyo3_8_3/test")
+addCommandAlias("itKyo", s"integrationTestsKyo$scala3NextSuffix/test")
 
 lazy val root = project
   .in(file("."))
@@ -178,7 +179,7 @@ addCommandAlias(
   ";benchmarksZio/Jmh/run -rf json -rff benchmarks/results/zio.json " +
     ";benchmarksCe/Jmh/run -rf json -rff benchmarks/results/ce.json " +
     ";benchmarksOx/Jmh/run -rf json -rff benchmarks/results/ox.json " +
-    ";benchmarksKyo3_8_3/Jmh/run -rf json -rff benchmarks/results/kyo.json"
+    s";benchmarksKyo$scala3NextSuffix/Jmh/run -rf json -rff benchmarks/results/kyo.json"
 )
 
 lazy val commonSettings = Def.settings(

--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,8 @@ addCommandAlias("itCe", "integrationTestsCe/test")
 addCommandAlias("itOx", "integrationTestsOx/test")
 addCommandAlias("itKyo", s"integrationTestsKyo$scala3NextSuffix/test")
 
+addCommandAlias("exampleKyo", s"examplesKyo$scala3NextSuffix/run")
+
 addCommandAlias(
   "docAll",
   s"all core/doc clientZio/doc clientCe/doc clientOx/doc clientKyo$scala3NextSuffix/doc"

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,7 +33,7 @@ Then run a tour:
 sbt examplesZio/run
 sbt examplesCe/run
 sbt examplesOx/run
-sbt examplesKyo3_8_3/run
+sbt exampleKyo
 ```
 
 ## Spotlights

--- a/examples/kyo/src/main/scala/sage/examples/kyo/Tour.scala
+++ b/examples/kyo/src/main/scala/sage/examples/kyo/Tour.scala
@@ -7,7 +7,7 @@ import sage.backend.*
 
 /**
   * Runnable Kyo tour. The client is opened with `scoped` and its `Scope` discharged with `Scope.run`, the idiomatic Kyo construction form,
-  * then shared across every snippet. Start a server on localhost:6379 first (see examples/README.md), then `sbt examplesKyo3_8_3/run`.
+  * then shared across every snippet. Start a server on localhost:6379 first (see examples/README.md), then `sbt exampleKyo`.
   */
 object Tour extends KyoApp {
 


### PR DESCRIPTION
Supersedes #129, which only bumped the version and left the Kyo cross-project IDs stale, breaking the `lint`, `unit`, `docs`, and `integration (Kyo)` CI jobs.

## What

- Bump `scala3NextVersion` from 3.8.3 to 3.8.4.
- Derive the Kyo project-id suffix from the version (`scala3NextSuffix = scala3NextVersion.replace('.', '_')`) instead of hardcoding `3_8_3` in the `fmt`, `check`, `testUnit`, `itKyo`, and `benchAll` command aliases.

## Why

The Kyo cells are cross-built per Scala-Next version, so their project IDs embed the version (`clientKyo3_8_4`, `integrationTestsKyo3_8_4`, etc.). A version bump renames those projects, but the aliases referenced the old `3_8_3` names, so every alias resolved to a nonexistent project and failed with sbt `usage:` errors. Sourcing the suffix from the version keeps the value in one place, so future 3.8.x bumps no longer need manual alias edits.

## Verification

Run locally against Scala 3.8.4:

- `check` (lint): pass
- `testUnit`: 127 tests, 0 failed
- `integrationTestsKyo3_8_4/Test/compile`: pass