### PR TITLE
Expose typed errors (SageException) on the ZIO and Kyo backends

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -9,6 +9,7 @@ Every sage failure is a `SageException`, a single sealed hierarchy you can match
 | `ProtocolError(message)` | Malformed RESP3 on the wire; the connection is discarded. |
 | `DecodeError(expected, actual)` | A reply was well-formed but not the shape a decoder or codec required (the built-in codecs decode strictly). |
 | `ServerError(code, detail)` | An error reply from the server. `code` is the leading token (`WRONGTYPE`, `NOSCRIPT`, `BUSYGROUP`, the generic `ERR`, …). |
+| `ConnectionFailed(message)` | The initial connection could not be established (host unreachable, connection refused, or connect timeout). Distinct from `ConnectionLost`, which is a live connection dropping. |
 | `ConnectionLost(mayHaveExecuted)` | The connection dropped around this command. |
 | `NotConnected()` | The client was never started, or has been closed. |
 | `UnsupportedServer(message)` | The server rejected `HELLO 3` (it predates RESP3, or is a RESP2-only proxy). |

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,6 +1,6 @@
 # Error handling
 
-Every sage failure is a `SageException`, a single sealed hierarchy you can match exhaustively. How a failure reaches you depends on your backend: a failed ZIO `Task`, a raised Cats Effect `IO`, a Kyo `Abort[Throwable]`, a thrown exception in Ox direct style, or a failed `scala.concurrent.Future` on Pekko. In every case the value is the same `SageException`.
+Every sage failure is a `SageException`, a single sealed hierarchy you can match exhaustively. On ZIO and Kyo the error channel is that `SageException` itself (`IO[SageException, *]`, `Abort[SageException]`), so the compiler holds you to handling it. On Cats Effect, Ox, and Pekko the same `SageException` arrives through the ecosystem's untyped failure channel: a raised `IO`, a thrown exception, a failed `scala.concurrent.Future`. The runtime value is always a `SageException`; ZIO and Kyo also put it in the type.
 
 ## The hierarchy
 
@@ -51,10 +51,10 @@ When `mayHaveExecuted` is `true`, do not blindly retry a non-idempotent command:
 
 ## How failures surface per backend
 
-The same `SageException` is delivered through each ecosystem's normal failure channel:
+The same `SageException` is delivered through each ecosystem's normal failure channel. ZIO and Kyo carry it in the type as well, so on those two a non-`SageException` is a defect (a ZIO die, a Kyo `Panic`) rather than a typed failure:
 
-- **ZIO**: a failed `Task`; recover with `catchAll` / `catchSome`.
-- **Cats Effect**: a raised `IO`; recover with `handleErrorWith` / `recoverWith`.
-- **Kyo**: an `Abort[Throwable]`; handle with the `Abort` combinators.
+- **ZIO**: a failed `IO[SageException, *]`; recover with `catchAll` / `catchSome`, which hand you a `SageException` directly.
+- **Cats Effect**: a raised `IO`; recover with `handleErrorWith` / `recoverWith` and match the `SageException`.
+- **Kyo**: an `Abort[SageException]`; handle with the `Abort` combinators.
 - **Ox**: thrown in direct style; handle with an ordinary `try`/`catch`.
 - **Pekko**: a failed `scala.concurrent.Future`; recover with `recover` / `recoverWith`.

--- a/sage-client/kyo/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/kyo/src/main/scala/sage/backend/SageClient.scala
@@ -21,11 +21,13 @@ import sage.commands.*
 type SageClient = Client[[A] =>> A < (Abort[SageException] & Async), String]
 
 // Narrow the carrier to the typed channel: a SageException stays a failure, anything else becomes a Panic.
+private val toSageException: Throwable => Nothing < Abort[SageException] = {
+  case e: SageException => Abort.fail(e)
+  case e                => Abort.panic(e)
+}
+
 private def refine[A](v: A < (Abort[Throwable] & Async))(using Frame): A < (Abort[SageException] & Async) =
