### PR TITLE
Add a Pekko/Future backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Build API docs (no Scaladoc warnings)
         run: |
           set -o pipefail
-          sbt -batch core/doc clientZio/doc clientCe/doc clientOx/doc clientKyo3_8_3/doc 2>&1 | tee doc.log
+          sbt -batch core/doc clientZio/doc clientCe/doc clientOx/doc clientPekko/doc clientKyo3_8_3/doc 2>&1 | tee doc.log
           if grep -E "Couldn't resolve|-- (\[E\] )?(Warning|Error)" doc.log; then
             echo "::error::Scaladoc emitted warnings; see the log above"
             exit 1
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        backend: [Zio, Ce, Ox, Kyo]
+        backend: [Zio, Ce, Ox, Pekko, Kyo]
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Sage** is a **Redis & Valkey client for Scala 3**: one client for any effect system, built on a from-scratch native Redis protocol implementation.
 
-**Use any effect system.** First-class [ZIO](https://zio.dev), [Cats Effect](https://typelevel.org/cats-effect/), [Kyo](https://getkyo.io), and [Ox](https://ox.softwaremill.com) artifacts, each with its ecosystem's native types and no wrapper visible.
+**Use any effect system.** First-class [ZIO](https://zio.dev), [Cats Effect](https://typelevel.org/cats-effect/), [Kyo](https://getkyo.io), [Ox](https://ox.softwaremill.com), and [Pekko](https://pekko.apache.org) artifacts, each with its ecosystem's native types and no wrapper visible.
 
 **Fast, native Redis protocol.** RESP3, commands, and codecs implemented directly in Scala 3, with no Java client wrapped underneath and fast by design.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,7 +17,7 @@ Allocation profile: add `-prof gc` to any run (see below).
 
 ## Clients
 
-One JVM per backend (the four sage backends are cross-compiled from the same `sage.*` sources and collide on a classpath; kyo is on a
+One JVM per backend (the sage backends are cross-compiled from the same `sage.*` sources and collide on a classpath; kyo is on a
 different Scala version), so the harness is one `projectMatrix` cell per backend. Competitors live in the cell whose ecosystem they target:
 
 | `client` param | Cell | Notes |
@@ -26,6 +26,7 @@ different Scala version), so the harness is one `projectMatrix` cell per backend
 | `sage-ce` / `redis4cats` | `benchmarksCe` | redis4cats wraps Lettuce. |
 | `sage-ox` / `lettuce` | `benchmarksOx` | `lettuce` is the async/auto-pipelined Lettuce client — the JVM ceiling. |
 | `sage-kyo` | `benchmarksKyo3_8_3` | no native Kyo competitor exists. |
+| `sage-pekko` | `benchmarksPekko` | no native Pekko (Future) competitor exists. |
 
 Dropped after review: Jedis (sync Java), laserdisc (Scala 2.13 + RESP2), rediculous (RESP2, dormant) — none are Scala-3 + RESP3 peers.
 

--- a/benchmarks/pekko/src/main/scala/sage/benchmarks/Clients.scala
+++ b/benchmarks/pekko/src/main/scala/sage/benchmarks/Clients.scala
@@ -27,7 +27,7 @@ final class SagePekkoBench(host: String, port: Int) extends BenchClient {
   private given ExecutionContext             = system.executionContext
 
   private val client: SageClient =
-    Await.result(SageClient.connectUnmanaged(SageConfig(topology = Topology.Standalone(Endpoint(host, port)))), 30.seconds)
+    Await.result(SageClient.connect(SageConfig(topology = Topology.Standalone(Endpoint(host, port)))), 30.seconds)
 
   // bounds in-flight commands by running each item of a group sequentially while groups run in parallel
   private def seqTraverse[A, B](as: List[A])(f: A => Future[B]): Future[List[B]] =

--- a/benchmarks/pekko/src/main/scala/sage/benchmarks/Clients.scala
+++ b/benchmarks/pekko/src/main/scala/sage/benchmarks/Clients.scala
@@ -1,0 +1,77 @@
+package sage.benchmarks
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration.*
+
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+
+import sage.*
+import sage.backend.*
+import sage.client.{Endpoint, SageConfig, Topology}
+
+/**
+  * The Pekko cell's benchmark clients: sage only. There is no Pekko-based Redis client to use as a competitor baseline, so this cell measures
+  * the sage Future surface on its own, the same way the Kyo cell does.
+  */
+object Clients {
+  def build(host: String, port: Int, name: String): BenchClient = name match {
+    case "sage-pekko" => new SagePekkoBench(host, port)
+    case other        => throw new IllegalArgumentException(s"unknown client: $other")
+  }
+}
+
+final class SagePekkoBench(host: String, port: Int) extends BenchClient {
+
+  private given system: ActorSystem[Nothing] = ActorSystem(Behaviors.empty, "sage-bench")
+  private given ExecutionContext             = system.executionContext
+
+  private val client: SageClient =
+    Await.result(SageClient.connectUnmanaged(SageConfig(topology = Topology.Standalone(Endpoint(host, port)))), 30.seconds)
+
+  // bounds in-flight commands by running each item of a group sequentially while groups run in parallel
+  private def seqTraverse[A, B](as: List[A])(f: A => Future[B]): Future[List[B]] =
+    as.foldLeft(Future.successful(List.empty[B]))((accF, a) => accF.flatMap(acc => f(a).map(_ :: acc))).map(_.reverse)
+
+  private def seqRun[A](as: List[A])(f: A => Future[Any]): Future[Unit] =
+    as.foldLeft(Future.unit)((accF, a) => accF.flatMap(_ => f(a).map(_ => ())))
+
+  def name: String = "sage-pekko"
+
+  def seed(prefix: String, count: Int, value: String, hashKey: String, fields: Int): Unit = {
+    val sets = seqRun((0 until count).toList)(i => client.set(s"$prefix:$i", value))
+    val hash = (0 until fields).map(i => (s"f$i", value)).toList match {
+      case h :: t => client.hSet(hashKey, h, t*).map(_ => ())
+      case Nil    => Future.unit
+    }
+    val _    = Await.result(sets.flatMap(_ => hash), 120.seconds)
+  }
+
+  def getAll(keys: Array[String], concurrency: Int): Long =
+    Await.result(
+      Future
+        .traverse(Payloads.groups(keys, concurrency).toList)(g => seqTraverse(g.toList)(client.get[String]))
+        .map(_.flatten.flatten.map(_.length.toLong).sum),
+      120.seconds
+    )
+
+  def setAll(keys: Array[String], value: String, concurrency: Int): Long =
+    Await.result(
+      Future
+        .traverse(Payloads.groups(keys, concurrency).toList)(g => seqRun(g.toList)(client.set(_, value)))
+        .map(_ => keys.length.toLong),
+      120.seconds
+    )
+
+  def mget(keys: Array[String]): Long =
+    Await.result(client.mGet[String](keys.head, keys.tail*).map(_.flatten.map(_.length.toLong).sum), 120.seconds)
+
+  def hgetall(key: String): Long =
+    Await.result(client.hGetAll[String, String](key).map(_.size.toLong), 120.seconds)
+
+  def close(): Unit = {
+    val _ = Await.result(client.close, 30.seconds)
+    system.terminate()
+    val _ = Await.ready(system.whenTerminated, 10.seconds)
+  }
+}

--- a/benchmarks/pekko/src/main/scala/sage/benchmarks/PekkoBenchmarks.scala
+++ b/benchmarks/pekko/src/main/scala/sage/benchmarks/PekkoBenchmarks.scala
@@ -1,0 +1,46 @@
+package sage.benchmarks
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations.*
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@OperationsPerInvocation(1000) // = Payloads.KeyCount
+@Fork(1)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 5, time = 3)
+class ThroughputBench extends RedisBenchState {
+
+  @Param(Array("sage-pekko")) var client: String            = "sage-pekko"
+  @Param(Array("1", "8", "64", "256")) var concurrency: Int = 1
+  @Param(Array("16", "1024")) var valueSize: Int            = 16
+
+  protected def subjectName: String                                             = client
+  override protected def seedValueBytes: Int                                    = valueSize
+  protected def buildClient(host: String, port: Int, name: String): BenchClient = Clients.build(host, port, name)
+
+  @Benchmark def get(): Long = subject.getAll(keys, concurrency)
+  @Benchmark def set(): Long = subject.setAll(keys, Payloads.value(valueSize), concurrency)
+}
+
+// a single big-reply command per invocation (no concurrency, that's the throughput workload); valueSize sizes the seeded values
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 5, time = 3)
+class CollectionBench extends RedisBenchState {
+
+  @Param(Array("sage-pekko")) var client: String = "sage-pekko"
+  @Param(Array("16")) var valueSize: Int         = 16
+
+  protected def subjectName: String                                             = client
+  override protected def seedValueBytes: Int                                    = valueSize
+  protected def buildClient(host: String, port: Int, name: String): BenchClient = Clients.build(host, port, name)
+
+  @Benchmark def mget(): Long    = subject.mget(keys)
+  @Benchmark def hgetall(): Long = subject.hgetall(Payloads.HashKey)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import _root_.io.getkyo.compat.CompatBackendAxis
 import sbt.VirtualAxis
 
 val scala3Version     = "3.3.8"
@@ -12,12 +13,17 @@ val zioVersion        = "2.1.26"
 val catsEffectVersion = "3.7.0"
 val fs2Version        = "3.13.0"
 val oxVersion         = "1.0.5"
+val pekkoVersion      = "1.6.0"
 
 // competitor baselines for the runtime benchmark harness (dev-only, never published) — see benchmarks/README.md
 val zioRedisVersion   = "1.2.1"
 val redis4catsVersion = "2.0.3"
 val lettuceVersion    = "7.6.0.RELEASE"
 val rediscalaVersion  = "2.1.0"
+
+// The Pekko backend rides the Future effect cell (kyo-compat-future) plus Pekko Streams. A distinct axis name keeps it separate from the
+// implicit Future anchor (which dedups by name); the nonexistent kyo-compat-pekko dep it makes the plugin inject is stripped in jvmSettings.
+val PekkoLib = CompatBackendAxis("pekko", "Pekko", "-pekko", Set("jvm"))
 
 inThisBuild(
   List(
@@ -37,25 +43,26 @@ name := "sage"
 addCommandAlias(
   "fmt",
   "all scalafmtSbt scalafmt test:scalafmt " +
-    "benchmarksZio/scalafmt benchmarksCe/scalafmt benchmarksOx/scalafmt benchmarksKyo3_8_3/scalafmt"
+    "benchmarksZio/scalafmt benchmarksCe/scalafmt benchmarksOx/scalafmt benchmarksPekko/scalafmt benchmarksKyo3_8_3/scalafmt"
 )
 addCommandAlias(
   "check",
   "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck " +
-    "benchmarksZio/scalafmtCheck benchmarksCe/scalafmtCheck benchmarksOx/scalafmtCheck benchmarksKyo3_8_3/scalafmtCheck"
+    "benchmarksZio/scalafmtCheck benchmarksCe/scalafmtCheck benchmarksOx/scalafmtCheck benchmarksPekko/scalafmtCheck benchmarksKyo3_8_3/scalafmtCheck"
 )
 
 addCommandAlias(
   "testUnit",
-  "all core/test clientZio/test clientCe/test clientOx/test clientKyo3_8_3/test " +
-    "clientFuture/Test/compile integrationTestsFuture/Test/compile " +
-    "benchmarksZio/compile benchmarksCe/compile benchmarksOx/compile benchmarksKyo3_8_3/compile " +
-    "examplesZio/Compile/compile examplesCe/Compile/compile examplesOx/Compile/compile " +
+  "all core/test clientZio/test clientCe/test clientOx/test clientPekko/test clientKyo3_8_3/test " +
+    "clientFuture/Test/compile integrationTestsFuture/Test/compile integrationTestsPekko/Test/compile " +
+    "benchmarksZio/compile benchmarksCe/compile benchmarksOx/compile benchmarksPekko/compile benchmarksKyo3_8_3/compile " +
+    "examplesZio/Compile/compile examplesCe/Compile/compile examplesOx/Compile/compile examplesPekko/Compile/compile " +
     "examplesKyo3_8_3/Compile/compile examplesFuture/Compile/compile"
 )
 addCommandAlias("itZio", "integrationTestsZio/test")
 addCommandAlias("itCe", "integrationTestsCe/test")
 addCommandAlias("itOx", "integrationTestsOx/test")
+addCommandAlias("itPekko", "integrationTestsPekko/test")
 addCommandAlias("itKyo", "integrationTestsKyo3_8_3/test")
 
 lazy val root = project
@@ -103,11 +110,18 @@ lazy val client = (projectMatrix in file("sage-client"))
       if (m.endsWith("-zio")) Seq("dev.zio" %% "zio" % zioVersion, "dev.zio" %% "zio-streams" % zioVersion)
       else if (m.endsWith("-ce")) Seq("org.typelevel" %% "cats-effect" % catsEffectVersion, "co.fs2" %% "fs2-core" % fs2Version)
       else if (m.endsWith("-ox")) Seq("com.softwaremill.ox" %% "core" % oxVersion)
+      else if (m.endsWith("-pekko"))
+        Seq(
+          "io.getkyo"        %% "kyo-compat-future" % kyoVersion,
+          "org.apache.pekko" %% "pekko-stream"      % pekkoVersion,
+          "org.apache.pekko" %% "pekko-actor-typed" % pekkoVersion
+        )
       else Seq.empty
     }
   )
   .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq(scala3NextVersion))
-  .compatLibrary(ZioLib, CeLib, OxLib)(VirtualAxis.jvm)(Seq(scala3Version))
+  .compatLibrary(ZioLib, CeLib, OxLib, PekkoLib)(VirtualAxis.jvm)(Seq(scala3Version))
+  .jvmSettings(stripBogusPekkoCompatDep)
 
 // the shared testcontainers suite runs once per backend cell, catching backend-specific lowering bugs against real servers;
 // command-behavior (sage.integration.commands), security (sage.integration.security), cluster (sage.integration.cluster), and master-replica
@@ -129,7 +143,8 @@ lazy val integrationTests = (projectMatrix in file("integration-tests"))
     }
   )
   .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq(scala3NextVersion))
