### PR TITLE
Deduplicate node registry, paged streams, and command decoders

### DIFF
--- a/sage-client/ce/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/ce/src/main/scala/sage/backend/SageClient.scala
@@ -1,7 +1,5 @@
 package sage.backend
 
-import java.util.concurrent.TimeUnit
-
 import scala.annotation.unused
 import scala.concurrent.duration.FiniteDuration
 
@@ -62,20 +60,16 @@ extension [K](client: Client[IO, K])(using @unused ev: KeyCodec[K]) {
   ): fs2.Stream[IO, (V, Double)] =
     scanStream(cursor => client.run(SortedSets.zScan[K, V](key, cursor, pattern, count)))
 
+  // drives a shared Paged step machine as an fs2 Stream, flattening each page into individual elements
+  private def paged[S, A](init: S)(step: Paged.Step[S, A]): fs2.Stream[IO, A] =
+    CStream.unfold[S, Vector[A]](init)(step).flatMap(items => CStream.init(items)).lower
+
   private def scanStream[A](fetch: ScanCursor => IO[ScanPage[A]]): fs2.Stream[IO, A] =
-    CStream
-      .unfold[Option[ScanCursor], Vector[A]](Some(ScanCursor.start))(Paged.byCursor(cursor => CIO.lift(fetch(cursor))))
-      .flatMap(items => CStream.init(items))
-      .lower
+    paged[Option[ScanCursor], A](Some(ScanCursor.start))(Paged.byCursor(cursor => CIO.lift(fetch(cursor))))
 
   // walks every scan target in turn, each with its own node-local cursor, so a cluster SCAN sweeps all masters instead of one
   private def scanStreamAll[A](fetch: ScanTarget => ScanCursor => IO[ScanPage[A]]): fs2.Stream[IO, A] =
-    CStream
-      .unfold[ScanStep, Vector[A]](ScanStep.Begin)(
-        Paged.acrossTargets(CIO.lift(client.scanTargets))(target => cursor => CIO.lift(fetch(target)(cursor)))
-      )
-      .flatMap(items => CStream.init(items))
-      .lower
+    paged[ScanStep, A](ScanStep.Begin)(Paged.acrossTargets(CIO.lift(client.scanTargets))(target => cursor => CIO.lift(fetch(target)(cursor))))
 
   /**
     * Lazily pages an entire stream by range, batching `XRANGE` and advancing past the last id each page. Stops when a page comes back empty.
@@ -86,12 +80,9 @@ extension [K](client: Client[IO, K])(using @unused ev: KeyCodec[K]) {
     end: StreamRangeId = StreamRangeId.Max,
     batch: Long = 100L
   ): fs2.Stream[IO, StreamEntry[F, V]] =
-    CStream
-      .unfold[Option[StreamRangeId], Vector[StreamEntry[F, V]]](Some(start))(
-        Paged.byRange(batch)(from => CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))))
-      )
-      .flatMap(items => CStream.init(items))
-      .lower
+    paged[Option[StreamRangeId], StreamEntry[F, V]](Some(start))(
+      Paged.byRange(batch)(from => CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))))
+    )
 
   /**
     * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Tombstone
@@ -106,12 +97,9 @@ extension [K](client: Client[IO, K])(using @unused ev: KeyCodec[K]) {
     start: StreamId = StreamId.Zero,
     count: Option[Long] = None
   ): fs2.Stream[IO, StreamEntry[F, V]] =
-    CStream
-      .unfold[Option[StreamId], Vector[StreamEntry[F, V]]](Some(start))(
-        Paged.byAutoClaim(from => CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))))
-      )
-      .flatMap(items => CStream.init(items))
-      .lower
+    paged[Option[StreamId], StreamEntry[F, V]](Some(start))(
+      Paged.byAutoClaim(from => CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))))
+    )
 
   /**
     * Follows a stream without a consumer group: replays every entry after `from`, then blocks for new entries forever, advancing past the
@@ -122,16 +110,13 @@ extension [K](client: Client[IO, K])(using @unused ev: KeyCodec[K]) {
     key: K,
     from: StreamId = StreamId.Zero,
     count: Option[Long] = None,
-    block: BlockTimeout = SageClient.defaultPoll
+    block: BlockTimeout = Paged.defaultPoll
   ): fs2.Stream[IO, StreamEntry[F, V]] =
-    CStream
-      .unfold[StreamId, Vector[StreamEntry[F, V]]](from)(
-        Paged.tail(last =>
-          CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map(_.flatMap(_._2))
-        )
+    paged[StreamId, StreamEntry[F, V]](from)(
+      Paged.tail(last =>
+        CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map(_.flatMap(_._2))
       )
-      .flatMap(items => CStream.init(items))
-      .lower
+    )
 
   /**
     * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
@@ -143,7 +128,7 @@ extension [K](client: Client[IO, K])(using @unused ev: KeyCodec[K]) {
     consumer: String,
     key: K,
     count: Option[Long] = None,
-    block: BlockTimeout = SageClient.defaultPoll
+    block: BlockTimeout = Paged.defaultPoll
   )(handle: StreamEntry[F, V] => IO[Unit]): IO[Unit] =
     consumeStream[F, V](group, consumer, key, count, block)
       .evalMap(entry => handle(entry) >> client.run(Streams.xAck(key, group)(entry.id)).void)
@@ -157,18 +142,15 @@ extension [K](client: Client[IO, K])(using @unused ev: KeyCodec[K]) {
     count: Option[Long],
     block: BlockTimeout
   ): fs2.Stream[IO, StreamEntry[F, V]] =
-    CStream
-      .unfold[Either[StreamId, Unit], Vector[StreamEntry[F, V]]](Left(StreamId.Zero))(
-        Paged.consume(
-          drainPending = after =>
-            CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map(_.flatMap(_._2)),
-          tailNew = CIO
-            .lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block))))
-            .map(_.flatMap(_._2))
-        )
+    paged[Either[StreamId, Unit], StreamEntry[F, V]](Left(StreamId.Zero))(
+      Paged.consume(
+        drainPending = after =>
+          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map(_.flatMap(_._2)),
+        tailNew = CIO
+          .lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block))))
+          .map(_.flatMap(_._2))
       )
-      .flatMap(items => CStream.init(items))
-      .lower
+    )
 
   /**
     * Subscribes to one or more channels; closing the stream's scope unsubscribes. Survives reconnects via auto-resubscribe, dropping
@@ -225,10 +207,6 @@ object SageClient {
     * use `as` to reach any other key type over the same connection.
     */
   type Keyed[K] = Client[IO, K]
-
-  // bounded poll so xConsume's blocking read returns periodically, keeping cancellation responsive
-  private[backend] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, TimeUnit.SECONDS))
-
   def connect(config: SageConfig): IO[SageClient] =
     Client.connect(config).lower.map(new Lowered(_))
 

