### PR TITLE
Back off increasingly when a connection flaps

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -50,6 +50,9 @@ final private[client] class MultiplexedConnection private (
   // this lifecycle lock, so there is no pool<->connection lock order to keep
   private val liveEpoch                            = new AtomicReference[Generation](Generation.notLive)
   @volatile private var onLivenessLost: () => Unit = () => ()
+  // reconnect cadence, guarded by `lock` and persisted across generations so a flapping peer keeps backing off (see nextReconnectAttempt)
+  private var reconnectAttempt: Int                = 0
+  private var liveSinceMillis: Long                = 0L
 
   private[internal] def setOnLivenessLost(hook: () => Unit): Unit = onLivenessLost = hook
 
@@ -63,6 +66,7 @@ final private[client] class MultiplexedConnection private (
   private def transition(to: State): Unit = {
     state = to
     liveEpoch.set(if (to == State.Live) generation else Generation.notLive)
+    if (to == State.Live) liveSinceMillis = scheduler.nowMillis
   }
 
   // the live connection, or null when not Live so callers fail fast rather than join a dead or reconnecting generation
@@ -176,8 +180,17 @@ final private[client] class MultiplexedConnection private (
     } finally locked { if (establishing eq conn) establishing = null }
   }
 
-  private def scheduleReconnect(attempt: Int): Unit =
+  private def scheduleReconnect(attempt: Int): Unit = {
+    reconnectAttempt = attempt
     scheduler.after(Backoff.jitteredMillis(backoff, attempt, scheduler).millis)(attemptReconnect(attempt))
+  }
+
+  // stable past the backoff ceiling resets the count (a healthy session's loss retries fast); a sooner drop is a flap, so it carries forward
+  private def nextReconnectAttempt(): Int = {
+    val stable = liveSinceMillis != 0L && scheduler.nowMillis - liveSinceMillis >= backoff.maxDelay.toMillis
+    reconnectAttempt = if (stable) 0 else reconnectAttempt + 1
+    reconnectAttempt
+  }
 
   private def attemptReconnect(attempt: Int): Unit = {
     val proceed = locked(state == State.Reconnecting)
@@ -210,7 +223,7 @@ final private[client] class MultiplexedConnection private (
       if (conn eq current)
         state match {
           case State.Live         =>
-            transition(State.Reconnecting); scheduleReconnect(0); events.emit(SageEvent.Connection.Disconnected(node)); true
+            transition(State.Reconnecting); scheduleReconnect(nextReconnectAttempt()); events.emit(SageEvent.Connection.Disconnected(node)); true
           case State.Reconnecting => scheduleReconnect(0); false
           case State.Draining     => transition(State.Closed); stopWatchdog(); false
           case State.Closed       => false

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -52,7 +52,6 @@ final private[client] class MultiplexedConnection private (
   @volatile private var onLivenessLost: () => Unit = () => ()
   // reconnect cadence, guarded by `lock` and persisted across generations so a flapping peer keeps backing off (see nextReconnectAttempt)
   private var reconnectAttempt: Int                = 0
-  // -1L, not 0L: a clock can legitimately read 0 (the test scheduler starts there), so 0 cannot mean "never been Live"
   private var liveSinceMillis: Long                = -1L
 
   private[internal] def setOnLivenessLost(hook: () => Unit): Unit = onLivenessLost = hook

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -52,7 +52,8 @@ final private[client] class MultiplexedConnection private (
   @volatile private var onLivenessLost: () => Unit = () => ()
   // reconnect cadence, guarded by `lock` and persisted across generations so a flapping peer keeps backing off (see nextReconnectAttempt)
   private var reconnectAttempt: Int                = 0
-  private var liveSinceMillis: Long                = 0L
+  // -1L, not 0L: a clock can legitimately read 0 (the test scheduler starts there), so 0 cannot mean "never been Live"
+  private var liveSinceMillis: Long                = -1L
 
   private[internal] def setOnLivenessLost(hook: () => Unit): Unit = onLivenessLost = hook
 
@@ -187,7 +188,7 @@ final private[client] class MultiplexedConnection private (
 
   // stable past the backoff ceiling resets the count (a healthy session's loss retries fast); a sooner drop is a flap, so it carries forward
   private def nextReconnectAttempt(): Int = {
-    val stable = liveSinceMillis != 0L && scheduler.nowMillis - liveSinceMillis >= backoff.maxDelay.toMillis
+    val stable = liveSinceMillis >= 0L && scheduler.nowMillis - liveSinceMillis >= backoff.maxDelay.toMillis
     reconnectAttempt = if (stable) 0 else reconnectAttempt + 1
     reconnectAttempt
   }

--- a/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
@@ -261,6 +261,27 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     assertEquals(afterReconnect, Some(Success("PONG")))
   }
 
+  test("the initial connection at clock 0 counts as stable: a loss after the ceiling resets to the initial delay") {
+    val backoff                                         = BackoffConfig(initialDelay = 10.millis, maxDelay = 10.seconds, multiplier = 2.0)
+    val scheduler                                       = new ManualScheduler // starts at clock 0, the value 0L must not read as "never been Live"
+    val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
+      val transport = new FakeTransport(onFrame, onClosed, _ => Nil, autoWrite = true)
+      transports += transport
+      transport
+    }
+    val connection                                      =
+      MultiplexedConnection.connect(factory, scheduler, Vector.empty[Command[?]], backoff, noWatchdog, 1.second, Duration.Zero)
+    import MultiplexedConnection.State
+
+    scheduler.advance(11.seconds) // the first generation went Live at clock 0 and stays up past the ceiling
+    transports.last.emit(Frame.SimpleString("stray"))
+    scheduler.advance(9.millis)
+    assertEquals(connection.currentState, State.Reconnecting, "still backing off before the reset 10ms initial delay")
+    scheduler.advance(1.milli)
+    assertEquals(connection.currentState, State.Live, "a stable loss must retry at attempt 0, not advance to attempt 1")
+  }
+
   test("a flapping connection backs off increasingly, and a stable connection resets the backoff") {
     val backoff                                         = BackoffConfig(initialDelay = 10.millis, maxDelay = 10.seconds, multiplier = 2.0)
     val scheduler                                       = new ManualScheduler

--- a/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
@@ -261,6 +261,44 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     assertEquals(afterReconnect, Some(Success("PONG")))
   }
 
+  test("a flapping connection backs off increasingly, and a stable connection resets the backoff") {
+    val backoff                                         = BackoffConfig(initialDelay = 10.millis, maxDelay = 10.seconds, multiplier = 2.0)
+    val scheduler                                       = new ManualScheduler
+    val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
+      val transport = new FakeTransport(onFrame, onClosed, _ => Nil, autoWrite = true)
+      transports += transport
+      transport
+    }
+    val connection                                      =
+      MultiplexedConnection.connect(factory, scheduler, Vector.empty[Command[?]], backoff, noWatchdog, 1.second, Duration.Zero)
+    import MultiplexedConnection.State
+
+    // a flap (Live but dropped before the stable window) carries the attempt forward, so the backoff grows instead of resetting every cycle
+    assertEquals(connection.currentState, State.Live)
+    transports.last.emit(Frame.SimpleString("stray")) // flap 1 -> attempt 1 -> 20ms
+    assertEquals(connection.currentState, State.Reconnecting)
+    scheduler.advance(19.millis)
+    assertEquals(connection.currentState, State.Reconnecting, "still backing off before the 20ms attempt-1 delay")
+    scheduler.advance(1.milli)
+    assertEquals(connection.currentState, State.Live)
+
+    transports.last.emit(Frame.SimpleString("stray")) // flap 2 -> attempt 2 -> 40ms, not reset to the 10ms initial delay
+    scheduler.advance(39.millis)
+    assertEquals(connection.currentState, State.Reconnecting, "the backoff doubled to 40ms rather than resetting to 10ms")
+    scheduler.advance(1.milli)
+    assertEquals(connection.currentState, State.Live)
+
+    // staying Live past the backoff ceiling marks a healthy session, so the next loss resets the cadence to the initial delay
+    scheduler.advance(11.seconds)
+    assertEquals(connection.currentState, State.Live)
+    transports.last.emit(Frame.SimpleString("stray")) // stable -> attempt 0 -> 10ms
+    scheduler.advance(9.millis)
+    assertEquals(connection.currentState, State.Reconnecting, "still backing off before the reset 10ms initial delay")
+    scheduler.advance(1.milli)
+    assertEquals(connection.currentState, State.Live)
+  }
+
   test("a socket dying in the establish->Live window is not published Live, and the reconnect loop recovers") {
     final class DyingAfterBootstrap(onFrame: Frame => Unit, onClosed: () => Unit) extends Transport {
       def start(): Unit                    = ()

--- a/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
@@ -263,7 +263,7 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
 
   test("the initial connection at clock 0 counts as stable: a loss after the ceiling resets to the initial delay") {
     val backoff                                         = BackoffConfig(initialDelay = 10.millis, maxDelay = 10.seconds, multiplier = 2.0)
-    val scheduler                                       = new ManualScheduler // starts at clock 0, the value 0L must not read as "never been Live"
+    val scheduler                                       = new ManualScheduler
     val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
     val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
       val transport = new FakeTransport(onFrame, onClosed, _ => Nil, autoWrite = true)
@@ -274,7 +274,7 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
       MultiplexedConnection.connect(factory, scheduler, Vector.empty[Command[?]], backoff, noWatchdog, 1.second, Duration.Zero)
     import MultiplexedConnection.State
 
-    scheduler.advance(11.seconds) // the first generation went Live at clock 0 and stays up past the ceiling
+    scheduler.advance(11.seconds)
     transports.last.emit(Frame.SimpleString("stray"))
     scheduler.advance(9.millis)
     assertEquals(connection.currentState, State.Reconnecting, "still backing off before the reset 10ms initial delay")


### PR DESCRIPTION
## Problem

The reconnect attempt counter in `MultiplexedConnection` was only a threaded parameter with no persisted state. Each time a connection reached `State.Live` and then dropped again, `onConnTerminated` scheduled the next reconnect at attempt `0`. A server that completed the HELLO handshake but reset within milliseconds was therefore reconnected with a delay in `[0, initialDelay]` (~0-50ms by default) every cycle — a tight retry storm against a flapping peer with no exponential growth.

## Solution

Persist the attempt count (`reconnectAttempt`) and the time the connection became Live (`liveSinceMillis`), both guarded by the lifecycle lock. On a fresh liveness loss, `nextReconnectAttempt()` resets to `0` only when the connection stayed Live longer than the backoff ceiling (a healthy session whose loss is a new incident); otherwise it carries the count forward so a flapping connection keeps backing off exponentially.

## Tests

Adds a `MultiplexedConnectionSpec` case asserting the backoff doubles across successive flaps (20ms -> 40ms) and resets to the initial delay after a stable uptime.