-  .compatLibrary(ZioLib, CeLib, OxLib)(VirtualAxis.jvm)(Seq(scala3Version))
+  .compatLibrary(ZioLib, CeLib, OxLib, PekkoLib)(VirtualAxis.jvm)(Seq(scala3Version))
+  .jvmSettings(stripBogusPekkoCompatDep)
 
 // Runnable, never-published usage examples — one cell per backend so each compiles against its own native artifact (ZIO Task, Cats Effect
 // IO, Ox direct style, Kyo). Aggregated by root and compiled in CI via the testUnit alias; the forced future anchor cell carries no example
@@ -143,7 +158,8 @@ lazy val examples = (projectMatrix in file("examples"))
   // (e.g. Cats Effect's IOApp) that an example extends
   .settings(Compile / doc / sources := Seq.empty)
   .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq(scala3NextVersion))
-  .compatLibrary(ZioLib, CeLib, OxLib)(VirtualAxis.jvm)(Seq(scala3Version))
+  .compatLibrary(ZioLib, CeLib, OxLib, PekkoLib)(VirtualAxis.jvm)(Seq(scala3Version))
+  .jvmSettings(stripBogusPekkoCompatDep)
 
 // Runtime end-to-end benchmark harness (JMH), dev-only and never published. One cell per backend (the backends are cross-compiled from the
 // same sage.* sources and would collide on one classpath, so they cannot share a module). Competitor baselines are added per cell: zio-redis
@@ -168,7 +184,8 @@ lazy val benchmarks = (projectMatrix in file("benchmarks"))
     }
   )
   .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq(scala3NextVersion))
-  .compatLibrary(ZioLib, CeLib, OxLib)(VirtualAxis.jvm)(Seq(scala3Version))
+  .compatLibrary(ZioLib, CeLib, OxLib, PekkoLib)(VirtualAxis.jvm)(Seq(scala3Version))
+  .jvmSettings(stripBogusPekkoCompatDep)
 
 // the runtime benchmark harness: runs every backend cell's JMH suite against its own self-provisioned Redis (the future anchor cell is skipped),
 // each writing JMH JSON to benchmarks/results/<cell>.json. benchmarks/merge-results.sh merges them into one all.json covering every client
@@ -178,6 +195,7 @@ addCommandAlias(
   ";benchmarksZio/Jmh/run -rf json -rff benchmarks/results/zio.json " +
     ";benchmarksCe/Jmh/run -rf json -rff benchmarks/results/ce.json " +
     ";benchmarksOx/Jmh/run -rf json -rff benchmarks/results/ox.json " +
+    ";benchmarksPekko/Jmh/run -rf json -rff benchmarks/results/pekko.json " +
     ";benchmarksKyo3_8_3/Jmh/run -rf json -rff benchmarks/results/kyo.json"
 )
 