--- a/sage-client/kyo/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/kyo/src/main/scala/sage/backend/SageClient.scala
@@ -135,7 +135,7 @@ extension [K](client: Client[[A] =>> A < (Abort[SageException] & Async), K])(usi
     key: K,
     from: StreamId = StreamId.Zero,
     count: Option[Long] = None,
-    block: BlockTimeout = SageClient.defaultPoll
+    block: BlockTimeout = Paged.defaultPoll
   )(using Tag[F], Tag[V]): Stream[StreamEntry[F, V], Abort[SageException] & Async] =
     paged[StreamId, StreamEntry[F, V]](from)(
       Paged.tail(last =>
@@ -153,7 +153,7 @@ extension [K](client: Client[[A] =>> A < (Abort[SageException] & Async), K])(usi
     consumer: String,
     key: K,
     count: Option[Long] = None,
-    block: BlockTimeout = SageClient.defaultPoll
+    block: BlockTimeout = Paged.defaultPoll
   )(handle: StreamEntry[F, V] => Unit < (Abort[SageException] & Async))(using Tag[F], Tag[V], Frame): Unit < (Abort[SageException] & Async) =
     consumeStream[F, V](group, consumer, key, count, block)
       .foreach(entry => handle(entry).flatMap(_ => client.run(Streams.xAck(key, group)(entry.id)).map(_ => ())))
@@ -258,10 +258,6 @@ object SageClient {
     * use `as` to reach any other key type over the same connection.
     */
   type Keyed[K] = Client[[A] =>> A < (Abort[SageException] & Async), K]
-
-  // bounded poll so xConsume's blocking read returns periodically, keeping cancellation responsive
-  private[backend] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, java.util.concurrent.TimeUnit.SECONDS))
-
   def connect(config: SageConfig): SageClient < (Abort[SageException] & Async) =
     refine(Client.connect(config).lower).map(new Lowered(_))
 

--- a/sage-client/ox/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/backend/SageClient.scala
@@ -1,6 +1,5 @@
 package sage.backend
 
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.annotation.unused
@@ -64,20 +63,16 @@ extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]
   ): Ox ?=> Flow[(V, Double)] =
     scanStream(cursor => client.run(SortedSets.zScan[K, V](key, cursor, pattern, count)))
 
+  // drives a shared Paged step machine as a Flow, flattening each page into individual elements
+  private def paged[S, A](init: S)(step: Paged.Step[S, A]): Ox ?=> Flow[A] =
+    CStream.unfold[S, Vector[A]](init)(step).flatMap(items => CStream.init(items)).lower
+
   private def scanStream[A](fetch: ScanCursor => (Ox ?=> ScanPage[A])): Ox ?=> Flow[A] =
-    CStream
-      .unfold[Option[ScanCursor], Vector[A]](Some(ScanCursor.start))(Paged.byCursor(cursor => CIO.lift(fetch(cursor))))
-      .flatMap(items => CStream.init(items))
-      .lower
+    paged[Option[ScanCursor], A](Some(ScanCursor.start))(Paged.byCursor(cursor => CIO.lift(fetch(cursor))))
 
   // walks every scan target in turn, each with its own node-local cursor, so a cluster SCAN sweeps all masters instead of one
   private def scanStreamAll[A](fetch: ScanTarget => ScanCursor => (Ox ?=> ScanPage[A])): Ox ?=> Flow[A] =
-    CStream
-      .unfold[ScanStep, Vector[A]](ScanStep.Begin)(
-        Paged.acrossTargets(CIO.lift(client.scanTargets))(target => cursor => CIO.lift(fetch(target)(cursor)))
-      )
-      .flatMap(items => CStream.init(items))
-      .lower
+    paged[ScanStep, A](ScanStep.Begin)(Paged.acrossTargets(CIO.lift(client.scanTargets))(target => cursor => CIO.lift(fetch(target)(cursor))))
 
   /**
     * Lazily pages an entire stream by range, batching `XRANGE` and advancing past the last id each page. Stops when a page comes back empty.
@@ -88,12 +83,9 @@ extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]
     end: StreamRangeId = StreamRangeId.Max,
     batch: Long = 100L
   ): Ox ?=> Flow[StreamEntry[F, V]] =
-    CStream
-      .unfold[Option[StreamRangeId], Vector[StreamEntry[F, V]]](Some(start))(
-        Paged.byRange(batch)(from => CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))))
-      )
-      .flatMap(items => CStream.init(items))
-      .lower
+    paged[Option[StreamRangeId], StreamEntry[F, V]](Some(start))(
+      Paged.byRange(batch)(from => CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))))
+    )
 
   /**
     * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Tombstone
@@ -108,12 +100,9 @@ extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]
     start: StreamId = StreamId.Zero,
     count: Option[Long] = None
   ): Ox ?=> Flow[StreamEntry[F, V]] =
-    CStream
-      .unfold[Option[StreamId], Vector[StreamEntry[F, V]]](Some(start))(
-        Paged.byAutoClaim(from => CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))))
-      )
-      .flatMap(items => CStream.init(items))
-      .lower
+    paged[Option[StreamId], StreamEntry[F, V]](Some(start))(
+      Paged.byAutoClaim(from => CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))))
+    )
 
   /**
     * Follows a stream without a consumer group: replays every entry after `from`, then blocks for new entries forever, advancing past the
@@ -124,16 +113,13 @@ extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]
     key: K,
     from: StreamId = StreamId.Zero,
     count: Option[Long] = None,
-    block: BlockTimeout = SageClient.defaultPoll
+    block: BlockTimeout = Paged.defaultPoll
   ): Ox ?=> Flow[StreamEntry[F, V]] =
-    CStream
-      .unfold[StreamId, Vector[StreamEntry[F, V]]](from)(
-        Paged.tail(last =>
-          CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map(_.flatMap(_._2))
-        )
+    paged[StreamId, StreamEntry[F, V]](from)(
+      Paged.tail(last =>
+        CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map(_.flatMap(_._2))
       )
-      .flatMap(items => CStream.init(items))
-      .lower
+    )
 
   /**
     * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
@@ -145,7 +131,7 @@ extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]
     consumer: String,
     key: K,
     count: Option[Long] = None,
-    block: BlockTimeout = SageClient.defaultPoll
+    block: BlockTimeout = Paged.defaultPoll
   )(handle: StreamEntry[F, V] => (Ox ?=> Unit)): Ox ?=> Unit =
     consumeStream[F, V](group, consumer, key, count, block).runForeach { entry =>
       handle(entry)
@@ -160,18 +146,15 @@ extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]
     count: Option[Long],
     block: BlockTimeout
   ): Ox ?=> Flow[StreamEntry[F, V]] =
-    CStream
-      .unfold[Either[StreamId, Unit], Vector[StreamEntry[F, V]]](Left(StreamId.Zero))(
-        Paged.consume(
-          drainPending = after =>
-            CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map(_.flatMap(_._2)),
-          tailNew = CIO
-            .lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block))))
-            .map(_.flatMap(_._2))
-        )
+    paged[Either[StreamId, Unit], StreamEntry[F, V]](Left(StreamId.Zero))(
+      Paged.consume(
+        drainPending = after =>
+          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map(_.flatMap(_._2)),
+        tailNew = CIO
+          .lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block))))
+          .map(_.flatMap(_._2))
       )
-      .flatMap(items => CStream.init(items))
-      .lower
+    )
 
   /**
     * Subscribes to one or more channels, returning once the server has confirmed the SUBSCRIBE so a publish issued after this call cannot
@@ -220,10 +203,6 @@ object SageClient {
     * use `as` to reach any other key type over the same connection.
     */
   type Keyed[K] = Client[[A] =>> Ox ?=> A, K]
