### PR TITLE
Reduce allocations in decoding

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/TxSupport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/TxSupport.scala
@@ -17,11 +17,17 @@ import sage.protocol.Frame
   */
 private[internal] object TxSupport {
 
-  def collapseStrict[Out](results: Vector[Either[SageException, Any]], toOut: Vector[Any] => Out): CIO[Out] =
-    results.collectFirst { case Left(error) => error } match {
-      case Some(error) => CIO.fail(error)
-      case None        => CIO.value(toOut(results.collect { case Right(value) => value }))
-    }
+  def collapseStrict[Out](results: Vector[Either[SageException, Any]], toOut: Vector[Any] => Out): CIO[Out] = {
+    val values = Vector.newBuilder[Any]
+    values.sizeHint(results.length)
+    val it     = results.iterator
+    while (it.hasNext)
+      it.next() match {
+        case Right(value) => values += value
+        case Left(error)  => return CIO.fail(error)
+      }
+    CIO.value(toOut(values.result()))
+  }
 
   // decoders return Either and never throw; a non-SageException here is a decoder bug surfaced as a decode failure rather than allowed
   // to escape the per-position result model.

--- a/sage-core/src/main/scala/sage/commands/Decode.scala
+++ b/sage-core/src/main/scala/sage/commands/Decode.scala
@@ -127,6 +127,22 @@ private[commands] object Decode {
   def each[A, B](items: IterableOnce[A])(f: A => Either[DecodeError, B]): Either[DecodeError, Vector[B]] =
     buildEach(items, Vector.newBuilder[B])(f)
 
+  // steps a flat alternating array two elements at a time, without grouped(2)'s throwaway 2-element Vector per pair; caller guarantees even length
+  private def buildPairs[B, C](elements: Vector[Frame], builder: mutable.Builder[B, C])(
+    f: (Frame, Frame) => Either[DecodeError, B]
+  ): Either[DecodeError, C] = {
+    builder.sizeHint(elements.length / 2)
+    var i = 0
+    while (i < elements.length) {
+      f(elements(i), elements(i + 1)) match {
+        case Right(value) => builder += value
+        case Left(error)  => return Left(error)
+      }
+      i += 2
+    }
+    Right(builder.result())
+  }
+
   // a fixed-arity RESP Array decoded position by position; `label` is the structural description reported on a shape mismatch
   def array2[A, B, R](a: Frame => Either[DecodeError, A], b: Frame => Either[DecodeError, B], label: String)(
     combine: (A, B) => R
@@ -190,7 +206,17 @@ private[commands] object Decode {
   val fieldMap: Frame => Either[DecodeError, Map[String, Frame]] = {
     case Frame.Map(entries) => Right(entries.collect { case (Frame.BulkString(k), v) => k.asUtf8String -> v }.toMap)
     case Frame.Array(elements) if elements.length % 2 == 0 =>
-      Right(elements.grouped(2).collect { case Vector(Frame.BulkString(k), v) => k.asUtf8String -> v }.toMap)
+      val builder = Map.newBuilder[String, Frame]
+      builder.sizeHint(elements.length / 2)
+      var i       = 0
+      while (i < elements.length) {
+        elements(i) match {
+          case Frame.BulkString(k) => builder += (k.asUtf8String -> elements(i + 1))
+          case _                   => ()
+        }
+        i += 2
+      }
+      Right(builder.result())
     case other => Left(DecodeError("map", Frame.describe(other)))
   }
 
@@ -208,10 +234,10 @@ private[commands] object Decode {
   // HSCAN's items are a flat field, value, field, value, … array; HRANDFIELD WITHVALUES nests each pair in its own array.
   def flatPairs[K, V](using KeyCodec[K], ValueCodec[V]): Frame => Either[DecodeError, Vector[(K, V)]] = {
     case Frame.Array(elements) if elements.length % 2 == 0 =>
-      buildEach(elements.grouped(2), Vector.newBuilder[(K, V)]) { pair =>
+      buildPairs(elements, Vector.newBuilder[(K, V)]) { (fieldFrame, valueFrame) =>
         for {
-          field <- key(pair(0))
-          value <- this.value(pair(1))
+          field <- key(fieldFrame)
+          value <- this.value(valueFrame)
         } yield field -> value
       }
     case other => Left(DecodeError("array of field/value pairs", Frame.describe(other)))
@@ -272,10 +298,10 @@ private[commands] object Decode {
   // ZSCAN's items are a flat member, score, member, score array with scores as bulk strings, not RESP3 doubles
   def scoredMembersFlat[V](using ValueCodec[V]): Frame => Either[DecodeError, Vector[(V, Double)]] = {
     case Frame.Array(elements) if elements.length % 2 == 0 =>
-      buildEach(elements.grouped(2), Vector.newBuilder[(V, Double)]) { pair =>
+      buildPairs(elements, Vector.newBuilder[(V, Double)]) { (memberFrame, scoreFrame) =>
         for {
-          member <- value(pair(0))
-          s      <- scoreText(pair(1))
+          member <- value(memberFrame)
+          s      <- scoreText(scoreFrame)
         } yield member -> s
       }
     case other => Left(DecodeError("array of member/score pairs", Frame.describe(other)))

--- a/sage-core/src/main/scala/sage/commands/HyperLogLog.scala
+++ b/sage-core/src/main/scala/sage/commands/HyperLogLog.scala
@@ -10,12 +10,12 @@ private[sage] object HyperLogLog {
 
   // cacheable despite PFCOUNT's documented register-cache write: that write preserves the estimate, so it fires no invalidation
   def pfCount[K](first: K, rest: K*)(using keyCodec: KeyCodec[K]): Command[Long] = {
-    val keys = (first +: rest.toVector).map(keyCodec.encode)
+    val keys = (first +: rest).iterator.map(keyCodec.encode).toVector
     Command.read("PFCOUNT", keys.indices.toVector, keys, Decode.long)
   }
 
   def pfMerge[K](destination: K, sources: K*)(using keyCodec: KeyCodec[K]): Command[Unit] = {
-    val keys = (destination +: sources.toVector).map(keyCodec.encode)
+    val keys = (destination +: sources).iterator.map(keyCodec.encode).toVector
     Command("PFMERGE", keys.indices.toVector, keys, Decode.ok)
   }
 }

--- a/sage-core/src/main/scala/sage/commands/Pubsub.scala
+++ b/sage-core/src/main/scala/sage/commands/Pubsub.scala
@@ -135,12 +135,15 @@ private[sage] object Pubsub {
     frame match {
       case Frame.Array(elements) if elements.length % 2 == 0 =>
         val builder = Map.newBuilder[String, Long]
-        val pairs   = elements.grouped(2)
-        while (pairs.hasNext)
-          pairs.next() match {
-            case Vector(Frame.BulkString(ch), Frame.Integer(count)) => builder += ch.asUtf8String -> count
-            case other                                              => return Left(DecodeError("channel/count pair", other.map(Frame.describe).mkString(", ")))
+        builder.sizeHint(elements.length / 2)
+        var i       = 0
+        while (i < elements.length) {
+          (elements(i), elements(i + 1)) match {
+            case (Frame.BulkString(ch), Frame.Integer(count)) => builder += ch.asUtf8String -> count
+            case (a, b)                                       => return Left(DecodeError("channel/count pair", s"${Frame.describe(a)}, ${Frame.describe(b)}"))
           }
+          i += 2
+        }
         Right(builder.result())
       case other => Left(DecodeError("array of channel/count pairs", Frame.describe(other)))
     }

--- a/sage-core/src/main/scala/sage/commands/StreamInfo.scala
+++ b/sage-core/src/main/scala/sage/commands/StreamInfo.scala
@@ -245,7 +245,12 @@ private[sage] object StreamInfo {
     def of(frame: Frame): Either[DecodeError, Fields] =
       frame match {
         case Frame.Map(entries) => build(entries)
-        case Frame.Array(elements) if elements.length % 2 == 0 => build(elements.grouped(2).map(p => p(0) -> p(1)).toVector)
+        case Frame.Array(elements) if elements.length % 2 == 0 =>
+          val pairs = Vector.newBuilder[(Frame, Frame)]
+          pairs.sizeHint(elements.length / 2)
+          var i     = 0
+          while (i < elements.length) { pairs += (elements(i) -> elements(i + 1)); i += 2 }
+          build(pairs.result())
         case other => Left(DecodeError("introspection map", Frame.describe(other)))
       }
 

--- a/sage-core/src/main/scala/sage/commands/Strings.scala
+++ b/sage-core/src/main/scala/sage/commands/Strings.scala
@@ -139,7 +139,7 @@ private[sage] object Strings {
     Command("INCRBYFLOAT", Command.FirstKey, Vector(keyCodec.encode(key), Bytes.utf8(Doubles.format(increment))), Decode.double)
 
   def mGet[K, V](first: K, rest: K*)(using keyCodec: KeyCodec[K], valueCodec: ValueCodec[V]): Command[Vector[Option[V]]] = {
-    val keys = (first +: rest.toVector).map(keyCodec.encode)
+    val keys = (first +: rest).iterator.map(keyCodec.encode).toVector
     Command.read("MGET", keys.indices.toVector, keys, Decode.vector(Decode.optionalValue))
   }
 

--- a/sage-core/src/main/scala/sage/protocol/RespParser.scala
+++ b/sage-core/src/main/scala/sage/protocol/RespParser.scala
@@ -273,6 +273,7 @@ final private[sage] class RespParser {
       readPos = cursor
       val agg = new Agg(kind, count)
       agg.elements = Vector.newBuilder[Frame]
+      agg.elements.sizeHint(count)
       push(agg)
     }
   }
@@ -284,7 +285,7 @@ final private[sage] class RespParser {
     else {
       readPos = cursor
       val agg = new Agg(kind, count)
-      if (kind == Map) agg.pairs = Vector.newBuilder[(Frame, Frame)]
+      if (kind == Map) { agg.pairs = Vector.newBuilder[(Frame, Frame)]; agg.pairs.sizeHint(count) }
       push(agg)
     }
   }


### PR DESCRIPTION
Allocation hygiene on the per-reply decode / per-pipeline collapse paths.

## Changes

- **`buildPairs` helper + `flatPairs`/`scoredMembersFlat`/`fieldMap` (`Decode.scala`)**, plus the `XINFO` (`StreamInfo`) and `PUBSUB NUMSUB` (`Pubsub`) array forms: replace `grouped(2)` — which allocates a throwaway 2-element `Vector` (+ `GroupedIterator` buffer) per pair over an already random-access `Vector[Frame]` — with index-stepping into a size-hinted builder. Preserves short-circuit-on-`Left`, ordering, and `fieldMap`'s drop-non-string-key semantics. Benefits HSCAN/ZSCAN/HRANDFIELD-WITHVALUES. (HGETALL is RESP3 `Frame.Map` and never hit this path.)
- **`RespParser` size-hints**: `agg.elements` / `agg.pairs` builders now `sizeHint(count)` from the already-parsed header count, so MGET/HGETALL/KEYS/stream reads avoid builder regrowth on large replies.
- **`TxSupport.collapseStrict`**: single short-circuiting pass into a size-hinted builder instead of `collectFirst` then `collect` (two scans + a second vector) on every successful strict pipeline.
- **Multi-key arg builders** (`mGet`, `pfCount`, `pfMerge`): `(first +: rest).iterator.map(encode).toVector` — one Vector instead of `rest.toVector` + `+:` + `.map`.

## Tests

Behavior-preserving; covered by the existing core decode/parser suites (695) and clientCe pipeline suite (136), all green. No new correctness tests since no behavior changed.