### PR TITLE
Add CommandTracer SPI and OpenTelemetry tracing module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ val scala3NextSuffix  = scala3NextVersion.replace('.', '_') // Kyo cells embed t
 
 val munitVersion          = "1.3.3"
 val testcontainersVersion = "0.44.1"
+val otelVersion           = "1.40.0"
 
 // backend effect libraries, declared explicitly so Scala Steward keeps them current
 val kyoVersion        = "1.0.0-RC4"
@@ -54,7 +55,7 @@ addCommandAlias(
 
 addCommandAlias(
   "testUnit",
-  s"all core/test clientZio/test clientCe/test clientOx/test clientPekko/test clientKyo$scala3NextSuffix/test " +
+  s"all core/test opentelemetry/test clientZio/test clientCe/test clientOx/test clientPekko/test clientKyo$scala3NextSuffix/test " +
     "clientFuture/Test/compile integrationTestsFuture/Test/compile integrationTestsPekko/Test/compile " +
     s"benchmarksZio/compile benchmarksCe/compile benchmarksOx/compile benchmarksPekko/compile benchmarksKyo$scala3NextSuffix/compile " +
     "examplesZio/Compile/compile examplesCe/Compile/compile examplesOx/Compile/compile examplesPekko/Compile/compile " +
@@ -78,7 +79,7 @@ lazy val root = project
   .settings(publish / skip := true)
   // benchmarks is intentionally NOT aggregated: it is dev-only/on-demand and pulls JMH + testcontainers + competitor clients, which should
   // not be dragged into ordinary root compile/test/CI. The benchAll alias and benchmarks<Cell>/Jmh/run target its cells directly.
-  .aggregate(core.projectRefs ++ client.projectRefs ++ integrationTests.projectRefs ++ examples.projectRefs: _*)
+  .aggregate(core.projectRefs ++ client.projectRefs ++ opentelemetry.projectRefs ++ integrationTests.projectRefs ++ examples.projectRefs: _*)
 
 // Pure sans-IO core: RESP3 protocol, command model, codecs. Zero external dependencies.
 // Built for both Scala LTS (published) and Scala Next (compile-only, so the kyo client cell can depend on it).
@@ -96,6 +97,26 @@ lazy val core = (projectMatrix in file("sage-core"))
     autoScalaLibrary = true,
     axisValues = Seq(VirtualAxis.jvm, VirtualAxis.scalaVersionAxis(scala3NextVersion, scala3NextVersion)),
     process = (p: Project) => p.settings(publish / skip := true)
+  )
+
+// OpenTelemetry tracing. LTS-only: a Scala Next (kyo) app consumes the LTS artifact, as it already does for sage-core.
+lazy val opentelemetry = (projectMatrix in file("sage-opentelemetry"))
+  .dependsOn(core)
+  .settings(name := "sage-opentelemetry")
+  .settings(commonSettings)
+  .settings(parallelUnitTests)
+  .settings(
+    libraryDependencies ++= Seq(
+      "io.opentelemetry" % "opentelemetry-api"         % otelVersion,
+      "io.opentelemetry" % "opentelemetry-sdk"         % otelVersion % Test,
+      "io.opentelemetry" % "opentelemetry-sdk-testing" % otelVersion % Test
+    )
+  )
+  .defaultAxes(VirtualAxis.jvm, VirtualAxis.scalaVersionAxis(scala3Version, scala3Version))
+  .customRow(
+    autoScalaLibrary = true,
+    axisValues = Seq(VirtualAxis.jvm, VirtualAxis.scalaVersionAxis(scala3Version, scala3Version)),
+    process = identity[Project] _
   )
 
 // Runtime written once against kyo-compat, cross-published per backend. JDK 21+.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -80,7 +80,7 @@ val config = SageConfig(
 
 It emits one `CLIENT` span per command, named for the command (`GET`, `SET`, ...), with `db.system=redis`, `db.operation.name`, `peer.service` (default `redis`, configurable), `component=redis-client`, and the server address once routing resolves it; a failure sets an error status carrying the exception. Only the command name is recorded, never arguments or keys, so secrets and user values stay out of your traces. Spans follow the ambient sampling decision.
 
-One span is emitted per command that reaches the server: an ordinary command, a blocking command, and each command in a pipeline (cluster redirects fold into the command's own span). A `cached` read served from the local cache reaches no server and produces no span; one that does reach the server is traced like any other command. (A local cache miss reaches the server but is currently untraced.)
+One span is emitted per command that reaches the server: an ordinary command, a blocking command, and each command in a pipeline (cluster redirects fold into the command's own span). A `cached` read served from the local cache reaches no server and produces no span; one that misses and fetches from the server is traced like any other command.
 
 In a `transaction`, each read during the watch phase and the `WATCH` itself are traced like ordinary commands, and the atomic `MULTI`/`EXEC` body gets a single span named `MULTI`. That span reflects the round trip, not whether the transaction committed, so a `WATCH` abort or an error inside `EXEC` still settles it successfully. Transaction commands are traced but emit no `CommandCompleted`, so the listener contract is unchanged.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -3,7 +3,7 @@
 Sage exposes two integration points, for two different jobs:
 
 - **`SageListener`** is an asynchronous observer of `SageEvent`s (command completions, connection transitions, cache outcomes, topology changes), called off the command path. Use it for metrics and operational logging.
-- **`CommandTracer`** produces distributed-tracing spans synchronously on the command path, so each Redis command appears as a client span nested under the surrounding request in an APM such as Datadog or Jaeger. Use it for distributed tracing — see [Distributed tracing](#distributed-tracing).
+- **`CommandTracer`** produces distributed-tracing spans synchronously on the command path, so each Redis command appears as a client span nested under the surrounding request in an APM such as Datadog or Jaeger. Use it for distributed tracing: see [Distributed tracing](#distributed-tracing).
 
 They are separate types because their constraints differ: a listener runs after the fact and may drop events under load, so it cannot produce spans that nest under the active request; a tracer runs on the caller's fiber as the command is submitted, so it can.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -78,7 +78,7 @@ val config = SageConfig(
 )
 ```
 
-It emits one `CLIENT` span per command, named for the command (`GET`, `SET`, ...), with `db.system=redis`, `db.operation.name`, `peer.service` (default `redis`, configurable), `component=redis-client`, and the server address once routing resolves it; a failure sets an error status carrying the exception. Only the command name is recorded, never arguments or keys, so secrets and user values stay out of your traces. Spans follow the ambient sampling decision.
+It emits one `CLIENT` span per command, named for the command (`GET`, `SET`, ...), with `db.system=redis`, `db.operation.name`, `peer.service` (default `redis`, configurable), `component=redis-client`, and the server address (the configured endpoint for a standalone server, the routed node for a cluster or master/replica); a failure sets an error status carrying the exception. Only the command name is recorded, never arguments or keys, so secrets and user values stay out of your traces. Spans follow the ambient sampling decision.
 
 One span is emitted per command that reaches the server: an ordinary command, a blocking command, and each command in a pipeline (cluster redirects fold into the command's own span). A `cached` read served from the local cache reaches no server and produces no span; one that misses and fetches from the server is traced like any other command.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,8 +1,15 @@
 # Observability
 
-Sage reports what its runtime is doing through events. Register one or more `SageListener` on `SageConfig`, and each receives every `SageEvent`: command completions, connection transitions, cache outcomes, and topology changes. This is how you wire sage into your metrics, tracing, or logging.
+Sage exposes two integration points, for two different jobs:
+
+- **`SageListener`** is an asynchronous observer of `SageEvent`s (command completions, connection transitions, cache outcomes, topology changes), called off the command path. Use it for metrics and operational logging.
+- **`CommandTracer`** produces distributed-tracing spans synchronously on the command path, so each Redis command appears as a client span nested under the surrounding request in an APM such as Datadog or Jaeger. Use it for distributed tracing — see [Distributed tracing](#distributed-tracing).
+
+They are separate types because their constraints differ: a listener runs after the fact and may drop events under load, so it cannot produce spans that nest under the active request; a tracer runs on the caller's fiber as the command is submitted, so it can.
 
 ## Events
+
+Register one or more `SageListener` on `SageConfig`, and each receives every `SageEvent`: command completions, connection transitions, cache outcomes, and topology changes. This is how you wire sage into your metrics or logging.
 
 | Event | Reported when |
 | --- | --- |
@@ -14,7 +21,7 @@ Sage reports what its runtime is doing through events. Register one or more `Sag
 
 Events carry no command arguments or payloads, so secrets such as `AUTH` credentials and user values never reach a listener. `node` is `Some` in a cluster (the relevant master) and `None` on a standalone server.
 
-## Registering a listener
+### Registering a listener
 
 A `SageListener` has one synchronous, `Unit`-returning method. Match on the event you care about and forward it to your metrics system:
 
@@ -40,7 +47,7 @@ val config = SageConfig(
 
 `SageListener` lives in the core and is the same on every backend, so this snippet is backend-independent.
 
-## Delivery guarantees
+### Delivery guarantees
 
 Listeners are invoked off the command path, so they cannot block or break command execution:
 
@@ -51,3 +58,39 @@ Listeners are invoked off the command path, so they cannot block or break comman
 ::: warning
 Delivery is best-effort: events are dropped once the dispatch queue fills, and a throwing listener is swallowed. Listeners suit metrics, sampling, and operational logging, not anything that must be a complete or lossless record.
 :::
+
+## Distributed tracing
+
+A `SageListener` is the wrong tool for distributed tracing: by the time it runs on the dispatcher thread the caller's trace context is gone, so its spans would not nest under the in-flight request, and a dropped event would orphan a span. A `CommandTracer` instead runs synchronously on the command path, so each Redis span is a child of whatever span is active when the command is issued.
+
+Set one on `SageConfig.tracer`. The `sage-opentelemetry` module provides an OpenTelemetry implementation:
+
+```scala
+libraryDependencies += "com.github.ghostdogpr" %% "sage-opentelemetry" % "@VERSION@"
+```
+
+```scala
+import sage.opentelemetry.OpenTelemetryCommandTracer
+
+val config = SageConfig(
+  topology = Topology.Standalone(Endpoint("localhost", 6379)),
+  tracer   = Some(OpenTelemetryCommandTracer.global()) // reads the globally-registered OpenTelemetry
+)
+```
+
+It emits one `CLIENT` span per command, named for the command (`GET`, `SET`, ...), with `db.system=redis`, `db.operation.name`, `peer.service` (default `redis`, configurable), `component=redis-client`, and the server address once routing resolves it; a failure sets an error status carrying the exception. Only the command name is recorded, never arguments or keys, so secrets and user values stay out of your traces. Spans follow the ambient sampling decision.
+
+One span is emitted per command that reaches the server: an ordinary command, a blocking command, and each command in a pipeline (cluster redirects fold into the command's own span). A `cached` read served from the local cache reaches no server and produces no span; one that does reach the server is traced like any other command. (A local cache miss reaches the server but is currently untraced.)
+
+In a `transaction`, each read during the watch phase and the `WATCH` itself are traced like ordinary commands, and the atomic `MULTI`/`EXEC` body gets a single span named `MULTI`. That span reflects the round trip, not whether the transaction committed, so a `WATCH` abort or an error inside `EXEC` still settles it successfully. Transaction commands are traced but emit no `CommandCompleted`, so the listener contract is unchanged.
+
+The tracer reads the active span from OpenTelemetry's thread-local current context (`Context.current()`) on the fiber that submits the command. The module depends only on the OpenTelemetry **API**, so an APM agent supplies the implementation: when the agent instruments your runtime and propagates its context across that runtime's threads, the Redis span nests under the active request span with no further wiring. This is the case for ZIO under the Datadog Java agent. Configuring the agent itself (for Datadog, enabling its OpenTelemetry support) is covered by the agent's own documentation.
+
+### Context on a fiber runtime without an agent
+
+Running a bare OpenTelemetry SDK with no agent is the case that needs attention: on a fiber runtime the active span lives in fiber-local state (a ZIO `FiberRef`, a Cats Effect `IOLocal`), which is not the current context the tracer reads, so spans would be orphaned. Configure context storage so that `Context.current()` sees the active span:
+
+- **ZIO**: with `zio-telemetry`, wire OpenTelemetry through the `OpenTelemetry.contextJVM` and `OpenTelemetry.global` layers (rather than `OpenTelemetry.contextZIO` and `OpenTelemetry.custom`), which back tracing with OpenTelemetry's native context so the SDK reads the active span. See zio-telemetry's auto-instrumentation interop documentation.
+- **cats-effect**: with `otel4s` on Cats Effect 3.6+, add the `otel4s-oteljava-context-storage` dependency, enable the `cats.effect.trackFiberContext` system property, and provide `IOLocalContextStorage.localProvider[IO]`. This keeps the Java `Context` and the otel4s fiber context aligned so the SDK reads the active span. Note that the stock OpenTelemetry Java agent does not keep Cats Effect context in sync; otel4s ships a dedicated agent distribution for the agent case.
+
+`OpenTelemetryCommandTracer.withContextProvider` lets you supply a custom `() => Context` for a context source that is thread-local but non-default.

--- a/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
+++ b/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
@@ -7,7 +7,7 @@ import javax.net.ssl.SSLContext
 
 import scala.concurrent.duration.*
 
-import sage.SageListener
+import sage.{CommandTracer, SageListener}
 
 /**
   * Exponential reconnect backoff with full jitter (a random wait in `[0, base]`), spreading the reconnect storm across clients.
@@ -157,6 +157,8 @@ enum Topology {
   *                       a connection. Must be 0 for a cluster topology, which has only database 0
   * @param clientName     sets `CLIENT SETNAME`, visible in `CLIENT LIST`/`CLIENT INFO`; the library name and version are announced automatically
   * @param listeners      observers of runtime [[sage.SageEvent]]s — see [[sage.SageListener]]
+  * @param tracer         an optional distributed tracer, driven synchronously on the command path so its spans nest under the caller's active
+  *                       span — see [[sage.CommandTracer]]. `None` (the default) emits no spans
   */
 final case class SageConfig(
   connectTimeout: FiniteDuration = 10.seconds,
@@ -172,7 +174,8 @@ final case class SageConfig(
   readFrom: ReadFrom = ReadFrom.Master,
   database: Int = 0,
   clientName: Option[String] = None,
-  listeners: Vector[SageListener] = Vector.empty
+  listeners: Vector[SageListener] = Vector.empty,
+  tracer: Option[CommandTracer] = None
 )
 
 object SageConfig {

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2142,16 +2142,13 @@ object Client {
   private[internal] def notCacheable(command: Command[?]): NotCacheable =
     NotCacheable(s"${command.name} is not cacheable: cached requires a cacheable command with at least one key")
 
-  // run a submit that registers a reply callback; if it throws synchronously instead (e.g. a closed transport), complete with the error so the
-  // caller's CIO.async settles rather than hangs
+  // if the submit throws synchronously (e.g. a closed transport) instead of registering a callback, complete with the error so CIO.async settles
   private[internal] def completing[A](complete: Try[A] => Unit)(submit: => Unit): Unit =
     try submit
     catch { case NonFatal(error) => complete(Failure(error)) }
 
   // a pipeline batched onto a single connection: scatter each reply into its submission-order slot, and on a disconnect report a failed
   // completion per position before failing the effect once. Shared by standalone/master-replica; the cluster runtime splits per node instead.
-  // `spans` are started by the caller on its fiber and passed in (empty when no tracer), so a master-replica pipeline running this on an offload
-  // worker still nests its spans correctly while the duration clock starts here, on the executing thread.
   private[internal] def submitBatchOnOne(
     events: Events,
     commands: Vector[Command[?]],
@@ -2166,7 +2163,6 @@ object Client {
     }
     if (!submitAll(commands, callbacks)) {
       val error = NotConnected()
-      // this path completes the effect without invoking callbacks, so end any tracing spans they started rather than leak them unsettled
       callbacks.foreach(Events.abandonSpan(_, error))
       if (events.emitsEvents)
         commands.foreach(c => events.emit(SageEvent.CommandCompleted(c.name, None, Duration.Zero, Outcome.Failed(error))))
@@ -2259,7 +2255,7 @@ object Client {
         config.auth,
         config.clientCache.maxBytes,
         config.clientCache.enabled,
-        Events(config.listeners, config.tracer),
+        Events(config.listeners, config.tracer, serverNode = Some(Node(endpoint.host, endpoint.port))),
         config.database,
         config.clientName
       )
@@ -2496,7 +2492,6 @@ object Client {
       else if (command.isBlocking)
         CIO.fail(new IllegalArgumentException("a Transaction cannot run blocking commands; run them individually on the client"))
       else
-        // a live watch-phase read is an ordinary round trip, so trace it like any command; submitting drives `tracked` on every path
         CIO.async[A] { complete =>
           val tracked = Events.trackSpan(events, command, complete)
           submitting(tracked)(conn.submit(command, faulting(tracked)))

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2331,15 +2331,18 @@ object Client {
   ) extends Client[CIO, String] {
 
     def run[A](command: Command[A]): CIO[A] =
-      command.execution match {
-        case Execution.Ordinary => CIO.async(callback => connection.submit(command, Events.trackCommand(events, command, callback)))
-        case Execution.Blocking => CIO.async(callback => pool.use(command, Events.trackCommand(events, command, callback)))
+      CIO.async { callback =>
+        val tracked = Events.trackCommand(events, command, callback)
+        command.execution match {
+          case Execution.Ordinary => Client.completing(tracked)(connection.submit(command, tracked))
+          case Execution.Blocking => Client.completing(tracked)(pool.use(command, tracked))
+        }
       }
 
     def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =
       if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command))
       else if (!cachingEnabled) run(command) // tracking was never enabled, so run uncached rather than issue an unbacked CLIENT CACHING YES
-      else CIO.async(callback => connection.cachedSubmit(command, ttl.toMillis, callback))
+      else CIO.async(callback => Client.completing(callback)(connection.cachedSubmit(command, ttl.toMillis, callback)))
 
     def scanTargets: CIO[Vector[ScanTarget]] = CIO.value(Vector(ScanTarget.any))
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -11,7 +11,7 @@ import scala.util.control.NonFatal
 
 import kyo.compat.*
 
-import sage.{Bytes, Message, Outcome, PatternMessage, SageEvent, SageException}
+import sage.{Bytes, CommandSpan, Message, Outcome, PatternMessage, SageEvent, SageException}
 import sage.SageException.*
 import sage.client.{AuthConfig, BackoffConfig, DedicatedPoolConfig, Endpoint, PubSubConfig, ReadFrom, SageConfig, Topology, WatchdogConfig}
 import sage.cluster.Node
@@ -2142,27 +2142,40 @@ object Client {
   private[internal] def notCacheable(command: Command[?]): NotCacheable =
     NotCacheable(s"${command.name} is not cacheable: cached requires a cacheable command with at least one key")
 
+  // run a submit that registers a reply callback; if it throws synchronously instead (e.g. a closed transport), complete with the error so the
+  // caller's CIO.async settles rather than hangs
+  private[internal] def completing[A](complete: Try[A] => Unit)(submit: => Unit): Unit =
+    try submit
+    catch { case NonFatal(error) => complete(Failure(error)) }
+
   // a pipeline batched onto a single connection: scatter each reply into its submission-order slot, and on a disconnect report a failed
   // completion per position before failing the effect once. Shared by standalone/master-replica; the cluster runtime splits per node instead.
+  // `spans` are started by the caller on its fiber and passed in (empty when no tracer), so a master-replica pipeline running this on an offload
+  // worker still nests its spans correctly while the duration clock starts here, on the executing thread.
   private[internal] def submitBatchOnOne(
     events: Events,
     commands: Vector[Command[?]],
+    spans: Vector[CommandSpan],
     submitAll: (Vector[Command[?]], Vector[Try[Any] => Unit]) => Boolean,
     complete: Try[Vector[Either[SageException, Any]]] => Unit
   ): Unit = {
     val collector = new TxSupport.IndexedCollector[Either[SageException, Any]](commands.length, complete)
-    val callbacks = Vector.tabulate(commands.length)(i =>
-      Events.trackCommand[Any](events, commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)))
-    )
+    val callbacks = Vector.tabulate(commands.length) { i =>
+      val span = if (spans.isEmpty) CommandSpan.noop else spans(i)
+      Events.trackCommand[Any](events, commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)), span)
+    }
     if (!submitAll(commands, callbacks)) {
-      if (events.enabled)
-        commands.foreach(c => events.emit(SageEvent.CommandCompleted(c.name, None, Duration.Zero, Outcome.Failed(NotConnected()))))
-      complete(Failure(NotConnected()))
+      val error = NotConnected()
+      // this path completes the effect without invoking callbacks, so end any tracing spans they started rather than leak them unsettled
+      callbacks.foreach(Events.abandonSpan(_, error))
+      if (events.emitsEvents)
+        commands.foreach(c => events.emit(SageEvent.CommandCompleted(c.name, None, Duration.Zero, Outcome.Failed(error))))
+      complete(Failure(error))
     }
   }
 
   /**
-    * The construction seam each backend's `connect`/`scoped` builds on: validates `config`, then connects per its [[Topology]].
+    * The construction entry point each backend's `connect`/`scoped` builds on: validates `config`, then connects per its [[Topology]].
     */
   def connect(config: SageConfig): CIO[Client[CIO, String]] =
     validate(config) match {
@@ -2246,7 +2259,7 @@ object Client {
         config.auth,
         config.clientCache.maxBytes,
         config.clientCache.enabled,
-        Events(config.listeners),
+        Events(config.listeners, config.tracer),
         config.database,
         config.clientName
       )
@@ -2350,7 +2363,7 @@ object Client {
 
     private def acquireScope: CIO[TxScope] =
       CIO.blocking {
-        try new TxScope(pool.acquireForTransaction())
+        try new TxScope(pool.acquireForTransaction(), events = events)
         catch {
           case e: NotConnected => throw e
           case e: TimedOut     => throw e
@@ -2367,7 +2380,9 @@ object Client {
       else if (p.commands.exists(_.isBlocking))
         CIO.fail(new IllegalArgumentException("a Pipeline cannot carry blocking commands; run them individually on the client"))
       else
-        CIO.async(complete => Client.submitBatchOnOne(events, p.commands, connection.submitAll, complete))
+        CIO.async { complete =>
+          Client.submitBatchOnOne(events, p.commands, Events.startSpans(events, p.commands), connection.submitAll, complete)
+        }
 
     def subscribeChannels[V: ValueCodec](channel: String, rest: String*): CIO[Subscription[CIO, Message[V]]] =
       CIO.blocking(channelMessages(subscriptions.subscribeChannels(channel +: rest.toVector)))
@@ -2382,7 +2397,7 @@ object Client {
     def close: CIO[Unit] = CIO.blocking { subscriptions.close(); pool.close(); connection.close(); events.close() }
   }
 
-  // wrap a raw subscription as the effect-typed seam each backend lowers into its native stream; a channel/shard delivery is a Message
+  // wrap a raw subscription as the effect-typed interface each backend lowers into its native stream; a channel/shard delivery is a Message
   private[internal] def channelMessages[V](raw: SubscriptionConnection.RawSubscription)(using ValueCodec[V]): Subscription[CIO, Message[V]] =
     new Subscription[CIO, Message[V]] {
       // async, not blocking: the reader thread completes the callback, so a fiber parks instead of pinning a runtime worker
@@ -2419,7 +2434,8 @@ object Client {
       case NonFatal(e)      => throw DecodeError.fromThrowable(e)
     }
 
-  final private[internal] class TxScope(val conn: DedicatedConnection, onFault: Throwable => Unit = _ => ()) extends TransactionScope[CIO, String] {
+  final private[internal] class TxScope(val conn: DedicatedConnection, onFault: Throwable => Unit = _ => (), events: Events = Events.disabled)
+    extends TransactionScope[CIO, String] {
 
     // tracks whether watched keys may still be armed on the connection; set as soon as WATCH is attempted, cleared by EXEC/UNWATCH
     val armed = new AtomicBoolean(false)
@@ -2443,7 +2459,9 @@ object Client {
 
     private def submitting[A](complete: Try[A] => Unit)(submit: => Unit): Unit = {
       lock.lock()
-      try if (released) complete(Failure(TxSupport.scopeReleasedError)) else submit
+      try
+        if (released) complete(Failure(TxSupport.scopeReleasedError))
+        else Client.completing(complete)(submit)
       finally lock.unlock()
     }
 
@@ -2464,9 +2482,11 @@ object Client {
 
     def watch[K: KeyCodec](key: K, rest: K*): CIO[Unit] =
       CIO.async[Unit] { complete =>
-        submitting(complete) {
+        val watchCmd = Connection.watch(key, rest*)
+        val tracked  = Events.trackSpan(events, watchCmd, complete)
+        submitting(tracked) {
           armed.set(true)
-          conn.submit(Connection.watch(key, rest*), faulting(complete))
+          conn.submit(watchCmd, faulting(tracked))
         }
       }
 
@@ -2476,7 +2496,11 @@ object Client {
       else if (command.isBlocking)
         CIO.fail(new IllegalArgumentException("a Transaction cannot run blocking commands; run them individually on the client"))
       else
-        CIO.async[A](complete => submitting(complete)(conn.submit(command, faulting(complete))))
+        // a live watch-phase read is an ordinary round trip, so trace it like any command; submitting drives `tracked` on every path
+        CIO.async[A] { complete =>
+          val tracked = Events.trackSpan(events, command, complete)
+          submitting(tracked)(conn.submit(command, faulting(tracked)))
+        }
 
     def discard: CIO[Unit] =
       CIO.async[Unit] { complete =>
@@ -2507,7 +2531,8 @@ object Client {
       else
         CIO
           .async[Vector[Frame]] { complete =>
-            submitting(complete)(conn.submitRaw(Connection.multi +: p.commands :+ Connection.exec, faulting(complete)))
+            val tracked = Events.trackSpan(events, Connection.multi, complete)
+            submitting(tracked)(conn.submitRaw(Connection.multi +: p.commands :+ Connection.exec, faulting(tracked)))
           }
           .flatMap { frames =>
             armed.set(false) // EXEC clears WATCH/MULTI state server-side whether it committed or aborted

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -14,7 +14,7 @@ import kyo.compat.*
 import sage.{CommandSpan, Message, PatternMessage, SageEvent, SageException}
 import sage.SageException.{ConnectionLost, CrossSlot, NotConnected, ServerError}
 import sage.client.{BackoffConfig, ClusterConfig, DedicatedPoolConfig, ReadFrom, SageConfig, WatchdogConfig}
-import sage.cluster.{ClusterTopology, Node, NodeGroup, Redirect, RedirectKind, Rejected, Route, Shard, Slot}
+import sage.cluster.{ClusterTopology, Node, NodeGroup, Redirect, RedirectKind, Rejected, Route, Shard, Slot, SplitPlan}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.{Cluster, Command, Connection, Pipeline, Reply}
 import sage.protocol.Frame
@@ -447,8 +447,12 @@ final private[client] class ClusterLive(
       )
     else
       CIO.async { complete =>
-        val spans = Events.startSpans(events, p.commands)
-        offload(runPipeline(p, complete, spans))
+        val plan = topologyRef.get().split(p)
+        // a malformed command is a programmer error: fail before any span is started or the batch is offloaded, never as a per-position result
+        plan.rejected.iterator.collectFirst { case (index, Rejected.Malformed) => index } match {
+          case Some(index) => complete(Failure(malformedKeys(p.commands(index).name)))
+          case None        => offload(runPipeline(p, complete, Events.startSpans(events, p.commands), plan))
+        }
       }
 
   // a position a stale topology can't resolve (redirect, unreachable node, Unowned) falls back to per-command dispatch; the collector completes
@@ -456,7 +460,8 @@ final private[client] class ClusterLive(
   private def runPipeline[Out, R](
     p: Pipeline[Out, R],
     complete: Try[Vector[Either[SageException, Any]]] => Unit,
-    spans: Vector[CommandSpan]
+    spans: Vector[CommandSpan],
+    plan: SplitPlan
   ): Unit = {
     val n                         = p.commands.length
     val collector                 = new TxSupport.IndexedCollector[Either[SageException, Any]](n, complete)
@@ -468,15 +473,6 @@ final private[client] class ClusterLive(
     val useReplica                = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
     def reroute(index: Int): Unit = offload(dispatch(p.commands(index), cluster.maxRedirects, emits(index), allowReplica = useReplica))
 
-    val plan = topologyRef.get().split(p)
-    // a malformed command is a programmer error: fail the whole effect before anything reaches the wire, never as a per-position result
-    plan.rejected.iterator.collectFirst { case (index, Rejected.Malformed) => index } match {
-      case Some(index) =>
-        val error = malformedKeys(p.commands(index).name)
-        emits.foreach(Events.abandonSpan(_, error))
-        complete(Failure(error)); return
-      case None        => ()
-    }
     plan.rejected.foreach {
       case (index, Rejected.CrossSlot(slots)) => emits(index)(Failure(crossSlot(p.commands(index).name, slots)))
       case (index, Rejected.Unowned(_))       => reroute(index) // dispatch refreshes then re-routes

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -464,7 +464,6 @@ final private[client] class ClusterLive(
     plan.rejected.iterator.collectFirst { case (index, Rejected.Malformed) => index } match {
       case Some(index) =>
         val error = malformedKeys(p.commands(index).name)
-        // this path completes the effect without invoking emits, so end their spans here rather than leak them unsettled
         emits.foreach(Events.abandonSpan(_, error))
         complete(Failure(error)); return
       case None        => ()
@@ -834,7 +833,6 @@ final private[client] class ClusterLive(
   // means "the node I queried", so substitute `from` as redirects do
   private def adopt(from: Node, shards: Vector[Shard]): Unit = {
     val resolved     = shards.map(shard => shard.copy(master = resolve(shard.master, from), replicas = shard.replicas.map(resolve(_, from))))
-    // TopologyChanged is a listener-only event, so only do the slot-owner bookkeeping when a listener is registered, not for a tracer-only client
     val previous     = if (events.emitsEvents) slotOwningMasters(topologyRef.get()).toSet else Set.empty[Node]
     val newTopology  = ClusterTopology.from(resolved)
     topologyRef.set(newTopology)

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -11,7 +11,7 @@ import scala.util.control.NonFatal
 
 import kyo.compat.*
 
-import sage.{Message, PatternMessage, SageEvent, SageException}
+import sage.{CommandSpan, Message, PatternMessage, SageEvent, SageException}
 import sage.SageException.{ConnectionLost, CrossSlot, NotConnected, ServerError}
 import sage.client.{BackoffConfig, ClusterConfig, DedicatedPoolConfig, ReadFrom, SageConfig, WatchdogConfig}
 import sage.cluster.{ClusterTopology, Node, NodeGroup, Redirect, RedirectKind, Rejected, Route, Shard, Slot}
@@ -110,14 +110,20 @@ final private[client] class ClusterLive(
   }
 
   def run[A](command: Command[A]): CIO[A] =
-    CIO.async[A](complete => offload(dispatch(command, cluster.maxRedirects, Events.trackCommand(events, command, complete))))
+    CIO.async[A] { complete =>
+      val span = Events.startSpan(events, command)
+      offload(dispatch(command, cluster.maxRedirects, Events.trackCommand(events, command, complete, span)))
+    }
 
   // caching is not applied in cluster mode (per-node tracking through redirects/failover is unsupported): the read runs uncached but on the
   // master (allowReplica = false), so it never honors ReadFrom and the call stays portable; the cacheability guard still applies
   def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =
     if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command))
     else
-      CIO.async[A](complete => offload(dispatch(command, cluster.maxRedirects, Events.trackCommand(events, command, complete), allowReplica = false)))
+      CIO.async[A] { complete =>
+        val span = Events.startSpan(events, command)
+        offload(dispatch(command, cluster.maxRedirects, Events.trackCommand(events, command, complete, span), allowReplica = false))
+      }
 
   // SCAN cursors are node-local, so a full SCAN must sweep every slot-owning master; a reshard mid-scan can still miss or duplicate keys
   def scanTargets: CIO[Vector[ScanTarget]] =
@@ -134,7 +140,10 @@ final private[client] class ClusterLive(
   def runOn[A](target: ScanTarget, command: Command[A]): CIO[A] =
     target.node match {
       case Some(node) =>
-        CIO.async[A](complete => offload(sendTo(node, command, asking = false, redirectsLeft = 0, Events.trackCommand(events, command, complete))))
+        CIO.async[A] { complete =>
+          val span = Events.startSpan(events, command)
+          offload(sendTo(node, command, asking = false, redirectsLeft = 0, Events.trackCommand(events, command, complete, span)))
+        }
       case None       => run(command)
     }
 
@@ -428,15 +437,24 @@ final private[client] class ClusterLive(
         )
       )
     else
-      CIO.async(complete => offload(runPipeline(p, complete)))
+      CIO.async { complete =>
+        val spans = Events.startSpans(events, p.commands)
+        offload(runPipeline(p, complete, spans))
+      }
 
   // a position a stale topology can't resolve (redirect, unreachable node, Unowned) falls back to per-command dispatch; the collector completes
   // the effect once every position has landed terminally, never on a redirect
-  private def runPipeline[Out, R](p: Pipeline[Out, R], complete: Try[Vector[Either[SageException, Any]]] => Unit): Unit = {
+  private def runPipeline[Out, R](
+    p: Pipeline[Out, R],
+    complete: Try[Vector[Either[SageException, Any]]] => Unit,
+    spans: Vector[CommandSpan]
+  ): Unit = {
     val n                         = p.commands.length
     val collector                 = new TxSupport.IndexedCollector[Either[SageException, Any]](n, complete)
-    val emits                     =
-      Vector.tabulate(n)(i => Events.trackCommand[Any](events, p.commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result))))
+    val emits                     = Vector.tabulate(n) { i =>
+      val span = if (spans.isEmpty) CommandSpan.noop else spans(i)
+      Events.trackCommand[Any](events, p.commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)), span)
+    }
     // all-or-nothing: reroutes honor the same choice so a slot is never split across master and replica
     val useReplica                = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
     def reroute(index: Int): Unit = offload(dispatch(p.commands(index), cluster.maxRedirects, emits(index), allowReplica = useReplica))
@@ -444,7 +462,11 @@ final private[client] class ClusterLive(
     val plan = topologyRef.get().split(p)
     // a malformed command is a programmer error: fail the whole effect before anything reaches the wire, never as a per-position result
     plan.rejected.iterator.collectFirst { case (index, Rejected.Malformed) => index } match {
-      case Some(index) => complete(Failure(malformedKeys(p.commands(index).name))); return
+      case Some(index) =>
+        val error = malformedKeys(p.commands(index).name)
+        // this path completes the effect without invoking emits, so end their spans here rather than leak them unsettled
+        emits.foreach(Events.abandonSpan(_, error))
+        complete(Failure(error)); return
       case None        => ()
     }
     plan.rejected.foreach {
@@ -543,14 +565,20 @@ final private[client] class ClusterLive(
 
     def watch[K: KeyCodec](key: K, rest: K*): CIO[Unit] = {
       val command = Connection.watch(key, rest*)
-      CIO.async[Unit](complete => offload(withConn(command, complete) { c => armed.set(true); c.submit(command, faulting(complete)) }))
+      CIO.async[Unit] { complete =>
+        val tracked = Events.trackSpan(events, command, complete)
+        offload(withConn(command, tracked) { c => armed.set(true); c.submit(command, faulting(tracked)) })
+      }
     }
 
     def run[A](command: Command[A]): CIO[A] =
       if (command.isBlocking)
         CIO.fail(new IllegalArgumentException("a Transaction cannot run blocking commands; run them individually on the client"))
       else
-        CIO.async[A](complete => offload(withConn(command, complete)(c => c.submit(command, faulting(complete)))))
+        CIO.async[A] { complete =>
+          val tracked = Events.trackSpan(events, command, complete)
+          offload(withConn(command, tracked)(c => c.submit(command, faulting(tracked))))
+        }
 
     def discard: CIO[Unit] =
       CIO.async[Unit] { complete =>
@@ -559,7 +587,7 @@ final private[client] class ClusterLive(
           try
             if (released) complete(Failure(TxSupport.scopeReleasedError))
             else if (conn == null) complete(Success(())) // nothing leased, nothing watched
-            else { armed.set(false); conn.submit(Connection.unwatch, faulting(complete)) }
+            else Client.completing(complete) { armed.set(false); conn.submit(Connection.unwatch, faulting(complete)) }
           finally lock.unlock()
         }
       }
@@ -603,7 +631,10 @@ final private[client] class ClusterLive(
         CIO.fail(new IllegalArgumentException("a Transaction cannot carry blocking commands; run them individually on the client"))
       else
         CIO
-          .async[Vector[Frame]](complete => offload(submitExec(p, complete)))
+          .async[Vector[Frame]] { complete =>
+            val tracked = Events.trackSpan(events, Connection.multi, complete)
+            offload(submitExec(p, tracked))
+          }
           .flatMap { frames =>
             armed.set(false) // EXEC clears WATCH/MULTI state server-side whether it committed or aborted
             refreshOnExecFault(frames)
@@ -618,7 +649,7 @@ final private[client] class ClusterLive(
         else
           pipelineSlot(p).flatMap(ensureConn) match {
             case Left(error) => refreshOnFault(error); complete(Failure(error))
-            case Right(_)    => conn.submitRaw(Connection.multi +: p.commands :+ Connection.exec, faulting(complete))
+            case Right(_)    => Client.completing(complete)(conn.submitRaw(Connection.multi +: p.commands :+ Connection.exec, faulting(complete)))
           }
       finally lock.unlock()
     }
@@ -630,7 +661,7 @@ final private[client] class ClusterLive(
         else
           commandSlot(command).flatMap(ensureConn) match {
             case Left(error) => refreshOnFault(error); complete(Failure(error))
-            case Right(_)    => use(conn)
+            case Right(_)    => Client.completing(complete)(use(conn))
           }
       finally lock.unlock()
     }
@@ -803,11 +834,12 @@ final private[client] class ClusterLive(
   // means "the node I queried", so substitute `from` as redirects do
   private def adopt(from: Node, shards: Vector[Shard]): Unit = {
     val resolved     = shards.map(shard => shard.copy(master = resolve(shard.master, from), replicas = shard.replicas.map(resolve(_, from))))
-    val previous     = if (events.enabled) slotOwningMasters(topologyRef.get()).toSet else Set.empty[Node]
+    // TopologyChanged is a listener-only event, so only do the slot-owner bookkeeping when a listener is registered, not for a tracer-only client
+    val previous     = if (events.emitsEvents) slotOwningMasters(topologyRef.get()).toSet else Set.empty[Node]
     val newTopology  = ClusterTopology.from(resolved)
     topologyRef.set(newTopology)
     // skip the empty -> populated bootstrap transition: discovering the topology at connect is not a change
-    if (events.enabled && previous.nonEmpty) {
+    if (events.emitsEvents && previous.nonEmpty) {
       val current = slotOwningMasters(newTopology)
       if (current.toSet != previous) events.emit(SageEvent.TopologyChanged(current))
     }
@@ -882,7 +914,7 @@ private[client] object ClusterLive {
         val upgrade = Tls.buildUpgrade(config.tls, node.host, node.port)
         (onFrame, onClosed) => SocketTransport.connect(node.host, node.port, config.connectTimeout, upgrade, onFrame, onClosed)
       }
-      val events                                                  = Events(config.listeners)
+      val events                                                  = Events(config.listeners, config.tracer)
       val live                                                    = new ClusterLive(
         factory,
         scheduler,

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -112,7 +112,10 @@ final private[client] class ClusterLive(
   def run[A](command: Command[A]): CIO[A] =
     CIO.async[A] { complete =>
       val span = Events.startSpan(events, command)
-      offload(dispatch(command, cluster.maxRedirects, Events.trackCommand(events, command, complete, span)))
+      offload {
+        val tracked = Events.trackCommand(events, command, complete, span)
+        Client.completing(tracked)(dispatch(command, cluster.maxRedirects, tracked))
+      }
     }
 
   // caching is not applied in cluster mode (per-node tracking through redirects/failover is unsupported): the read runs uncached but on the
@@ -122,7 +125,10 @@ final private[client] class ClusterLive(
     else
       CIO.async[A] { complete =>
         val span = Events.startSpan(events, command)
-        offload(dispatch(command, cluster.maxRedirects, Events.trackCommand(events, command, complete, span), allowReplica = false))
+        offload {
+          val tracked = Events.trackCommand(events, command, complete, span)
+          Client.completing(tracked)(dispatch(command, cluster.maxRedirects, tracked, allowReplica = false))
+        }
       }
 
   // SCAN cursors are node-local, so a full SCAN must sweep every slot-owning master; a reshard mid-scan can still miss or duplicate keys
@@ -142,7 +148,10 @@ final private[client] class ClusterLive(
       case Some(node) =>
         CIO.async[A] { complete =>
           val span = Events.startSpan(events, command)
-          offload(sendTo(node, command, asking = false, redirectsLeft = 0, Events.trackCommand(events, command, complete, span)))
+          offload {
+            val tracked = Events.trackCommand(events, command, complete, span)
+            Client.completing(tracked)(sendTo(node, command, asking = false, redirectsLeft = 0, tracked))
+          }
         }
       case None       => run(command)
     }

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -456,7 +456,6 @@ final private[client] class ClusterLive(
     complete: Try[Vector[Either[SageException, Any]]] => Unit,
     deferred: Vector[() => CommandSpan]
   ): Unit = {
-    val n    = p.commands.length
     val plan = topologyRef.get().split(p)
     // a malformed command is a programmer error: fail the whole effect before any span is started, never as a per-position result
     plan.rejected.iterator.collectFirst { case (index, Rejected.Malformed) => index } match {

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -447,26 +447,34 @@ final private[client] class ClusterLive(
       )
     else
       CIO.async { complete =>
-        val plan = topologyRef.get().split(p)
-        // a malformed command is a programmer error: fail before any span is started or the batch is offloaded, never as a per-position result
-        plan.rejected.iterator.collectFirst { case (index, Rejected.Malformed) => index } match {
-          case Some(index) => complete(Failure(malformedKeys(p.commands(index).name)))
-          case None        => offload(runPipeline(p, complete, Events.startSpans(events, p.commands), plan))
-        }
+        offload(runPipeline(p, complete, Events.deferSpans(events, p.commands)))
       }
 
-  // a position a stale topology can't resolve (redirect, unreachable node, Unowned) falls back to per-command dispatch; the collector completes
-  // the effect once every position has landed terminally, never on a redirect
+  // a position a stale topology can't resolve falls back to per-command dispatch; the collector completes once every position lands terminally
   private def runPipeline[Out, R](
     p: Pipeline[Out, R],
     complete: Try[Vector[Either[SageException, Any]]] => Unit,
-    spans: Vector[CommandSpan],
+    deferred: Vector[() => CommandSpan]
+  ): Unit = {
+    val n    = p.commands.length
+    val plan = topologyRef.get().split(p)
+    // a malformed command is a programmer error: fail the whole effect before any span is started, never as a per-position result
+    plan.rejected.iterator.collectFirst { case (index, Rejected.Malformed) => index } match {
+      case Some(index) => complete(Failure(malformedKeys(p.commands(index).name)))
+      case None        => dispatchPipeline(p, complete, deferred, plan)
+    }
+  }
+
+  private def dispatchPipeline[Out, R](
+    p: Pipeline[Out, R],
+    complete: Try[Vector[Either[SageException, Any]]] => Unit,
+    deferred: Vector[() => CommandSpan],
     plan: SplitPlan
   ): Unit = {
     val n                         = p.commands.length
     val collector                 = new TxSupport.IndexedCollector[Either[SageException, Any]](n, complete)
     val emits                     = Vector.tabulate(n) { i =>
-      val span = if (spans.isEmpty) CommandSpan.noop else spans(i)
+      val span = if (deferred.isEmpty) CommandSpan.noop else Events.startDeferred(deferred(i))
       Events.trackCommand[Any](events, p.commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)), span)
     }
     // all-or-nothing: reroutes honor the same choice so a slot is never split across master and replica

--- a/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
@@ -102,8 +102,7 @@ private[client] object Events {
 
   private val noSpanFactory: () => CommandSpan = () => CommandSpan.noop
 
-  // like startSpan but lazy: capture the caller's context now, start the span only when the thunk is invoked (a cache miss), via startDeferred.
-  // For offloaded paths only; the routed node is attributed at the fetch, not here, so serverNode does not apply.
+  // like startSpan but lazy: capture the caller's context now, start the span only when the thunk is invoked (a cache miss), via startDeferred
   def deferSpan(events: Events, command: Command[?]): () => CommandSpan =
     events.tracer match {
       case Some(t) =>
@@ -118,6 +117,9 @@ private[client] object Events {
 
   def startSpans(events: Events, commands: Vector[Command[?]]): Vector[CommandSpan] =
     if (events.tracer.isEmpty) Vector.empty else commands.map(c => startSpan(events, c))
+
+  def deferSpans(events: Events, commands: Vector[Command[?]]): Vector[() => CommandSpan] =
+    if (events.tracer.isEmpty) Vector.empty else commands.map(c => deferSpan(events, c))
 
   def trackCommand[A](events: Events, command: Command[?], callback: Try[A] => Unit): Try[A] => Unit =
     if (!events.enabled) callback else new CommandEmit[A](command.name, System.nanoTime(), events, callback, startSpan(events, command))

--- a/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
@@ -102,22 +102,19 @@ private[client] object Events {
 
   private val noSpanFactory: () => CommandSpan = () => CommandSpan.noop
 
-  // like startSpan but lazy: capture the caller's context now, start the span only if the thunk is invoked (a cache miss)
+  // like startSpan but lazy: capture the caller's context now, start the span only when the thunk is invoked (a cache miss), via startDeferred.
+  // For offloaded paths only; the routed node is attributed at the fetch, not here, so serverNode does not apply.
   def deferSpan(events: Events, command: Command[?]): () => CommandSpan =
     events.tracer match {
       case Some(t) =>
-        val start =
-          try t.prepare(command)
-          catch { case NonFatal(_) => noSpanFactory }
-        () => {
-          val span =
-            try start()
-            catch { case NonFatal(_) => CommandSpan.noop }
-          routeToServerNode(events, span)
-          span
-        }
+        try t.prepare(command)
+        catch { case NonFatal(_) => noSpanFactory }
       case None    => noSpanFactory
     }
+
+  def startDeferred(factory: () => CommandSpan): CommandSpan =
+    try factory()
+    catch { case NonFatal(_) => CommandSpan.noop }
 
   def startSpans(events: Events, commands: Vector[Command[?]]): Vector[CommandSpan] =
     if (events.tracer.isEmpty) Vector.empty else commands.map(c => startSpan(events, c))

--- a/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
@@ -169,20 +169,13 @@ private[client] object Events {
 
     @volatile private var node: Option[Node] = None
 
-    def at(n: Node): Unit = {
-      node = Some(n)
-      try span.routedTo(n)
-      catch { case NonFatal(_) => () }
-    }
+    def at(n: Node): Unit = { node = Some(n); routeSpan(span, n) }
 
-    private def endSpan(outcome: Outcome): Unit = try span.settled(outcome)
-    catch { case NonFatal(_) => () }
-
-    def abandon(error: Throwable): Unit = endSpan(Outcome.Failed(error))
+    def abandon(error: Throwable): Unit = settleSpan(span, Outcome.Failed(error))
 
     def apply(result: Try[A]): Unit = {
       val outcome = Outcome.of(result)
-      endSpan(outcome)
+      settleSpan(span, outcome)
       if (emitsEvent && events.emitsEvents)
         events.emit(SageEvent.CommandCompleted(name, node, FiniteDuration(System.nanoTime() - startNanos, NANOSECONDS), outcome))
       callback(result)

--- a/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
@@ -6,17 +6,20 @@ import scala.concurrent.duration.{FiniteDuration, NANOSECONDS}
 import scala.util.Try
 import scala.util.control.NonFatal
 
-import sage.{Outcome, SageEvent, SageListener}
+import sage.{CommandSpan, CommandTracer, Outcome, SageEvent, SageListener}
 import sage.cluster.Node
 import sage.commands.Command
 
 /**
-  * The event-delivery seam. [[emit]] is called from the runtime's hot paths (the reply thread, routing offloads) and must never block: it
-  * does a single non-blocking enqueue. A slow or throwing listener can therefore neither stall command execution nor corrupt it. When no
-  * listener is registered the whole thing is a no-op ([[Events.disabled]]) and no thread runs.
+  * Carries two independent observability integrations. [[emit]] feeds the asynchronous [[SageListener]] path: called from the runtime's hot
+  * paths (the reply thread, routing offloads), it must never block, so it does a single non-blocking enqueue drained by a daemon thread.
+  * [[tracer]] feeds the synchronous [[CommandTracer]] path, whose spans start and settle inline on the command path. With neither registered
+  * the whole thing is a no-op ([[Events.disabled]]) and no thread runs.
   */
 private[client] trait Events {
   def enabled: Boolean
+  def emitsEvents: Boolean
+  def tracer: Option[CommandTracer]
   def emit(event: SageEvent): Unit
   def close(): Unit
 }
@@ -28,33 +31,41 @@ private[client] object Events {
   final private val QueueDepth = 1024
 
   val disabled: Events = new Events {
-    def enabled: Boolean             = false
-    def emit(event: SageEvent): Unit = ()
-    def close(): Unit                = ()
+    def enabled: Boolean              = false
+    def emitsEvents: Boolean          = false
+    def tracer: Option[CommandTracer] = None
+    def emit(event: SageEvent): Unit  = ()
+    def close(): Unit                 = ()
   }
 
-  def apply(listeners: Vector[SageListener]): Events =
-    if (listeners.isEmpty) disabled else new Dispatcher(listeners)
+  def apply(listeners: Vector[SageListener], tracer: Option[CommandTracer] = None): Events =
+    if (listeners.isEmpty && tracer.isEmpty) disabled else new Live(listeners, tracer)
 
   /**
-    * One bounded queue drained by a single daemon thread that fans each event to every listener, each call guarded so a throwing listener
-    * cannot kill the loop or affect its peers. A full queue drops the newest event silently.
+    * Drives the two integrations. Listeners, when present, are fanned to from one bounded queue drained by a single daemon thread, each call
+    * guarded so a throwing listener cannot kill the loop or affect its peers; a full queue drops the newest event silently. A tracer carries no
+    * thread of its own — it runs inline on the command path. With a tracer but no listener, no queue and no thread exist.
     */
-  final private class Dispatcher(listeners: Vector[SageListener]) extends Events {
+  final private class Live(listeners: Vector[SageListener], val tracer: Option[CommandTracer]) extends Events {
 
-    private val queue             = new ArrayBlockingQueue[SageEvent](QueueDepth)
+    def enabled: Boolean     = true
+    def emitsEvents: Boolean = listeners.nonEmpty
+
+    private val queue             = if (listeners.isEmpty) null else new ArrayBlockingQueue[SageEvent](QueueDepth)
     @volatile private var running = true
 
-    private val worker = {
-      val t = new Thread(() => drain(), "sage-listener")
-      t.setDaemon(true)
-      t.start()
-      t
-    }
+    private val worker =
+      if (listeners.isEmpty) null
+      else {
+        val t = new Thread(() => drain(), "sage-listener")
+        t.setDaemon(true)
+        t.start()
+        t
+      }
 
-    def enabled: Boolean             = true
-    def emit(event: SageEvent): Unit = { val _ = queue.offer(event) }
-    def close(): Unit                = { running = false; worker.interrupt() }
+    def emit(event: SageEvent): Unit = if (queue != null) { val _ = queue.offer(event) }
+
+    def close(): Unit = if (worker != null) { running = false; worker.interrupt() }
 
     private def drain(): Unit = {
       try while (running) dispatch(queue.take())
@@ -74,13 +85,34 @@ private[client] object Events {
     }
   }
 
-  /**
-    * Wraps a command's terminal reply callback so it emits a [[SageEvent.CommandCompleted]] when the command settles, timing from the wrap.
-    * The node is left unset until the routing layer attributes it via [[attributeNode]] (standalone never does, so it stays `None`). Returns
-    * the callback unchanged when events are disabled, so a client without listeners pays nothing.
-    */
+  // Start the command's span on the caller's fiber, where the parent context is live; a no-op span when no tracer is set. Split from
+  // [[trackCommand]] so an offloaded path starts the span here but the duration clock starts later, on the executing thread.
+  def startSpan(events: Events, command: Command[?]): CommandSpan =
+    events.tracer match {
+      case Some(t) =>
+        try t.onCommand(command)
+        catch { case NonFatal(_) => CommandSpan.noop }
+      case None    => CommandSpan.noop
+    }
+
+  // One span per command, or an empty vector when no tracer is set, so the common no-tracer pipeline path allocates nothing.
+  def startSpans(events: Events, commands: Vector[Command[?]]): Vector[CommandSpan] =
+    if (events.tracer.isEmpty) Vector.empty else commands.map(c => startSpan(events, c))
+
+  // Wrap a command's reply callback so it settles the span and emits a CommandCompleted on completion. The node is filled in later via
+  // attributeNode (never for standalone). Returns the callback unchanged when nothing is registered, so a client without either pays nothing.
   def trackCommand[A](events: Events, command: Command[?], callback: Try[A] => Unit): Try[A] => Unit =
-    if (!events.enabled) callback else new CommandEmit[A](command.name, System.nanoTime(), events, callback)
+    if (!events.enabled) callback else new CommandEmit[A](command, System.nanoTime(), events, callback, startSpan(events, command))
+
+  // Offloaded-path overload, taking a span already started on the caller's fiber (via startSpan): only the duration clock starts here, on the
+  // executing thread, so a listener's CommandCompleted.duration never picks up offload-scheduling latency.
+  def trackCommand[A](events: Events, command: Command[?], callback: Try[A] => Unit, span: CommandSpan): Try[A] => Unit =
+    if (!events.enabled) callback else new CommandEmit[A](command, System.nanoTime(), events, callback, span)
+
+  // Span-only tracking for a transaction's commands: traces them without emitting a CommandCompleted, so they stay invisible to listeners.
+  def trackSpan[A](events: Events, command: Command[?], callback: Try[A] => Unit): Try[A] => Unit =
+    if (events.tracer.isEmpty) callback
+    else new CommandEmit[A](command, System.nanoTime(), events, callback, startSpan(events, command), emitsEvent = false)
 
   // set on the tracking callback by the routing layer at the node-known terminal site, just before it completes; a no-op for any other callback
   def attributeNode(callback: AnyRef, node: Node): Unit =
@@ -89,14 +121,40 @@ private[client] object Events {
       case _                    => ()
     }
 
-  final private class CommandEmit[A](command: String, startNanos: Long, events: Events, callback: Try[A] => Unit) extends (Try[A] => Unit) {
+  // settle only the span, for fail-fast paths that complete the effect without invoking the callback, so a started span is not left unsettled
+  def abandonSpan(callback: AnyRef, error: Throwable): Unit =
+    callback match {
+      case emit: CommandEmit[?] => emit.abandon(error)
+      case _                    => ()
+    }
+
+  final private class CommandEmit[A](
+    command: Command[?],
+    startNanos: Long,
+    events: Events,
+    callback: Try[A] => Unit,
+    span: CommandSpan,
+    emitsEvent: Boolean = true
+  ) extends (Try[A] => Unit) {
 
     @volatile private var node: Option[Node] = None
 
-    def at(n: Node): Unit = node = Some(n)
+    def at(n: Node): Unit = {
+      node = Some(n)
+      try span.routedTo(n)
+      catch { case NonFatal(_) => () }
+    }
+
+    private def endSpan(outcome: Outcome): Unit = try span.settled(outcome)
+    catch { case NonFatal(_) => () }
+
+    def abandon(error: Throwable): Unit = endSpan(Outcome.Failed(error))
 
     def apply(result: Try[A]): Unit = {
-      events.emit(SageEvent.CommandCompleted(command, node, FiniteDuration(System.nanoTime() - startNanos, NANOSECONDS), Outcome.of(result)))
+      val outcome = Outcome.of(result)
+      endSpan(outcome)
+      if (emitsEvent && events.emitsEvents)
+        events.emit(SageEvent.CommandCompleted(command.name, node, FiniteDuration(System.nanoTime() - startNanos, NANOSECONDS), outcome))
       callback(result)
     }
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
@@ -128,6 +128,15 @@ private[client] object Events {
       case _                    => ()
     }
 
+  // route/settle a span held directly rather than through a CommandEmit (the cache-miss fetch)
+  def routeSpan(span: CommandSpan, node: Node): Unit =
+    try span.routedTo(node)
+    catch { case NonFatal(_) => () }
+
+  def settleSpan(span: CommandSpan, outcome: Outcome): Unit =
+    try span.settled(outcome)
+    catch { case NonFatal(_) => () }
+
   final private class CommandEmit[A](
     command: Command[?],
     startNanos: Long,

--- a/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
@@ -115,6 +115,9 @@ private[client] object Events {
     try factory()
     catch { case NonFatal(_) => CommandSpan.noop }
 
+  def startOrDefer(events: Events, command: Command[?], deferred: () => CommandSpan): CommandSpan =
+    if (deferred == null) startSpan(events, command) else startDeferred(deferred)
+
   def startSpans(events: Events, commands: Vector[Command[?]]): Vector[CommandSpan] =
     if (events.tracer.isEmpty) Vector.empty else commands.map(c => startSpan(events, c))
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
@@ -20,6 +20,8 @@ private[client] trait Events {
   def enabled: Boolean
   def emitsEvents: Boolean
   def tracer: Option[CommandTracer]
+  // the server a span is routed to when routing resolves no node itself (standalone's endpoint); None for cluster/master-replica
+  def serverNode: Option[Node]
   def emit(event: SageEvent): Unit
   def close(): Unit
 }
@@ -34,19 +36,20 @@ private[client] object Events {
     def enabled: Boolean              = false
     def emitsEvents: Boolean          = false
     def tracer: Option[CommandTracer] = None
+    def serverNode: Option[Node]      = None
     def emit(event: SageEvent): Unit  = ()
     def close(): Unit                 = ()
   }
 
-  def apply(listeners: Vector[SageListener], tracer: Option[CommandTracer] = None): Events =
-    if (listeners.isEmpty && tracer.isEmpty) disabled else new Live(listeners, tracer)
+  def apply(listeners: Vector[SageListener], tracer: Option[CommandTracer] = None, serverNode: Option[Node] = None): Events =
+    if (listeners.isEmpty && tracer.isEmpty) disabled else new Live(listeners, tracer, serverNode)
 
   /**
     * Drives the two integrations. Listeners, when present, are fanned to from one bounded queue drained by a single daemon thread, each call
     * guarded so a throwing listener cannot kill the loop or affect its peers; a full queue drops the newest event silently. A tracer carries no
     * thread of its own — it runs inline on the command path. With a tracer but no listener, no queue and no thread exist.
     */
-  final private class Live(listeners: Vector[SageListener], val tracer: Option[CommandTracer]) extends Events {
+  final private class Live(listeners: Vector[SageListener], val tracer: Option[CommandTracer], val serverNode: Option[Node]) extends Events {
 
     def enabled: Boolean     = true
     def emitsEvents: Boolean = listeners.nonEmpty
@@ -85,34 +88,51 @@ private[client] object Events {
     }
   }
 
-  // Start the command's span on the caller's fiber, where the parent context is live; a no-op span when no tracer is set. Split from
-  // [[trackCommand]] so an offloaded path starts the span here but the duration clock starts later, on the executing thread.
+  // start the span on the caller's fiber, where the parent context is live; the duration clock starts later, in trackCommand
   def startSpan(events: Events, command: Command[?]): CommandSpan =
     events.tracer match {
       case Some(t) =>
-        try t.onCommand(command)
-        catch { case NonFatal(_) => CommandSpan.noop }
+        val span =
+          try t.onCommand(command)
+          catch { case NonFatal(_) => CommandSpan.noop }
+        routeToServerNode(events, span)
+        span
       case None    => CommandSpan.noop
     }
 
-  // One span per command, or an empty vector when no tracer is set, so the common no-tracer pipeline path allocates nothing.
+  private val noSpanFactory: () => CommandSpan = () => CommandSpan.noop
+
+  // like startSpan but lazy: capture the caller's context now, start the span only if the thunk is invoked (a cache miss)
+  def deferSpan(events: Events, command: Command[?]): () => CommandSpan =
+    events.tracer match {
+      case Some(t) =>
+        val start =
+          try t.prepare(command)
+          catch { case NonFatal(_) => noSpanFactory }
+        () => {
+          val span =
+            try start()
+            catch { case NonFatal(_) => CommandSpan.noop }
+          routeToServerNode(events, span)
+          span
+        }
+      case None    => noSpanFactory
+    }
+
   def startSpans(events: Events, commands: Vector[Command[?]]): Vector[CommandSpan] =
     if (events.tracer.isEmpty) Vector.empty else commands.map(c => startSpan(events, c))
 
-  // Wrap a command's reply callback so it settles the span and emits a CommandCompleted on completion. The node is filled in later via
-  // attributeNode (never for standalone). Returns the callback unchanged when nothing is registered, so a client without either pays nothing.
   def trackCommand[A](events: Events, command: Command[?], callback: Try[A] => Unit): Try[A] => Unit =
-    if (!events.enabled) callback else new CommandEmit[A](command, System.nanoTime(), events, callback, startSpan(events, command))
+    if (!events.enabled) callback else new CommandEmit[A](command.name, System.nanoTime(), events, callback, startSpan(events, command))
 
-  // Offloaded-path overload, taking a span already started on the caller's fiber (via startSpan): only the duration clock starts here, on the
-  // executing thread, so a listener's CommandCompleted.duration never picks up offload-scheduling latency.
+  // overload taking a span already started on the caller's fiber, for offloaded paths; only the duration clock starts here
   def trackCommand[A](events: Events, command: Command[?], callback: Try[A] => Unit, span: CommandSpan): Try[A] => Unit =
-    if (!events.enabled) callback else new CommandEmit[A](command, System.nanoTime(), events, callback, span)
+    if (!events.enabled) callback else new CommandEmit[A](command.name, System.nanoTime(), events, callback, span)
 
-  // Span-only tracking for a transaction's commands: traces them without emitting a CommandCompleted, so they stay invisible to listeners.
+  // traces a transaction's commands without emitting a CommandCompleted, so they stay invisible to listeners
   def trackSpan[A](events: Events, command: Command[?], callback: Try[A] => Unit): Try[A] => Unit =
     if (events.tracer.isEmpty) callback
-    else new CommandEmit[A](command, System.nanoTime(), events, callback, startSpan(events, command), emitsEvent = false)
+    else new CommandEmit[A](command.name, System.nanoTime(), events, callback, startSpan(events, command), emitsEvent = false)
 
   // set on the tracking callback by the routing layer at the node-known terminal site, just before it completes; a no-op for any other callback
   def attributeNode(callback: AnyRef, node: Node): Unit =
@@ -121,14 +141,18 @@ private[client] object Events {
       case _                    => ()
     }
 
-  // settle only the span, for fail-fast paths that complete the effect without invoking the callback, so a started span is not left unsettled
   def abandonSpan(callback: AnyRef, error: Throwable): Unit =
     callback match {
       case emit: CommandEmit[?] => emit.abandon(error)
       case _                    => ()
     }
 
-  // route/settle a span held directly rather than through a CommandEmit (the cache-miss fetch)
+  private def routeToServerNode(events: Events, span: CommandSpan): Unit =
+    events.serverNode match {
+      case Some(node) => routeSpan(span, node)
+      case None       => ()
+    }
+
   def routeSpan(span: CommandSpan, node: Node): Unit =
     try span.routedTo(node)
     catch { case NonFatal(_) => () }
@@ -138,7 +162,7 @@ private[client] object Events {
     catch { case NonFatal(_) => () }
 
   final private class CommandEmit[A](
-    command: Command[?],
+    name: String,
     startNanos: Long,
     events: Events,
     callback: Try[A] => Unit,
@@ -163,7 +187,7 @@ private[client] object Events {
       val outcome = Outcome.of(result)
       endSpan(outcome)
       if (emitsEvent && events.emitsEvents)
-        events.emit(SageEvent.CommandCompleted(command.name, node, FiniteDuration(System.nanoTime() - startNanos, NANOSECONDS), outcome))
+        events.emit(SageEvent.CommandCompleted(name, node, FiniteDuration(System.nanoTime() - startNanos, NANOSECONDS), outcome))
       callback(result)
     }
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -154,13 +154,20 @@ final private[client] class MasterReplicaLive(
 
   def run[A](command: Command[A]): CIO[A] =
     CIO.async[A] { complete =>
-      val tracked = Events.trackCommand(events, command, complete)
-      offload(if (readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command)) sendRead(command, tracked) else sendMaster(command, tracked))
+      val span = Events.startSpan(events, command)
+      offload {
+        val tracked = Events.trackCommand(events, command, complete, span)
+        if (readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command)) sendRead(command, tracked) else sendMaster(command, tracked)
+      }
     }
 
   def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =
     if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command))
-    else if (!cachingEnabled) CIO.async[A](complete => offload(sendMaster(command, Events.trackCommand(events, command, complete))))
+    else if (!cachingEnabled)
+      CIO.async[A] { complete =>
+        val span = Events.startSpan(events, command)
+        offload(sendMaster(command, Events.trackCommand(events, command, complete, span)))
+      }
     else CIO.async[A](complete => offload(sendMasterCached(command, ttl.toMillis, complete)))
 
   private def sendMaster[A](command: Command[A], complete: Try[A] => Unit): Unit =
@@ -253,6 +260,7 @@ final private[client] class MasterReplicaLive(
       CIO.fail(new IllegalArgumentException("a Pipeline cannot carry blocking commands; run them individually on the client"))
     else
       CIO.async { complete =>
+        val spans = Events.startSpans(events, p.commands)
         offload {
           // all-or-nothing: a fully replica-eligible pipeline batches on a replica, else the master, never split
           val useReplica = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
@@ -260,7 +268,7 @@ final private[client] class MasterReplicaLive(
           // no reachable node fires no wire fault, so re-discover here or a stale replica set / down master strands the pipeline forever
           if (nc == null) triggerRefresh()
           val submit     = if (nc == null) (_: Vector[Command[?]], _: Vector[Try[Any] => Unit]) => false else nc.submitAll
-          Client.submitBatchOnOne(events, p.commands, submit, complete)
+          Client.submitBatchOnOne(events, p.commands, spans, submit, complete)
         }
       }
 
@@ -298,7 +306,7 @@ final private[client] class MasterReplicaLive(
           case e: NotConnected => triggerRefresh(); throw e
           case NonFatal(_)     => triggerRefresh(); throw ConnectionLost(mayHaveExecuted = false)
         }
-      try new MasterReplicaLive.TxLease(new Client.TxScope(nc.acquireForTransaction(), refreshOnTxFault), nc)
+      try new MasterReplicaLive.TxLease(new Client.TxScope(nc.acquireForTransaction(), refreshOnTxFault, events), nc)
       catch {
         case e: NotConnected => triggerRefresh(); throw e
         case e: TimedOut     => throw e
@@ -382,7 +390,7 @@ private[client] object MasterReplicaLive {
         val upgrade = Tls.buildUpgrade(config.tls, node.host, node.port)
         (onFrame, onClosed) => SocketTransport.connect(node.host, node.port, config.connectTimeout, upgrade, onFrame, onClosed)
       }
-      val events                                                  = Events(config.listeners)
+      val events                                                  = Events(config.listeners, config.tracer)
       val live                                                    =
         new MasterReplicaLive(factory, scheduler, bootstrap, config, seeds, masterReplica.minRefreshInterval, events)
       try { live.bootstrapRoles(); live }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -10,7 +10,7 @@ import scala.util.control.NonFatal
 
 import kyo.compat.*
 
-import sage.{Message, PatternMessage, SageException}
+import sage.{CommandSpan, Message, PatternMessage, SageException}
 import sage.SageException.{ConnectionLost, NotConnected, TimedOut}
 import sage.client.{ReadFrom, SageConfig}
 import sage.cluster.Node
@@ -168,13 +168,17 @@ final private[client] class MasterReplicaLive(
         val span = Events.startSpan(events, command)
         offload(sendMaster(command, Events.trackCommand(events, command, complete, span)))
       }
-    else CIO.async[A](complete => offload(sendMasterCached(command, ttl.toMillis, complete)))
+    else
+      CIO.async[A] { complete =>
+        val deferred = Events.deferSpan(events, command)
+        offload(sendMasterCached(command, ttl.toMillis, complete, deferred))
+      }
 
   private def sendMaster[A](command: Command[A], complete: Try[A] => Unit): Unit =
     onMaster(complete)((nc, _, cb) => nc.submit[A](command, asking = false, cb))
 
-  private def sendMasterCached[A](command: Command[A], ttlMillis: Long, complete: Try[A] => Unit): Unit =
-    onMaster(complete)((nc, _, cb) => nc.cachedSubmit[A](command, ttlMillis, cb))
+  private def sendMasterCached[A](command: Command[A], ttlMillis: Long, complete: Try[A] => Unit, deferred: () => CommandSpan): Unit =
+    onMaster(complete)((nc, _, cb) => nc.cachedSubmit[A](command, ttlMillis, cb, deferred))
 
   // run `submit` on the master, completing with node attribution; an ownership fault (a demoted master) kicks a re-discovery
   private def onMaster[A](complete: Try[A] => Unit)(submit: (NodeClient, Node, Try[A] => Unit) => Unit): Unit = {

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -157,7 +157,9 @@ final private[client] class MasterReplicaLive(
       val span = Events.startSpan(events, command)
       offload {
         val tracked = Events.trackCommand(events, command, complete, span)
-        if (readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command)) sendRead(command, tracked) else sendMaster(command, tracked)
+        Client.completing(tracked) {
+          if (readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command)) sendRead(command, tracked) else sendMaster(command, tracked)
+        }
       }
     }
 
@@ -166,12 +168,15 @@ final private[client] class MasterReplicaLive(
     else if (!cachingEnabled)
       CIO.async[A] { complete =>
         val span = Events.startSpan(events, command)
-        offload(sendMaster(command, Events.trackCommand(events, command, complete, span)))
+        offload {
+          val tracked = Events.trackCommand(events, command, complete, span)
+          Client.completing(tracked)(sendMaster(command, tracked))
+        }
       }
     else
       CIO.async[A] { complete =>
         val deferred = Events.deferSpan(events, command)
-        offload(sendMasterCached(command, ttl.toMillis, complete, deferred))
+        offload(Client.completing(complete)(sendMasterCached(command, ttl.toMillis, complete, deferred)))
       }
 
   private def sendMaster[A](command: Command[A], complete: Try[A] => Unit): Unit =

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -10,7 +10,7 @@ import scala.util.control.NonFatal
 
 import kyo.compat.*
 
-import sage.{CommandSpan, Message, PatternMessage, SageException}
+import sage.{CommandSpan, Message, Outcome, PatternMessage, SageException}
 import sage.SageException.{ConnectionLost, NotConnected, TimedOut}
 import sage.client.{ReadFrom, SageConfig}
 import sage.cluster.Node
@@ -182,8 +182,12 @@ final private[client] class MasterReplicaLive(
   private def sendMaster[A](command: Command[A], complete: Try[A] => Unit): Unit =
     onMaster(complete)((nc, _, cb) => nc.submit[A](command, asking = false, cb))
 
-  private def sendMasterCached[A](command: Command[A], ttlMillis: Long, complete: Try[A] => Unit, deferred: () => CommandSpan): Unit =
-    onMaster(complete)((nc, _, cb) => nc.cachedSubmit[A](command, ttlMillis, cb, deferred))
+  private def sendMasterCached[A](command: Command[A], ttlMillis: Long, complete: Try[A] => Unit, deferred: () => CommandSpan): Unit = {
+    var reached = false
+    onMaster(complete) { (nc, _, cb) => reached = true; nc.cachedSubmit[A](command, ttlMillis, cb, deferred) }
+    // onMaster short-circuited (master down) without reaching cachedSubmit, so settle a Failed span the deferred factory would otherwise never start
+    if (!reached) Events.settleSpan(Events.startDeferred(deferred), Outcome.Failed(NotConnected()))
+  }
 
   // run `submit` on the master, completing with node attribution; an ownership fault (a demoted master) kicks a re-discovery
   private def onMaster[A](complete: Try[A] => Unit)(submit: (NodeClient, Node, Try[A] => Unit) => Unit): Unit = {

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -310,7 +310,11 @@ final private[client] class MultiplexedConnection private (
                 events.emit(SageEvent.CommandCompleted(command.name, node, FiniteDuration(System.nanoTime() - started, NANOSECONDS), outcome))
             }
           }
-          submitAll(Vector(Connection.clientCachingYes, raw), Vector(_ => (), onReply.asInstanceOf[Try[Any] => Unit]))
+          try submitAll(Vector(Connection.clientCachingYes, raw), Vector(_ => (), onReply.asInstanceOf[Try[Any] => Unit]))
+          catch {
+            // nothing was sent: release the slots the entries won't retire, and fail the fetch as a reply failure would
+            case NonFatal(error) => release(2); onReply(Failure(error))
+          }
       }
     }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -289,6 +289,9 @@ final private[client] class MultiplexedConnection private (
         case ClientCache.Acquire.Wait       => release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name))
         case ClientCache.Acquire.Fetch      =>
           if (events.emitsEvents) events.emit(SageEvent.Cache.Miss(command.name))
+          // a miss reaches the server, so it is traced like an ordinary command; a hit/wait above is not
+          val span                        = Events.startSpan(events, command)
+          node.foreach(Events.routeSpan(span, _))
           val started                     = System.nanoTime()
           val raw                         = Command[Frame](command.name, command.keyIndices, command.args, frame => Right(frame))
           val onReply: Try[Frame] => Unit = { result =>
@@ -296,17 +299,13 @@ final private[client] class MultiplexedConnection private (
               case Success(frame) => cache.store(commandBytes, keys, frame, scheduler.nowMillis, ttlMillis)
               case Failure(error) => cache.fail(commandBytes, error)
             }
-            // a miss touched the server, so unlike a hit it also produces a CommandCompleted; the outcome reflects the decoded reply. gated on
-            // emitsEvents (not enabled): a tracer-only client has no listener to receive it, and a cached miss is not span-traced either
-            if (events.emitsEvents)
-              events.emit(
-                SageEvent.CommandCompleted(
-                  command.name,
-                  node,
-                  FiniteDuration(System.nanoTime() - started, NANOSECONDS),
-                  Outcome.of(result.flatMap(decodeFrame(command, _)))
-                )
-              )
+            if (events.enabled) {
+              // the outcome reflects the decoded reply, not the raw identity-decoded frame
+              val outcome = Outcome.of(result.flatMap(decodeFrame(command, _)))
+              Events.settleSpan(span, outcome)
+              if (events.emitsEvents)
+                events.emit(SageEvent.CommandCompleted(command.name, node, FiniteDuration(System.nanoTime() - started, NANOSECONDS), outcome))
+            }
           }
           submitAll(Vector(Connection.clientCachingYes, raw), Vector(_ => (), onReply.asInstanceOf[Try[Any] => Unit]))
       }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration.*
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
-import sage.{Bytes, Outcome, SageEvent, SageException}
+import sage.{Bytes, CommandSpan, Outcome, SageEvent, SageException}
 import sage.SageException.{ConnectionLost, NotConnected}
 import sage.client.{BackoffConfig, WatchdogConfig}
 import sage.cluster.Node
@@ -81,11 +81,15 @@ final private[client] class MultiplexedConnection private (
   }
 
   // Captures one generation so the cache lookup and the fetch share a connection; a reconnect mid-flight fails the fetch as a normal loss.
-  def cachedSubmit[A](command: Command[A], ttlMillis: Long, callback: Try[A] => Unit): Unit = {
+  // deferred (master-replica) captured the context before offloading; null starts the span inline (standalone). Only a server-bound command is traced.
+  def cachedSubmit[A](command: Command[A], ttlMillis: Long, callback: Try[A] => Unit, deferred: () => CommandSpan = null): Unit = {
     // a Fetch sends [CLIENT CACHING YES, read]; a cache hit/wait sends nothing and releases the reservation
     val conn = reserved(2)
-    if (conn == null) callback(Failure(NotConnected()))
-    else conn.cachedSubmit(command, ttlMillis, callback)
+    if (conn == null) {
+      val error = NotConnected()
+      Events.settleSpan(if (deferred == null) Events.startSpan(events, command) else deferred(), Outcome.Failed(error))
+      callback(Failure(error))
+    } else conn.cachedSubmit(command, ttlMillis, callback, deferred)
   }
 
   // ASKING must immediately precede its command on the wire (it arms the target node for the next command on the connection). Writing the
@@ -274,7 +278,7 @@ final private[client] class MultiplexedConnection private (
 
     // OPTIN tracking: a cached read writes [CLIENT CACHING YES, <read>] adjacently so only this read is tracked. The read is submitted with
     // an identity decoder so the raw reply Frame reaches the cache; each waiter decodes it with its own command's decoder.
-    def cachedSubmit[A](command: Command[A], ttlMillis: Long, callback: Try[A] => Unit): Unit = {
+    def cachedSubmit[A](command: Command[A], ttlMillis: Long, callback: Try[A] => Unit, deferred: () => CommandSpan): Unit = {
       val commandBytes                = command.encode
       val keys                        = command.keys
       def deliver(frame: Frame): Unit = callback(decodeFrame(command, frame))
@@ -289,8 +293,7 @@ final private[client] class MultiplexedConnection private (
         case ClientCache.Acquire.Wait       => release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name))
         case ClientCache.Acquire.Fetch      =>
           if (events.emitsEvents) events.emit(SageEvent.Cache.Miss(command.name))
-          // a miss reaches the server, so it is traced like an ordinary command; a hit/wait above is not
-          val span                        = Events.startSpan(events, command)
+          val span                        = if (deferred == null) Events.startSpan(events, command) else deferred()
           node.foreach(Events.routeSpan(span, _))
           val started                     = System.nanoTime()
           val raw                         = Command[Frame](command.name, command.keyIndices, command.args, frame => Right(frame))

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -87,7 +87,7 @@ final private[client] class MultiplexedConnection private (
     val conn = reserved(2)
     if (conn == null) {
       val error = NotConnected()
-      Events.settleSpan(if (deferred == null) Events.startSpan(events, command) else deferred(), Outcome.Failed(error))
+      Events.settleSpan(if (deferred == null) Events.startSpan(events, command) else Events.startDeferred(deferred), Outcome.Failed(error))
       callback(Failure(error))
     } else conn.cachedSubmit(command, ttlMillis, callback, deferred)
   }
@@ -293,7 +293,7 @@ final private[client] class MultiplexedConnection private (
         case ClientCache.Acquire.Wait       => release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name))
         case ClientCache.Acquire.Fetch      =>
           if (events.emitsEvents) events.emit(SageEvent.Cache.Miss(command.name))
-          val span                        = if (deferred == null) Events.startSpan(events, command) else deferred()
+          val span                        = if (deferred == null) Events.startSpan(events, command) else Events.startDeferred(deferred)
           node.foreach(Events.routeSpan(span, _))
           val started                     = System.nanoTime()
           val raw                         = Command[Frame](command.name, command.keyIndices, command.args, frame => Right(frame))

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -87,7 +87,7 @@ final private[client] class MultiplexedConnection private (
     val conn = reserved(2)
     if (conn == null) {
       val error = NotConnected()
-      Events.settleSpan(if (deferred == null) Events.startSpan(events, command) else Events.startDeferred(deferred), Outcome.Failed(error))
+      Events.settleSpan(Events.startOrDefer(events, command, deferred), Outcome.Failed(error))
       callback(Failure(error))
     } else conn.cachedSubmit(command, ttlMillis, callback, deferred)
   }
@@ -293,7 +293,7 @@ final private[client] class MultiplexedConnection private (
         case ClientCache.Acquire.Wait       => release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name))
         case ClientCache.Acquire.Fetch      =>
           if (events.emitsEvents) events.emit(SageEvent.Cache.Miss(command.name))
-          val span                        = if (deferred == null) Events.startSpan(events, command) else Events.startDeferred(deferred)
+          val span                        = Events.startOrDefer(events, command, deferred)
           node.foreach(Events.routeSpan(span, _))
           val started                     = System.nanoTime()
           val raw                         = Command[Frame](command.name, command.keyIndices, command.args, frame => Right(frame))

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -285,10 +285,10 @@ final private[client] class MultiplexedConnection private (
       cache.acquire(commandBytes, keys, scheduler.nowMillis, waiter) match {
         // a Hit serves locally; a Wait coalesces onto an in-flight fetch — both avoid a server round trip, so both are reported as a hit
         // and release the two slots reserved for the (now unsent) fetch
-        case ClientCache.Acquire.Hit(frame) => release(2); events.emit(SageEvent.Cache.Hit(command.name)); deliver(frame)
-        case ClientCache.Acquire.Wait       => release(2); events.emit(SageEvent.Cache.Hit(command.name))
+        case ClientCache.Acquire.Hit(frame) => release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name)); deliver(frame)
+        case ClientCache.Acquire.Wait       => release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name))
         case ClientCache.Acquire.Fetch      =>
-          events.emit(SageEvent.Cache.Miss(command.name))
+          if (events.emitsEvents) events.emit(SageEvent.Cache.Miss(command.name))
           val started                     = System.nanoTime()
           val raw                         = Command[Frame](command.name, command.keyIndices, command.args, frame => Right(frame))
           val onReply: Try[Frame] => Unit = { result =>
@@ -296,8 +296,9 @@ final private[client] class MultiplexedConnection private (
               case Success(frame) => cache.store(commandBytes, keys, frame, scheduler.nowMillis, ttlMillis)
               case Failure(error) => cache.fail(commandBytes, error)
             }
-            // a miss touched the server, so unlike a hit it also produces a CommandCompleted; the outcome reflects the decoded reply
-            if (events.enabled)
+            // a miss touched the server, so unlike a hit it also produces a CommandCompleted; the outcome reflects the decoded reply. gated on
+            // emitsEvents (not enabled): a tracer-only client has no listener to receive it, and a cached miss is not span-traced either
+            if (events.emitsEvents)
               events.emit(
                 SageEvent.CommandCompleted(
                   command.name,

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
@@ -3,6 +3,7 @@ package sage.client.internal
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
+import sage.CommandSpan
 import sage.client.{BackoffConfig, DedicatedPoolConfig, WatchdogConfig}
 import sage.cluster.Node
 import sage.commands.Command
@@ -18,8 +19,8 @@ final private[client] class NodeClient(connection: MultiplexedConnection, pool: 
     else if (asking) connection.submitAsking(command, callback)
     else connection.submit(command, callback)
 
-  def cachedSubmit[A](command: Command[A], ttlMillis: Long, callback: Try[A] => Unit): Unit =
-    connection.cachedSubmit(command, ttlMillis, callback)
+  def cachedSubmit[A](command: Command[A], ttlMillis: Long, callback: Try[A] => Unit, deferred: () => CommandSpan): Unit =
+    connection.cachedSubmit(command, ttlMillis, callback, deferred)
 
   // a pipeline's per-node batch: one round-trip on this node's Multiplexed Connection. False when not connected (nothing submitted), so
   // the caller re-routes each position rather than fabricating per-position errors. Blocking commands never reach here (rejected up front).

--- a/sage-client/shared/src/main/scala/sage/client/internal/Scheduler.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Scheduler.scala
@@ -6,7 +6,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
 
 /**
-  * The clock and timer seam under the reconnect loop and the watchdog, injected so tests drive virtual time. `nowMillis` is monotonic. A
+  * The clock and timer abstraction under the reconnect loop and the watchdog, injected so tests drive virtual time. `nowMillis` is monotonic. A
   * one-shot `after` task may block (connect, bootstrap); a periodic `every` tick must not.
   */
 private[client] trait Scheduler {

--- a/sage-client/shared/src/main/scala/sage/client/internal/Subscription.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Subscription.scala
@@ -1,7 +1,7 @@
 package sage.client.internal
 
 /**
-  * The effect-typed seam behind a backend's native subscription stream: `next` yields the next message or `None` at end, `close`
+  * The effect-typed interface behind a backend's native subscription stream: `next` yields the next message or `None` at end, `close`
   * unsubscribes. A backend wraps this with its native stream's finalizer so closing the stream's scope calls `close`.
   */
 trait Subscription[F[_], A] {

--- a/sage-client/shared/src/main/scala/sage/client/internal/Transport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Transport.scala
@@ -3,7 +3,7 @@ package sage.client.internal
 import sage.Bytes
 
 /**
-  * The socket layer's seam: the layer above speaks frames and send items, never bytes or threads. Implementations deliver every parsed
+  * The socket layer's boundary: the layer above speaks frames and send items, never bytes or threads. Implementations deliver every parsed
   * frame to an `onFrame` callback taken at construction, and invoke `onClosed` exactly once when the connection terminates for any reason,
   * including `close()`; by then every queued-but-unwritten item has been `dropped()`.
   */

--- a/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
@@ -7,10 +7,10 @@ import scala.concurrent.duration.*
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success}
 
-import sage.{Bytes, CommandSpan, CommandTracer, Outcome, SageEvent, SageListener}
+import sage.{Bytes, CommandTracer, SageEvent, SageListener}
 import sage.client.{BackoffConfig, WatchdogConfig}
 import sage.cluster.Node
-import sage.commands.{Command, Connection, Strings}
+import sage.commands.{Connection, Strings}
 import sage.protocol.Frame
 
 class EventsSpec extends munit.FunSuite {
@@ -19,25 +19,13 @@ class EventsSpec extends munit.FunSuite {
   private val noWatchdog   = WatchdogConfig(enabled = false)
 
   // a synchronous sink, so wiring assertions are deterministic; the real Dispatcher's async behavior is exercised separately
-  final private class Recording(val tracer: Option[CommandTracer] = None) extends Events {
+  final private class Recording(val tracer: Option[CommandTracer] = None, val serverNode: Option[Node] = None) extends Events {
     private val buf                  = mutable.ArrayBuffer.empty[SageEvent]
     def enabled: Boolean             = true
     def emitsEvents: Boolean         = true
     def emit(event: SageEvent): Unit = synchronized { val _ = buf += event }
     def close(): Unit                = ()
     def events: Vector[SageEvent]    = synchronized(buf.toVector)
-  }
-
-  // a fake tracer recording its span lifecycle as a flat log, so the synchronous tracing wiring can be asserted without OpenTelemetry
-  final private class RecordingTracer extends CommandTracer {
-    val log                                         = mutable.ArrayBuffer.empty[String]
-    def onCommand(command: Command[?]): CommandSpan = {
-      log += s"start:${command.name}"
-      new CommandSpan {
-        def routedTo(node: Node): Unit      = log += s"routed:${node.host}:${node.port}"
-        def settled(outcome: Outcome): Unit = log += s"settled:$outcome"
-      }
-    }
   }
 
   final private class Capturing(latch: CountDownLatch) extends SageListener {
@@ -166,6 +154,26 @@ class EventsSpec extends munit.FunSuite {
     tracked(Success("PONG"))
     assertEquals(tracer.log.toVector, Vector("start:PING", "settled:Succeeded"))
     assert(rec.events.exists { case _: SageEvent.CommandCompleted => true; case _ => false }) // listener still sees the completion
+  }
+
+  test("startSpan routes to a fixed serverNode when set (standalone), without a node ever being attributed") {
+    val tracer = new RecordingTracer
+    val rec    = new Recording(Some(tracer), serverNode = Some(Node("localhost", 6379)))
+    val span   = Events.startSpan(rec, Connection.ping(None))
+    assertEquals(tracer.log.toVector, Vector("start:PING", "routed:localhost:6379"))
+    Events.settleSpan(span, sage.Outcome.Succeeded)
+    assertEquals(tracer.log.toVector, Vector("start:PING", "routed:localhost:6379", "settled:Succeeded"))
+  }
+
+  test("deferSpan starts nothing until its factory is invoked, then routes the fixed serverNode") {
+    val tracer = new RecordingTracer
+    val rec    = new Recording(Some(tracer), serverNode = Some(Node("localhost", 6379)))
+    val make   = Events.deferSpan(rec, Connection.ping(None))
+    assertEquals(tracer.log.toVector, Vector.empty) // capturing the context starts no span (a cache hit never invokes the factory)
+    val span = make()
+    assertEquals(tracer.log.toVector, Vector("start:PING", "routed:localhost:6379"))
+    Events.settleSpan(span, sage.Outcome.Succeeded)
+    assertEquals(tracer.log.last, "settled:Succeeded")
   }
 
   test("a failure settles the span as Failed") {

--- a/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
@@ -147,13 +147,13 @@ class EventsSpec extends munit.FunSuite {
   test("startSpan starts the span once on the caller; the trackCommand overload reuses it and still emits the event") {
     val tracer  = new RecordingTracer
     val rec     = new Recording(Some(tracer))
-    val span    = Events.startSpan(rec, Connection.ping(None))                           // span starts here, on the caller's fiber
+    val span    = Events.startSpan(rec, Connection.ping(None))
     assertEquals(tracer.log.toVector, Vector("start:PING"))
-    val tracked = Events.trackCommand[String](rec, Connection.ping(None), _ => (), span) // reuses the span, does not start a second
+    val tracked = Events.trackCommand[String](rec, Connection.ping(None), _ => (), span)
     assertEquals(tracer.log.toVector, Vector("start:PING"))
     tracked(Success("PONG"))
     assertEquals(tracer.log.toVector, Vector("start:PING", "settled:Succeeded"))
-    assert(rec.events.exists { case _: SageEvent.CommandCompleted => true; case _ => false }) // listener still sees the completion
+    assert(rec.events.exists { case _: SageEvent.CommandCompleted => true; case _ => false })
   }
 
   test("startSpan routes to a fixed serverNode when set (standalone), without a node ever being attributed") {
@@ -191,7 +191,7 @@ class EventsSpec extends munit.FunSuite {
     val tracked = Events.trackSpan[String](rec, Connection.ping(None), _ => ())
     tracked(Success("PONG"))
     assertEquals(tracer.log.toVector, Vector("start:PING", "settled:Succeeded"))
-    assertEquals(rec.events, Vector.empty) // span-only: a transaction's commands stay invisible to listeners
+    assertEquals(rec.events, Vector.empty)
 
     val cb: scala.util.Try[String] => Unit = _ => ()
     assert(Events.trackSpan[String](Events.disabled, Connection.ping(None), cb) eq cb) // no tracer, no wrap

--- a/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
@@ -165,13 +165,13 @@ class EventsSpec extends munit.FunSuite {
     assertEquals(tracer.log.toVector, Vector("start:PING", "routed:localhost:6379", "settled:Succeeded"))
   }
 
-  test("deferSpan starts nothing until its factory is invoked, then routes the fixed serverNode") {
+  test("deferSpan starts no span until startDeferred invokes its factory (a cache miss)") {
     val tracer = new RecordingTracer
-    val rec    = new Recording(Some(tracer), serverNode = Some(Node("localhost", 6379)))
+    val rec    = new Recording(Some(tracer))
     val make   = Events.deferSpan(rec, Connection.ping(None))
-    assertEquals(tracer.log.toVector, Vector.empty) // capturing the context starts no span (a cache hit never invokes the factory)
-    val span = make()
-    assertEquals(tracer.log.toVector, Vector("start:PING", "routed:localhost:6379"))
+    assertEquals(tracer.log.toVector, Vector.empty) // capturing the context starts no span; a hit never invokes it
+    val span = Events.startDeferred(make)
+    assertEquals(tracer.log.toVector, Vector("start:PING"))
     Events.settleSpan(span, sage.Outcome.Succeeded)
     assertEquals(tracer.log.last, "settled:Succeeded")
   }

--- a/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
@@ -7,10 +7,10 @@ import scala.concurrent.duration.*
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success}
 
-import sage.{Bytes, SageEvent, SageListener}
+import sage.{Bytes, CommandSpan, CommandTracer, Outcome, SageEvent, SageListener}
 import sage.client.{BackoffConfig, WatchdogConfig}
 import sage.cluster.Node
-import sage.commands.{Connection, Strings}
+import sage.commands.{Command, Connection, Strings}
 import sage.protocol.Frame
 
 class EventsSpec extends munit.FunSuite {
@@ -19,12 +19,25 @@ class EventsSpec extends munit.FunSuite {
   private val noWatchdog   = WatchdogConfig(enabled = false)
 
   // a synchronous sink, so wiring assertions are deterministic; the real Dispatcher's async behavior is exercised separately
-  final private class Recording extends Events {
+  final private class Recording(val tracer: Option[CommandTracer] = None) extends Events {
     private val buf                  = mutable.ArrayBuffer.empty[SageEvent]
     def enabled: Boolean             = true
+    def emitsEvents: Boolean         = true
     def emit(event: SageEvent): Unit = synchronized { val _ = buf += event }
     def close(): Unit                = ()
     def events: Vector[SageEvent]    = synchronized(buf.toVector)
+  }
+
+  // a fake tracer recording its span lifecycle as a flat log, so the synchronous tracing wiring can be asserted without OpenTelemetry
+  final private class RecordingTracer extends CommandTracer {
+    val log                                         = mutable.ArrayBuffer.empty[String]
+    def onCommand(command: Command[?]): CommandSpan = {
+      log += s"start:${command.name}"
+      new CommandSpan {
+        def routedTo(node: Node): Unit      = log += s"routed:${node.host}:${node.port}"
+        def settled(outcome: Outcome): Unit = log += s"settled:$outcome"
+      }
+    }
   }
 
   final private class Capturing(latch: CountDownLatch) extends SageListener {
@@ -128,6 +141,62 @@ class EventsSpec extends munit.FunSuite {
       case Vector(SageEvent.CommandCompleted("INCR", Some(Node("redis", 7000)), _, sage.Outcome.Failed(_))) => ()
       case other                                                                                            => fail(s"unexpected: $other")
     }
+  }
+
+  // --- tracing ---------------------------------------------------------------------------------------------------------------------------
+
+  test("a tracer-only bus is enabled but emits no events, and drives the span lifecycle through trackCommand") {
+    val tracer = new RecordingTracer
+    val bus    = Events(Vector.empty, Some(tracer))
+    assert(bus.enabled)
+    assert(!bus.emitsEvents) // no listeners, so no CommandCompleted events are produced
+    val tracked = Events.trackCommand[String](bus, Connection.ping(None), _ => ())
+    Events.attributeNode(tracked, Node("redis", 7000))
+    tracked(Success("PONG"))
+    assertEquals(tracer.log.toVector, Vector("start:PING", "routed:redis:7000", "settled:Succeeded"))
+  }
+
+  test("startSpan starts the span once on the caller; the trackCommand overload reuses it and still emits the event") {
+    val tracer  = new RecordingTracer
+    val rec     = new Recording(Some(tracer))
+    val span    = Events.startSpan(rec, Connection.ping(None))                           // span starts here, on the caller's fiber
+    assertEquals(tracer.log.toVector, Vector("start:PING"))
+    val tracked = Events.trackCommand[String](rec, Connection.ping(None), _ => (), span) // reuses the span, does not start a second
+    assertEquals(tracer.log.toVector, Vector("start:PING"))
+    tracked(Success("PONG"))
+    assertEquals(tracer.log.toVector, Vector("start:PING", "settled:Succeeded"))
+    assert(rec.events.exists { case _: SageEvent.CommandCompleted => true; case _ => false }) // listener still sees the completion
+  }
+
+  test("a failure settles the span as Failed") {
+    val tracer  = new RecordingTracer
+    val bus     = Events(Vector.empty, Some(tracer))
+    val tracked = Events.trackCommand[Long](bus, Strings.incr[String]("k"), _ => ())
+    tracked(Failure(sage.SageException.NotConnected()))
+    assertEquals(tracer.log.head, "start:INCR")
+    assert(tracer.log.last.startsWith("settled:Failed"))
+  }
+
+  test("trackSpan drives the span but emits no event, and is transparent when no tracer is set") {
+    val tracer  = new RecordingTracer
+    val rec     = new Recording(Some(tracer)) // emitsEvents is true, yet trackSpan must still not emit a CommandCompleted
+    val tracked = Events.trackSpan[String](rec, Connection.ping(None), _ => ())
+    tracked(Success("PONG"))
+    assertEquals(tracer.log.toVector, Vector("start:PING", "settled:Succeeded"))
+    assertEquals(rec.events, Vector.empty) // span-only: a transaction's commands stay invisible to listeners
+
+    val cb: scala.util.Try[String] => Unit = _ => ()
+    assert(Events.trackSpan[String](Events.disabled, Connection.ping(None), cb) eq cb) // no tracer, no wrap
+  }
+
+  test("abandonSpan settles the span without invoking the callback (the fail-fast path)") {
+    val tracer  = new RecordingTracer
+    val bus     = Events(Vector.empty, Some(tracer))
+    var called  = false
+    val tracked = Events.trackCommand[String](bus, Connection.ping(None), _ => called = true)
+    Events.abandonSpan(tracked, sage.SageException.NotConnected())
+    assert(!called, "abandonSpan must not invoke the wrapped callback")
+    assert(tracer.log.last.startsWith("settled:Failed"))
   }
 
   // --- connection lifecycle --------------------------------------------------------------------------------------------------------------

--- a/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
@@ -4,9 +4,10 @@ import scala.collection.mutable
 import scala.concurrent.duration.*
 import scala.util.{Failure, Success, Try}
 
-import sage.Bytes
+import sage.{Bytes, CommandSpan, CommandTracer, Outcome}
 import sage.SageException.{ConnectionLost, DecodeError, NotConnected, ServerError}
 import sage.client.{BackoffConfig, WatchdogConfig}
+import sage.cluster.Node
 import sage.commands.{Command, Connection, Strings}
 import sage.protocol.Frame
 
@@ -501,7 +502,9 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     assertEquals(connection.currentState, MultiplexedConnection.State.Closed)
   }
 
-  private def cachedConnection(): (MultiplexedConnection, ManualScheduler, mutable.ArrayBuffer[FakeTransport]) = {
+  private def cachedConnection(
+    events: Events = Events.disabled
+  ): (MultiplexedConnection, ManualScheduler, mutable.ArrayBuffer[FakeTransport]) = {
     val scheduler                                       = new ManualScheduler
     val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
     val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
@@ -510,8 +513,21 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
       transport
     }
     val connection                                      =
-      MultiplexedConnection.connect(factory, scheduler, Vector.empty, fixedBackoff, noWatchdog, 1.second, Duration.Zero, cacheMaxBytes = 1L << 20)
+      MultiplexedConnection
+        .connect(factory, scheduler, Vector.empty, fixedBackoff, noWatchdog, 1.second, Duration.Zero, cacheMaxBytes = 1L << 20, events = events)
     (connection, scheduler, transports)
+  }
+
+  // records each span's lifecycle as a flat log so the cache-miss tracing wiring can be asserted without OpenTelemetry
+  final private class RecordingTracer extends CommandTracer {
+    val log                                         = mutable.ArrayBuffer.empty[String]
+    def onCommand(command: Command[?]): CommandSpan = {
+      log += s"start:${command.name}"
+      new CommandSpan {
+        def routedTo(node: Node): Unit      = log += s"routed:${node.host}:${node.port}"
+        def settled(outcome: Outcome): Unit = log += s"settled:$outcome"
+      }
+    }
   }
 
   private def invalidationOf(redisKey: String): Frame =
@@ -575,5 +591,19 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     transports(1).emit(Frame.SimpleString("OK"))
     transports(1).emit(Frame.BulkString(Bytes.utf8("baz")))
     assertEquals(afterReconnect, Some(Success(Some("baz"))))
+  }
+
+  test("a cache miss is traced like an ordinary command; a local hit is not") {
+    val tracer                      = new RecordingTracer
+    val (connection, _, transports) = cachedConnection(Events(Vector.empty, Some(tracer)))
+    val get                         = Strings.get[String, String]("foo")
+
+    connection.cachedSubmit(get, 60000L, _ => ()) // miss -> fetch
+    transports.head.emit(Frame.SimpleString("OK"))
+    transports.head.emit(Frame.BulkString(Bytes.utf8("bar")))
+    assertEquals(tracer.log.toVector, Vector("start:GET", "settled:Succeeded"))
+
+    connection.cachedSubmit(get, 60000L, _ => ())                               // served locally
+    assertEquals(tracer.log.toVector, Vector("start:GET", "settled:Succeeded")) // unchanged: no span for a hit
   }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
@@ -4,10 +4,9 @@ import scala.collection.mutable
 import scala.concurrent.duration.*
 import scala.util.{Failure, Success, Try}
 
-import sage.{Bytes, CommandSpan, CommandTracer, Outcome}
+import sage.Bytes
 import sage.SageException.{ConnectionLost, DecodeError, NotConnected, ServerError}
 import sage.client.{BackoffConfig, WatchdogConfig}
-import sage.cluster.Node
 import sage.commands.{Command, Connection, Strings}
 import sage.protocol.Frame
 
@@ -518,18 +517,6 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     (connection, scheduler, transports)
   }
 
-  // records each span's lifecycle as a flat log so the cache-miss tracing wiring can be asserted without OpenTelemetry
-  final private class RecordingTracer extends CommandTracer {
-    val log                                         = mutable.ArrayBuffer.empty[String]
-    def onCommand(command: Command[?]): CommandSpan = {
-      log += s"start:${command.name}"
-      new CommandSpan {
-        def routedTo(node: Node): Unit      = log += s"routed:${node.host}:${node.port}"
-        def settled(outcome: Outcome): Unit = log += s"settled:$outcome"
-      }
-    }
-  }
-
   private def invalidationOf(redisKey: String): Frame =
     Frame.Push(Vector(Frame.BulkString(Bytes.utf8("invalidate")), Frame.Array(Vector(Frame.BulkString(Bytes.utf8(redisKey))))))
 
@@ -595,7 +582,8 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
 
   test("a cache miss is traced like an ordinary command; a local hit is not") {
     val tracer                      = new RecordingTracer
-    val (connection, _, transports) = cachedConnection(Events(Vector.empty, Some(tracer)))
+    val events                      = Events(Vector.empty, Some(tracer))
+    val (connection, _, transports) = cachedConnection(events)
     val get                         = Strings.get[String, String]("foo")
 
     connection.cachedSubmit(get, 60000L, _ => ()) // miss -> fetch
@@ -605,5 +593,16 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
 
     connection.cachedSubmit(get, 60000L, _ => ())                               // served locally
     assertEquals(tracer.log.toVector, Vector("start:GET", "settled:Succeeded")) // unchanged: no span for a hit
+  }
+
+  test("a cached read that fails fast (not connected) settles a Failed span, like an ordinary command") {
+    val tracer                              = new RecordingTracer
+    val (connection, _, _)                  = cachedConnection(Events(Vector.empty, Some(tracer)))
+    connection.close()
+    var result: Option[Try[Option[String]]] = None
+    connection.cachedSubmit(Strings.get[String, String]("foo"), 60000L, r => result = Some(r))
+    assert(result.exists(_.isFailure))
+    assertEquals(tracer.log.head, "start:GET")
+    assert(tracer.log.last.startsWith("settled:Failed"))
   }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/RecordingTracer.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/RecordingTracer.scala
@@ -1,0 +1,19 @@
+package sage.client.internal
+
+import scala.collection.mutable
+
+import sage.{CommandSpan, CommandTracer, Outcome}
+import sage.cluster.Node
+import sage.commands.Command
+
+// records each span's lifecycle as a flat log, so span wiring can be asserted without OpenTelemetry
+final class RecordingTracer extends CommandTracer {
+  val log                                         = mutable.ArrayBuffer.empty[String]
+  def onCommand(command: Command[?]): CommandSpan = {
+    log += s"start:${command.name}"
+    new CommandSpan {
+      def routedTo(node: Node): Unit      = log += s"routed:${node.host}:${node.port}"
+      def settled(outcome: Outcome): Unit = log += s"settled:$outcome"
+    }
+  }
+}

--- a/sage-client/zio/src/test/scala/sage/client/internal/TxScopeFaultSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/internal/TxScopeFaultSpec.scala
@@ -50,6 +50,11 @@ class TxScopeFaultSpec extends munit.FunSuite {
     }
   }
 
+  test("a synchronous failure while submitting completes the effect instead of hanging") {
+    val (scope, _) = txScope(p => if (p.asUtf8String.contains("HELLO")) Seq(helloReply) else throw ConnectionLost(mayHaveExecuted = false))
+    scope.run(Strings.set("k", "v")).unsafeRun.failed.map(e => assert(e.isInstanceOf[ConnectionLost], s"expected ConnectionLost, got $e"))
+  }
+
   test("a transaction whose EXEC hits a READONLY invokes the onFault hook") {
     val respond: Bytes => Seq[Frame] = p =>
       if (p.asUtf8String.contains("HELLO")) Seq(helloReply)

--- a/sage-core/src/main/scala/sage/CommandTracer.scala
+++ b/sage-core/src/main/scala/sage/CommandTracer.scala
@@ -1,0 +1,46 @@
+package sage
+
+import sage.cluster.Node
+import sage.commands.Command
+
+/**
+  * Produces one tracing span per command, synchronously on the command path. Unlike a [[SageListener]] (asynchronous and lossy, with no access
+  * to the caller's context), a tracer runs on the caller's fiber as the command is submitted, so its spans nest under the active request. It is
+  * effect-agnostic and dependency-free, so it lives in the core and an integration module binds to it. A tracer sees the command's name but
+  * never its arguments, keeping secrets out of traces. sage guards every call, so a throwing tracer cannot break command execution.
+  */
+trait CommandTracer {
+
+  /**
+    * Called once per command, on the caller's fiber as it is submitted — where the parent context is live. The returned [[CommandSpan]] is
+    * given its routed node (when known) and settled when the command does.
+    */
+  def onCommand(command: Command[?]): CommandSpan
+}
+
+/**
+  * A single in-flight command span, handed out by [[CommandTracer.onCommand]] and driven to completion by the runtime.
+  */
+trait CommandSpan {
+
+  /**
+    * The node this command reached; sets the span's server-address attributes. Called once before [[settled]] (after routing, for a cluster).
+    */
+  def routedTo(node: Node): Unit
+
+  /**
+    * Ends the span, recording an error status on a failure. The runtime settles at most once, but an implementation must tolerate a repeat.
+    */
+  def settled(outcome: Outcome): Unit
+}
+
+object CommandSpan {
+
+  /**
+    * A span that records nothing, returned when no tracer is set so the runtime need not branch on whether a span exists.
+    */
+  val noop: CommandSpan = new CommandSpan {
+    def routedTo(node: Node): Unit      = ()
+    def settled(outcome: Outcome): Unit = ()
+  }
+}

--- a/sage-core/src/main/scala/sage/CommandTracer.scala
+++ b/sage-core/src/main/scala/sage/CommandTracer.scala
@@ -16,6 +16,14 @@ trait CommandTracer {
     * given its routed node (when known) and settled when the command does.
     */
   def onCommand(command: Command[?]): CommandSpan
+
+  /**
+    * For a command whose execution — and so whether a span is even needed — is decided later, possibly on another thread: a cached read that
+    * only reaches the server on a miss. Called on the caller's fiber to capture the live parent context; the returned thunk starts the span with
+    * that parent if and when the command actually runs (never, for a local cache hit). The default starts the span lazily via [[onCommand]];
+    * override when the parent context must be captured up front, before the deferred work moves off the caller's fiber.
+    */
+  def prepare(command: Command[?]): () => CommandSpan = () => onCommand(command)
 }
 
 /**

--- a/sage-opentelemetry/src/main/scala/sage/opentelemetry/OpenTelemetryCommandTracer.scala
+++ b/sage-opentelemetry/src/main/scala/sage/opentelemetry/OpenTelemetryCommandTracer.scala
@@ -24,11 +24,19 @@ final class OpenTelemetryCommandTracer private (
   contextProvider: () => Context
 ) extends CommandTracer {
 
-  def onCommand(command: Command[?]): CommandSpan = {
+  def onCommand(command: Command[?]): CommandSpan = startSpan(command, contextProvider())
+
+  // capture the caller's context now; start the span only when the deferred work runs (a cache miss's fetch), so a local hit starts none
+  override def prepare(command: Command[?]): () => CommandSpan = {
+    val parent = contextProvider()
+    () => startSpan(command, parent)
+  }
+
+  private def startSpan(command: Command[?], parent: Context): CommandSpan = {
     val span = tracer
       .spanBuilder(command.name)
       .setSpanKind(SpanKind.CLIENT)
-      .setParent(contextProvider())
+      .setParent(parent)
       .setAttribute(OpenTelemetryCommandTracer.DbSystem, "redis")
       .setAttribute(OpenTelemetryCommandTracer.DbOperation, command.name)
       .setAttribute(OpenTelemetryCommandTracer.PeerService, peerService)

--- a/sage-opentelemetry/src/main/scala/sage/opentelemetry/OpenTelemetryCommandTracer.scala
+++ b/sage-opentelemetry/src/main/scala/sage/opentelemetry/OpenTelemetryCommandTracer.scala
@@ -1,0 +1,92 @@
+package sage.opentelemetry
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import io.opentelemetry.api.{GlobalOpenTelemetry, OpenTelemetry}
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.{SpanKind, StatusCode, Tracer}
+import io.opentelemetry.context.Context
+
+import sage.{CommandSpan, CommandTracer, Outcome}
+import sage.cluster.Node
+import sage.commands.Command
+
+/**
+  * A [[CommandTracer]] emitting one OpenTelemetry `CLIENT` span per command, attributed to match Datadog's Lettuce instrumentation: the span
+  * name is the command (e.g. `GET`), `db.system` is `redis`, and `peer.service` collapses a cluster's nodes into one Redis dependency. The
+  * span's parent is the context `contextProvider` reads when the command is submitted — by default the thread-local current context, correct
+  * wherever an APM agent propagates context across thread pools; a bare OpenTelemetry SDK on a fiber runtime needs a fiber-native provider
+  * instead. Only the command name is recorded; arguments and keys never reach a span.
+  */
+final class OpenTelemetryCommandTracer private (
+  tracer: Tracer,
+  peerService: String,
+  contextProvider: () => Context
+) extends CommandTracer {
+
+  def onCommand(command: Command[?]): CommandSpan = {
+    val span = tracer
+      .spanBuilder(command.name)
+      .setSpanKind(SpanKind.CLIENT)
+      .setParent(contextProvider())
+      .setAttribute(OpenTelemetryCommandTracer.DbSystem, "redis")
+      .setAttribute(OpenTelemetryCommandTracer.DbOperation, command.name)
+      .setAttribute(OpenTelemetryCommandTracer.PeerService, peerService)
+      .setAttribute(OpenTelemetryCommandTracer.Component, "redis-client")
+      .startSpan()
+    new OpenTelemetryCommandTracer.Span(span)
+  }
+}
+
+object OpenTelemetryCommandTracer {
+
+  private val DbSystem      = AttributeKey.stringKey("db.system")
+  private val DbOperation   = AttributeKey.stringKey("db.operation.name")
+  private val PeerService   = AttributeKey.stringKey("peer.service")
+  private val Component     = AttributeKey.stringKey("component")
+  private val ServerAddress = AttributeKey.stringKey("server.address")
+  private val ServerPort    = AttributeKey.longKey("server.port")
+
+  /**
+    * Builds a tracer from an explicit [[OpenTelemetry]] (the testable form: inject an in-memory SDK), reading the thread-local current context
+    * as each command's parent. `peerService` is the name every Redis node reports as, so a cluster shows as a single dependency; default `redis`.
+    */
+  def apply(openTelemetry: OpenTelemetry, peerService: String = "redis"): CommandTracer =
+    new OpenTelemetryCommandTracer(openTelemetry.getTracer("sage"), peerService, () => Context.current())
+
+  /**
+    * Builds a tracer from the globally-registered [[OpenTelemetry]] — the zero-configuration form for an APM agent (e.g. the Datadog Java agent
+    * with `dd.trace.otel.enabled=true`) that installs itself as the global instance.
+    */
+  def global(peerService: String = "redis"): CommandTracer =
+    apply(GlobalOpenTelemetry.get(), peerService)
+
+  /**
+    * The advanced form: supply a custom parent-context provider. Use a fiber-native provider (reading a ZIO `FiberRef` or a cats-effect
+    * `IOLocal`) when running a bare OpenTelemetry SDK with no APM agent on a fiber runtime, where the thread-local current context is empty.
+    */
+  def withContextProvider(openTelemetry: OpenTelemetry, peerService: String, contextProvider: () => Context): CommandTracer =
+    new OpenTelemetryCommandTracer(openTelemetry.getTracer("sage"), peerService, contextProvider)
+
+  final private class Span(span: io.opentelemetry.api.trace.Span) extends CommandSpan {
+
+    // the runtime settles a span at most once, but a fail-fast path and a late callback could race; guard so the span ends exactly once
+    private val ended = new AtomicBoolean(false)
+
+    def routedTo(node: Node): Unit = {
+      val _ = span.setAttribute(ServerAddress, node.host)
+      val _ = span.setAttribute(ServerPort, node.port.toLong)
+    }
+
+    def settled(outcome: Outcome): Unit =
+      if (ended.compareAndSet(false, true)) {
+        outcome match {
+          case Outcome.Succeeded   => ()
+          case Outcome.Failed(err) =>
+            val _ = span.setStatus(StatusCode.ERROR, Option(err.getMessage).getOrElse(err.getClass.getName))
+            val _ = span.recordException(err)
+        }
+        span.end()
+      }
+  }
+}

--- a/sage-opentelemetry/src/test/scala/sage/opentelemetry/OpenTelemetryCommandTracerTest.scala
+++ b/sage-opentelemetry/src/test/scala/sage/opentelemetry/OpenTelemetryCommandTracerTest.scala
@@ -99,6 +99,24 @@ class OpenTelemetryCommandTracerTest extends munit.FunSuite {
     assertEquals(redis.getTraceId, server.getTraceId)
   }
 
+  test("prepare captures the parent context up front, so a span started after the context is gone still nests under it") {
+    val (sdk, exporter) = fixture
+    val tracer          = OpenTelemetryCommandTracer(sdk)
+    val parent          = sdk.getTracer("test").spanBuilder("request").startSpan()
+
+    // capture while the parent is current, then start the span after the scope is closed (mimicking a fetch on an offload worker)
+    val scope     = parent.makeCurrent()
+    val startSpan = tracer.prepare(command("GET"))
+    scope.close()
+    startSpan().settled(Outcome.Succeeded)
+    parent.end()
+
+    val spans = exporter.getFinishedSpanItems.asScala.toList
+    val redis = spans.find(_.getName == "GET").get
+    assertEquals(redis.getParentSpanContext.getSpanId, parent.getSpanContext.getSpanId)
+    assertEquals(redis.getTraceId, parent.getSpanContext.getTraceId)
+  }
+
   test("settling twice ends the span only once") {
     val (sdk, exporter) = fixture
     val tracer          = OpenTelemetryCommandTracer(sdk)

--- a/sage-opentelemetry/src/test/scala/sage/opentelemetry/OpenTelemetryCommandTracerTest.scala
+++ b/sage-opentelemetry/src/test/scala/sage/opentelemetry/OpenTelemetryCommandTracerTest.scala
@@ -1,0 +1,114 @@
+package sage.opentelemetry
+
+import scala.jdk.CollectionConverters.*
+
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.{SpanKind, StatusCode}
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.`export`.SimpleSpanProcessor
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+
+import sage.Outcome
+import sage.cluster.Node
+import sage.commands.Command
+
+class OpenTelemetryCommandTracerTest extends munit.FunSuite {
+
+  // a fresh in-memory SDK + tracer per test, so finished spans never leak across tests
+  private def fixture: (OpenTelemetrySdk, InMemorySpanExporter) = {
+    val exporter = InMemorySpanExporter.create()
+    val sdk      = OpenTelemetrySdk
+      .builder()
+      .setTracerProvider(SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)).build())
+      .build()
+    (sdk, exporter)
+  }
+
+  private def get(span: io.opentelemetry.sdk.trace.data.SpanData, key: String): String =
+    span.getAttributes.get(AttributeKey.stringKey(key))
+
+  private def command(name: String): Command[Unit] =
+    Command(name, Command.NoKeys, Vector.empty, _ => Right(()))
+
+  test("a successful command yields one CLIENT span named for the command, with the Datadog-parity attributes") {
+    val (sdk, exporter) = fixture
+    val tracer          = OpenTelemetryCommandTracer(sdk)
+
+    tracer.onCommand(command("GET")).settled(Outcome.Succeeded)
+
+    val spans = exporter.getFinishedSpanItems.asScala.toList
+    assertEquals(spans.size, 1)
+    val span  = spans.head
+    assertEquals(span.getName, "GET")
+    assertEquals(span.getKind, SpanKind.CLIENT)
+    assertEquals(get(span, "db.system"), "redis")
+    assertEquals(get(span, "db.operation.name"), "GET")
+    assertEquals(get(span, "peer.service"), "redis")
+    assertEquals(get(span, "component"), "redis-client")
+    assertEquals(span.getStatus.getStatusCode, StatusCode.UNSET)
+  }
+
+  test("peerService is configurable, collapsing a cluster's nodes into one dependency") {
+    val (sdk, exporter) = fixture
+    val tracer          = OpenTelemetryCommandTracer(sdk, peerService = "my-redis")
+
+    tracer.onCommand(command("SET")).settled(Outcome.Succeeded)
+
+    assertEquals(get(exporter.getFinishedSpanItems.asScala.head, "peer.service"), "my-redis")
+  }
+
+  test("routedTo sets the server address and port") {
+    val (sdk, exporter) = fixture
+    val tracer          = OpenTelemetryCommandTracer(sdk)
+
+    val span = tracer.onCommand(command("GET"))
+    span.routedTo(Node("redis.internal", 6380))
+    span.settled(Outcome.Succeeded)
+
+    val data = exporter.getFinishedSpanItems.asScala.head
+    assertEquals(get(data, "server.address"), "redis.internal")
+    assertEquals(data.getAttributes.get(AttributeKey.longKey("server.port")), java.lang.Long.valueOf(6380L))
+  }
+
+  test("a failure records ERROR status and the exception") {
+    val (sdk, exporter) = fixture
+    val tracer          = OpenTelemetryCommandTracer(sdk)
+
+    tracer.onCommand(command("GET")).settled(Outcome.Failed(new RuntimeException("boom")))
+
+    val data = exporter.getFinishedSpanItems.asScala.head
+    assertEquals(data.getStatus.getStatusCode, StatusCode.ERROR)
+    assert(data.getEvents.asScala.exists(_.getName == "exception"), "expected a recorded exception event")
+  }
+
+  test("the span nests under the active context's span") {
+    val (sdk, exporter) = fixture
+    val tracer          = OpenTelemetryCommandTracer(sdk)
+    val parent          = sdk.getTracer("test").spanBuilder("request").startSpan()
+
+    val scope = parent.makeCurrent()
+    try tracer.onCommand(command("GET")).settled(Outcome.Succeeded)
+    finally scope.close()
+    parent.end()
+
+    val spans  = exporter.getFinishedSpanItems.asScala.toList
+    val redis  = spans.find(_.getName == "GET").get
+    val server = spans.find(_.getName == "request").get
+    assertEquals(redis.getParentSpanContext.getSpanId, server.getSpanContext.getSpanId)
+    assertEquals(redis.getTraceId, server.getTraceId)
+  }
+
+  test("settling twice ends the span only once") {
+    val (sdk, exporter) = fixture
+    val tracer          = OpenTelemetryCommandTracer(sdk)
+
+    val span = tracer.onCommand(command("GET"))
+    span.settled(Outcome.Succeeded)
+    span.settled(Outcome.Failed(new RuntimeException("late")))
+
+    val spans = exporter.getFinishedSpanItems.asScala.toList
+    assertEquals(spans.size, 1)
+    assertEquals(spans.head.getStatus.getStatusCode, StatusCode.UNSET)
+  }
+}


### PR DESCRIPTION
## What

Adds distributed tracing to sage so Redis commands show up as client spans nested under the surrounding request in an APM (Datadog, Jaeger, ...), restoring the visibility lost when migrating off a Lettuce-based client.

Two integration points, kept separate because their constraints differ:

- **`SageListener`** (existing): asynchronous, off the command path, lossy under load. For metrics and logging.
- **`CommandTracer`** (new): synchronous, runs on the caller's fiber as the command is submitted, so its spans nest under the active request.

## Changes

- **sage-core**: `CommandTracer` / `CommandSpan` SPI, opted into via `SageConfig.tracer`.
- **sage-opentelemetry** (new module, LTS-only; a Scala Next/kyo app consumes the LTS artifact): an OpenTelemetry implementation emitting one `CLIENT` span per command (`db.system=redis`, `db.operation.name`, `peer.service`, `component=redis-client`, server address once routing resolves it, error status carrying the exception on failure). Only the command name is recorded, never arguments or keys, so secrets stay out of traces.
- Spans wired through the standalone, cluster, and master/replica paths, including pipelines and transactions. Span start is captured on the caller's fiber and decoupled from the duration clock, so listener-observed `CommandCompleted` durations are unchanged.
- Transaction submit paths that throw synchronously now complete the effect instead of hanging.
- Docs: `docs/observability.md`.

## Behavior notes

- One span per command that reaches the server; a locally-served `cached` read produces none, while a cache miss's fetch is traced like an ordinary command.
- A transaction's `MULTI`/`EXEC` body gets one `MULTI` span reflecting the round trip, not the commit outcome. Transaction commands remain tracing-only and emit no `CommandCompleted`.
- Under a JVM APM agent (e.g. ZIO + Datadog) context propagates automatically. On a bare SDK over a fiber runtime, the effect system's OpenTelemetry context storage must be configured so `Context.current()` sees the active span; documented per backend.

## Testing

`EventsSpec` covers the tracing helpers; `MultiplexedConnectionSpec` asserts the cache miss is traced and a hit is not; `OpenTelemetryCommandTracerTest` asserts span shape via `InMemorySpanExporter`; a `TxScopeFaultSpec` regression covers the synchronous-throw completion. `sbt check` and `testUnit` pass across backends.