-
-  // bounded poll so xConsume's blocking read returns periodically, keeping cancellation responsive
-  private[backend] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, TimeUnit.SECONDS))
-
   def connect(config: SageConfig): Ox ?=> SageClient = new Lowered(Client.connect(config).lower)
 
   def scoped(config: SageConfig): Ox ?=> SageClient =

--- a/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
@@ -1,7 +1,5 @@
 package sage.backend
 
-import java.util.concurrent.TimeUnit
-
 import scala.annotation.unused
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration.FiniteDuration
@@ -106,7 +104,7 @@ extension [K](client: Client[Future, K])(using @unused ev: KeyCodec[K]) {
     key: K,
     from: StreamId = StreamId.Zero,
     count: Option[Long] = None,
-    block: BlockTimeout = SageClient.defaultPoll
+    block: BlockTimeout = Paged.defaultPoll
   ): Source[StreamEntry[F, V], NotUsed] =
     SageClient.boundedPoll(block, "xTail") match {
       case Left(e)     => Source.failed(e)
@@ -130,7 +128,7 @@ extension [K](client: Client[Future, K])(using @unused ev: KeyCodec[K]) {
     consumer: String,
     key: K,
     count: Option[Long] = None,
-    block: BlockTimeout = SageClient.defaultPoll
+    block: BlockTimeout = Paged.defaultPoll
   )(handle: StreamEntry[F, V] => Future[Unit])(using system: ActorSystem[?]): RunningConsumer =
     SageClient.boundedPoll(block, "xConsume") match {
       case Left(e)     => RunningConsumer.failed(e)
@@ -230,9 +228,6 @@ object SageClient {
     * use `as` to reach any other key type over the same connection.
     */
   type Keyed[K] = Client[Future, K]
-
-  // bounded poll so xConsume's blocking read returns periodically, keeping RunningConsumer.stop() responsive
-  private[backend] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, TimeUnit.SECONDS))
 
   /**
     * Connects and returns a Pekko-native client. The caller owns the client lifecycle and must call `close` explicitly.

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2396,29 +2396,32 @@ object Client {
     def close: CIO[Unit] = CIO.blocking { subscriptions.close(); pool.close(); connection.close(); events.close() }
   }
 
-  // wrap a raw subscription as the effect-typed interface each backend lowers into its native stream; a channel/shard delivery is a Message
-  private[internal] def channelMessages[V](raw: SubscriptionConnection.RawSubscription)(using ValueCodec[V]): Subscription[CIO, Message[V]] =
-    new Subscription[CIO, Message[V]] {
+  // wrap a raw subscription as the effect-typed interface each backend lowers into its native stream; `build` returns None to end the stream
+  private def messages[M](raw: SubscriptionConnection.RawSubscription)(
+    build: SubscriptionConnection.Delivery => Option[M]
+  ): Subscription[CIO, M] =
+    new Subscription[CIO, M] {
       // async, not blocking: the reader thread completes the callback, so a fiber parks instead of pinning a runtime worker
-      def next: CIO[Option[Message[V]]] = CIO.async { complete =>
+      def next: CIO[Option[M]] = CIO.async { complete =>
         raw.next {
-          case Some(SubscriptionConnection.Delivery.Channel(ch, payload)) => complete(Try(Some(Message(ch, decodeOrThrow[V](payload)))))
-          case _                                                          => complete(Success(None))
+          case Some(delivery) => complete(Try(build(delivery)))
+          case None           => complete(Success(None))
         }
       }
-      def close: CIO[Unit]              = CIO.blocking(raw.close())
+      def close: CIO[Unit]     = CIO.blocking(raw.close())
+    }
+
+  // a channel/shard delivery is a Message
+  private[internal] def channelMessages[V](raw: SubscriptionConnection.RawSubscription)(using ValueCodec[V]): Subscription[CIO, Message[V]] =
+    messages(raw) {
+      case SubscriptionConnection.Delivery.Channel(ch, payload) => Some(Message(ch, decodeOrThrow[V](payload)))
+      case _                                                    => None
     }
 
   private[internal] def patternMessages[V](raw: SubscriptionConnection.RawSubscription)(using ValueCodec[V]): Subscription[CIO, PatternMessage[V]] =
-    new Subscription[CIO, PatternMessage[V]] {
-      def next: CIO[Option[PatternMessage[V]]] = CIO.async { complete =>
-        raw.next {
-          case Some(SubscriptionConnection.Delivery.Pattern(pat, ch, payload)) =>
-            complete(Try(Some(PatternMessage(pat, ch, decodeOrThrow[V](payload)))))
-          case _                                                               => complete(Success(None))
-        }
-      }
-      def close: CIO[Unit]                     = CIO.blocking(raw.close())
+    messages(raw) {
+      case SubscriptionConnection.Delivery.Pattern(pat, ch, payload) => Some(PatternMessage(pat, ch, decodeOrThrow[V](payload)))
+      case _                                                         => None
     }
 
   // fail the stream on a bad payload rather than dropping it

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -4,7 +4,6 @@ import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.util.concurrent.locks.ReentrantLock
 
-import scala.collection.mutable
 import scala.concurrent.duration.*
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
@@ -78,19 +77,22 @@ final private[client] class ClusterLive(
     () => pickNode(topologyRef.get())
   )
 
-  private val nodesLock        = new ReentrantLock()
-  private val established      = mutable.HashMap.empty[Node, NodeClient]
-  private val pendingEstablish = mutable.HashMap.empty[Node, ClusterLive.Establish]
-  // set once by close; routing and node establishment refuse afterwards, so close is terminal like the standalone client's
+  // the master registry, driving redirects/refresh; read-write bootstrap (no READONLY) keeps it distinct from replicaPool
+  private val masterPool       = new NodePool(
+    nodeFactory,
+    scheduler,
+    bootstrap,
+    reconnect,
+    watchdog,
+    connectTimeout,
+    closeTimeout,
+    dedicatedPool,
+    events = events
+  )
+  // set once by close; routing refuses afterwards, so close is terminal like the standalone client's
   @volatile private var closed = false
 
   private val refreshThrottle = new RefreshThrottle(scheduler, cluster.minRefreshInterval.toMillis)
-
-  private inline def lockedNodes[A](inline body: A): A = {
-    nodesLock.lock()
-    try body
-    finally nodesLock.unlock()
-  }
 
   // if no seed answers, throws the last failure so the first connect surfaces a handshake/TLS error like a standalone connect, not None
   private[client] def bootstrapTopology(): Unit = {
@@ -414,8 +416,7 @@ final private[client] class ClusterLive(
   private def resolve(target: Node, from: Node): Node = if (target.host.isEmpty) Node(from.host, target.port) else target
 
   private def pickNode(topology: ClusterTopology): Option[Node] =
-    lockedNodes(established.collectFirst { case (node, nc) if nc.isLive => node })
-      .orElse(topology.shards.headOption.map(_.master))
+    masterPool.firstLiveNode.orElse(topology.shards.headOption.map(_.master))
 
   private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
 
@@ -770,52 +771,7 @@ final private[client] class ClusterLive(
     }
   }
 
-  // --- node registry (single-flight establish) -----------------------------------------------------------------------------------------
-
-  private def getOrEstablish(node: Node): NodeClient = {
-    var existing: NodeClient          = null
-    var waitOn: ClusterLive.Establish = null
-    var mine: ClusterLive.Establish   = null
-    lockedNodes {
-      if (closed) throw NotConnected()
-      established.get(node) match {
-        case Some(nc) => existing = nc
-        case None     =>
-          pendingEstablish.get(node) match {
-            case Some(p) => waitOn = p
-            case None    => mine = new ClusterLive.Establish; pendingEstablish.put(node, mine)
-          }
-      }
-    }
-    if (existing != null) existing
-    else if (waitOn != null) waitOn.get()
-    else
-      try {
-        val nc    =
-          NodeClient.connect(
-            nodeFactory(node),
-            scheduler,
-            bootstrap,
-            reconnect,
-            watchdog,
-            connectTimeout,
-            closeTimeout,
-            dedicatedPool,
-            node = Some(node),
-            events = events
-          )
-        // a close that landed during the blocking connect must not re-publish this bundle into a closed client
-        val stale = lockedNodes { pendingEstablish.remove(node); if (closed) true else { established.put(node, nc); false } }
-        if (stale) { nc.close(); throw NotConnected() }
-        mine.succeed(nc)
-        nc
-      } catch {
-        case error: Throwable =>
-          lockedNodes(pendingEstablish.remove(node))
-          mine.fail(error)
-          throw error
-      }
-  }
+  private def getOrEstablish(node: Node): NodeClient = masterPool.getOrEstablish(node)
 
   // --- topology refresh (single-flight, throttled) -------------------------------------------------------------------------------------
 
@@ -824,10 +780,7 @@ final private[client] class ClusterLive(
   private def refresh(force: Boolean): Unit =
     refreshThrottle(force)(querySlots(refreshCandidates()).foreach { case (from, shards) => adopt(from, shards) })
 
-  private def refreshCandidates(): Vector[Node] = {
-    val (live, others) = lockedNodes(established.toVector).partition(_._2.isLive)
-    (live.map(_._1) ++ others.map(_._1) ++ seeds).distinct
-  }
+  private def refreshCandidates(): Vector[Node] = (masterPool.candidatesByLiveness ++ seeds).distinct
 
   private def querySlots(candidates: Vector[Node]): Option[(Node, Vector[Shard])] =
     candidates.iterator.flatMap(trySlots).nextOption()
@@ -861,11 +814,7 @@ final private[client] class ClusterLive(
       if (current.toSet != previous) events.emit(SageEvent.TopologyChanged(current))
     }
     val masters      = resolved.map(_.master).toSet
-    val gone         = lockedNodes {
-      val absent = established.keysIterator.filterNot(masters.contains).toVector
-      absent.flatMap(node => established.remove(node))
-    }
-    gone.foreach(nc => offload(nc.close()))
+    masterPool.retain(masters.contains)
     // prune replica connections and their cursors for replicas the new topology no longer lists, mirroring the master prune
     val replicaNodes = resolved.iterator.flatMap(_.replicas).toSet
     replicaPool.retain(replicaNodes.contains)
@@ -876,46 +825,15 @@ final private[client] class ClusterLive(
   }
 
   private def closeAll(): Unit = {
-    val (all, waiters) = lockedNodes {
-      closed = true
-      val snapshot = established.values.toVector
-      val pending  = pendingEstablish.values.toVector
-      established.clear()
-      pendingEstablish.clear()
-      (snapshot, pending)
-    }
-    // release callers blocked on an in-flight connect; the establisher observes `closed` on return and closes the node it opened
-    waiters.foreach(_.fail(NotConnected()))
+    closed = true
+    masterPool.close()
     subscriptions.close()
     replicaPool.close()
-    all.foreach(_.close())
     events.close()
   }
 }
 
 private[client] object ClusterLive {
-
-  // one-shot single-flight cell: the establisher fills it, concurrent callers block on `get`. First settle wins, so a `close` that
-  // fails the waiters cannot be overwritten by a late establisher.
-  final private class Establish {
-    private val latch                                           = new CountDownLatch(1)
-    private val settled                                         = new java.util.concurrent.atomic.AtomicBoolean(false)
-    @volatile private var result: Either[Throwable, NodeClient] = null
-
-    def succeed(nc: NodeClient): Unit = settle(Right(nc))
-    def fail(error: Throwable): Unit  = settle(Left(error))
-
-    private def settle(outcome: Either[Throwable, NodeClient]): Unit =
-      if (settled.compareAndSet(false, true)) { result = outcome; latch.countDown() }
-
-    def get(): NodeClient = {
-      latch.await()
-      result match {
-        case Right(nc)   => nc
-        case Left(error) => throw error
-      }
-    }
-  }
 
   def connect(
     config: SageConfig,

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -46,6 +46,14 @@ final private[client] class NodePool(
 
   def existingLive(node: Node): Option[NodeClient] = locked(established.get(node)).filter(_.isLive)
 
+  def firstLiveNode: Option[Node] = locked(established.collectFirst { case (node, nc) if nc.isLive => node })
+
+  // live nodes first, so a refresh prefers a known-good node
+  def candidatesByLiveness: Vector[Node] = {
+    val (live, others) = locked(established.toVector).partition(_._2.isLive)
+    live.map(_._1) ++ others.map(_._1)
+  }
+
   def getOrEstablish(node: Node): NodeClient = {
     var existing: NodeClient       = null
     var waitOn: NodePool.Establish = null

--- a/sage-client/shared/src/main/scala/sage/client/internal/Paged.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Paged.scala
@@ -1,7 +1,12 @@
 package sage.client.internal
 
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.FiniteDuration
+
 import kyo.compat.*
 
+import sage.BlockTimeout
 import sage.commands.{ScanCursor, ScanPage, StreamEntry, StreamId, StreamRangeId, XAutoClaimResult}
 
 /**
@@ -17,6 +22,9 @@ private[sage] object Paged {
     * A page step: from state `S`, fetch the next page of `A`s and the state to resume from, or `None` to end the stream.
     */
   type Step[S, A] = S => CIO[Option[(Vector[A], S)]]
+
+  // the tailing streams' default poll (xTail/xConsume); bounded so the blocking read returns periodically and cancellation stays responsive
+  val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, TimeUnit.SECONDS))
 
   /**
     * Cursor scan (HSCAN/SSCAN/ZSCAN, and a single SCAN target): page until the server returns no continuation cursor. Termination is on the

--- a/sage-client/zio/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/zio/src/main/scala/sage/backend/SageClient.scala
@@ -1,7 +1,5 @@
 package sage.backend
 
-import java.util.concurrent.TimeUnit
-
 import scala.annotation.unused
 import scala.concurrent.duration.FiniteDuration
 
@@ -70,22 +68,16 @@ extension [K](client: Client[IO[SageException, *], K])(using @unused ev: KeyCode
   ): ZStream[Any, SageException, (V, Double)] =
     scanStream(cursor => client.run(SortedSets.zScan[K, V](key, cursor, pattern, count)))
 
+  // drives a shared Paged step machine as a ZStream, flattening each page into individual elements
+  private def paged[S, A](init: S)(step: Paged.Step[S, A]): ZStream[Any, SageException, A] =
+    CStream.unfold[S, Vector[A]](init)(step).flatMap(items => CStream.init(items)).lower.refineToOrDie[SageException]
+
   private def scanStream[A](fetch: ScanCursor => IO[SageException, ScanPage[A]]): ZStream[Any, SageException, A] =
-    CStream
-      .unfold[Option[ScanCursor], Vector[A]](Some(ScanCursor.start))(Paged.byCursor(cursor => CIO.lift(fetch(cursor))))
-      .flatMap(items => CStream.init(items))
-      .lower
-      .refineToOrDie[SageException]
+    paged[Option[ScanCursor], A](Some(ScanCursor.start))(Paged.byCursor(cursor => CIO.lift(fetch(cursor))))
 
   // walks every scan target in turn, each with its own node-local cursor, so a cluster SCAN sweeps all masters instead of one
   private def scanStreamAll[A](fetch: ScanTarget => ScanCursor => IO[SageException, ScanPage[A]]): ZStream[Any, SageException, A] =
-    CStream
-      .unfold[ScanStep, Vector[A]](ScanStep.Begin)(
-        Paged.acrossTargets(CIO.lift(client.scanTargets))(target => cursor => CIO.lift(fetch(target)(cursor)))
-      )
-      .flatMap(items => CStream.init(items))
-      .lower
-      .refineToOrDie[SageException]
+    paged[ScanStep, A](ScanStep.Begin)(Paged.acrossTargets(CIO.lift(client.scanTargets))(target => cursor => CIO.lift(fetch(target)(cursor))))
 
   /**
     * Lazily pages an entire stream by range, batching `XRANGE` and advancing past the last id each page. Stops when a page comes back empty.
@@ -96,13 +88,9 @@ extension [K](client: Client[IO[SageException, *], K])(using @unused ev: KeyCode
     end: StreamRangeId = StreamRangeId.Max,
     batch: Long = 100L
   ): ZStream[Any, SageException, StreamEntry[F, V]] =
-    CStream
-      .unfold[Option[StreamRangeId], Vector[StreamEntry[F, V]]](Some(start))(
-        Paged.byRange(batch)(from => CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))))
-      )
-      .flatMap(items => CStream.init(items))
-      .lower
-      .refineToOrDie[SageException]
+    paged[Option[StreamRangeId], StreamEntry[F, V]](Some(start))(
+      Paged.byRange(batch)(from => CIO.lift(client.run(Streams.xRange[K, F, V](key, from, end, Some(batch)))))
+    )
 
   /**
     * Auto-claims idle pending entries for `consumer`, advancing the `XAUTOCLAIM` cursor each call until it wraps back to the start. Tombstone
@@ -117,13 +105,9 @@ extension [K](client: Client[IO[SageException, *], K])(using @unused ev: KeyCode
     start: StreamId = StreamId.Zero,
     count: Option[Long] = None
   ): ZStream[Any, SageException, StreamEntry[F, V]] =
-    CStream
-      .unfold[Option[StreamId], Vector[StreamEntry[F, V]]](Some(start))(
-        Paged.byAutoClaim(from => CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))))
-      )
-      .flatMap(items => CStream.init(items))
-      .lower
-      .refineToOrDie[SageException]
+    paged[Option[StreamId], StreamEntry[F, V]](Some(start))(
+      Paged.byAutoClaim(from => CIO.lift(client.run(Streams.xAutoClaim[K, F, V](key, group, consumer, minIdle, from, count))))
+    )
 
   /**
     * Follows a stream without a consumer group: replays every entry after `from`, then blocks for new entries forever, advancing past the
@@ -134,17 +118,13 @@ extension [K](client: Client[IO[SageException, *], K])(using @unused ev: KeyCode
     key: K,
     from: StreamId = StreamId.Zero,
     count: Option[Long] = None,
-    block: BlockTimeout = SageClient.defaultPoll
+    block: BlockTimeout = Paged.defaultPoll
   ): ZStream[Any, SageException, StreamEntry[F, V]] =
-    CStream
-      .unfold[StreamId, Vector[StreamEntry[F, V]]](from)(
-        Paged.tail(last =>
-          CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map(_.flatMap(_._2))
-        )
+    paged[StreamId, StreamEntry[F, V]](from)(
+      Paged.tail(last =>
+        CIO.lift(client.run(Streams.xRead[K, F, V]((key, ReadId.After(last)))(count = count, block = Some(block)))).map(_.flatMap(_._2))
       )
-      .flatMap(items => CStream.init(items))
-      .lower
-      .refineToOrDie[SageException]
+    )
 
   /**
     * Tails a consumer group: first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new
@@ -156,7 +136,7 @@ extension [K](client: Client[IO[SageException, *], K])(using @unused ev: KeyCode
     consumer: String,
     key: K,
     count: Option[Long] = None,
-    block: BlockTimeout = SageClient.defaultPoll
+    block: BlockTimeout = Paged.defaultPoll
   )(handle: StreamEntry[F, V] => IO[SageException, Unit]): IO[SageException, Unit] =
     consumeStream[F, V](group, consumer, key, count, block)
       .mapZIO(entry => handle(entry) *> client.run(Streams.xAck(key, group)(entry.id)).unit)
@@ -169,19 +149,15 @@ extension [K](client: Client[IO[SageException, *], K])(using @unused ev: KeyCode
     count: Option[Long],
     block: BlockTimeout
   ): ZStream[Any, SageException, StreamEntry[F, V]] =
-    CStream
-      .unfold[Either[StreamId, Unit], Vector[StreamEntry[F, V]]](Left(StreamId.Zero))(
-        Paged.consume(
-          drainPending = after =>
-            CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map(_.flatMap(_._2)),
-          tailNew = CIO
-            .lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block))))
-            .map(_.flatMap(_._2))
-        )
+    paged[Either[StreamId, Unit], StreamEntry[F, V]](Left(StreamId.Zero))(
+      Paged.consume(
+        drainPending = after =>
+          CIO.lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.After(after)))(count = count))).map(_.flatMap(_._2)),
+        tailNew = CIO
+          .lift(client.run(Streams.xReadGroup[K, F, V](group, consumer)((key, GroupReadId.New))(count = count, block = Some(block))))
+          .map(_.flatMap(_._2))
       )
-      .flatMap(items => CStream.init(items))
-      .lower
-      .refineToOrDie[SageException]
+    )
 
   /**
     * Subscribes to one or more channels; closing the stream's scope unsubscribes. Survives reconnects via auto-resubscribe, dropping
@@ -245,10 +221,6 @@ object SageClient {
     * use `as` to reach any other key type over the same connection.
     */
   type Keyed[K] = Client[IO[SageException, *], K]
