### PR TITLE
Parse bracketed IPv6 hosts in fromUri and reject ambiguous authorities

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
+++ b/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
@@ -256,17 +256,37 @@ object SageConfig {
   private def isHex(c: Char): Boolean = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
 
   private def parseEndpoints(uri: String, hosts: String): Either[String, Vector[Endpoint]] =
-    hosts.split(",").toVector.foldRight(Right(Vector.empty): Either[String, Vector[Endpoint]]) { (hostPort, acc) =>
-      acc.flatMap { rest =>
-        val colon           = hostPort.lastIndexOf(':')
-        val (host, portStr) = if (colon < 0) (hostPort, "") else (hostPort.substring(0, colon), hostPort.substring(colon + 1))
-        if (host.isEmpty) Left(s"invalid redis URI '$uri': empty host in '$hostPort'")
-        else if (portStr.isEmpty) Right(Endpoint(host) +: rest)
-        else
-          portStr.toIntOption.filter(p => p >= 1 && p <= 65535) match {
-            case Some(port) => Right(Endpoint(host, port) +: rest)
-            case None       => Left(s"invalid redis URI '$uri': invalid port in '$hostPort'")
-          }
-      }
+    hosts.split(",").toVector.foldRight(Right(Vector.empty): Either[String, Vector[Endpoint]]) { (token, acc) =>
+      acc.flatMap(rest => parseEndpoint(uri, token).map(_ +: rest))
     }
+
+  // an IPv6 literal must be bracketed (`[::1]`/`[::1]:6379`), brackets stripped from the host; a bare `::1` or empty port is rejected, not guessed
+  private def parseEndpoint(uri: String, token: String): Either[String, Endpoint] = {
+    def fail(reason: String): Either[String, Endpoint]                    = Left(s"invalid redis URI '$uri': $reason in '$token'")
+    def withPort(host: String, portStr: String): Either[String, Endpoint] =
+      if (portStr.isEmpty) fail("empty port")
+      else
+        portStr.toIntOption.filter(p => p >= 1 && p <= 65535) match {
+          case Some(port) => Right(Endpoint(host, port))
+          case None       => fail("invalid port")
+        }
+    if (token.startsWith("[")) {
+      val close = token.indexOf(']')
+      if (close < 0) fail("unterminated IPv6 literal")
+      else {
+        val host = token.substring(1, close)
+        val tail = token.substring(close + 1)
+        if (host.isEmpty) fail("empty host")
+        else if (tail.isEmpty) Right(Endpoint(host))
+        else if (tail.startsWith(":")) withPort(host, tail.substring(1))
+        else fail("expected ':port' after the IPv6 literal")
+      }
+    } else
+      token.indexOf(':') match {
+        case -1    => if (token.isEmpty) fail("empty host") else Right(Endpoint(token))
+        case colon =>
+          val host = token.substring(0, colon)
+          if (host.isEmpty) fail("empty host") else withPort(host, token.substring(colon + 1))
+      }
+  }
 }

--- a/sage-client/shared/src/test/scala/sage/client/SageConfigSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/SageConfigSpec.scala
@@ -46,6 +46,24 @@ class SageConfigSpec extends munit.FunSuite {
     )
   }
 
+  test("a bracketed IPv6 literal is the host, brackets stripped, with or without a port") {
+    assertEquals(parsed("redis://[::1]").topology, Topology.Standalone(Endpoint("::1", 6379)))
+    assertEquals(parsed("redis://[::1]:6380").topology, Topology.Standalone(Endpoint("::1", 6380)))
+    assertEquals(parsed("redis://[2001:db8::1]:6379/2").database, 2)
+    assertEquals(
+      parsed("redis://[fe80::1]:6379,[fe80::2]:6380").topology,
+      Topology.Cluster(Vector(Endpoint("fe80::1", 6379), Endpoint("fe80::2", 6380)))
+    )
+  }
+
+  test("an unbracketed IPv6 literal or an empty port fails rather than misparsing") {
+    assert(SageConfig.fromUri("redis://::1").isLeft)     // ambiguous with host:port, must be bracketed
+    assert(SageConfig.fromUri("redis://[::1").isLeft)    // unterminated bracket
+    assert(SageConfig.fromUri("redis://[::1]x").isLeft)  // junk after the literal
+    assert(SageConfig.fromUri("redis://h:").isLeft)      // colon with no port is not a default
+    assert(SageConfig.fromUri("redis://[]:6379").isLeft) // empty host
+  }
+
   test("a cluster URI cannot select a non-zero database") {
     assert(SageConfig.fromUri("redis://a,b/2").isLeft)
     assert(SageConfig.fromUri("redis://a,b/0").isRight)


### PR DESCRIPTION
## Problem

`parseEndpoints` split `host:port` with `lastIndexOf(':')` and had no bracket handling, so:
- `fromUri("redis://[::1]:6379")` returned `Endpoint(host = "[::1]", port = 6379)` with the brackets retained, breaking name resolution, SNI, and TLS.
- `fromUri("redis://::1")` silently returned `Endpoint(host = ":", port = 1)`.

Both returned a wrong `Right` instead of a `Left`, surfacing later as an opaque connect failure or a connection to the wrong address.

## Solution

Replace the inline split with `parseEndpoint`: a bracketed IPv6 literal becomes the host with its brackets stripped, an unbracketed multi-colon authority is rejected as ambiguous (IPv6 must be bracketed), unterminated brackets and trailing junk are rejected, and a colon with no port is an error rather than silently defaulting.

## Tests

Adds `SageConfigSpec` cases for bracketed IPv6 with/without port, cluster IPv6 seeds, and IPv6 + db path, plus rejection of `::1`, `[::1`, `[::1]x`, `h:`, and `[]:6379`.