### PR TITLE
Reject out-of-range ROLE replica ports instead of wrapping

### DIFF
--- a/sage-core/src/main/scala/sage/commands/Server.scala
+++ b/sage-core/src/main/scala/sage/commands/Server.scala
@@ -163,7 +163,7 @@ private[sage] object Server {
         case "slave"    =>
           rest match {
             case Vector(Frame.BulkString(host), Frame.Integer(port), Frame.BulkString(state), Frame.Integer(offset)) =>
-              Right(Role.Replica(host.asUtf8String, port.toInt, state.asUtf8String, offset))
+              decodePort(port).map(Role.Replica(host.asUtf8String, _, state.asUtf8String, offset))
             case other                                                                                               =>
               Left(DecodeError("replica role [host, port, state, offset]", other.map(Frame.describe).mkString(", ")))
           }
@@ -289,11 +289,14 @@ private[sage] object Server {
       case Some(CommandFilterBy.Pattern(glob))    => Vector(FilterBy, PatternWord, Bytes.utf8(glob))
     }
 
+  private def decodePort(value: Long): Either[DecodeError, Int] =
+    if (value >= 1L && value <= 65535L) Right(value.toInt) else Left(DecodeError("port in 1..65535", value.toString))
+
   private def decodeReplicas(frame: Frame): Either[DecodeError, Vector[ReplicaNode]] =
     Decode.vector {
       case Frame.Array(Vector(Frame.BulkString(host), Frame.BulkString(port), Frame.BulkString(offset))) =>
         for {
-          p <- port.asUtf8String.toIntOption.toRight(DecodeError("replica port", port.asUtf8String))
+          p <- port.asUtf8String.toLongOption.toRight(DecodeError("replica port", port.asUtf8String)).flatMap(decodePort)
           o <- offset.asUtf8String.toLongOption.toRight(DecodeError("replica offset", offset.asUtf8String))
         } yield ReplicaNode(host.asUtf8String, p, o)
       case other                                                                                         => Left(DecodeError("replica [host, port, offset]", Frame.describe(other)))

--- a/sage-core/src/test/scala/sage/commands/ServerSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ServerSpec.scala
@@ -36,6 +36,15 @@ class ServerSpec extends munit.FunSuite {
     assertEquals(Reply.run(Server.role, sentinel), Right(Role.Sentinel(Vector("master1", "master2"))))
   }
 
+  test("ROLE rejects an out-of-range replica port instead of wrapping it") {
+    val wrapping =
+      Frame.Array(Vector(bulk("slave"), bulk("127.0.0.1"), Frame.Integer(Int.MaxValue.toLong + 1L), bulk("connected"), Frame.Integer(0L)))
+    assert(Reply.run(Server.role, wrapping).isLeft, "a port above Int.MaxValue must not wrap to a valid-looking port")
+    val tooLarge =
+      Frame.Array(Vector(bulk("master"), Frame.Integer(0L), Frame.Array(Vector(Frame.Array(Vector(bulk("127.0.0.1"), bulk("70000"), bulk("0")))))))
+    assert(Reply.run(Server.role, tooLarge).isLeft, "a replica port outside 1..65535 must be a DecodeError")
+  }
+
   test("SLOWLOG GET decodes entries, defaulting client fields absent on old servers") {
     val withClient = Frame.Array(
       Vector(


### PR DESCRIPTION
## Problem

`decodeRole`'s `slave` case built `Role.Replica(host, port.toInt, ...)` where `port` is a `Long` (RESP integer). A malformed or buggy server reply with a port above `Int.MaxValue` silently wraps to a different, valid-looking port instead of being rejected. The master role's replica list (`decodeReplicas`) parsed via `toIntOption`, which rejects `> Int.MaxValue` but still accepted out-of-range valid Ints such as `70000`.

## Solution

Add a `decodePort(Long): Either[DecodeError, Int]` helper that requires `1..65535` before narrowing, and use it in both the replica (`slave`) role and `decodeReplicas`. An out-of-range port now yields a `DecodeError` rather than a wrapped value.

## Tests

Adds a `ServerSpec` case: a `slave` port of `Int.MaxValue + 1` (the wrap) and a master-list replica port of `70000` both decode to `Left`.