-
-  // bounded poll so xConsume's blocking read returns periodically, keeping cancellation responsive
-  private[backend] val defaultPoll: BlockTimeout = BlockTimeout.After(FiniteDuration(5, TimeUnit.SECONDS))
-
   def connect(config: SageConfig): IO[SageException, SageClient] =
     Client.connect(config).lower.refineToOrDie[SageException].map(new Lowered(_))
 

--- a/sage-core/src/main/scala/sage/commands/Decode.scala
+++ b/sage-core/src/main/scala/sage/commands/Decode.scala
@@ -37,6 +37,14 @@ private[commands] object Decode {
     case other                   => Left(DecodeError("double bulk string", Frame.describe(other)))
   }
 
+  // shared TTL/expiry shape (TTL, EXPIRETIME, HTTL, …): `-2` absent, `-1` no expiry, else present
+  def expiryInteger[A](absent: A, noExpiry: A, expected: String)(present: Long => A): Frame => Either[DecodeError, A] = {
+    case Frame.Integer(-2)                    => Right(absent)
+    case Frame.Integer(-1)                    => Right(noExpiry)
+    case Frame.Integer(amount) if amount >= 0 => Right(present(amount))
+    case other                                => Left(DecodeError(expected, Frame.describe(other)))
+  }
+
   def value[V](using codec: ValueCodec[V]): Frame => Either[DecodeError, V] = {
     case Frame.BulkString(bytes) => codec.decode(bytes)
     case other                   => Left(DecodeError("bulk string", Frame.describe(other)))
@@ -301,19 +309,11 @@ private[commands] object Decode {
       buildPairs(elements, Vector.newBuilder[(V, Double)]) { (memberFrame, scoreFrame) =>
         for {
           member <- value(memberFrame)
-          s      <- scoreText(scoreFrame)
+          s      <- double(scoreFrame)
         } yield member -> s
       }
     case other => Left(DecodeError("array of member/score pairs", Frame.describe(other)))
   }
-
-  private def scoreText(frame: Frame): Either[DecodeError, Double] =
-    frame match {
-      case Frame.BulkString(bytes) =>
-        val text = bytes.asUtf8String
-        Doubles.parse(text).toRight(DecodeError("double", s"bulk string '$text'"))
-      case other                   => Left(DecodeError("score bulk string", Frame.describe(other)))
-    }
 }
 
 private[commands] object TimeArgs {

--- a/sage-core/src/main/scala/sage/commands/Hashes.scala
+++ b/sage-core/src/main/scala/sage/commands/Hashes.scala
@@ -277,19 +277,13 @@ private[sage] object Hashes {
     case other             => Left(DecodeError("field expiry integer", Frame.describe(other)))
   }
 
-  private def fieldTtl(unit: TimeUnit): Frame => Either[DecodeError, FieldTtl] = {
-    case Frame.Integer(-2)                    => Right(FieldTtl.NoField)
-    case Frame.Integer(-1)                    => Right(FieldTtl.NoExpiry)
-    case Frame.Integer(amount) if amount >= 0 => Right(FieldTtl.Expires(FiniteDuration(amount, unit)))
-    case other                                => Left(DecodeError("field ttl integer", Frame.describe(other)))
-  }
+  private def fieldTtl(unit: TimeUnit): Frame => Either[DecodeError, FieldTtl] =
+    Decode.expiryInteger(FieldTtl.NoField, FieldTtl.NoExpiry, "field ttl integer")(amount => FieldTtl.Expires(FiniteDuration(amount, unit)))
 
-  private def fieldExpiryTime(toInstant: Long => Instant): Frame => Either[DecodeError, FieldExpiryTime] = {
-    case Frame.Integer(-2)                    => Right(FieldExpiryTime.NoField)
-    case Frame.Integer(-1)                    => Right(FieldExpiryTime.NoExpiry)
-    case Frame.Integer(amount) if amount >= 0 => Right(FieldExpiryTime.At(toInstant(amount)))
-    case other                                => Left(DecodeError("field expiry time integer", Frame.describe(other)))
-  }
+  private def fieldExpiryTime(toInstant: Long => Instant): Frame => Either[DecodeError, FieldExpiryTime] =
+    Decode.expiryInteger(FieldExpiryTime.NoField, FieldExpiryTime.NoExpiry, "field expiry time integer")(amount =>
+      FieldExpiryTime.At(toInstant(amount))
+    )
 
   private val fieldPersist: Frame => Either[DecodeError, FieldPersist] = {
     case Frame.Integer(-2) => Right(FieldPersist.NoField)

--- a/sage-core/src/main/scala/sage/commands/KeyArgs.scala
+++ b/sage-core/src/main/scala/sage/commands/KeyArgs.scala
@@ -1,0 +1,13 @@
+package sage.commands
+
+import sage.Bytes
+import sage.codec.KeyCodec
+
+private[commands] object KeyArgs {
+
+  // the `numkeys key…` block: encoded keys prefixed by their count, with 1-based key positions
+  def numKeyed[K](keys: Vector[K])(using keyCodec: KeyCodec[K]): (Vector[Int], Vector[Bytes]) = {
+    val encoded = keys.map(keyCodec.encode)
+    (Vector.tabulate(encoded.size)(_ + 1), Bytes.utf8(encoded.size.toString) +: encoded)
+  }
+}

--- a/sage-core/src/main/scala/sage/commands/Keys.scala
+++ b/sage-core/src/main/scala/sage/commands/Keys.scala
@@ -379,17 +379,9 @@ private[sage] object Keys {
       case ExpireCondition.IfLess      => Vector(Lt)
     }
 
-  private def ttlDecode(unit: scala.concurrent.duration.TimeUnit): Frame => Either[DecodeError, Ttl] = {
-    case Frame.Integer(-2)                    => Right(Ttl.NoKey)
-    case Frame.Integer(-1)                    => Right(Ttl.NoExpiry)
-    case Frame.Integer(amount) if amount >= 0 => Right(Ttl.Expires(FiniteDuration(amount, unit)))
-    case other                                => Left(DecodeError("ttl integer", Frame.describe(other)))
-  }
+  private def ttlDecode(unit: scala.concurrent.duration.TimeUnit): Frame => Either[DecodeError, Ttl] =
+    Decode.expiryInteger(Ttl.NoKey, Ttl.NoExpiry, "ttl integer")(amount => Ttl.Expires(FiniteDuration(amount, unit)))
 
-  private def expiryTimeDecode(toInstant: Long => Instant): Frame => Either[DecodeError, ExpiryTime] = {
-    case Frame.Integer(-2)                    => Right(ExpiryTime.NoKey)
-    case Frame.Integer(-1)                    => Right(ExpiryTime.NoExpiry)
-    case Frame.Integer(amount) if amount >= 0 => Right(ExpiryTime.At(toInstant(amount)))
-    case other                                => Left(DecodeError("expiry time integer", Frame.describe(other)))
-  }
+  private def expiryTimeDecode(toInstant: Long => Instant): Frame => Either[DecodeError, ExpiryTime] =
+    Decode.expiryInteger(ExpiryTime.NoKey, ExpiryTime.NoExpiry, "expiry time integer")(amount => ExpiryTime.At(toInstant(amount)))
 }

--- a/sage-core/src/main/scala/sage/commands/Lists.scala
+++ b/sage-core/src/main/scala/sage/commands/Lists.scala
@@ -135,11 +135,11 @@ private[sage] object Lists {
     first: K,
     rest: K*
   )(side: ListSide, count: Option[Long] = None)(using keyCodec: KeyCodec[K], valueCodec: ValueCodec[V]): Command[Option[(K, Vector[V])]] = {
-    val keys = (first +: rest.toVector).map(keyCodec.encode)
+    val (keyIndices, prefix) = KeyArgs.numKeyed(first +: rest.toVector)
     Command(
       "LMPOP",
-      keyIndices = Vector.tabulate(keys.size)(_ + 1),
-      args = (Bytes.utf8(keys.size.toString) +: keys :+ ListSide.wire(side)) ++ longArg(Count, count),
+      keyIndices,
+      args = (prefix :+ ListSide.wire(side)) ++ longArg(Count, count),
       decode = mpopReply[K, V]
     )
   }

--- a/sage-core/src/main/scala/sage/commands/Sets.scala
+++ b/sage-core/src/main/scala/sage/commands/Sets.scala
@@ -65,11 +65,11 @@ private[sage] object Sets {
     storeOp("SINTERSTORE", destination, first +: rest.toVector)
 
   def sInterCard[K](first: K, rest: K*)(limit: Option[Long] = None)(using keyCodec: KeyCodec[K]): Command[Long] = {
-    val keys = (first +: rest.toVector).map(keyCodec.encode)
+    val (keyIndices, prefix) = KeyArgs.numKeyed(first +: rest.toVector)
     Command.read(
       "SINTERCARD",
-      keyIndices = Vector.tabulate(keys.size)(_ + 1),
-      args = (Bytes.utf8(keys.size.toString) +: keys) ++ limit.toVector.flatMap(n => Vector(Limit, Bytes.utf8(n.toString))),
+      keyIndices,
+      args = prefix ++ limit.toVector.flatMap(n => Vector(Limit, Bytes.utf8(n.toString))),
       Decode.long
     )
   }

--- a/sage-core/src/main/scala/sage/commands/SortedSets.scala
+++ b/sage-core/src/main/scala/sage/commands/SortedSets.scala
@@ -244,7 +244,7 @@ private[sage] object SortedSets {
     using keyCodec: KeyCodec[K],
     valueCodec: ValueCodec[V]
   ): Command[Option[(K, Vector[(V, Double)])]] = {
-    val (indices, prefix) = numKeyed(first +: rest.toVector)
+    val (indices, prefix) = KeyArgs.numKeyed(first +: rest.toVector)
     Command("ZMPOP", indices, (prefix :+ minMaxArg(minMax)) ++ countArg(count), mpopReply[K, V])
   }
 
@@ -290,7 +290,7 @@ private[sage] object SortedSets {
     using keyCodec: KeyCodec[K],
     valueCodec: ValueCodec[V]
   ): Command[Vector[V]] = {
-    val (indices, prefix) = numKeyed(first +: rest.toVector)
+    val (indices, prefix) = KeyArgs.numKeyed(first +: rest.toVector)
     Command.read("ZUNION", indices, prefix ++ weightsArgs(weights) ++ aggregateArgs(aggregate), Decode.vector(Decode.value[V]))
   }
 
@@ -298,7 +298,7 @@ private[sage] object SortedSets {
     using keyCodec: KeyCodec[K],
     valueCodec: ValueCodec[V]
   ): Command[Vector[(V, Double)]] = {
-    val (indices, prefix) = numKeyed(first +: rest.toVector)
+    val (indices, prefix) = KeyArgs.numKeyed(first +: rest.toVector)
     Command.read("ZUNION", indices, (prefix ++ weightsArgs(weights) ++ aggregateArgs(aggregate)) :+ WithScores, Decode.scoredMembers[V])
   }
 
@@ -313,7 +313,7 @@ private[sage] object SortedSets {
     using keyCodec: KeyCodec[K],
     valueCodec: ValueCodec[V]
   ): Command[Vector[V]] = {
-    val (indices, prefix) = numKeyed(first +: rest.toVector)
+    val (indices, prefix) = KeyArgs.numKeyed(first +: rest.toVector)
     Command.read("ZINTER", indices, prefix ++ weightsArgs(weights) ++ aggregateArgs(aggregate), Decode.vector(Decode.value[V]))
   }
 
@@ -321,7 +321,7 @@ private[sage] object SortedSets {
     using keyCodec: KeyCodec[K],
     valueCodec: ValueCodec[V]
   ): Command[Vector[(V, Double)]] = {
-    val (indices, prefix) = numKeyed(first +: rest.toVector)
+    val (indices, prefix) = KeyArgs.numKeyed(first +: rest.toVector)
     Command.read("ZINTER", indices, (prefix ++ weightsArgs(weights) ++ aggregateArgs(aggregate)) :+ WithScores, Decode.scoredMembers[V])
   }
 
@@ -333,17 +333,17 @@ private[sage] object SortedSets {
   }
 
   def zInterCard[K](first: K, rest: K*)(limit: Option[Long] = None)(using keyCodec: KeyCodec[K]): Command[Long] = {
-    val (indices, prefix) = numKeyed(first +: rest.toVector)
+    val (indices, prefix) = KeyArgs.numKeyed(first +: rest.toVector)
     Command.read("ZINTERCARD", indices, prefix ++ limit.toVector.flatMap(n => Vector(LimitWord, Bytes.utf8(n.toString))), Decode.long)
   }
 
   def zDiff[K, V](first: K, rest: K*)(using keyCodec: KeyCodec[K], valueCodec: ValueCodec[V]): Command[Vector[V]] = {
-    val (indices, prefix) = numKeyed(first +: rest.toVector)
+    val (indices, prefix) = KeyArgs.numKeyed(first +: rest.toVector)
     Command.read("ZDIFF", indices, prefix, Decode.vector(Decode.value[V]))
   }
 
   def zDiffWithScores[K, V](first: K, rest: K*)(using keyCodec: KeyCodec[K], valueCodec: ValueCodec[V]): Command[Vector[(V, Double)]] = {
-    val (indices, prefix) = numKeyed(first +: rest.toVector)
+    val (indices, prefix) = KeyArgs.numKeyed(first +: rest.toVector)
     Command.read("ZDIFF", indices, prefix :+ WithScores, Decode.scoredMembers[V])
   }
 
@@ -394,11 +394,6 @@ private[sage] object SortedSets {
   private val rankWithScore: Frame => Either[DecodeError, Option[(Long, Double)]] = {
     case Frame.Null => Right(None)
     case other      => Decode.array2(Decode.long, Decode.score, "rank/score pair or null")(_ -> _)(other).map(Some(_))
-  }
-
-  private def numKeyed[K](keys: Vector[K])(using keyCodec: KeyCodec[K]): (Vector[Int], Vector[Bytes]) = {
-    val encoded = keys.map(keyCodec.encode)
-    (Vector.tabulate(encoded.size)(_ + 1), Bytes.utf8(encoded.size.toString) +: encoded)
   }
 
   private def storeKeyed[K](destination: K, keys: Vector[K])(using keyCodec: KeyCodec[K]): (Vector[Int], Vector[Bytes]) = {

--- a/sage-core/src/main/scala/sage/protocol/RespParser.scala
+++ b/sage-core/src/main/scala/sage/protocol/RespParser.scala
@@ -217,8 +217,8 @@ final private[sage] class RespParser {
           if (cr < 0) Incomplete
           else if (cr != pos + 1) fail(s"unexpected content in null frame: '${stringAt(pos + 1, cr)}'")
           else leaf(cr + 2, Frame.Null)
-        case '$'   => bulk(pos, allowNull = true, "invalid bulk string length", (start, length) => Frame.BulkString(bytesAt(start, start + length)))
-        case '!'   => bulk(pos, allowNull = false, "invalid bulk error length", (start, length) => Frame.BulkError(bytesAt(start, start + length)))
+        case '$'   => bulk(pos, allowNull = true, "invalid bulk string length", isError = false)
+        case '!'   => bulk(pos, allowNull = false, "invalid bulk error length", isError = true)
         case '='   => verbatim(pos)
         case '*'   => openElements(pos, Arr, allowNull = true)
         case '~'   => openElements(pos, Set, allowNull = false)
@@ -236,7 +236,7 @@ final private[sage] class RespParser {
     Produced
   }
 
-  private def bulk(pos: Int, allowNull: Boolean, lengthError: String, make: (Int, Int) => Frame): Int = {
+  private def bulk(pos: Int, allowNull: Boolean, lengthError: String, isError: Boolean): Int = {
     val length = readLength(pos + 1, allowNull)
     if (length == Incomplete) Incomplete
     else if (length == Invalid) fail(s"$lengthError: '${headerText(pos + 1)}'")
@@ -246,7 +246,10 @@ final private[sage] class RespParser {
       val end   = payloadEnd(start, length)
       if (end == Incomplete) Incomplete
       else if (end == Invalid) Invalid // payloadEnd set failMessage
-      else leaf(end, make(start, length))
+      else {
+        val bytes = bytesAt(start, start + length)
+        leaf(end, if (isError) Frame.BulkError(bytes) else Frame.BulkString(bytes))
+      }
     }
   }
 


### PR DESCRIPTION
Collapses several structural duplications flagged in review. No behaviour change; purely internal simplification.

## Changes

- **Cluster node registry** — `ClusterLive` re-implemented `establish`/single-flight/prune/close nearly verbatim from `NodePool`. It now delegates to an internal `NodePool`, via two small accessors (`firstLiveNode`, `candidatesByLiveness`). Removes ~120 lines including the duplicate `Establish` cell.
- **Paged streams** — `zio`/`ce`/`ox` each inlined `CStream.unfold(...).flatMap(CStream.init)` six times. Each now has a `paged` helper (mirroring the existing `kyo`/`pekko` factoring), and the copy-pasted `defaultPoll` moves to a single `Paged.defaultPoll`.
- **Commands** — the numkeys key-block assembly in `Sets`/`Lists` now uses the shared `KeyArgs.numKeyed` (promoted out of `SortedSets`); the four `-2/-1/n` TTL/expiry decoders in `Keys`/`Hashes` fold into `Decode.expiryInteger`; `Decode.scoreText` is dropped in favour of `Decode.double`.
- **Pub/sub** — `Client.channelMessages`/`patternMessages` factored through one `messages` builder.
- **Parser** — `RespParser.bulk` takes a kind flag instead of a per-bulk-frame closure, removing one allocation on the decode path.

Net: −146 lines across 17 files.

## Not included

Left the riskier items from the review alone: the FIFO reply-matching machinery shared by `MultiplexedConnection`/`DedicatedConnection` (concurrency-critical), the four map-frame extractors (they diverge intentionally per command), and the `ClusterTxScope` slot check (the engine's `route` returns a `Route`, not the single pin-slot the scope needs).

## Testing

- `core` unit: 696 pass
- client unit (zio): 193 pass
- integration (Redis + Valkey): zio 320, ce 37, ox 37 — all pass
- `scalafmtCheckAll` clean