@@ -201,3 +219,7 @@ lazy val commonSettings = Def.settings(
 // only for container-free cells: integration suites each boot their own container, so running them in
 // parallel would multiply peak load and invite timing races
 lazy val parallelUnitTests = Def.settings(Test / testForkedParallel := true)
+
+// compatLibrary auto-injects a nonexistent kyo-compat-pekko for the custom axis; drop it (via jvmSettings, after the plugin's per-row settings).
+lazy val stripBogusPekkoCompatDep: Setting[?] =
+  libraryDependencies := libraryDependencies.value.filterNot(m => m.organization == "io.getkyo" && m.name.startsWith("kyo-compat-pekko"))

--- a/docs/client-side-caching.md
+++ b/docs/client-side-caching.md
@@ -13,7 +13,7 @@ val v1 = client.cached(Commands.get[String, String]("cached:key"), 1.minute)
 val v2 = client.cached(Commands.get[String, String]("cached:key"), 1.minute)
 ```
 
-```scala [ZIO · Cats Effect · Kyo]
+```scala [ZIO · Cats Effect · Kyo · Pekko]
 for {
   _  <- client.set("cached:key", "v1")
   v1 <- client.cached(Commands.get[String, String]("cached:key"), 1.minute)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,7 +16,7 @@ val greeting = client.get[String]("greeting")
 val same = client.run(Commands.get[String, String]("greeting"))
 ```
 
-```scala [ZIO · Cats Effect · Kyo]
+```scala [ZIO · Cats Effect · Kyo · Pekko]
 for {
   greeting <- client.get[String]("greeting")
   // the same command, built as a value and run explicitly

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,6 +1,6 @@
 # Error handling
 
-Every sage failure is a `SageException`, a single sealed hierarchy you can match exhaustively. How a failure reaches you depends on your backend: a failed ZIO `Task`, a raised Cats Effect `IO`, a Kyo `Abort[Throwable]`, or a thrown exception in Ox direct style. In every case the value is the same `SageException`.
+Every sage failure is a `SageException`, a single sealed hierarchy you can match exhaustively. How a failure reaches you depends on your backend: a failed ZIO `Task`, a raised Cats Effect `IO`, a Kyo `Abort[Throwable]`, a thrown exception in Ox direct style, or a failed `scala.concurrent.Future` on Pekko. In every case the value is the same `SageException`.
 
 ## The hierarchy
 
@@ -57,3 +57,4 @@ The same `SageException` is delivered through each ecosystem's normal failure ch
 - **Cats Effect**: a raised `IO`; recover with `handleErrorWith` / `recoverWith`.
 - **Kyo**: an `Abort[Throwable]`; handle with the `Abort` combinators.
 - **Ox**: thrown in direct style; handle with an ordinary `try`/`catch`.
+- **Pekko**: a failed `scala.concurrent.Future`; recover with `recover` / `recoverWith`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,6 +18,7 @@ One per effect system, all sharing the same runtime:
 - Cats Effect: `sage-client-ce`
 - Kyo: `sage-client-kyo`
 - Ox: `sage-client-ox`
+- Pekko: `sage-client-pekko`
 
 `sage-core` comes in transitively, so you depend on the backend artifact only. See [Getting started](/getting-started).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 **Sage** is a native [Redis](https://redis.io) and [Valkey](https://valkey.io) client for [Scala 3](https://www.scala-lang.org/). There is no Java client wrapped underneath: the RESP3 protocol, the commands, and the codecs are implemented directly in Scala, on a zero-dependency, effect-free core.
 
-That core is paired with a runtime written once and cross-published for [Ox](https://ox.softwaremill.com), [ZIO](https://zio.dev), [Cats Effect](https://typelevel.org/cats-effect/), and [Kyo](https://getkyo.io), so you use sage with your ecosystem's native types and no wrapper in sight. It targets RESP3 and modern Redis 8+ / Valkey 8+, runs on Scala 3.3.x LTS and later, and requires JDK 21+.
+That core is paired with a runtime written once and cross-published for [Ox](https://ox.softwaremill.com), [ZIO](https://zio.dev), [Cats Effect](https://typelevel.org/cats-effect/), [Kyo](https://getkyo.io), and [Apache Pekko](https://pekko.apache.org), so you use sage with your ecosystem's native types and no wrapper in sight. It targets RESP3 and modern Redis 8+ / Valkey 8+, runs on Scala 3.3.x LTS and later, and requires JDK 21+.
 
 ## Installation
 
@@ -26,13 +26,20 @@ Add the artifact for your effect system. The core is pulled in transitively, so 
 "com.github.ghostdogpr" %% "sage-client-kyo" % "@VERSION@"
 ```
 
+```scala [Pekko]
+"com.github.ghostdogpr" %% "sage-client-pekko" % "@VERSION@"
+// Pekko also needs Pekko Streams and the typed actor module; you provide the ActorSystem
+"org.apache.pekko" %% "pekko-stream" % "1.6.0"
+"org.apache.pekko" %% "pekko-actor-typed" % "1.6.0"
+```
+
 :::
 
 Two imports cover everything: `import sage.*` for the command vocabulary and connection config, and `import sage.backend.*` for the client. That second import is the same regardless of effect system; only the dependency you choose differs.
 
 ## Your first connection
 
-A `SageClient` owns all connections to one server or cluster. You build it from a `SageConfig` using your ecosystem's idiomatic construction form: a scoped resource for Ox and Kyo, a `ZLayer` for ZIO, and a `Resource` for Cats Effect. The command surface is identical across all four; only this wiring differs.
+A `SageClient` owns all connections to one server or cluster. You build it from a `SageConfig` using your ecosystem's idiomatic construction form: a scoped resource for Ox and Kyo, a `ZLayer` for ZIO, a `Resource` for Cats Effect, and a `Future` on Pekko that registers a `CoordinatedShutdown` task to close the client when your `ActorSystem` terminates. The command surface is identical across all five; only this wiring differs.
 
 ::: code-group
 
@@ -119,6 +126,35 @@ object Main extends KyoApp {
 }
 ```
 
+```scala [Pekko]
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import sage.*
+import sage.backend.*
+
+@main def main(): Unit = {
+  // you own the ActorSystem; the client closes when it terminates
+  given system: ActorSystem[Nothing] = ActorSystem(Behaviors.empty, "sage")
+  given ExecutionContext             = system.executionContext
+
+  val config = SageConfig(
+    topology = Topology.Standalone(Endpoint("localhost", 6379))
+  )
+
+  val done =
+    for {
+      client   <- SageClient.connect(config)
+      _        <- client.set("greeting", "hello")
+      greeting <- client.get[String]("greeting")
+    } yield println(s"greeting=$greeting") // Some("hello")
+
+  done.onComplete(_ => system.terminate())
+}
+```
+
 :::
 
 ::: tip How it works
@@ -129,7 +165,7 @@ Two cases step off that connection automatically. Commands that hold per-connect
 
 ## A short tour
 
-The snippets below show the same operations on each backend: pick your tab. In Ox they return values directly; in ZIO, Cats Effect, and Kyo they are steps in a for-comprehension over that ecosystem's effect type. Each assumes a `client` in scope and the usual imports for your effect type (plus `import scala.concurrent.duration.*` where a duration appears).
+The snippets below show the same operations on each backend: pick your tab. In Ox they return values directly; in ZIO, Cats Effect, Kyo, and Pekko they are steps in a for-comprehension over that ecosystem's effect type, where on Pekko that type is `scala.concurrent.Future` (each `for` needs an `ExecutionContext`, for example `system.executionContext`). Each assumes a `client` in scope and the usual imports for your effect type (plus `import scala.concurrent.duration.*` where a duration appears).
 
 ### Commands
 
@@ -150,7 +186,7 @@ client.set("user:ada", User("Ada", 36))
 val ada = client.get[User]("user:ada") // Some(User("Ada", 36))
 ```
 
-```scala [ZIO · Cats Effect · Kyo]
+```scala [ZIO · Cats Effect · Kyo · Pekko]
 for {
   _        <- client.set("greeting", "hello")
   greeting <- client.get[String]("greeting")
@@ -183,7 +219,7 @@ val tuple = client.pipeline(
 )
 ```
 
-```scala [ZIO · Cats Effect · Kyo]
+```scala [ZIO · Cats Effect · Kyo · Pekko]
 for {
   _     <- client.set("pipe:a", "x")
   _     <- client.set("pipe:n", 10)
@@ -213,7 +249,7 @@ val result = client.transaction { tx =>
 }
 ```
 
-```scala [ZIO · Cats Effect · Kyo]
+```scala [ZIO · Cats Effect · Kyo · Pekko]
 for {
   _      <- client.set("tx:n", 1)
   result <- client.transaction { tx =>
@@ -237,9 +273,9 @@ The distinction is covered in [Pipelines & transactions](/pipelines-transactions
 
 ### Pub/Sub
 
-Subscribing yields a stream of messages in your ecosystem's native stream type: an Ox `Flow`, a ZIO `ZStream`, an fs2 `Stream`, or a Kyo `Stream`. Ending the stream, or closing its scope, unsubscribes.
+Subscribing yields a stream of messages in your ecosystem's native stream type: an Ox `Flow`, a ZIO `ZStream`, an fs2 `Stream`, a Kyo `Stream`, or a Pekko Streams `Source`. Ending the stream, or closing its scope, unsubscribes.
 
-Because publishing here happens right after subscribing, these examples use the variant that returns only once the server has confirmed the subscription, so the publish can't outrun the registration: `subscribeScoped` on ZIO and Kyo, `subscribeResource` on Cats Effect, and plain `subscribe` on Ox (where the call is already synchronous). The plain stream-returning `subscribe` registers lazily on first pull and is the right choice for a long-lived consumer that isn't racing its own publisher.
+Because publishing here happens right after subscribing, these examples use the variant that returns only once the server has confirmed the subscription, so the publish can't outrun the registration: `subscribeScoped` on ZIO and Kyo, `subscribeResource` on Cats Effect, and plain `subscribe` on Ox (where the call is already synchronous). On Pekko, `subscribe` returns a `Source` whose materialized value is a `Future[Done]` that completes once the subscription is registered, so awaiting it before publishing closes the same gap on a standalone or master-replica server (in cluster mode that confirmation is best-effort, as on every backend). The plain stream-returning `subscribe` registers lazily on first pull and is the right choice for a long-lived consumer that isn't racing its own publisher.
 
 ::: code-group
 
@@ -282,6 +318,19 @@ for {
 } yield chunk.toList.map(_.payload)
 ```
 
+```scala [Pekko]
+// Keep.both keeps the confirmation Future[Done] and the collected messages;
+// await it before publishing so the publish can't outrun the registration (best-effort in cluster)
+val (confirmed, collected) =
+  client.subscribe[String]("news").take(3).toMat(Sink.seq)(Keep.both).run()
+val messages =
+  for {
+    _        <- confirmed
+    _        <- Future.traverse(1 to 3)(i => client.publish("news", s"item-$i"))
+    received <- collected
+  } yield received.map(_.payload).toList
+```
+
 :::
 
 Classic and sharded pub/sub are both covered in [Pub/Sub](/pubsub).
@@ -299,7 +348,7 @@ val v1 = client.cached(Commands.get[String, String]("cached:key"), 1.minute)
 val v2 = client.cached(Commands.get[String, String]("cached:key"), 1.minute)
 ```
 
-```scala [ZIO · Cats Effect · Kyo]
+```scala [ZIO · Cats Effect · Kyo · Pekko]
 for {
   _  <- client.set("cached:key", "v1")
   v1 <- client.cached(Commands.get[String, String]("cached:key"), 1.minute)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,7 @@ Two imports cover everything: `import sage.*` for the command vocabulary and con
 
 ## Your first connection
 
-A `SageClient` owns all connections to one server or cluster. You build it from a `SageConfig` using your ecosystem's idiomatic construction form: a scoped resource for Ox and Kyo, a `ZLayer` for ZIO, a `Resource` for Cats Effect, and a `Future` on Pekko that you close explicitly. The command surface is identical across all five; only this wiring differs.
+A `SageClient` owns all connections to one server or cluster. You build it from a `SageConfig` using your ecosystem's idiomatic construction form: a scoped resource for Ox and Kyo, a `ZLayer` for ZIO, a `Resource` for Cats Effect, and a `use` block on Pekko that closes the client when your program finishes. The command surface is identical across all five; only this wiring differs.
 
 ::: code-group
 
@@ -136,7 +136,6 @@ import sage.*
 import sage.backend.*
 
 @main def main(): Unit = {
-  // you own both the ActorSystem and the client lifecycle
   given system: ActorSystem[Nothing] = ActorSystem(Behaviors.empty, "sage")
   given ExecutionContext             = system.executionContext
 
@@ -145,13 +144,11 @@ import sage.backend.*
   )
 
   val done =
-    SageClient.connect(config).flatMap { client =>
-      val run =
-        for {
-          _        <- client.set("greeting", "hello")
-          greeting <- client.get[String]("greeting")
-        } yield println(s"greeting=$greeting") // Some("hello")
-      run.transformWith(result => client.close.transform(_ => result))
+    SageClient.use(config) { client =>
+      for {
+        _        <- client.set("greeting", "hello")
+        greeting <- client.get[String]("greeting")
+      } yield println(s"greeting=$greeting") // Some("hello")
     }
 
   done.onComplete(_ => system.terminate())

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,7 @@ Two imports cover everything: `import sage.*` for the command vocabulary and con
 
 ## Your first connection
 
-A `SageClient` owns all connections to one server or cluster. You build it from a `SageConfig` using your ecosystem's idiomatic construction form: a scoped resource for Ox and Kyo, a `ZLayer` for ZIO, a `Resource` for Cats Effect, and a `Future` on Pekko that registers a `CoordinatedShutdown` task to close the client when your `ActorSystem` terminates. The command surface is identical across all five; only this wiring differs.
+A `SageClient` owns all connections to one server or cluster. You build it from a `SageConfig` using your ecosystem's idiomatic construction form: a scoped resource for Ox and Kyo, a `ZLayer` for ZIO, a `Resource` for Cats Effect, and a `Future` on Pekko that you close explicitly. The command surface is identical across all five; only this wiring differs.
 
 ::: code-group
 
@@ -136,7 +136,7 @@ import sage.*
 import sage.backend.*
 
 @main def main(): Unit = {
-  // you own the ActorSystem; the client closes when it terminates
+  // you own both the ActorSystem and the client lifecycle
   given system: ActorSystem[Nothing] = ActorSystem(Behaviors.empty, "sage")
   given ExecutionContext             = system.executionContext
 
@@ -145,11 +145,14 @@ import sage.backend.*
   )
 
   val done =
-    for {
-      client   <- SageClient.connect(config)
-      _        <- client.set("greeting", "hello")
-      greeting <- client.get[String]("greeting")
-    } yield println(s"greeting=$greeting") // Some("hello")
+    SageClient.connect(config).flatMap { client =>
+      val run =
+        for {
+          _        <- client.set("greeting", "hello")
+          greeting <- client.get[String]("greeting")
+        } yield println(s"greeting=$greeting") // Some("hello")
+      run.transformWith(result => client.close.transform(_ => result))
+    }
 
   done.onComplete(_ => system.terminate())
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,9 +28,6 @@ Add the artifact for your effect system. The core is pulled in transitively, so 
 
 ```scala [Pekko]
 "com.github.ghostdogpr" %% "sage-client-pekko" % "@VERSION@"
-// Pekko also needs Pekko Streams and the typed actor module; you provide the ActorSystem
-"org.apache.pekko" %% "pekko-stream" % "1.6.0"
-"org.apache.pekko" %% "pekko-actor-typed" % "1.6.0"
 ```
 
 :::

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ hero:
 
 features:
   - title: Use any effect system
-    details: First-class ZIO, Cats Effect, Kyo, and Ox artifacts, each with its ecosystem's native types and no wrapper visible.
+    details: First-class ZIO, Cats Effect, Kyo, Ox, and Pekko artifacts, each with its ecosystem's native types and no wrapper visible.
   - title: Fast, native Redis protocol
     details: RESP3, commands, and codecs implemented directly in Scala 3, with no Java client wrapped underneath and fast by design.
   - title: Modern and feature-rich

--- a/docs/pipelines-transactions.md
+++ b/docs/pipelines-transactions.md
@@ -20,7 +20,7 @@ val tuple = client.pipeline(
 // tuple: (Option[String], Long)
 ```
 
-```scala [ZIO · Cats Effect · Kyo]
+```scala [ZIO · Cats Effect · Kyo · Pekko]
 for {
   _     <- client.set("pipe:a", "x")
   _     <- client.set("pipe:n", 10)
@@ -58,7 +58,7 @@ val attempt = client.pipelineAttempt(
 )
 ```
 
-```scala [ZIO · Cats Effect · Kyo]
+```scala [ZIO · Cats Effect · Kyo · Pekko]
 for {
   _       <- client.set("pipe:str", "hello")
   // INCR on a non-numeric string fails only at its own position;
@@ -94,7 +94,7 @@ val result = client.transaction { tx =>
 // result: Some((2, 6)), or None if "tx:n" changed before EXEC
 ```
 
-```scala [ZIO · Cats Effect · Kyo]
+```scala [ZIO · Cats Effect · Kyo · Pekko]
 for {
   _      <- client.set("tx:n", 1)
   result <- client.transaction { tx =>

--- a/docs/pubsub.md
+++ b/docs/pubsub.md
@@ -1,6 +1,6 @@
 # Pub/Sub
 
-Subscribing yields a stream of messages in your ecosystem's native stream type: an Ox `Flow`, a ZIO `ZStream`, an fs2 `Stream`, or a Kyo `Stream`. Each message carries the channel it arrived on and a payload decoded with a `ValueCodec`. Ending the stream, or closing its scope, unsubscribes.
+Subscribing yields a stream of messages in your ecosystem's native stream type: an Ox `Flow`, a ZIO `ZStream`, an fs2 `Stream`, a Kyo `Stream`, or a Pekko Streams `Source`. Each message carries the channel it arrived on and a payload decoded with a `ValueCodec`. Ending the stream, or closing its scope, unsubscribes.
 
 ## Classic channels
 
@@ -47,12 +47,25 @@ for {
 } yield chunk.toList.map(_.payload)
 ```
 
+```scala [Pekko]
+// Keep.both keeps the confirmation Future[Done] alongside the collected messages;
+// await it before publishing so the publish can't outrun the registration (best-effort in cluster)
+val (confirmed, collected) =
+  client.subscribe[String]("news").take(3).toMat(Sink.seq)(Keep.both).run()
+val messages =
+  for {
+    _        <- confirmed
+    _        <- Future.traverse(1 to 3)(i => client.publish("news", s"item-$i"))
+    received <- collected
+  } yield received.map(_.payload).toList
+```
+
 :::
 
 Pattern subscriptions are also available; they deliver a **pattern message** that additionally names the glob that matched.
 
 ::: tip Confirmed subscriptions
-The plain `subscribe` returns the stream immediately and registers the subscription lazily, on the first pull. That is fine for a long-lived consumer, but a `publish` sequenced right after it can outrun the registration and be missed. To close that gap, the effectful backends expose a variant that returns only once the server has confirmed the SUBSCRIBE: `subscribeScoped` / `pSubscribeScoped` / `sSubscribeScoped` on ZIO (a `ZIO[Scope, _, _]`) and Kyo, and `subscribeResource` / `pSubscribeResource` / `sSubscribeResource` on Cats Effect (a `Resource`). On Ox the plain `subscribe` is already this: the call is synchronous and returns once confirmed. The examples above use these so the publisher can't race the subscriber. With these variants the `Scope` or `Resource` owns the unsubscribe, so the subscription outlives the stream's completion and is released only when that scope closes.
+The plain `subscribe` returns the stream immediately and registers the subscription lazily, on the first pull. That is fine for a long-lived consumer, but a `publish` sequenced right after it can outrun the registration and be missed. To close that gap, the effectful backends expose a variant that returns only once the server has confirmed the SUBSCRIBE: `subscribeScoped` / `pSubscribeScoped` / `sSubscribeScoped` on ZIO (a `ZIO[Scope, _, _]`) and Kyo, and `subscribeResource` / `pSubscribeResource` / `sSubscribeResource` on Cats Effect (a `Resource`). On Ox the plain `subscribe` is already this: the call is synchronous and returns once confirmed. On Pekko, `subscribe` / `pSubscribe` / `sSubscribe` return a `Source[Message[V], Future[Done]]` whose materialized `Future[Done]` completes once the subscription is registered, so awaiting that value before publishing closes the same gap on a standalone or master-replica server (in cluster mode that confirmation is best-effort, as on every backend). The examples above use these so the publisher does not race the subscriber on a standalone or master-replica server. With the scoped variants the `Scope` or `Resource` owns the unsubscribe, so the subscription outlives the stream's completion and is released only when that scope closes; on Pekko, cancelling, completing, or failing the `Source` unsubscribes.
 :::
 
 ::: tip Connection isolation

--- a/docs/pubsub.md
+++ b/docs/pubsub.md
@@ -65,7 +65,14 @@ val messages =
 Pattern subscriptions are also available; they deliver a **pattern message** that additionally names the glob that matched.
 
 ::: tip Confirmed subscriptions
-The plain `subscribe` returns the stream immediately and registers the subscription lazily, on the first pull. That is fine for a long-lived consumer, but a `publish` sequenced right after it can outrun the registration and be missed. To close that gap, the effectful backends expose a variant that returns only once the server has confirmed the SUBSCRIBE: `subscribeScoped` / `pSubscribeScoped` / `sSubscribeScoped` on ZIO (a `ZIO[Scope, _, _]`) and Kyo, and `subscribeResource` / `pSubscribeResource` / `sSubscribeResource` on Cats Effect (a `Resource`). On Ox the plain `subscribe` is already this: the call is synchronous and returns once confirmed. On Pekko, `subscribe` / `pSubscribe` / `sSubscribe` return a `Source[Message[V], Future[Done]]` whose materialized `Future[Done]` completes once the subscription is registered, so awaiting that value before publishing closes the same gap on a standalone or master-replica server (in cluster mode that confirmation is best-effort, as on every backend). The examples above use these so the publisher does not race the subscriber on a standalone or master-replica server. With the scoped variants the `Scope` or `Resource` owns the unsubscribe, so the subscription outlives the stream's completion and is released only when that scope closes; on Pekko, cancelling, completing, or failing the `Source` unsubscribes.
+The plain `subscribe` returns the stream immediately and registers the subscription on the first pull, so a `publish` sequenced right after it can outrun the registration and be missed. Each backend has a way to wait for the server's SUBSCRIBE confirmation first (also in `p`/`s` forms):
+
+- **ZIO / Kyo**: `subscribeScoped`, a scoped effect.
+- **Cats Effect**: `subscribeResource`, a `Resource`.
+- **Ox**: plain `subscribe` already blocks until confirmed.
+- **Pekko**: plain `subscribe` returns a `Source` whose materialized `Future[Done]` completes once registered; await it before publishing.
+
+The examples above use these. Confirmation closes the race on a standalone or master-replica server; in cluster mode it is best-effort, as on every backend. With the scoped and resource variants that scope owns the unsubscribe, so the subscription outlives the stream and is released when the scope closes; on Pekko, ending the `Source` (cancel, complete, or fail) unsubscribes.
 :::
 
 ::: tip Connection isolation

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -108,7 +108,7 @@ client.xConsume[String, String, String]("workers", "w1", "stream:orders") {
 ```scala [Pekko]
 // a Future has no interruption, so the loop is returned as a RunningConsumer:
 // the handler returns Future[Unit], and you call stop() to halt it and await completion
-val consumer = client.xConsume[String, String, String]("workers", "w1", "stream:orders") {
+val consumer = client.xConsume[String, String]("workers", "w1", "stream:orders") {
   entry => Future(println(s"got ${entry.id}: ${entry.fields}"))
 }
 // later: consumer.stop() // Future[Done], resolves once the loop has drained

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -72,7 +72,7 @@ Each command position that admits a special ID token carries its own type, so an
 
 ## Tailing a group
 
-For a long-running worker, `xConsume` tails a group as a stream in your ecosystem's native type. It first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new entries. Your handler runs per entry, and the entry is acknowledged only after the handler succeeds, so a failure leaves it in the PEL for another attempt. On Pekko, where a `Future` cannot be cancelled, the loop runs in the background and `xConsume` hands back a `RunningConsumer`: call `stop()` to halt it between entries and await its `completion`.
+For a long-running worker, `xConsume` tails a group as a stream in your ecosystem's native type. It first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new entries. Your handler runs per entry, and the entry is acknowledged only after the handler succeeds, so a failure leaves it in the PEL for another attempt. On Pekko, where a `Future` cannot be cancelled, the loop runs in the background and `xConsume` hands back a `RunningConsumer`: call `stop()` to halt it between entries and await its `completion`. Pekko tailing helpers require a finite block timeout; the default bounded poll keeps stop/cancel responsive.
 
 ::: tip At-least-once delivery
 Because an entry is acknowledged only after the handler succeeds, the same entry can be delivered again after a crash or a failed handler. Make your handler idempotent. `xConsume` also blocks while tailing, so it is the body of a long-running worker, not a one-shot read.

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -17,7 +17,7 @@ val entries = client.xRange[String, String]("stream:orders")
 // Vector(StreamEntry(id, Vector(("item","book"), ("qty","2"))), ...)
 ```
 
-```scala [ZIO · Cats Effect · Kyo]
+```scala [ZIO · Cats Effect · Kyo · Pekko]
 for {
   _       <- client.del("stream:orders")
   _       <- client.xAdd("stream:orders")(("item", "book"), ("qty", "2"))
@@ -51,7 +51,7 @@ val ids = batches.flatMap(_._2).map(_.id)
 client.xAck("stream:orders", "workers")(ids.head, ids.tail*)
 ```
 
-```scala [ZIO · Cats Effect · Kyo]
+```scala [ZIO · Cats Effect · Kyo · Pekko]
 for {
   _       <- client.xGroupCreate(
                "stream:orders",
@@ -72,7 +72,7 @@ Each command position that admits a special ID token carries its own type, so an
 
 ## Tailing a group
 
-For a long-running worker, `xConsume` tails a group as a stream in your ecosystem's native type. It first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new entries. Your handler runs per entry, and the entry is acknowledged only after the handler succeeds, so a failure leaves it in the PEL for another attempt.
+For a long-running worker, `xConsume` tails a group as a stream in your ecosystem's native type. It first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new entries. Your handler runs per entry, and the entry is acknowledged only after the handler succeeds, so a failure leaves it in the PEL for another attempt. On Pekko, where a `Future` cannot be cancelled, the loop runs in the background and `xConsume` hands back a `RunningConsumer`: call `stop()` to halt it between entries and await its `completion`.
 
 ::: tip At-least-once delivery
 Because an entry is acknowledged only after the handler succeeds, the same entry can be delivered again after a crash or a failed handler. Make your handler idempotent. `xConsume` also blocks while tailing, so it is the body of a long-running worker, not a one-shot read.
@@ -103,6 +103,15 @@ client.xConsume[String, String, String]("workers", "w1", "stream:orders") {
 client.xConsume[String, String, String]("workers", "w1", "stream:orders") {
   entry => Console.printLine(s"got ${entry.id}: ${entry.fields}")
 }
+```
+
+```scala [Pekko]
+// a Future has no interruption, so the loop is returned as a RunningConsumer:
+// the handler returns Future[Unit], and you call stop() to halt it and await completion
+val consumer = client.xConsume[String, String, String]("workers", "w1", "stream:orders") {
+  entry => Future(println(s"got ${entry.id}: ${entry.fields}"))
+}
+// later: consumer.stop() // Future[Done], resolves once the loop has drained
 ```
 
 :::

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,8 @@
 # Examples
 
-Runnable, idiomatic sage usage from each backend. Every example uses its ecosystem's native types — ZIO `Task`, Cats Effect `IO`, Ox direct
-style, Kyo computations — with no wrapper visible. The module is never published and is compiled in CI as part of the normal build.
+Runnable, idiomatic sage usage from each backend. Every example uses its ecosystem's native types: ZIO `Task`, Cats Effect `IO`, Ox direct
+style, Kyo computations, Pekko `Future` plus Pekko Streams, with no wrapper visible. The module is never published and is compiled in CI as
+part of the normal build.
 
 Two imports cover everything: `import sage.*` for the command vocabulary and connection config, and `import sage.<backend>.*` for the client.
 
@@ -13,10 +14,11 @@ zio/      …Example.scala + Tour   the ZIO tour, plus the cluster + sharded pub
 ce/       …Example.scala + Tour   the Cats Effect tour, plus the TLS/ACL spotlight
 ox/       …Example.scala + Tour   the Ox tour, plus the master-replica + ReadFrom spotlight
 kyo/      …Example.scala + Tour   the Kyo tour
+pekko/    …Example.scala + Tour   the Pekko tour (scala.concurrent.Future + Pekko Streams)
 ```
 
 Each backend's `Tour` is a runnable entry point that wires the client with that ecosystem's idiomatic construction form (ZIO `layer`,
-Cats Effect `resource`, Ox/Kyo `scoped`) and runs the common feature set: commands across several families, a Pipeline, a WATCH-guarded
+Cats Effect `resource`, Ox/Kyo `scoped`, Pekko `connect` with a user-provided typed `ActorSystem`) and runs the common feature set: commands across several families, a Pipeline, a WATCH-guarded
 transaction, classic pub/sub, and a cached read. The `…Example` objects are the individual copy-pasteable snippets the tour stitches together.
 
 ## Running the tours
@@ -34,6 +36,7 @@ sbt examplesZio/run
 sbt examplesCe/run
 sbt examplesOx/run
 sbt examplesKyo3_8_3/run
+sbt examplesPekko/run
 ```
 
 ## Spotlights

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ pekko/    …Example.scala + Tour   the Pekko tour (scala.concurrent.Future + Pe
 ```
 
 Each backend's `Tour` is a runnable entry point that wires the client with that ecosystem's idiomatic construction form (ZIO `layer`,
-Cats Effect `resource`, Ox/Kyo `scoped`, Pekko `connect` with a user-provided typed `ActorSystem`) and runs the common feature set: commands across several families, a Pipeline, a WATCH-guarded
+Cats Effect `resource`, Ox/Kyo `scoped`, Pekko `connect` with an explicit `close` and a user-provided typed `ActorSystem`) and runs the common feature set: commands across several families, a Pipeline, a WATCH-guarded
 transaction, classic pub/sub, and a cached read. The `…Example` objects are the individual copy-pasteable snippets the tour stitches together.
 
 ## Running the tours

--- a/examples/pekko/src/main/scala/sage/examples/pekko/CachedReadsExample.scala
+++ b/examples/pekko/src/main/scala/sage/examples/pekko/CachedReadsExample.scala
@@ -1,0 +1,22 @@
+package sage.examples.pekko
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.*
+
+import sage.*
+import sage.backend.*
+
+/**
+  * A Cached Read opts in to client-side caching per call: the first read fetches and caches, the second is served from the local cache until
+  * a server invalidation push or the TTL evicts it.
+  */
+object CachedReadsExample {
+
+  def run(client: SageClient)(using ExecutionContext): Future[Unit] =
+    for {
+      _      <- client.set("cached:key", "v1")
+      first  <- client.cached(Commands.get[String, String]("cached:key"), 1.minute) // fetch + cache
+      second <- client.cached(Commands.get[String, String]("cached:key"), 1.minute) // local hit
+    } yield println(s"first=$first second=$second")
+}

--- a/examples/pekko/src/main/scala/sage/examples/pekko/CommandsExample.scala
+++ b/examples/pekko/src/main/scala/sage/examples/pekko/CommandsExample.scala
@@ -1,0 +1,38 @@
+package sage.examples.pekko
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.*
+
+import sage.*
+import sage.backend.*
+import sage.examples.User
+
+/**
+  * Commands across several families, each returning a `scala.concurrent.Future`.
+  */
+object CommandsExample {
+
+  def run(client: SageClient)(using ExecutionContext): Future[Unit] =
+    for {
+      // strings, numbers, and a conditional write with a TTL
+      _        <- client.set("greeting", "hello")
+      greeting <- client.get[String]("greeting")
+      _        <- client.incrBy("counter", 10)
+      _        <- client.set("session", "token", expiry = SetExpiry.In(1.minute), condition = SetCondition.IfNotExists)
+      // hashes
+      _        <- client.hSet("user:1", ("name", "Ada"), ("age", "36"))
+      profile  <- client.hGetAll[String, String]("user:1")
+      // lists: a blocking pop off a Dedicated Connection (data is pushed first, so it returns at once)
+      _        <- client.rPush("queue", "a", "b", "c")
+      head     <- client.blPop[String]("queue")(BlockTimeout.Forever)
+      // sets and sorted sets
+      _        <- client.sAdd("tags", "scala", "redis")
+      _        <- client.zAdd("scores")(("ada", 36.0))
+      // a custom-codec round-trip: User rides on the given ValueCodec from the shared module
+      _        <- client.set("user:ada", User("Ada", 36))
+      ada      <- client.get[User]("user:ada")
+      // a raw Lua eval yields a Frame; decode it with the strict helpers
+      sum      <- client.eval("return 1 + 1")
+    } yield println(s"greeting=$greeting profile=$profile head=$head ada=$ada sum=${sum.asLong}")
+}

--- a/examples/pekko/src/main/scala/sage/examples/pekko/PipelinesExample.scala
+++ b/examples/pekko/src/main/scala/sage/examples/pekko/PipelinesExample.scala
@@ -1,0 +1,24 @@
+package sage.examples.pekko
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import sage.*
+import sage.backend.*
+
+/**
+  * A Pipeline is an applicative composition of Commands sent in one round-trip, yielding a typed tuple. `pipelineAttempt` keeps each
+  * position's failure separate instead of failing the whole call.
+  */
+object PipelinesExample {
+
+  def run(client: SageClient)(using ExecutionContext): Future[Unit] =
+    for {
+      _       <- client.set("pipe:a", "x")
+      _       <- client.set("pipe:n", 10)
+      tuple   <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy("pipe:n", 5)))
+      _       <- client.set("pipe:str", "hello")
+      // INCR on a non-numeric string fails only at its own position; the GET still succeeds
+      attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr("pipe:str")))
+    } yield println(s"tuple=$tuple attempt=$attempt")
+}

--- a/examples/pekko/src/main/scala/sage/examples/pekko/PubSubExample.scala
+++ b/examples/pekko/src/main/scala/sage/examples/pekko/PubSubExample.scala
@@ -1,0 +1,30 @@
+package sage.examples.pekko
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{Keep, Sink}
+
+import sage.*
+import sage.backend.*
+
+/**
+  * Classic channel pub/sub surfaced as a native Pekko Streams `Source`. The materialized `Future[Done]` resolves once the SUBSCRIBE is
+  * confirmed, so the publishes below cannot race the registration; cancelling the stream (here, after `take(3)`) unsubscribes. Sharded
+  * pub/sub is shown in the cluster spotlight, where it belongs.
+  */
+object PubSubExample {
+
+  def run(client: SageClient)(using system: ActorSystem[?], ec: ExecutionContext): Future[Unit] = {
+    given Materializer        = Materializer(system)
+    val (confirmed, received) =
+      client.subscribe[String]("news").take(3).toMat(Sink.seq)(Keep.both).run()
+    for {
+      _        <- confirmed
+      _        <- Future.traverse(1 to 3)(i => client.publish("news", s"item-$i"))
+      messages <- received
+    } yield println(s"received=${messages.map(_.payload).toList}")
+  }
+}

--- a/examples/pekko/src/main/scala/sage/examples/pekko/PubSubExample.scala
+++ b/examples/pekko/src/main/scala/sage/examples/pekko/PubSubExample.scala
@@ -4,7 +4,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import org.apache.pekko.actor.typed.ActorSystem
-import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.{Materializer, SystemMaterializer}
 import org.apache.pekko.stream.scaladsl.{Keep, Sink}
 
 import sage.*
@@ -18,7 +18,7 @@ import sage.backend.*
 object PubSubExample {
 
   def run(client: SageClient)(using system: ActorSystem[?], ec: ExecutionContext): Future[Unit] = {
-    given Materializer        = Materializer(system)
+    given Materializer        = SystemMaterializer(system).materializer
     val (confirmed, received) =
       client.subscribe[String]("news").take(3).toMat(Sink.seq)(Keep.both).run()
     for {

--- a/examples/pekko/src/main/scala/sage/examples/pekko/StreamsExample.scala
+++ b/examples/pekko/src/main/scala/sage/examples/pekko/StreamsExample.scala
@@ -1,0 +1,28 @@
+package sage.examples.pekko
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import sage.*
+import sage.backend.*
+
+/**
+  * Redis Streams: append entries, read them back by range, then consume them through a Consumer Group with explicit acknowledgement. The
+  * stream is reset first so the example is deterministic on re-run.
+  */
+object StreamsExample {
+
+  def run(client: SageClient)(using ExecutionContext): Future[Unit] =
+    for {
+      _       <- client.del("stream:orders")
+      _       <- client.xAdd("stream:orders")(("item", "book"), ("qty", "2"))
+      _       <- client.xAdd("stream:orders")(("item", "pen"), ("qty", "5"))
+      len     <- client.xLen("stream:orders")
+      entries <- client.xRange[String, String]("stream:orders")
+      // a Consumer Group reading from the start of the stream
+      _       <- client.xGroupCreate("stream:orders", "workers", id = GroupStartId.At(StreamId.Zero))
+      batches <- client.xReadGroup[String, String]("workers", "w1")(("stream:orders", GroupReadId.New))()
+      ids      = batches.flatMap(_._2).map(_.id)
+      _       <- client.xAck("stream:orders", "workers")(ids.head, ids.tail*)
+    } yield println(s"len=$len read=${entries.size} acked=${ids.size}")
+}

--- a/examples/pekko/src/main/scala/sage/examples/pekko/Tour.scala
+++ b/examples/pekko/src/main/scala/sage/examples/pekko/Tour.scala
@@ -1,0 +1,41 @@
+package sage.examples.pekko
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration.*
+
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+
+import sage.*
+import sage.backend.*
+
+/**
+  * Runnable Pekko tour. A user-provided typed `ActorSystem` supplies the stream `Materializer` and the `ExecutionContext`; the client is
+  * connected once and shared across every snippet. Start a server on localhost:6379 first (see examples/README.md), then `sbt examplesPekko/run`.
+  */
+object Tour {
+
+  private val config = SageConfig(topology = Topology.Standalone(Endpoint("localhost", 6379)))
+
+  def main(args: Array[String]): Unit = {
+    given system: ActorSystem[Nothing] = ActorSystem(Behaviors.empty, "sage-tour")
+    given ExecutionContext             = system.executionContext
+
+    val program: Future[Unit] =
+      for {
+        client <- SageClient.connect(config)
+        _      <- CommandsExample.run(client)
+        _      <- PipelinesExample.run(client)
+        _      <- TransactionsExample.run(client)
+        _      <- PubSubExample.run(client)
+        _      <- CachedReadsExample.run(client)
+        _      <- StreamsExample.run(client)
+      } yield ()
+
+    try Await.result(program, 60.seconds)
+    finally {
+      system.terminate()
+      val _ = Await.ready(system.whenTerminated, 10.seconds)
+    }
+  }
+}

--- a/examples/pekko/src/main/scala/sage/examples/pekko/Tour.scala
+++ b/examples/pekko/src/main/scala/sage/examples/pekko/Tour.scala
@@ -11,7 +11,8 @@ import sage.backend.*
 
 /**
   * Runnable Pekko tour. A user-provided typed `ActorSystem` supplies the stream `Materializer` and the `ExecutionContext`; the client is
-  * connected once and shared across every snippet. Start a server on localhost:6379 first (see examples/README.md), then `sbt examplesPekko/run`.
+  * connected once, closed explicitly, and shared across every snippet. Start a server on localhost:6379 first (see examples/README.md), then
+  * `sbt examplesPekko/run`.
   */
 object Tour {
 
@@ -22,15 +23,18 @@ object Tour {
     given ExecutionContext             = system.executionContext
 
     val program: Future[Unit] =
-      for {
-        client <- SageClient.connect(config)
-        _      <- CommandsExample.run(client)
-        _      <- PipelinesExample.run(client)
-        _      <- TransactionsExample.run(client)
-        _      <- PubSubExample.run(client)
-        _      <- CachedReadsExample.run(client)
-        _      <- StreamsExample.run(client)
-      } yield ()
+      SageClient.connect(config).flatMap { client =>
+        val run =
+          for {
+            _ <- CommandsExample.run(client)
+            _ <- PipelinesExample.run(client)
+            _ <- TransactionsExample.run(client)
+            _ <- PubSubExample.run(client)
+            _ <- CachedReadsExample.run(client)
+            _ <- StreamsExample.run(client)
+          } yield ()
+        run.transformWith(result => client.close.recover { case _ => () }.transform(_ => result))
+      }
 
     try Await.result(program, 60.seconds)
     finally {

--- a/examples/pekko/src/main/scala/sage/examples/pekko/Tour.scala
+++ b/examples/pekko/src/main/scala/sage/examples/pekko/Tour.scala
@@ -10,9 +10,9 @@ import sage.*
 import sage.backend.*
 
 /**
-  * Runnable Pekko tour. A user-provided typed `ActorSystem` supplies the stream `Materializer` and the `ExecutionContext`; the client is
-  * connected once, closed explicitly, and shared across every snippet. Start a server on localhost:6379 first (see examples/README.md), then
-  * `sbt examplesPekko/run`.
+  * Runnable Pekko tour. A user-provided typed `ActorSystem` supplies the stream `Materializer` and the `ExecutionContext`; `use` connects the
+  * client, shares it across every snippet, and closes it when the program finishes. Start a server on localhost:6379 first (see
+  * examples/README.md), then `sbt examplesPekko/run`.
   */
 object Tour {
 
@@ -23,17 +23,15 @@ object Tour {
     given ExecutionContext             = system.executionContext
 
     val program: Future[Unit] =
-      SageClient.connect(config).flatMap { client =>
-        val run =
-          for {
-            _ <- CommandsExample.run(client)
-            _ <- PipelinesExample.run(client)
-            _ <- TransactionsExample.run(client)
-            _ <- PubSubExample.run(client)
-            _ <- CachedReadsExample.run(client)
-            _ <- StreamsExample.run(client)
-          } yield ()
-        run.transformWith(result => client.close.recover { case _ => () }.transform(_ => result))
+      SageClient.use(config) { client =>
+        for {
+          _ <- CommandsExample.run(client)
+          _ <- PipelinesExample.run(client)
+          _ <- TransactionsExample.run(client)
+          _ <- PubSubExample.run(client)
+          _ <- CachedReadsExample.run(client)
+          _ <- StreamsExample.run(client)
+        } yield ()
       }
 
     try Await.result(program, 60.seconds)

--- a/examples/pekko/src/main/scala/sage/examples/pekko/TransactionsExample.scala
+++ b/examples/pekko/src/main/scala/sage/examples/pekko/TransactionsExample.scala
@@ -1,0 +1,26 @@
+package sage.examples.pekko
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import sage.*
+import sage.backend.*
+
+/**
+  * A WATCH-guarded MULTI/EXEC transaction on one leased Dedicated Connection: read inside the scope, decide, then `exec` a Pipeline
+  * atomically. A `None` result means a watched key changed before EXEC, the normal optimistic-concurrency retry signal, not a failure.
+  */
+object TransactionsExample {
+
+  def run(client: SageClient)(using ExecutionContext): Future[Unit] =
+    for {
+      _      <- client.set("tx:n", 1)
+      result <- client.transaction { tx =>
+                  for {
+                    _   <- tx.watch("tx:n")
+                    _   <- tx.get[Int]("tx:n")
+                    res <- tx.exec((Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)))
+                  } yield res
+                }
+    } yield println(s"transaction result=$result")
+}

--- a/integration-tests/pekko/src/test/scala/sage/integration/PekkoSmokeSuite.scala
+++ b/integration-tests/pekko/src/test/scala/sage/integration/PekkoSmokeSuite.scala
@@ -137,17 +137,22 @@ class PekkoSmokeSuite extends ServerSuite(Images.redis) {
     }
   }
 
-  test("tailing helpers reject an infinite block timeout because Future cannot interrupt it") {
+  test("tailing helpers surface an infinite block timeout through the effect because Future cannot interrupt it") {
     withContainers { server =>
-      withClientMat(server) { (client, _, system) =>
-        Future {
-          given ActorSystem[Nothing] = system
-          intercept[IllegalArgumentException] {
-            client.xTail[String, String]("stream:forever", block = BlockTimeout.Forever)
-          }
-          intercept[IllegalArgumentException] {
-            client.xConsume[String, String]("workers", "w1", "stream:forever", block = BlockTimeout.Forever)(_ => Future.unit)
-          }
+      withClientMat(server) { (client, mat, system) =>
+        given ActorSystem[Nothing]              = system
+        given Materializer                      = mat
+        given scala.concurrent.ExecutionContext = system.executionContext
+        val tailed                              =
+          client.xTail[String, String]("stream:forever", block = BlockTimeout.Forever).runWith(Sink.ignore).failed
+        val consumed                            =
+          client.xConsume[String, String]("workers", "w1", "stream:forever", block = BlockTimeout.Forever)(_ => Future.unit).completion.failed
+        for {
+          e1 <- tailed
+          e2 <- consumed
+        } yield {
+          assert(e1.isInstanceOf[IllegalArgumentException], e1)
+          assert(e2.isInstanceOf[IllegalArgumentException], e2)
         }
       }
     }

--- a/integration-tests/pekko/src/test/scala/sage/integration/PekkoSmokeSuite.scala
+++ b/integration-tests/pekko/src/test/scala/sage/integration/PekkoSmokeSuite.scala
@@ -14,10 +14,17 @@ import sage.backend.*
 
 class PekkoSmokeSuite extends ServerSuite(Images.redis) {
 
-  private def withClientMat[A](server: GenericContainer)(body: (SageClient, Materializer) => Future[A]): A = {
-    given system: ActorSystem[Nothing] = ActorSystem(Behaviors.empty, "pekko-smoke")
-    val mat                            = Materializer(system)
-    try Await.result(SageClient.connect(configOf(server)).flatMap(client => body(client, mat)), 30.seconds)
+  private def withClientMat[A](server: GenericContainer)(body: (SageClient, Materializer, ActorSystem[Nothing]) => Future[A]): A = {
+    given system: ActorSystem[Nothing]      = ActorSystem(Behaviors.empty, "pekko-smoke")
+    given scala.concurrent.ExecutionContext = system.executionContext
+    val mat                                 = Materializer(system)
+    try
+      Await.result(
+        SageClient.connect(configOf(server)).flatMap { client =>
+          body(client, mat, system).transformWith(result => client.close.recover { case _ => () }.transform(_ => result))
+        },
+        30.seconds
+      )
     finally {
       system.terminate()
       val _ = Await.ready(system.whenTerminated, 10.seconds)
@@ -26,7 +33,7 @@ class PekkoSmokeSuite extends ServerSuite(Images.redis) {
 
   test("an end user connects and round-trips with scala.concurrent.Future") {
     withContainers { server =>
-      val values = withClientMat(server) { (client, _) =>
+      val values = withClientMat(server) { (client, _, _) =>
         for {
           pong <- client.ping()
           _    <- Future.traverse(1 to 50)(i => client.set(s"key-$i", s"value-$i"))
@@ -40,7 +47,7 @@ class PekkoSmokeSuite extends ServerSuite(Images.redis) {
 
   test("a pipeline returns a typed tuple natively, surfacing failures per position") {
     withContainers { server =>
-      val (out, attempt) = withClientMat(server) { (client, _) =>
+      val (out, attempt) = withClientMat(server) { (client, _, _) =>
         for {
           _       <- client.set("pipe:a", "x")
           _       <- client.set("pipe:n", 10)
@@ -57,7 +64,7 @@ class PekkoSmokeSuite extends ServerSuite(Images.redis) {
 
   test("a transaction commits atomically with Future, guarded by WATCH") {
     withContainers { server =>
-      val out = withClientMat(server) { (client, _) =>
+      val out = withClientMat(server) { (client, _, _) =>
         for {
           _   <- client.set("tx:n", 1)
           res <- client.transaction { tx =>
@@ -75,7 +82,7 @@ class PekkoSmokeSuite extends ServerSuite(Images.redis) {
 
   test("scanAll streams every key as a native Pekko Source") {
     withContainers { server =>
-      val keys = withClientMat(server) { (client, mat) =>
+      val keys = withClientMat(server) { (client, mat, _) =>
         given Materializer = mat
         for {
           _    <- Future.traverse(1 to 50)(i => client.set(s"scan-$i", "v"))
@@ -88,7 +95,7 @@ class PekkoSmokeSuite extends ServerSuite(Images.redis) {
 
   test("subscribe delivers published messages as a native Pekko Source") {
     withContainers { server =>
-      val messages = withClientMat(server) { (client, mat) =>
+      val messages = withClientMat(server) { (client, mat, _) =>
         given Materializer        = mat
         val (confirmed, received) =
           client.subscribe[String]("smoke").take(3).toMat(Sink.seq)(Keep.both).run()
@@ -106,7 +113,7 @@ class PekkoSmokeSuite extends ServerSuite(Images.redis) {
 
   test("hScanAll streams every field/value pair as a native Pekko Source") {
     withContainers { server =>
-      val pairs = withClientMat(server) { (client, mat) =>
+      val pairs = withClientMat(server) { (client, mat, _) =>
         given Materializer = mat
         for {
           _     <- Future.traverse(1 to 50)(i => client.hSet("hscan", (s"f$i", s"v$i")))
@@ -119,7 +126,7 @@ class PekkoSmokeSuite extends ServerSuite(Images.redis) {
 
   test("zScanAll streams every member/score pair as a native Pekko Source") {
     withContainers { server =>
-      val pairs = withClientMat(server) { (client, mat) =>
+      val pairs = withClientMat(server) { (client, mat, _) =>
         given Materializer = mat
         for {
           _     <- Future.traverse(1 to 50)(i => client.zAdd("zscan")((s"m$i", i.toDouble)))
@@ -127,6 +134,22 @@ class PekkoSmokeSuite extends ServerSuite(Images.redis) {
         } yield pairs
       }
       assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
+    }
+  }
+
+  test("tailing helpers reject an infinite block timeout because Future cannot interrupt it") {
+    withContainers { server =>
+      withClientMat(server) { (client, _, system) =>
+        Future {
+          given ActorSystem[Nothing] = system
+          intercept[IllegalArgumentException] {
+            client.xTail[String, String]("stream:forever", block = BlockTimeout.Forever)
+          }
+          intercept[IllegalArgumentException] {
+            client.xConsume[String, String]("workers", "w1", "stream:forever", block = BlockTimeout.Forever)(_ => Future.unit)
+          }
+        }
+      }
     }
   }
 }

--- a/integration-tests/pekko/src/test/scala/sage/integration/PekkoSmokeSuite.scala
+++ b/integration-tests/pekko/src/test/scala/sage/integration/PekkoSmokeSuite.scala
@@ -1,0 +1,132 @@
+package sage.integration
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.*
+
+import com.dimafeng.testcontainers.GenericContainer
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{Keep, Sink}
+
+import sage.*
+import sage.backend.*
+
+class PekkoSmokeSuite extends ServerSuite(Images.redis) {
+
+  private def withClientMat[A](server: GenericContainer)(body: (SageClient, Materializer) => Future[A]): A = {
+    given system: ActorSystem[Nothing] = ActorSystem(Behaviors.empty, "pekko-smoke")
+    val mat                            = Materializer(system)
+    try Await.result(SageClient.connect(configOf(server)).flatMap(client => body(client, mat)), 30.seconds)
+    finally {
+      system.terminate()
+      val _ = Await.ready(system.whenTerminated, 10.seconds)
+    }
+  }
+
+  test("an end user connects and round-trips with scala.concurrent.Future") {
+    withContainers { server =>
+      val values = withClientMat(server) { (client, _) =>
+        for {
+          pong <- client.ping()
+          _    <- Future.traverse(1 to 50)(i => client.set(s"key-$i", s"value-$i"))
+          got  <- Future.traverse(1 to 50)(i => client.get[String](s"key-$i"))
+        } yield (pong, got)
+      }
+      assertEquals(values._1, "PONG")
+      assertEquals(values._2.toList, (1 to 50).toList.map(i => Option(s"value-$i")))
+    }
+  }
+
+  test("a pipeline returns a typed tuple natively, surfacing failures per position") {
+    withContainers { server =>
+      val (out, attempt) = withClientMat(server) { (client, _) =>
+        for {
+          _       <- client.set("pipe:a", "x")
+          _       <- client.set("pipe:n", 10)
+          out     <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)))
+          _       <- client.set("pipe:str", "hello")
+          attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")))
+        } yield (out, attempt)
+      }
+      assertEquals(out, (Some("x"), 15L))
+      assert(attempt._1 == Right(Some("hello")), attempt._1)
+      assert(attempt._2.isLeft, attempt._2)
+    }
+  }
+
+  test("a transaction commits atomically with Future, guarded by WATCH") {
+    withContainers { server =>
+      val out = withClientMat(server) { (client, _) =>
+        for {
+          _   <- client.set("tx:n", 1)
+          res <- client.transaction { tx =>
+                   for {
+                     _   <- tx.watch("tx:n")
+                     _   <- tx.get[Int]("tx:n")
+                     res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)))
+                   } yield res
+                 }
+        } yield res
+      }
+      assertEquals(out, Some((2L, 6L)))
+    }
+  }
+
+  test("scanAll streams every key as a native Pekko Source") {
+    withContainers { server =>
+      val keys = withClientMat(server) { (client, mat) =>
+        given Materializer = mat
+        for {
+          _    <- Future.traverse(1 to 50)(i => client.set(s"scan-$i", "v"))
+          keys <- client.scanAll(pattern = Some("scan-*"), count = Some(10L)).runWith(Sink.seq)
+        } yield keys
+      }
+      assertEquals(keys.toSet, (1 to 50).map(i => s"scan-$i").toSet)
+    }
+  }
+
+  test("subscribe delivers published messages as a native Pekko Source") {
+    withContainers { server =>
+      val messages = withClientMat(server) { (client, mat) =>
+        given Materializer        = mat
+        val (confirmed, received) =
+          client.subscribe[String]("smoke").take(3).toMat(Sink.seq)(Keep.both).run()
+        for {
+          _        <- confirmed
+          // publish sequentially so the asserted m1/m2/m3 order is deterministic
+          _        <- (1 to 3).foldLeft(Future.successful(0L))((acc, i) => acc.flatMap(_ => client.publish("smoke", s"m$i")))
+          messages <- received
+        } yield messages
+      }
+      assertEquals(messages.map(_.channel).toSet, Set("smoke"))
+      assertEquals(messages.map(_.payload).toList, List("m1", "m2", "m3"))
+    }
+  }
+
+  test("hScanAll streams every field/value pair as a native Pekko Source") {
+    withContainers { server =>
+      val pairs = withClientMat(server) { (client, mat) =>
+        given Materializer = mat
+        for {
+          _     <- Future.traverse(1 to 50)(i => client.hSet("hscan", (s"f$i", s"v$i")))
+          pairs <- client.hScanAll[String, String]("hscan", count = Some(10L)).runWith(Sink.seq)
+        } yield pairs
+      }
+      assertEquals(pairs.toMap, (1 to 50).map(i => s"f$i" -> s"v$i").toMap)
+    }
+  }
+
+  test("zScanAll streams every member/score pair as a native Pekko Source") {
+    withContainers { server =>
+      val pairs = withClientMat(server) { (client, mat) =>
+        given Materializer = mat
+        for {
+          _     <- Future.traverse(1 to 50)(i => client.zAdd("zscan")((s"m$i", i.toDouble)))
+          pairs <- client.zScanAll[String]("zscan", count = Some(10L)).runWith(Sink.seq)
+        } yield pairs
+      }
+      assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
+    }
+  }
+}

--- a/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
@@ -6,6 +6,7 @@ import scala.annotation.unused
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success}
+import scala.util.control.NonFatal
 
 import kyo.compat.*
 import org.apache.pekko.{Done, NotUsed}
@@ -106,16 +107,18 @@ extension [K](client: Client[Future, K])(using @unused ev: KeyCodec[K]) {
     from: StreamId = StreamId.Zero,
     count: Option[Long] = None,
     block: BlockTimeout = SageClient.defaultPoll
-  ): Source[StreamEntry[F, V], NotUsed] = {
-    val poll = SageClient.boundedPoll(block, "xTail")
-    pagedSource[StreamId, StreamEntry[F, V]](from)(
-      Paged.tail(last =>
-        CIO
-          .lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(poll))))
-          .map(_.flatMap(_._2))
-      )
-    )
-  }
+  ): Source[StreamEntry[F, V], NotUsed] =
+    SageClient.boundedPoll(block, "xTail") match {
+      case Left(e)     => Source.failed(e)
+      case Right(poll) =>
+        pagedSource[StreamId, StreamEntry[F, V]](from)(
+          Paged.tail(last =>
+            CIO
+              .lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(poll))))
+              .map(_.flatMap(_._2))
+          )
+        )
+    }
 
   /**
     * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
@@ -128,16 +131,19 @@ extension [K](client: Client[Future, K])(using @unused ev: KeyCodec[K]) {
     key: K,
     count: Option[Long] = None,
     block: BlockTimeout = SageClient.defaultPoll
-  )(handle: StreamEntry[F, V] => Future[Unit])(using system: ActorSystem[?]): RunningConsumer = {
-    given Materializer     = SystemMaterializer(system).materializer
-    given ExecutionContext = system.executionContext
-    val (killSwitch, done) = consumeSource[F, V](group, consumer, key, count, SageClient.boundedPoll(block, "xConsume"))
-      .viaMat(KillSwitches.single)(Keep.right)
-      .mapAsync(1)(entry => handle(entry).flatMap(_ => client.run(Streams.xAck(key, group)(entry.id)).map(_ => ())))
-      .toMat(Sink.ignore)(Keep.both)
-      .run()
-    new RunningConsumer(killSwitch, done)
-  }
+  )(handle: StreamEntry[F, V] => Future[Unit])(using system: ActorSystem[?]): RunningConsumer =
+    SageClient.boundedPoll(block, "xConsume") match {
+      case Left(e)     => RunningConsumer.failed(e)
+      case Right(poll) =>
+        given Materializer     = SystemMaterializer(system).materializer
+        given ExecutionContext = system.executionContext
+        val (killSwitch, done) = consumeSource[F, V](group, consumer, key, count, poll)
+          .viaMat(KillSwitches.single)(Keep.right)
+          .mapAsync(1)(entry => handle(entry).flatMap(_ => client.run(Streams.xAck(key, group)(entry.id)).map(_ => ())))
+          .toMat(Sink.ignore)(Keep.both)
+          .run()
+        RunningConsumer(killSwitch, done)
+    }
 
   /**
     * Subscribes to one or more channels; the subscription opens when the `Source` is materialized and unsubscribes when the stream is
@@ -234,13 +240,30 @@ object SageClient {
   def connect(config: SageConfig): Future[SageClient] =
     Client.connect(config).unsafeRun.map(new Lowered(_))(ExecutionContext.parasitic)
 
-  private[backend] def boundedPoll(block: BlockTimeout, method: String): BlockTimeout =
+  /**
+    * Connects, runs `f`, then closes the client on every exit path (success, failure, or a failed body), so a connection is never leaked
+    * when the body throws or its `Future` fails. Teardown errors are swallowed, matching the close-on-release policy of the other backends'
+    * `scoped`/`resource` helpers. Prefer this over `connect` + manual `close` unless you need to own the lifecycle yourself.
+    */
+  def use[A](config: SageConfig)(f: SageClient => Future[A]): Future[A] = {
+    given ExecutionContext = ExecutionContext.parasitic
+    connect(config).flatMap { client =>
+      val ran =
+        try f(client)
+        catch { case NonFatal(e) => Future.failed(e) }
+      ran.transformWith(result => client.close.transformWith(_ => Future.fromTry(result)))
+    }
+  }
+
+  private[backend] def boundedPoll(block: BlockTimeout, method: String): Either[IllegalArgumentException, BlockTimeout] =
     block match {
       case BlockTimeout.Forever =>
-        throw new IllegalArgumentException(
-          s"$method cannot use BlockTimeout.Forever on the Pekko backend; Future cannot interrupt an in-flight blocking read"
+        Left(
+          new IllegalArgumentException(
+            s"$method cannot use BlockTimeout.Forever on the Pekko backend; Future cannot interrupt an in-flight blocking read"
+          )
         )
-      case other                => other
+      case other                => Right(other)
     }
 
   final private class Lowered(underlying: Client[CIO, String]) extends LoweredClient[Future](underlying) {
@@ -254,13 +277,22 @@ object SageClient {
   * `completion` is the loop's terminal signal: it succeeds when the loop drains and fails if a `handle` invocation (or its acknowledgement)
   * failed, mirroring how the other backends surface a handler error through their terminal effect.
   */
-final class RunningConsumer private[backend] (killSwitch: UniqueKillSwitch, val completion: Future[Done]) {
+final class RunningConsumer private[backend] (killSwitch: Option[UniqueKillSwitch], val completion: Future[Done]) {
 
   /**
     * Requests a graceful stop between entries and returns [[completion]] (which fails if the loop had already failed in `handle`).
     */
   def stop(): Future[Done] = {
-    killSwitch.shutdown()
+    killSwitch.foreach(_.shutdown())
     completion
   }
+}
+
+object RunningConsumer {
+
+  private[backend] def apply(killSwitch: UniqueKillSwitch, completion: Future[Done]): RunningConsumer =
+    new RunningConsumer(Some(killSwitch), completion)
+
+  private[backend] def failed(error: Throwable): RunningConsumer =
+    new RunningConsumer(None, Future.failed(error))
 }

--- a/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
@@ -1,0 +1,270 @@
+package sage.backend
+
+import java.util.concurrent.TimeUnit
+
+import scala.annotation.unused
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration.FiniteDuration
+import scala.util.{Failure, Success}
+
+import kyo.compat.*
+import org.apache.pekko.{Done, NotUsed}
+import org.apache.pekko.actor.CoordinatedShutdown
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.stream.{KillSwitches, Materializer, SystemMaterializer, UniqueKillSwitch}
+import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source}
+
+import sage.{Message, PatternMessage}
+import sage.client.SageConfig
+import sage.client.internal.{Client, LoweredClient, Paged, ScanStep, ScanTarget, Subscription}
+import sage.codec.{KeyCodec, ValueCodec}
+import sage.commands.*
+
+/**
+  * The Pekko-native surface: the same client, with every method returning `scala.concurrent.Future` and the streaming helpers returning a
+  * Pekko Streams `Source`. The Future effect comes from the kyo-compat Future cell; Pekko Streams is layered on top in this cell.
+  */
+type SageClient = Client[Future, String]
+
+extension [K](client: Client[Future, K])(using @unused ev: KeyCodec[K]) {
+
+  /**
+    * The full SCAN iteration: stops on the server's zero cursor, never on an empty page. SCAN may return a key more than once. In cluster
+    * mode it walks every slot-owning master in turn, each with its own node-local cursor, so the sweep covers the whole keyspace.
+    */
+  def scanAll(
+    pattern: Option[String] = None,
+    count: Option[Long] = None,
+    ofType: Option[RedisType] = None
+  ): Source[K, NotUsed] =
+    scanSourceAll(target => cursor => client.runOn(target, Keys.scan[K](cursor, pattern, count, ofType)))
+
+  /**
+    * The full HSCAN iteration over field/value pairs: stops on the server's zero cursor, never on an empty page.
+    */
+  def hScanAll[F: KeyCodec, V: ValueCodec](
+    key: K,
+    pattern: Option[String] = None,
+    count: Option[Long] = None
+  ): Source[(F, V), NotUsed] =
+    scanSource(cursor => client.run(Hashes.hScan[K, F, V](key, cursor, pattern, count)))
+
+  /**
+    * The full SSCAN iteration over set members: stops on the server's zero cursor, never on an empty page.
+    */
+  def sScanAll[V: ValueCodec](
+    key: K,
+    pattern: Option[String] = None,
+    count: Option[Long] = None
+  ): Source[V, NotUsed] =
+    scanSource(cursor => client.run(Sets.sScan[K, V](key, cursor, pattern, count)))
+
+  /**
+    * The full ZSCAN iteration over member/score pairs: stops on the server's zero cursor, never on an empty page.
+    */
+  def zScanAll[V: ValueCodec](
+    key: K,
+    pattern: Option[String] = None,
+    count: Option[Long] = None
+  ): Source[(V, Double), NotUsed] =
+    scanSource(cursor => client.run(SortedSets.zScan[K, V](key, cursor, pattern, count)))
+
+  /**
+    * Lazily pages an entire stream by range, batching `XRANGE` and advancing past the last id each page. Stops when a page comes back empty.
+    */
+  def xRangeAll[F: KeyCodec, V: ValueCodec](
+    key: K,
+    start: StreamRangeId = StreamRangeId.Min,
+    end: StreamRangeId = StreamRangeId.Max,
+    batch: Long = 100L
+  ): Source[StreamEntry[F, V], NotUsed] =
+    pagedSource[Option[StreamRangeId], StreamEntry[F, V]](Some(start))(
+      Paged.byRange(batch)(from => CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))))
+    )
+
+  /**
+    * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start.
+    * Tombstone entries are skipped, so every emitted entry carries data.
+    */
+  def xAutoClaimAll[F: KeyCodec, V: ValueCodec](
+    key: K,
+    group: String,
+    consumer: String,
+    minIdle: FiniteDuration,
+    start: StreamId = StreamId.Zero,
+    count: Option[Long] = None
+  ): Source[StreamEntry[F, V], NotUsed] =
+    pagedSource[Option[StreamId], StreamEntry[F, V]](Some(start))(
+      Paged.byAutoClaim(from => CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))))
+    )
+
+  /**
+    * Follows a stream without a consumer group: replays every entry after `from`, then blocks for new entries forever. Cancel the `Source`
+    * to stop tailing.
+    */
+  def xTail[F: KeyCodec, V: ValueCodec](
+    key: K,
+    from: StreamId = StreamId.Zero,
+    count: Option[Long] = None,
+    block: BlockTimeout = SageClient.defaultPoll
+  ): Source[StreamEntry[F, V], NotUsed] =
+    pagedSource[StreamId, StreamEntry[F, V]](from)(
+      Paged.tail(last =>
+        CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map(_.flatMap(_._2))
+      )
+    )
+
+  /**
+    * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
+    * entries forever. `handle` runs per entry; the entry is acknowledged only after `handle` succeeds. Since a `Future` cannot be cancelled,
+    * the loop is returned as a [[RunningConsumer]]: call `stop()` to halt it between entries and await its `completion`.
+    */
+  def xConsume[F: KeyCodec, V: ValueCodec](
+    group: String,
+    consumer: String,
+    key: K,
+    count: Option[Long] = None,
+    block: BlockTimeout = SageClient.defaultPoll
+  )(handle: StreamEntry[F, V] => Future[Unit])(using system: ActorSystem[?]): RunningConsumer = {
+    given Materializer     = SystemMaterializer(system).materializer
+    given ExecutionContext = system.executionContext
+    val (killSwitch, done) = consumeSource[F, V](group, consumer, key, count, block)
+      .viaMat(KillSwitches.single)(Keep.right)
+      .mapAsync(1)(entry => handle(entry).flatMap(_ => client.run(Streams.xAck(key, group)(entry.id)).map(_ => ())))
+      .toMat(Sink.ignore)(Keep.both)
+      .run()
+    new RunningConsumer(killSwitch, done)
+  }
+
+  /**
+    * Subscribes to one or more channels; the subscription opens when the `Source` is materialized and unsubscribes when the stream is
+    * cancelled, completes, or fails. The materialized value is a `Future[Done]` that completes once the subscription is registered, so a
+    * publish sequenced after it does not race the registration on a standalone or master-replica server. In cluster mode that confirmation is
+    * best-effort (it may resolve before every owning node has acked), matching the shared runtime's subscribe semantics across all backends.
+    */
+  def subscribe[V: ValueCodec](channel: String, rest: String*): Source[Message[V], Future[Done]] =
+    subscriptionSource(client.subscribeChannels[V](channel, rest*))
+
+  /**
+    * Subscribes to one or more glob patterns; each delivery names the matching pattern and the concrete channel.
+    */
+  def pSubscribe[V: ValueCodec](pattern: String, rest: String*): Source[PatternMessage[V], Future[Done]] =
+    subscriptionSource(client.subscribePatterns[V](pattern, rest*))
+
+  /**
+    * Subscribes to one or more Shard Channels; in a cluster each is routed to the Node owning its Slot, and resubscription follows the Slot
+    * on migration or failover. A sharded delivery is an ordinary [[Message]].
+    */
+  def sSubscribe[V: ValueCodec](channel: String, rest: String*): Source[Message[V], Future[Done]] =
+    subscriptionSource(client.subscribeShardChannels[V](channel, rest*))
+
+  private def scanSource[A](fetch: ScanCursor => Future[ScanPage[A]]): Source[A, NotUsed] =
+    pagedSource[Option[ScanCursor], A](Some(ScanCursor.start))(Paged.byCursor(cursor => CIO.lift(fetch(cursor))))
+
+  // walks every scan target in turn, each with its own node-local cursor, so a cluster SCAN sweeps all masters instead of one
+  private def scanSourceAll[A](fetch: ScanTarget => ScanCursor => Future[ScanPage[A]]): Source[A, NotUsed] =
+    pagedSource[ScanStep, A](ScanStep.Begin)(
+      Paged.acrossTargets(CIO.lift(client.scanTargets))(target => cursor => CIO.lift(fetch(target)(cursor)))
+    )
+
+  private def consumeSource[F: KeyCodec, V: ValueCodec](
+    group: String,
+    consumer: String,
+    key: K,
+    count: Option[Long],
+    block: BlockTimeout
+  ): Source[StreamEntry[F, V], NotUsed] =
+    pagedSource[Either[StreamId, Unit], StreamEntry[F, V]](Left(StreamId.Zero))(
+      Paged.consume(
+        drainPending = after =>
+          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map(_.flatMap(_._2)),
+        tailNew = CIO
+          .lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block))))
+          .map(_.flatMap(_._2))
+      )
+    )
+
+  // drives a shared Paged step machine as a Source, flattening each page into individual elements
+  private def pagedSource[S, A](init: S)(step: Paged.Step[S, A]): Source[A, NotUsed] =
+    Source
+      .unfoldAsync[S, Vector[A]](init)(s => step(s).unsafeRun.map(_.map { case (items, next) => (next, items) })(ExecutionContext.parasitic))
+      .mapConcat(identity)
+
+  // opens on materialization, closes on cancel/complete/failure; the materialized Future[Done] resolves when the subscribe is confirmed
+  private def subscriptionSource[A](open: => Future[Subscription[Future, A]]): Source[A, Future[Done]] =
+    Source
+      .fromMaterializer { (_, _) =>
+        val confirmed = Promise[Done]()
+        Source
+          .unfoldResourceAsync[A, Subscription[Future, A]](
+            () => {
+              val opened = open
+              opened.onComplete {
+                case Success(_) => val _ = confirmed.trySuccess(Done)
+                case Failure(e) => val _ = confirmed.tryFailure(e)
+              }(ExecutionContext.parasitic)
+              opened
+            },
+            sub => sub.next,
+            // swallow unsubscribe errors on teardown (close-on-release policy)
+            sub => sub.close.map(_ => Done)(ExecutionContext.parasitic).recover { case _ => Done }(ExecutionContext.parasitic)
+          )
+          .mapMaterializedValue(_ => confirmed.future)
+      }
+      .mapMaterializedValue(_.flatten)
+}
+
+object SageClient {
+
+  /**
+    * A command surface re-typed to a non-String key, as returned by `client.as[K]`. The unqualified [[SageClient]] is String-keyed;
+    * use `as` to reach any other key type over the same connection.
+    */
+  type Keyed[K] = Client[Future, K]
+
+  // bounded poll so xConsume's blocking read returns periodically, keeping RunningConsumer.stop() responsive
+  private[backend] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, TimeUnit.SECONDS))
+
+  /**
+    * Connects and returns a Pekko-native client. Registers a `CoordinatedShutdown` task so the client closes when the user's
+    * `ActorSystem` terminates; pass the system in scope as a `using` argument.
+    */
+  def connect(config: SageConfig)(using system: ActorSystem[?]): Future[SageClient] = {
+    given ExecutionContext = system.executionContext
+    Client.connect(config).unsafeRun.map { underlying =>
+      val client = new Lowered(underlying)
+      // teardown must not fail the shutdown phase (close-on-release policy)
+      CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseBeforeActorSystemTerminate, "sage-client-close") { () =>
+        client.close.map(_ => Done).recover { case _ => Done }
+      }
+      client
+    }
+  }
+
+  /**
+    * Connects without registering any shutdown hook; the caller owns the client lifecycle and must call `close` explicitly.
+    */
+  def connectUnmanaged(config: SageConfig): Future[SageClient] =
+    Client.connect(config).unsafeRun.map(new Lowered(_))(ExecutionContext.parasitic)
+
+  final private class Lowered(underlying: Client[CIO, String]) extends LoweredClient[Future](underlying) {
+    protected def lower[A](c: CIO[A]): Future[A] = c.unsafeRun
+    protected def lift[A](fa: Future[A]): CIO[A] = CIO.lift(fa)
+  }
+}
+
+/**
+  * A handle to a running [[xConsume]] loop. Since `Future` has no interruption, the loop is stopped cooperatively via a Pekko `KillSwitch`.
+  * `completion` is the loop's terminal signal: it succeeds when the loop drains and fails if a `handle` invocation (or its acknowledgement)
+  * failed, mirroring how the other backends surface a handler error through their terminal effect.
+  */
+final class RunningConsumer private[backend] (killSwitch: UniqueKillSwitch, val completion: Future[Done]) {
+
+  /**
+    * Requests a graceful stop between entries and returns [[completion]] (which fails if the loop had already failed in `handle`).
+    */
+  def stop(): Future[Done] = {
+    killSwitch.shutdown()
+    completion
+  }
+}

--- a/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
@@ -245,15 +245,13 @@ object SageClient {
     * when the body throws or its `Future` fails. Teardown errors are swallowed, matching the close-on-release policy of the other backends'
     * `scoped`/`resource` helpers. Prefer this over `connect` + manual `close` unless you need to own the lifecycle yourself.
     */
-  def use[A](config: SageConfig)(f: SageClient => Future[A]): Future[A] = {
-    given ExecutionContext = ExecutionContext.parasitic
+  def use[A](config: SageConfig)(f: SageClient => Future[A])(using ExecutionContext): Future[A] =
     connect(config).flatMap { client =>
       val ran =
         try f(client)
         catch { case NonFatal(e) => Future.failed(e) }
       ran.transformWith(result => client.close.transformWith(_ => Future.fromTry(result)))
     }
-  }
 
   private[backend] def boundedPoll(block: BlockTimeout, method: String): Either[IllegalArgumentException, BlockTimeout] =
     block match {

--- a/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
@@ -9,7 +9,6 @@ import scala.util.{Failure, Success}
 
 import kyo.compat.*
 import org.apache.pekko.{Done, NotUsed}
-import org.apache.pekko.actor.CoordinatedShutdown
 import org.apache.pekko.actor.typed.ActorSystem
 import org.apache.pekko.stream.{KillSwitches, Materializer, SystemMaterializer, UniqueKillSwitch}
 import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source}
@@ -107,12 +106,16 @@ extension [K](client: Client[Future, K])(using @unused ev: KeyCodec[K]) {
     from: StreamId = StreamId.Zero,
     count: Option[Long] = None,
     block: BlockTimeout = SageClient.defaultPoll
-  ): Source[StreamEntry[F, V], NotUsed] =
+  ): Source[StreamEntry[F, V], NotUsed] = {
+    val poll = SageClient.boundedPoll(block, "xTail")
     pagedSource[StreamId, StreamEntry[F, V]](from)(
       Paged.tail(last =>
-        CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map(_.flatMap(_._2))
+        CIO
+          .lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(poll))))
+          .map(_.flatMap(_._2))
       )
     )
+  }
 
   /**
     * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
@@ -128,7 +131,7 @@ extension [K](client: Client[Future, K])(using @unused ev: KeyCodec[K]) {
   )(handle: StreamEntry[F, V] => Future[Unit])(using system: ActorSystem[?]): RunningConsumer = {
     given Materializer     = SystemMaterializer(system).materializer
     given ExecutionContext = system.executionContext
-    val (killSwitch, done) = consumeSource[F, V](group, consumer, key, count, block)
+    val (killSwitch, done) = consumeSource[F, V](group, consumer, key, count, SageClient.boundedPoll(block, "xConsume"))
       .viaMat(KillSwitches.single)(Keep.right)
       .mapAsync(1)(entry => handle(entry).flatMap(_ => client.run(Streams.xAck(key, group)(entry.id)).map(_ => ())))
       .toMat(Sink.ignore)(Keep.both)
@@ -226,26 +229,19 @@ object SageClient {
   private[backend] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, TimeUnit.SECONDS))
 
   /**
-    * Connects and returns a Pekko-native client. Registers a `CoordinatedShutdown` task so the client closes when the user's
-    * `ActorSystem` terminates; pass the system in scope as a `using` argument.
+    * Connects and returns a Pekko-native client. The caller owns the client lifecycle and must call `close` explicitly.
     */
-  def connect(config: SageConfig)(using system: ActorSystem[?]): Future[SageClient] = {
-    given ExecutionContext = system.executionContext
-    Client.connect(config).unsafeRun.map { underlying =>
-      val client = new Lowered(underlying)
-      // teardown must not fail the shutdown phase (close-on-release policy)
-      CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseBeforeActorSystemTerminate, "sage-client-close") { () =>
-        client.close.map(_ => Done).recover { case _ => Done }
-      }
-      client
-    }
-  }
-
-  /**
-    * Connects without registering any shutdown hook; the caller owns the client lifecycle and must call `close` explicitly.
-    */
-  def connectUnmanaged(config: SageConfig): Future[SageClient] =
+  def connect(config: SageConfig): Future[SageClient] =
     Client.connect(config).unsafeRun.map(new Lowered(_))(ExecutionContext.parasitic)
+
+  private[backend] def boundedPoll(block: BlockTimeout, method: String): BlockTimeout =
+    block match {
+      case BlockTimeout.Forever =>
+        throw new IllegalArgumentException(
+          s"$method cannot use BlockTimeout.Forever on the Pekko backend; Future cannot interrupt an in-flight blocking read"
+        )
+      case other                => other
+    }
 
   final private class Lowered(underlying: Client[CIO, String]) extends LoweredClient[Future](underlying) {
     protected def lower[A](c: CIO[A]): Future[A] = c.unsafeRun


### PR DESCRIPTION
Adds a fifth runtime backend that rides the kyo-compat Future cell, so the whole command surface is available returning `scala.concurrent.Future`, with the streaming helpers returning Pekko Streams `Source`. The core and shared client are unchanged; this is a new `sage-client/pekko` module plus its examples, integration smoke suite, benchmarks, docs, and build wiring.

## What's here

- **`sage-client/pekko`**: the `SageClient = Client[Future, String]` surface and the Pekko-native extensions (`scanAll`, `xRangeAll`, `xAutoClaimAll`, `xTail`, `xConsume`, `subscribe`/`pSubscribe`/`sSubscribe`). `subscribe` materializes a `Future[Done]` that resolves once the subscription is registered, so a publish sequenced after it does not race the registration.
- **Lifecycle**: `SageClient.connect` for callers who own the lifecycle, and `SageClient.use(config) { client => ... }` which closes the client on every exit path, mirroring the `scoped`/`resource` helpers on the other backends.
- **Streams under Future**: since a `Future` cannot be interrupted, `xConsume` returns a `RunningConsumer` whose `stop()` halts the loop cooperatively via a Pekko `KillSwitch` and whose `completion` carries any handler failure. The tailing helpers use a bounded poll so `stop()`/cancel stay responsive, and reject `BlockTimeout.Forever` by surfacing the error through the returned `Source`/`RunningConsumer` rather than throwing at the call site.
- **Examples, benchmarks, docs**: a runnable Pekko tour and per-topic examples, JMH benchmarks, a testcontainers smoke suite, and Pekko tabs across the docs.
- **Build**: a distinct compat axis for the Pekko row, pulling in Pekko Streams and the typed actor module.

## Tests

`integrationTestsPekko/test` (8 smoke tests against a real server) passes; the module compiles and is scalafmt-clean.