-  Abort.recover[Throwable] {
-    case e: SageException => Abort.fail(e)
-    case e                => Abort.panic(e)
-  }(v)
+  Abort.recover[Throwable](toSageException)(v)
 
 extension [K](client: Client[[A] =>> A < (Abort[SageException] & Async), K])(using @unused ev: KeyCodec[K]) {
 

--- a/sage-client/kyo/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/kyo/src/main/scala/sage/backend/SageClient.scala
@@ -7,25 +7,32 @@ import _root_.kyo.{<, Abort, Async, Duration, Frame, Maybe, Scope, Stream, Tag}
 import _root_.kyo.Duration.toMillis
 import _root_.kyo.compat.*
 
-import sage.{Message, PatternMessage}
+import sage.{Message, PatternMessage, SageException}
 import sage.client.SageConfig
 import sage.client.internal.{Client, LoweredClient, Paged, ScanStep, ScanTarget, Subscription}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
 
 /**
-  * The Kyo-native surface: the same client, with every method returning a Kyo pending computation.
+  * The Kyo-native surface: the same client, with every method returning a pending computation whose `Abort` channel is the sealed
+  * [[SageException]], so failures are matched exhaustively. Anything that is not a `SageException` is a Kyo `Panic` (a defect), never a
+  * typed failure.
   */
-type SageClient = Client[[A] =>> A < (Abort[Throwable] & Async), String]
+type SageClient = Client[[A] =>> A < (Abort[SageException] & Async), String]
 
-private type KyoEff[A] = A < (Abort[Throwable] & Async)
+// Narrow the carrier to the typed channel: a SageException stays a failure, anything else becomes a Panic.
+private def refine[A](v: A < (Abort[Throwable] & Async))(using Frame): A < (Abort[SageException] & Async) =
+  Abort.recover[Throwable] {
+    case e: SageException => Abort.fail(e)
+    case e                => Abort.panic(e)
+  }(v)
 
-extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @unused ev: KeyCodec[K]) {
+extension [K](client: Client[[A] =>> A < (Abort[SageException] & Async), K])(using @unused ev: KeyCodec[K]) {
 
   /**
     * Runs a read with client-side caching and a Kyo `Duration` TTL — the Kyo-native form of [[sage.client.internal.Client.cached]].
     */
-  def cached[A](command: Command[A], ttl: Duration): A < (Abort[Throwable] & Async) =
+  def cached[A](command: Command[A], ttl: Duration): A < (Abort[SageException] & Async) =
     client.cached(command, FiniteDuration(ttl.toMillis, java.util.concurrent.TimeUnit.MILLISECONDS))
 
   /**
@@ -36,7 +43,7 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
     pattern: Option[String] = None,
     count: Option[Long] = None,
     ofType: Option[RedisType] = None
-  )(using Tag[K]): Stream[K, Abort[Throwable] & Async] =
+  )(using Tag[K]): Stream[K, Abort[SageException] & Async] =
     scanStreamAll(target => cursor => client.runOn(target, Keys.scan[K](cursor, pattern, count, ofType)))
 
   /**
@@ -46,7 +53,7 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
-  )(using Tag[F], Tag[V]): Stream[(F, V), Abort[Throwable] & Async] =
+  )(using Tag[F], Tag[V]): Stream[(F, V), Abort[SageException] & Async] =
     scanStream(cursor => client.run(Hashes.hScan[K, F, V](key, cursor, pattern, count)))
 
   /**
@@ -56,7 +63,7 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
-  )(using Tag[V]): Stream[V, Abort[Throwable] & Async] =
+  )(using Tag[V]): Stream[V, Abort[SageException] & Async] =
     scanStream(cursor => client.run(Sets.sScan[K, V](key, cursor, pattern, count)))
 
   /**
@@ -66,21 +73,25 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
-  )(using Tag[V]): Stream[(V, Double), Abort[Throwable] & Async] =
+  )(using Tag[V]): Stream[(V, Double), Abort[SageException] & Async] =
     scanStream(cursor => client.run(SortedSets.zScan[K, V](key, cursor, pattern, count)))
 
   // chunkSize = 1: emit each page as it arrives — the default rechunks to 4096, withholding an infinite tail (xTail/xConsume) until then.
-  // The page-step logic itself is shared in `Paged`; here we only lower its `CIO` to Kyo and turn the `Option` end-signal into a `Maybe`.
-  private def paged[S, A](start: S)(step: Paged.Step[S, A])(using Tag[A]): Stream[A, Abort[Throwable] & Async] =
+  // The page-step logic itself is shared in `Paged`; here we lower its `CIO` to Kyo, refine the channel, and turn the `Option` end-signal into a `Maybe`.
+  private def paged[S, A](start: S)(step: Paged.Step[S, A])(using Tag[A]): Stream[A, Abort[SageException] & Async] =
     Stream
-      .unfold[S, Vector[A], Abort[Throwable] & Async](start, chunkSize = 1)(s => step(s).lower.map(Maybe.fromOption))
+      .unfold[S, Vector[A], Abort[SageException] & Async](start, chunkSize = 1)(s => refine(step(s).lower).map(Maybe.fromOption))
       .flatMap(items => Stream.init(items))
 
-  private def scanStream[A](fetch: ScanCursor => KyoEff[ScanPage[A]])(using Tag[A]): Stream[A, Abort[Throwable] & Async] =
+  private def scanStream[A](fetch: ScanCursor => ScanPage[A] < (Abort[SageException] & Async))(
+    using Tag[A]
+  ): Stream[A, Abort[SageException] & Async] =
     paged[Option[ScanCursor], A](Some(ScanCursor.start))(Paged.byCursor(cursor => CIO.lift(fetch(cursor))))
 
   // walks every scan target in turn, each with its own node-local cursor, so a cluster SCAN sweeps all masters instead of one
-  private def scanStreamAll[A](fetch: ScanTarget => ScanCursor => KyoEff[ScanPage[A]])(using Tag[A]): Stream[A, Abort[Throwable] & Async] =
+  private def scanStreamAll[A](
+    fetch: ScanTarget => ScanCursor => ScanPage[A] < (Abort[SageException] & Async)
+  )(using Tag[A]): Stream[A, Abort[SageException] & Async] =
     paged[ScanStep, A](ScanStep.Begin)(Paged.acrossTargets(CIO.lift(client.scanTargets))(target => cursor => CIO.lift(fetch(target)(cursor))))
 
   /**
@@ -91,7 +102,7 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
     start: StreamRangeId = StreamRangeId.Min,
     end: StreamRangeId = StreamRangeId.Max,
     batch: Long = 100L
-  )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[Throwable] & Async] =
+  )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[SageException] & Async] =
     paged[Option[StreamRangeId], StreamEntry[F, V]](Some(start))(
       Paged.byRange(batch)(from => CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))))
     )
@@ -108,7 +119,7 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
     minIdle: FiniteDuration,
     start: StreamId = StreamId.Zero,
     count: Option[Long] = None
-  )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[Throwable] & Async] =
+  )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[SageException] & Async] =
     paged[Option[StreamId], StreamEntry[F, V]](Some(start))(
       Paged.byAutoClaim(from => CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))))
     )
@@ -123,7 +134,7 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
     from: StreamId = StreamId.Zero,
     count: Option[Long] = None,
     block: BlockTimeout = SageClient.defaultPoll
-  )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[Throwable] & Async] =
+  )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[SageException] & Async] =
     paged[StreamId, StreamEntry[F, V]](from)(
       Paged.tail(last =>
         CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map(_.flatMap(_._2))
@@ -141,7 +152,7 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
     key: K,
     count: Option[Long] = None,
     block: BlockTimeout = SageClient.defaultPoll
-  )(handle: StreamEntry[F, V] => KyoEff[Unit])(using Tag[F], Tag[V], Frame): KyoEff[Unit] =
+  )(handle: StreamEntry[F, V] => Unit < (Abort[SageException] & Async))(using Tag[F], Tag[V], Frame): Unit < (Abort[SageException] & Async) =
     consumeStream[F, V](group, consumer, key, count, block)
       .foreach(entry => handle(entry).flatMap(_ => client.run(Streams.xAck(key, group)(entry.id)).map(_ => ())))
 
@@ -151,7 +162,7 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
     key: K,
     count: Option[Long],
     block: BlockTimeout
-  )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[Throwable] & Async] =
+  )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[SageException] & Async] =
     paged[Either[StreamId, Unit], StreamEntry[F, V]](Left(StreamId.Zero))(
       Paged.consume(
         drainPending = after =>
@@ -166,7 +177,10 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
     * Subscribes to one or more channels; closing the enclosing `Scope` unsubscribes. Survives reconnects via auto-resubscribe, dropping
     * messages published during the reconnect gap.
     */
-  def subscribe[V: ValueCodec](channel: String, rest: String*)(using Tag[Message[V]], Frame): Stream[Message[V], Abort[Throwable] & Async & Scope] =
+  def subscribe[V: ValueCodec](channel: String, rest: String*)(
+    using Tag[Message[V]],
+    Frame
+  ): Stream[Message[V], Abort[SageException] & Async & Scope] =
     streamOf(client.subscribeChannels[V](channel, rest*))
 
   /**
@@ -175,14 +189,17 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
   def pSubscribe[V: ValueCodec](pattern: String, rest: String*)(
     using Tag[PatternMessage[V]],
     Frame
-  ): Stream[PatternMessage[V], Abort[Throwable] & Async & Scope] =
+  ): Stream[PatternMessage[V], Abort[SageException] & Async & Scope] =
     streamOf(client.subscribePatterns[V](pattern, rest*))
 
   /**
     * Subscribes to one or more Shard Channels; in a cluster each is routed to the Node owning its Slot, and resubscription follows the Slot
     * on migration or failover. A sharded delivery is an ordinary [[Message]].
     */
-  def sSubscribe[V: ValueCodec](channel: String, rest: String*)(using Tag[Message[V]], Frame): Stream[Message[V], Abort[Throwable] & Async & Scope] =
+  def sSubscribe[V: ValueCodec](channel: String, rest: String*)(
+    using Tag[Message[V]],
+    Frame
+  ): Stream[Message[V], Abort[SageException] & Async & Scope] =
     streamOf(client.subscribeShardChannels[V](channel, rest*))
 
   /**
@@ -192,7 +209,7 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
   def subscribeScoped[V: ValueCodec](channel: String, rest: String*)(
     using Tag[Message[V]],
     Frame
-  ): Stream[Message[V], Abort[Throwable] & Async & Scope] < (Abort[Throwable] & Async & Scope) =
+  ): Stream[Message[V], Abort[SageException] & Async & Scope] < (Abort[SageException] & Async & Scope) =
     scopedStreamOf(client.subscribeChannels[V](channel, rest*))
 
   /**
@@ -202,7 +219,7 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
   def pSubscribeScoped[V: ValueCodec](pattern: String, rest: String*)(
     using Tag[PatternMessage[V]],
     Frame
-  ): Stream[PatternMessage[V], Abort[Throwable] & Async & Scope] < (Abort[Throwable] & Async & Scope) =
+  ): Stream[PatternMessage[V], Abort[SageException] & Async & Scope] < (Abort[SageException] & Async & Scope) =
     scopedStreamOf(client.subscribePatterns[V](pattern, rest*))
 
   /**
@@ -212,21 +229,23 @@ extension [K](client: Client[[A] =>> A < (Abort[Throwable] & Async), K])(using @
   def sSubscribeScoped[V: ValueCodec](channel: String, rest: String*)(
     using Tag[Message[V]],
     Frame
-  ): Stream[Message[V], Abort[Throwable] & Async & Scope] < (Abort[Throwable] & Async & Scope) =
+  ): Stream[Message[V], Abort[SageException] & Async & Scope] < (Abort[SageException] & Async & Scope) =
     scopedStreamOf(client.subscribeShardChannels[V](channel, rest*))
 
   private def streamOf[A](
-    open: => Subscription[KyoEff, A] < (Abort[Throwable] & Async)
-  )(using Tag[A], Frame): Stream[A, Abort[Throwable] & Async & Scope] =
+    open: => Subscription[[B] =>> B < (Abort[SageException] & Async), A] < (Abort[SageException] & Async)
+  )(using Tag[A], Frame): Stream[A, Abort[SageException] & Async & Scope] =
     Stream.init(Scope.acquireRelease(open)(_.close).map(Seq(_))).flatMap(deliveries)
 
   private def scopedStreamOf[A](
-    open: => Subscription[KyoEff, A] < (Abort[Throwable] & Async)
-  )(using Tag[A], Frame): Stream[A, Abort[Throwable] & Async & Scope] < (Abort[Throwable] & Async & Scope) =
+    open: => Subscription[[B] =>> B < (Abort[SageException] & Async), A] < (Abort[SageException] & Async)
+  )(using Tag[A], Frame): Stream[A, Abort[SageException] & Async & Scope] < (Abort[SageException] & Async & Scope) =
     Scope.acquireRelease(open)(_.close).map(deliveries)
 
   // chunkSize = 1: emit each message as it arrives — the default rechunks to 4096, withholding a live stream until that many accumulate
-  private def deliveries[A](sub: Subscription[KyoEff, A])(using Tag[A], Frame): Stream[A, Abort[Throwable] & Async & Scope] =
+  private def deliveries[A](
+    sub: Subscription[[B] =>> B < (Abort[SageException] & Async), A]
+  )(using Tag[A], Frame): Stream[A, Abort[SageException] & Async & Scope] =
     Stream.repeatPresent(sub.next.map(opt => Maybe.fromOption(opt.map(Seq(_)))), chunkSize = 1)
 }
 
@@ -236,19 +255,19 @@ object SageClient {
     * A command surface re-typed to a non-String key, as returned by `client.as[K]`. The unqualified [[SageClient]] is String-keyed;
     * use `as` to reach any other key type over the same connection.
     */
-  type Keyed[K] = Client[[A] =>> A < (Abort[Throwable] & Async), K]
+  type Keyed[K] = Client[[A] =>> A < (Abort[SageException] & Async), K]
 
   // bounded poll so xConsume's blocking read returns periodically, keeping cancellation responsive
   private[backend] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, java.util.concurrent.TimeUnit.SECONDS))
 
