### PR TITLE
Avoid per-command Set and repeated cache-key hashing on routing/cache paths

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
@@ -139,7 +139,9 @@ private[client] object ClientCache {
 
   // a content-addressed Bytes key — universal `==`/`hashCode` on Bytes is reference-based by design (see Bytes)
   final class Key(val bytes: Bytes) {
-    override def hashCode(): Int             = bytes.contentHashCode
+    // memoized: contentHashCode scans the whole wire bytes, and a Key is hashed across several cache map ops
+    private val hash                         = bytes.contentHashCode
+    override def hashCode(): Int             = hash
     override def equals(other: Any): Boolean = other match {
       case that: Key => bytes.sameBytes(that.bytes)
       case _         => false

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
@@ -139,7 +139,6 @@ private[client] object ClientCache {
 
   // a content-addressed Bytes key — universal `==`/`hashCode` on Bytes is reference-based by design (see Bytes)
   final class Key(val bytes: Bytes) {
-    // memoized: contentHashCode scans the whole wire bytes, and a Key is hashed across several cache map ops
     private val hash                         = bytes.contentHashCode
     override def hashCode(): Int             = hash
     override def equals(other: Any): Boolean = other match {

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -724,7 +724,6 @@ final private[client] class ClusterLive(
       else if (command.keyIndices.isEmpty)
         Right(None)
       else {
-        // no Set on the common same-slot path (single key, or a shared hash tag); one is built only for a genuine cross-slot's error
         val keyIndices = command.keyIndices
         val first      = Slot.of(command.args(keyIndices.head))
         var i          = 1

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -724,9 +724,17 @@ final private[client] class ClusterLive(
       else if (command.keyIndices.isEmpty)
         Right(None)
       else {
-        val slots = command.keyIndices.iterator.map(index => Slot.of(command.args(index))).toSet
-        if (slots.sizeIs > 1) Left(crossSlot(command.name, slots))
-        else Right(Some(slots.head))
+        // no Set on the common same-slot path (single key, or a shared hash tag); one is built only for a genuine cross-slot's error
+        val keyIndices = command.keyIndices
+        val first      = Slot.of(command.args(keyIndices.head))
+        var i          = 1
+        var crossed    = false
+        while (i < keyIndices.length && !crossed) {
+          if (Slot.of(command.args(keyIndices(i))) != first) crossed = true
+          i += 1
+        }
+        if (crossed) Left(crossSlot(command.name, keyIndices.iterator.map(index => Slot.of(command.args(index))).toSet))
+        else Right(Some(first))
       }
 
     private def pipelineSlot[Out, R](p: Pipeline[Out, R]): Either[Throwable, Option[Slot]] = {

--- a/sage-core/src/main/scala/sage/cluster/Topology.scala
+++ b/sage-core/src/main/scala/sage/cluster/Topology.scala
@@ -36,7 +36,6 @@ final private[sage] class ClusterTopology private (val shards: Vector[Shard], ow
         case 0 => Route.Keyless
         case 1 => routeSlot(Slot.of(command.args(command.keyIndices.head)))
         case _ =>
-          // no Set on the common same-slot path (a shared hash tag); one is built only for a real cross-slot
           val keyIndices = command.keyIndices
           val first      = Slot.of(command.args(keyIndices.head))
           var i          = 1

--- a/sage-core/src/main/scala/sage/cluster/Topology.scala
+++ b/sage-core/src/main/scala/sage/cluster/Topology.scala
@@ -36,8 +36,16 @@ final private[sage] class ClusterTopology private (val shards: Vector[Shard], ow
         case 0 => Route.Keyless
         case 1 => routeSlot(Slot.of(command.args(command.keyIndices.head)))
         case _ =>
-          val slots = slotsOf(command)
-          if (slots.sizeIs > 1) Route.CrossSlot(slots) else routeSlot(slots.head)
+          // no Set on the common same-slot path (a shared hash tag); one is built only for a real cross-slot
+          val keyIndices = command.keyIndices
+          val first      = Slot.of(command.args(keyIndices.head))
+          var i          = 1
+          var crossed    = false
+          while (i < keyIndices.length && !crossed) {
+            if (Slot.of(command.args(keyIndices(i))) != first) crossed = true
+            i += 1
+          }
+          if (crossed) Route.CrossSlot(slotsOf(command)) else routeSlot(first)
       }
 
   def split(pipeline: Pipeline[?, ?]): SplitPlan = {


### PR DESCRIPTION
Low-risk allocation hygiene on the cluster-routing and client-cache paths. Behavior-preserving.

## Changes

- **`ClusterLive.commandSlot`** (`ClusterLive.scala`): built a `Set[Slot]` for **every keyed command** — even a single key (a `Set1`) — during pipeline/transaction slot resolution, just to detect a cross-slot. Now resolves the common same-slot path (single key, or multi-key sharing a hash tag) with a first-slot comparison loop (`Slot` is an opaque `Int`), allocating a `Set` only for a genuine cross-slot's error message.
- **`ClusterTopology.route`** (`Topology.scala`): same first-slot loop for the multi-key case. (`route` already special-cased single-key, so this only helps same-slot multi-key / hash-tag commands.)
- **`ClientCache.Key`** (`ClientCache.scala`): memoize `hashCode` — it is `contentHashCode`, an O(wire-length) scan, otherwise recomputed on every cache map op (get on acquire, then store/fail). Value unchanged.

## Tests

Behavior-preserving; covered by the existing `sage.cluster.*` / `sage.commands.*` (599) and `ClientCacheSpec` (7) plus the full clientCe suite (136), all green. Cross-slot detection and hash values are identical, so no new tests.