### PR TITLE
Mark a dedicated connection dead when its queued work is dropped

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
@@ -97,8 +97,8 @@ final private[client] class DedicatedConnection private (
 
     def writeAttempted(): Unit = { val _ = pending.add(this) }
 
-    // exactly one of dropped/complete/fail fires per entry; each retires the in-flight count before delivering the result
-    def dropped(): Unit = { inFlight.decrementAndGet(); callback(Failure(ConnectionLost(mayHaveExecuted = false))) }
+    // dropped fires only during teardown, ahead of onClosed; mark dead first so the pool can't recycle this connection mid-close
+    def dropped(): Unit = { dead = true; inFlight.decrementAndGet(); callback(Failure(ConnectionLost(mayHaveExecuted = false))) }
 
     def complete(frame: Frame): Unit = {
       val result = Reply.decode(command, frame)
@@ -125,7 +125,7 @@ final private[client] class DedicatedConnection private (
       while (i < n) { val _ = pending.add(new Slot(i)); i += 1 }
     }
 
-    def dropped(): Unit = finish(Failure(ConnectionLost(mayHaveExecuted = false)))
+    def dropped(): Unit = { dead = true; finish(Failure(ConnectionLost(mayHaveExecuted = false))) }
 
     private def finish(result: Try[Vector[Frame]]): Unit =
       if (done.compareAndSet(false, true)) {

--- a/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
@@ -91,6 +91,20 @@ class DedicatedPoolSpec extends munit.FunSuite {
     assertEquals(transports.size, 2)
   }
 
+  test("a dropped queued command marks the connection dead before failing the work, so the pool cannot recycle it") {
+    val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
+      val t = new FakeTransport(onFrame, onClosed, replyWith(Nil)); transports += t; t
+    }
+    val conn                                            = DedicatedConnection.establish(factory, Vector(Connection.hello()), 1000L)
+    transports.head.autoWrite = false // hold the write so the command stays queued: the path the transport drops on teardown
+
+    var healthyWhenFailed: Option[Boolean] = None
+    conn.submit(blPop, _ => healthyWhenFailed = Some(conn.isHealthy))
+    transports.head.close()
+    assertEquals(healthyWhenFailed, Some(false))
+  }
+
   test("acquire waits for a slot and fails TimedOut when the pool stays exhausted") {
     val config                        = DedicatedPoolConfig(maxConnections = 1, acquireTimeout = 50.millis, idleTimeout = Duration.Inf)
     val (pool, scheduler, transports) = make(replyWith(Nil), config = config) // the first BLPOP parks, holding the only slot

--- a/sage-client/shared/src/test/scala/sage/client/internal/FakeTransport.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/FakeTransport.scala
@@ -13,7 +13,7 @@ final class FakeTransport(
   onFrame: Frame => Unit,
   onClosed: () => Unit,
   respond: Bytes => Seq[Frame] = _ => Nil,
-  autoWrite: Boolean = true
+  var autoWrite: Boolean = true
 ) extends Transport {
 
   val written: mutable.ArrayBuffer[Bytes]                 = mutable.ArrayBuffer.empty


### PR DESCRIPTION
## Problem

On a connection loss, `SocketTransport.terminate()` drains its queued (unwritten) items via `dropped()` **before** calling `onClosed()`, and `onClosed()` is what sets `dead = true`. `DedicatedConnection`'s `dropped()` failed the work through the borrower callback without marking the connection dead, so the `release(conn)` that callback triggers saw `isHealthy == true` (via `healthyAndCurrent`) and recycled the connection to the idle set. A parked waiter could then reacquire an already-closing connection in the window before `onClosed` flipped `dead`.

## Solution

Set `dead = true` at the top of both `dropped()` paths (`Entry` and `RawBatch`). `dropped()` fires only during teardown, so marking dead there closes the window — the pool's recycle check always sees the connection as unhealthy.

This is fixed at the `DedicatedConnection` layer rather than reordering `SocketTransport` (shared with `MultiplexedConnection`, and carrying the #94 reader-fence ordering).

## Tests

Adds a `DedicatedPoolSpec` case driving the drop path (a queued-but-unwritten command, then transport close) and asserting the connection already reports `isHealthy == false` at the moment the work-failed callback runs — the point where the pool decides recycle-vs-discard. Without the fix this reads `true`. Required making `FakeTransport.autoWrite` mutable to hold the write after bootstrap.