-  def connect(config: SageConfig): SageClient < (Abort[Throwable] & Async) =
-    Client.connect(config).lower.map(new Lowered(_))
+  def connect(config: SageConfig): SageClient < (Abort[SageException] & Async) =
+    refine(Client.connect(config).lower).map(new Lowered(_))
 
-  def scoped(config: SageConfig): SageClient < (Scope & Abort[Throwable] & Async) =
-    Scope.acquireRelease(connect(config))(client => Abort.run(client.close))
+  def scoped(config: SageConfig): SageClient < (Scope & Abort[SageException] & Async) =
+    Scope.acquireRelease(connect(config))(client => Abort.run[SageException](client.close))
 
-  final private class Lowered(underlying: Client[CIO, String]) extends LoweredClient[[A] =>> A < (Abort[Throwable] & Async)](underlying) {
-    protected def lower[A](c: CIO[A]): A < (Abort[Throwable] & Async) = c.lower
-    protected def lift[A](fa: A < (Abort[Throwable] & Async)): CIO[A] = CIO.lift(fa)
+  final private class Lowered(underlying: Client[CIO, String]) extends LoweredClient[[A] =>> A < (Abort[SageException] & Async)](underlying) {
+    protected def lower[A](c: CIO[A]): A < (Abort[SageException] & Async) = refine(c.lower)
+    protected def lift[A](fa: A < (Abort[SageException] & Async)): CIO[A] = CIO.lift(fa)
   }
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -12,7 +12,7 @@ import scala.util.control.NonFatal
 import kyo.compat.*
 
 import sage.{Bytes, Message, Outcome, PatternMessage, SageEvent, SageException}
-import sage.SageException.{ConnectionLost, NotCacheable, NotConnected, ServerError, TimedOut, TlsError, UnsupportedServer}
+import sage.SageException.{ConnectionFailed, ConnectionLost, NotCacheable, NotConnected, ServerError, TimedOut, TlsError, UnsupportedServer}
 import sage.client.{AuthConfig, BackoffConfig, DedicatedPoolConfig, Endpoint, PubSubConfig, ReadFrom, SageConfig, Topology, WatchdogConfig}
 import sage.cluster.Node
 import sage.codec.{KeyCodec, ValueCodec}
@@ -2305,7 +2305,12 @@ object Client {
         UnsupportedServer(s"sage requires RESP3 (Redis 6.0+ or any Valkey); server rejected HELLO 3: ${e.getMessage}")
       case e: SSLException                                                                               =>
         TlsError(s"TLS handshake failed: ${e.getMessage}")
-      case other                                                                                         => other
+      case e: SageException                                                                              => e
+      // a raw network error would otherwise escape the sealed hierarchy
+      case other                                                                                         =>
+        val failed = ConnectionFailed(s"could not connect: $other")
+        failed.initCause(other)
+        failed
     }
 
   final private class Live(

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -12,7 +12,7 @@ import scala.util.control.NonFatal
 import kyo.compat.*
 
 import sage.{Bytes, Message, Outcome, PatternMessage, SageEvent, SageException}
-import sage.SageException.{ConnectionFailed, ConnectionLost, DecodeError, NotCacheable, NotConnected, ServerError, TimedOut, TlsError, UnsupportedServer}
+import sage.SageException.*
 import sage.client.{AuthConfig, BackoffConfig, DedicatedPoolConfig, Endpoint, PubSubConfig, ReadFrom, SageConfig, Topology, WatchdogConfig}
 import sage.cluster.Node
 import sage.codec.{KeyCodec, ValueCodec}

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -12,7 +12,7 @@ import scala.util.control.NonFatal
 import kyo.compat.*
 
 import sage.{Bytes, Message, Outcome, PatternMessage, SageEvent, SageException}
-import sage.SageException.{ConnectionFailed, ConnectionLost, NotCacheable, NotConnected, ServerError, TimedOut, TlsError, UnsupportedServer}
+import sage.SageException.{ConnectionFailed, ConnectionLost, DecodeError, NotCacheable, NotConnected, ServerError, TimedOut, TlsError, UnsupportedServer}
 import sage.client.{AuthConfig, BackoffConfig, DedicatedPoolConfig, Endpoint, PubSubConfig, ReadFrom, SageConfig, Topology, WatchdogConfig}
 import sage.cluster.Node
 import sage.codec.{KeyCodec, ValueCodec}
@@ -2407,11 +2407,16 @@ object Client {
       def close: CIO[Unit]                     = CIO.blocking(raw.close())
     }
 
-  // an undecodable payload fails the subscription stream rather than being silently dropped
+  // fail the stream on a bad payload rather than dropping it
   private def decodeOrThrow[V](payload: sage.Bytes)(using codec: ValueCodec[V]): V =
-    codec.decode(payload) match {
-      case Right(value) => value
-      case Left(error)  => throw error
+    try
+      codec.decode(payload) match {
+        case Right(value) => value
+        case Left(error)  => throw error
+      }
+    catch {
+      case e: SageException => throw e
+      case NonFatal(e)      => throw DecodeError.fromThrowable(e)
     }
 
   final private[internal] class TxScope(val conn: DedicatedConnection, onFault: Throwable => Unit = _ => ()) extends TransactionScope[CIO, String] {

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -323,11 +323,7 @@ final private[client] class ClusterLive(
     Frame.Array(merged.result())
   }
 
-  private def decodeMerged[A](command: Command[A], merged: Frame): Try[A] =
-    Reply.run(command, merged) match {
-      case Right(value) => Success(value)
-      case Left(error)  => Failure(error)
-    }
+  private def decodeMerged[A](command: Command[A], merged: Frame): Try[A] = Reply.decode(command, merged)
 
   private def sendToAny[A](topology: ClusterTopology, command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit =
     pickNode(topology) match {

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
@@ -4,7 +4,6 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference, AtomicReferenceArray}
 
 import scala.util.{Failure, Success, Try}
-import scala.util.control.NonFatal
 
 import sage.Bytes
 import sage.SageException
@@ -102,15 +101,7 @@ final private[client] class DedicatedConnection private (
     def dropped(): Unit = { inFlight.decrementAndGet(); callback(Failure(ConnectionLost(mayHaveExecuted = false))) }
 
     def complete(frame: Frame): Unit = {
-      val result =
-        try
-          Reply.run(command, frame) match {
-            case Right(value) => Success(value)
-            case Left(error)  => Failure(error)
-          }
-        catch {
-          case NonFatal(error) => Failure(error)
-        }
+      val result = Reply.decode(command, frame)
       inFlight.decrementAndGet()
       callback(result)
     }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -9,7 +9,7 @@ import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
 import sage.{Bytes, Outcome, SageEvent, SageException}
-import sage.SageException.{ConnectionLost, NotConnected}
+import sage.SageException.{ConnectionLost, DecodeError, NotConnected}
 import sage.client.{BackoffConfig, WatchdogConfig}
 import sage.cluster.Node
 import sage.commands.{Command, Connection, Invalidation, Reply}
@@ -232,14 +232,17 @@ final private[client] class MultiplexedConnection private (
     if (conn != null) conn.checkLiveness(scheduler.nowMillis, watchdog.pingInterval.toMillis, watchdog.pingTimeout.toMillis)
   }
 
-  // mirrors Entry.complete: top-level error frames become a ServerError, and a throwing user decoder fails the call rather than escaping
+  // mirrors Entry.complete: top-level error frames become a ServerError, and a throwing user codec becomes a DecodeError
   private def decodeFrame[A](command: Command[A], frame: Frame): Try[A] =
     try
       Reply.run(command, frame) match {
         case Right(value) => Success(value)
         case Left(error)  => Failure(error)
       }
-    catch { case NonFatal(error) => Failure(error) }
+    catch {
+      case error: SageException => Failure(error)
+      case NonFatal(error)      => Failure(DecodeError("a value the codec could decode", s"a codec that threw $error"))
+    }
 
   final private class Conn {
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -9,7 +9,7 @@ import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
 import sage.{Bytes, Outcome, SageEvent, SageException}
-import sage.SageException.{ConnectionLost, DecodeError, NotConnected}
+import sage.SageException.{ConnectionLost, NotConnected}
 import sage.client.{BackoffConfig, WatchdogConfig}
 import sage.cluster.Node
 import sage.commands.{Command, Connection, Invalidation, Reply}
@@ -232,17 +232,7 @@ final private[client] class MultiplexedConnection private (
     if (conn != null) conn.checkLiveness(scheduler.nowMillis, watchdog.pingInterval.toMillis, watchdog.pingTimeout.toMillis)
   }
 
-  // mirrors Entry.complete: top-level error frames become a ServerError, and a throwing user codec becomes a DecodeError
-  private def decodeFrame[A](command: Command[A], frame: Frame): Try[A] =
-    try
-      Reply.run(command, frame) match {
-        case Right(value) => Success(value)
-        case Left(error)  => Failure(error)
-      }
-    catch {
-      case error: SageException => Failure(error)
-      case NonFatal(error)      => Failure(DecodeError("a value the codec could decode", s"a codec that threw $error"))
-    }
+  private def decodeFrame[A](command: Command[A], frame: Frame): Try[A] = Reply.decode(command, frame)
 
   final private class Conn {
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -6,7 +6,6 @@ import java.util.concurrent.locks.ReentrantLock
 
 import scala.collection.mutable
 import scala.concurrent.duration.*
-import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
 
 import sage.Bytes
@@ -253,11 +252,7 @@ final private[client] class SubscriptionConnection(
         bootstrap,
         connectTimeoutMillis,
         (command, cb) => {
-          bootstrapWaiter = frame =>
-            cb(Reply.run(command, frame) match {
-              case Right(value) => Success(value)
-              case Left(error)  => Failure(error)
-            })
+          bootstrapWaiter = frame => cb(Reply.decode(command, frame))
           conn.send(command.encode)
         },
         () => conn.close()

--- a/sage-client/shared/src/main/scala/sage/client/internal/TxSupport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/TxSupport.scala
@@ -29,7 +29,7 @@ private[internal] object TxSupport {
     result match {
       case Success(value)            => Right(value)
       case Failure(e: SageException) => Left(e)
-      case Failure(other)            => Left(DecodeError("a decodable reply", s"decoder threw $other"))
+      case Failure(other)            => Left(DecodeError.fromThrowable(other))
     }
 
   // None = WATCH abort; Some = the per-position decoded results. A queueing-phase error fails the effect (nothing ran).
@@ -43,7 +43,7 @@ private[internal] object TxSupport {
         frames(n + 1) match {
           case Frame.Null                              => CIO.value(None)
           case Frame.Array(elems) if elems.length == n =>
-            CIO.value(Some(Vector.tabulate(n)(i => Reply.run(commands(i), elems(i)))))
+            CIO.value(Some(Vector.tabulate(n)(i => toEither(Reply.decode(commands(i), elems(i))))))
           case Frame.Array(elems)                      =>
             CIO.fail(ProtocolError(s"EXEC returned ${elems.length} results for $n queued commands"))
           case other                                   =>

--- a/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
@@ -228,7 +228,10 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     var result: Option[Try[String]] = None
     connection.submit(throwing, r => result = Some(r))
     transports.head.emit(Frame.SimpleString("PONG"))
-    assertEquals(result, Some(Failure(boom)))
+    result match {
+      case Some(Failure(e: DecodeError)) => assertEquals(e.getCause, boom)
+      case other                         => fail(s"expected a DecodeError wrapping the thrown exception, got $other")
+    }
   }
 
   test("a reply with nothing pending discards the connection") {

--- a/sage-client/zio/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/zio/src/main/scala/sage/backend/SageClient.scala
@@ -9,23 +9,24 @@ import kyo.compat.*
 import zio.*
 import zio.stream.ZStream
 
-import sage.{Message, PatternMessage}
+import sage.{Message, PatternMessage, SageException}
 import sage.client.SageConfig
 import sage.client.internal.{Client, LoweredClient, Paged, ScanStep, ScanTarget, Subscription}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
 
 /**
-  * The ZIO-native surface: the same client, with every method returning `Task`.
+  * The ZIO-native surface: the same client, with every method returning an `IO[SageException, *]`, so failures are matched exhaustively.
+  * Anything that is not a `SageException` is a defect (a ZIO die), never a typed failure.
   */
-type SageClient = Client[Task, String]
+type SageClient = Client[IO[SageException, *], String]
 
-extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
+extension [K](client: Client[IO[SageException, *], K])(using @unused ev: KeyCodec[K]) {
 
   /**
     * Runs a read with client-side caching and a ZIO `Duration` TTL — the ZIO-native form of [[sage.client.internal.Client.cached]].
     */
-  def cached[A](command: Command[A], ttl: Duration): Task[A] =
+  def cached[A](command: Command[A], ttl: Duration): IO[SageException, A] =
     client.cached(command, ttl.asFiniteDuration)
 
   /**
@@ -36,7 +37,7 @@ extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
     pattern: Option[String] = None,
     count: Option[Long] = None,
     ofType: Option[RedisType] = None
-  ): ZStream[Any, Throwable, K] =
+  ): ZStream[Any, SageException, K] =
     scanStreamAll(target => cursor => client.runOn(target, Keys.scan[K](cursor, pattern, count, ofType)))
 
   /**
@@ -46,7 +47,7 @@ extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
-  ): ZStream[Any, Throwable, (F, V)] =
+  ): ZStream[Any, SageException, (F, V)] =
     scanStream(cursor => client.run(Hashes.hScan[K, F, V](key, cursor, pattern, count)))
 
   /**
@@ -56,7 +57,7 @@ extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
-  ): ZStream[Any, Throwable, V] =
+  ): ZStream[Any, SageException, V] =
     scanStream(cursor => client.run(Sets.sScan[K, V](key, cursor, pattern, count)))
 
   /**
@@ -66,23 +67,25 @@ extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
     key: K,
     pattern: Option[String] = None,
     count: Option[Long] = None
-  ): ZStream[Any, Throwable, (V, Double)] =
+  ): ZStream[Any, SageException, (V, Double)] =
     scanStream(cursor => client.run(SortedSets.zScan[K, V](key, cursor, pattern, count)))
 
-  private def scanStream[A](fetch: ScanCursor => Task[ScanPage[A]]): ZStream[Any, Throwable, A] =
+  private def scanStream[A](fetch: ScanCursor => IO[SageException, ScanPage[A]]): ZStream[Any, SageException, A] =
     CStream
       .unfold[Option[ScanCursor], Vector[A]](Some(ScanCursor.start))(Paged.byCursor(cursor => CIO.lift(fetch(cursor))))
       .flatMap(items => CStream.init(items))
       .lower
+      .refineToOrDie[SageException]
 
   // walks every scan target in turn, each with its own node-local cursor, so a cluster SCAN sweeps all masters instead of one
-  private def scanStreamAll[A](fetch: ScanTarget => ScanCursor => Task[ScanPage[A]]): ZStream[Any, Throwable, A] =
+  private def scanStreamAll[A](fetch: ScanTarget => ScanCursor => IO[SageException, ScanPage[A]]): ZStream[Any, SageException, A] =
     CStream
       .unfold[ScanStep, Vector[A]](ScanStep.Begin)(
         Paged.acrossTargets(CIO.lift(client.scanTargets))(target => cursor => CIO.lift(fetch(target)(cursor)))
       )
       .flatMap(items => CStream.init(items))
       .lower
+      .refineToOrDie[SageException]
 
   /**
     * Lazily pages an entire stream by range, batching `XRANGE` and advancing past the last id each page. Stops when a page comes back empty.
@@ -92,13 +95,14 @@ extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
     start: StreamRangeId = StreamRangeId.Min,
     end: StreamRangeId = StreamRangeId.Max,
     batch: Long = 100L
-  ): ZStream[Any, Throwable, StreamEntry[F, V]] =
+  ): ZStream[Any, SageException, StreamEntry[F, V]] =
     CStream
       .unfold[Option[StreamRangeId], Vector[StreamEntry[F, V]]](Some(start))(
         Paged.byRange(batch)(from => CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))))
       )
       .flatMap(items => CStream.init(items))
       .lower
+      .refineToOrDie[SageException]
 
   /**
     * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Tombstone
@@ -112,13 +116,14 @@ extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
     minIdle: FiniteDuration,
     start: StreamId = StreamId.Zero,
     count: Option[Long] = None
-  ): ZStream[Any, Throwable, StreamEntry[F, V]] =
+  ): ZStream[Any, SageException, StreamEntry[F, V]] =
     CStream
       .unfold[Option[StreamId], Vector[StreamEntry[F, V]]](Some(start))(
         Paged.byAutoClaim(from => CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))))
       )
       .flatMap(items => CStream.init(items))
       .lower
+      .refineToOrDie[SageException]
 
   /**
     * Follows a stream without a consumer group: replays every entry after `from`, then blocks for new entries forever, advancing past the
@@ -130,7 +135,7 @@ extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
     from: StreamId = StreamId.Zero,
     count: Option[Long] = None,
     block: BlockTimeout = SageClient.defaultPoll
-  ): ZStream[Any, Throwable, StreamEntry[F, V]] =
+  ): ZStream[Any, SageException, StreamEntry[F, V]] =
     CStream
       .unfold[StreamId, Vector[StreamEntry[F, V]]](from)(
         Paged.tail(last =>
@@ -139,6 +144,7 @@ extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
       )
       .flatMap(items => CStream.init(items))
       .lower
+      .refineToOrDie[SageException]
 
   /**
     * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
@@ -151,7 +157,7 @@ extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
     key: K,
     count: Option[Long] = None,
     block: BlockTimeout = SageClient.defaultPoll
-  )(handle: StreamEntry[F, V] => Task[Unit]): Task[Unit] =
+  )(handle: StreamEntry[F, V] => IO[SageException, Unit]): IO[SageException, Unit] =
     consumeStream[F, V](group, consumer, key, count, block)
       .mapZIO(entry => handle(entry) *> client.run(Streams.xAck(key, group)(entry.id)).unit)
       .runDrain
@@ -162,7 +168,7 @@ extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
     key: K,
     count: Option[Long],
     block: BlockTimeout
-  ): ZStream[Any, Throwable, StreamEntry[F, V]] =
+  ): ZStream[Any, SageException, StreamEntry[F, V]] =
     CStream
       .unfold[Either[StreamId, Unit], Vector[StreamEntry[F, V]]](Left(StreamId.Zero))(
         Paged.consume(
@@ -175,52 +181,55 @@ extension [K](client: Client[Task, K])(using @unused ev: KeyCodec[K]) {
       )
       .flatMap(items => CStream.init(items))
       .lower
+      .refineToOrDie[SageException]
 
   /**
     * Subscribes to one or more channels; closing the stream's scope unsubscribes. Survives reconnects via auto-resubscribe, dropping
     * messages published during the reconnect gap.
     */
-  def subscribe[V: ValueCodec](channel: String, rest: String*): ZStream[Any, Throwable, Message[V]] =
+  def subscribe[V: ValueCodec](channel: String, rest: String*): ZStream[Any, SageException, Message[V]] =
     streamOf(client.subscribeChannels[V](channel, rest*))
 
   /**
     * Subscribes to one or more glob patterns; each delivery names the matching pattern and the concrete channel.
     */
-  def pSubscribe[V: ValueCodec](pattern: String, rest: String*): ZStream[Any, Throwable, PatternMessage[V]] =
+  def pSubscribe[V: ValueCodec](pattern: String, rest: String*): ZStream[Any, SageException, PatternMessage[V]] =
     streamOf(client.subscribePatterns[V](pattern, rest*))
 
   /**
     * Subscribes to one or more Shard Channels; in a cluster each is routed to the Node owning its Slot, and resubscription follows the Slot
     * on migration or failover. A sharded delivery is an ordinary [[Message]].
     */
-  def sSubscribe[V: ValueCodec](channel: String, rest: String*): ZStream[Any, Throwable, Message[V]] =
+  def sSubscribe[V: ValueCodec](channel: String, rest: String*): ZStream[Any, SageException, Message[V]] =
     streamOf(client.subscribeShardChannels[V](channel, rest*))
 
   /**
     * Like [[subscribe]], but the returned effect completes only once the server has confirmed the SUBSCRIBE, so a publish sequenced after it
     * cannot race the registration. Closing the `Scope` unsubscribes.
     */
-  def subscribeScoped[V: ValueCodec](channel: String, rest: String*): ZIO[Scope, Throwable, ZStream[Any, Throwable, Message[V]]] =
+  def subscribeScoped[V: ValueCodec](channel: String, rest: String*): ZIO[Scope, SageException, ZStream[Any, SageException, Message[V]]] =
     scopedStreamOf(client.subscribeChannels[V](channel, rest*))
 
   /**
     * Like [[pSubscribe]], but the returned effect completes only once the server has confirmed the PSUBSCRIBE. Closing the `Scope`
     * unsubscribes.
     */
-  def pSubscribeScoped[V: ValueCodec](pattern: String, rest: String*): ZIO[Scope, Throwable, ZStream[Any, Throwable, PatternMessage[V]]] =
+  def pSubscribeScoped[V: ValueCodec](pattern: String, rest: String*): ZIO[Scope, SageException, ZStream[Any, SageException, PatternMessage[V]]] =
     scopedStreamOf(client.subscribePatterns[V](pattern, rest*))
 
   /**
     * Like [[sSubscribe]], but the returned effect completes only once the server has confirmed the SSUBSCRIBE. Closing the `Scope`
     * unsubscribes.
     */
-  def sSubscribeScoped[V: ValueCodec](channel: String, rest: String*): ZIO[Scope, Throwable, ZStream[Any, Throwable, Message[V]]] =
+  def sSubscribeScoped[V: ValueCodec](channel: String, rest: String*): ZIO[Scope, SageException, ZStream[Any, SageException, Message[V]]] =
     scopedStreamOf(client.subscribeShardChannels[V](channel, rest*))
 
-  private def streamOf[A](open: Task[Subscription[Task, A]]): ZStream[Any, Throwable, A] =
+  private def streamOf[A](open: IO[SageException, Subscription[IO[SageException, *], A]]): ZStream[Any, SageException, A] =
     ZStream.unwrapScoped(scopedStreamOf(open))
 
-  private def scopedStreamOf[A](open: Task[Subscription[Task, A]]): ZIO[Scope, Throwable, ZStream[Any, Throwable, A]] =
+  private def scopedStreamOf[A](
+    open: IO[SageException, Subscription[IO[SageException, *], A]]
+  ): ZIO[Scope, SageException, ZStream[Any, SageException, A]] =
     ZIO.acquireRelease(open)(_.close.ignore).map { sub =>
       ZStream.repeatZIOOption(sub.next.mapError(Some(_)).flatMap {
         case Some(a) => ZIO.succeed(a)
@@ -235,22 +244,22 @@ object SageClient {
     * A command surface re-typed to a non-String key, as returned by `client.as[K]`. The unqualified [[SageClient]] is String-keyed;
     * use `as` to reach any other key type over the same connection.
     */
-  type Keyed[K] = Client[Task, K]
+  type Keyed[K] = Client[IO[SageException, *], K]
 
   // bounded poll so xConsume's blocking read returns periodically, keeping cancellation responsive
   private[backend] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, TimeUnit.SECONDS))
 
-  def connect(config: SageConfig): Task[SageClient] =
-    Client.connect(config).lower.map(new Lowered(_))
+  def connect(config: SageConfig): IO[SageException, SageClient] =
+    Client.connect(config).lower.refineToOrDie[SageException].map(new Lowered(_))
 
-  def scoped(config: SageConfig): ZIO[Scope, Throwable, SageClient] =
+  def scoped(config: SageConfig): ZIO[Scope, SageException, SageClient] =
     ZIO.acquireRelease(connect(config))(_.close.ignore)
 
-  def layer(config: SageConfig): ZLayer[Any, Throwable, SageClient] =
+  def layer(config: SageConfig): ZLayer[Any, SageException, SageClient] =
     ZLayer.scoped(scoped(config))
 
-  final private class Lowered(underlying: Client[CIO, String]) extends LoweredClient[Task](underlying) {
-    protected def lower[A](c: CIO[A]): Task[A] = c.lower
-    protected def lift[A](fa: Task[A]): CIO[A] = CIO.lift(fa)
+  final private class Lowered(underlying: Client[CIO, String]) extends LoweredClient[IO[SageException, *]](underlying) {
+    protected def lower[A](c: CIO[A]): IO[SageException, A] = c.lower.refineToOrDie[SageException]
+    protected def lift[A](fa: IO[SageException, A]): CIO[A] = CIO.lift(fa)
   }
 }

--- a/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
@@ -9,7 +9,7 @@ import scala.jdk.CollectionConverters.*
 import kyo.compat.*
 
 import sage.{Bytes, Outcome, SageEvent, SageListener}
-import sage.SageException.{NotConnected, UnsupportedServer}
+import sage.SageException.{ConnectionFailed, NotConnected, UnsupportedServer}
 import sage.client.internal.{Client, Events, FakeTransport, ManualScheduler, MultiplexedConnection}
 import sage.commands.{Command, Execution}
 import sage.protocol.Frame
@@ -46,6 +46,15 @@ class ConnectSpec extends munit.FunSuite {
     val (factory, _) = scripted(helloThenPong)
     Client.connectWith(factory).flatMap(client => client.ping()).unsafeRun.map { result =>
       assertEquals(result, "PONG")
+    }
+  }
+
+  test("a refused connection surfaces as a recoverable ConnectionFailed carrying the cause") {
+    val deadPort = { val s = new java.net.ServerSocket(0); val p = s.getLocalPort; s.close(); p } // a port nothing listens on
+    val config   = SageConfig(topology = Topology.Standalone(Endpoint("127.0.0.1", deadPort)), connectTimeout = 1.second)
+    Client.connect(config).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[ConnectionFailed], s"expected ConnectionFailed, got $error")
+      assert(error.getCause != null, "the original network error should be preserved as the cause")
     }
   }
 

--- a/sage-core/src/main/scala/sage/SageException.scala
+++ b/sage-core/src/main/scala/sage/SageException.scala
@@ -36,6 +36,12 @@ object SageException {
   }
 
   /**
+    * The initial connection could not be established (host unreachable, refused, or connect timeout). Distinct from [[ConnectionLost]], a
+    * live connection dropping around a command.
+    */
+  final case class ConnectionFailed(message: String) extends SageException(message)
+
+  /**
     * The connection dropped around this command. `mayHaveExecuted` is true when it was already in flight — the server may or may not have
     * applied it, so a non-idempotent command is not safe to blindly retry; false means it was never sent and retrying is safe.
     */

--- a/sage-core/src/main/scala/sage/SageException.scala
+++ b/sage-core/src/main/scala/sage/SageException.scala
@@ -19,6 +19,15 @@ object SageException {
     */
   final case class DecodeError(expected: String, actual: String) extends SageException(s"expected $expected, got $actual")
 
+  object DecodeError {
+
+    private[sage] def fromThrowable(error: Throwable): DecodeError = {
+      val wrapped = DecodeError("a value the codec could decode", s"the codec threw $error")
+      wrapped.initCause(error)
+      wrapped
+    }
+  }
+
   /**
     * An error reply from the server. `code` is the leading token Redis/Valkey put on every error (`WRONGTYPE`, `NOSCRIPT`, `BUSYGROUP`,
     * the generic `ERR`, …), split out so callers can branch on it — `case ServerError("WRONGTYPE", _)` — without parsing the message

--- a/sage-core/src/main/scala/sage/commands/Reply.scala
+++ b/sage-core/src/main/scala/sage/commands/Reply.scala
@@ -1,7 +1,10 @@
 package sage.commands
 
+import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
+
 import sage.SageException
-import sage.SageException.ServerError
+import sage.SageException.{DecodeError, ServerError}
 import sage.protocol.Frame
 
 /**
@@ -15,5 +18,23 @@ private[sage] object Reply {
       case Frame.SimpleError(message) => Left(ServerError.of(message))
       case Frame.BulkError(message)   => Left(ServerError.of(message.asUtf8String))
       case other                      => command.decode(other)
+    }
+
+  /**
+    * The decode boundary every transport uses: a throwing codec is caught and wrapped as a [[DecodeError]] (keeping the cause) rather than
+    * escaping as a raw throwable.
+    */
+  def decode[Out](command: Command[Out], frame: Frame): Try[Out] =
+    try
+      run(command, frame) match {
+        case Right(value) => Success(value)
+        case Left(error)  => Failure(error)
+      }
+    catch {
+      case error: SageException => Failure(error)
+      case NonFatal(error)      =>
+        val wrapped = DecodeError("a value the codec could decode", s"the codec threw $error")
+        wrapped.initCause(error)
+        Failure(wrapped)
     }
 }

--- a/sage-core/src/main/scala/sage/commands/Reply.scala
+++ b/sage-core/src/main/scala/sage/commands/Reply.scala
@@ -32,9 +32,6 @@ private[sage] object Reply {
       }
     catch {
       case error: SageException => Failure(error)
-      case NonFatal(error)      =>
-        val wrapped = DecodeError("a value the codec could decode", s"the codec threw $error")
-        wrapped.initCause(error)
-        Failure(wrapped)
+      case NonFatal(error)      => Failure(DecodeError.fromThrowable(error))
     }
 }


### PR DESCRIPTION
## What

The ZIO and Kyo backends now expose failures as the sealed `SageException` in their error channel rather than `Throwable`:

- ZIO: every command returns `IO[SageException, *]`
- Kyo: `A < (Abort[SageException] & Async)`

so callers match failures exhaustively and the compiler enforces handling. Anything that is not a `SageException` is a defect (a ZIO die / a Kyo `Panic`), never a typed failure. The cats-effect, Pekko, and Ox backends are unchanged: they carry the same `SageException` at runtime through their untyped channels (no error-type parameter to refine, and `Either` is not forced on them).

## Keeping failures in the typed channel

Two gaps would otherwise leak as defects under the refined channel, both closed here:

- **Decode**: a user codec that throws instead of returning `Left` is caught and wrapped as a `DecodeError` (the original throwable kept as the cause) at every transport (multiplexed, dedicated, cluster) plus transaction `EXEC` and subscription payloads. Previously only the multiplexed path wrapped it, so the same buggy codec was recoverable on one command and an uncatchable defect on another. The wrap is centralized in `DecodeError.fromThrowable`.
- **Connect**: a raw network error on the initial connection (refused, unreachable, connect timeout) is wrapped in a new `SageException.ConnectionFailed` rather than escaping as a raw `IOException`, so connection failures stay recoverable. Distinct from `ConnectionLost` (a live connection dropping around a command).

## Notes

- New sealed case: `ConnectionFailed`, so exhaustive `SageException` matches gain one branch.
- `docs/error-handling.md` updated with the two-tier model and the new case.