### PR TITLE
Fix pub/sub reliability bugs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -272,12 +272,12 @@ The distinction is covered in [Pipelines & transactions](/pipelines-transactions
 
 Subscribing yields a stream of messages in your ecosystem's native stream type: an Ox `Flow`, a ZIO `ZStream`, an fs2 `Stream`, a Kyo `Stream`, or a Pekko Streams `Source`. Ending the stream, or closing its scope, unsubscribes.
 
-Because publishing here happens right after subscribing, these examples use the variant that returns only once the server has confirmed the subscription, so the publish can't outrun the registration: `subscribeScoped` on ZIO and Kyo, `subscribeResource` on Cats Effect, and plain `subscribe` on Ox (where the call is already synchronous). On Pekko, `subscribe` returns a `Source` whose materialized value is a `Future[Done]` that completes once the subscription is registered, so awaiting it before publishing closes the same gap on a standalone or master-replica server (in cluster mode that confirmation is best-effort, as on every backend). The plain stream-returning `subscribe` registers lazily on first pull and is the right choice for a long-lived consumer that isn't racing its own publisher.
+Because publishing here happens right after subscribing, these examples use the variant that returns only once the server has confirmed the subscription, so the publish can't outrun the registration: `subscribeScoped` on ZIO, Kyo, and Ox, and `subscribeResource` on Cats Effect. On Pekko, `subscribe` returns a `Source` whose materialized value is a `Future[Done]` that completes once the subscription is registered, so awaiting it before publishing closes the same gap on a standalone or master-replica server (in cluster mode that confirmation is best-effort, as on every backend). The plain stream-returning `subscribe` registers lazily on each run and is the right choice for a long-lived consumer that isn't racing its own publisher.
 
 ::: code-group
 
 ```scala [Ox]
-val news = client.subscribe[String]("news")
+val news = client.subscribeScoped[String]("news")
 (1 to 3).foreach(i => client.publish("news", s"item-$i"))
 val messages = news.take(3).runToList()
 ```

--- a/docs/pubsub.md
+++ b/docs/pubsub.md
@@ -9,7 +9,7 @@ Subscribing yields a stream of messages in your ecosystem's native stream type: 
 ::: code-group
 
 ```scala [Ox]
-val news = client.subscribe[String]("news")
+val news = client.subscribeScoped[String]("news")
 (1 to 3).foreach(i => client.publish("news", s"item-$i"))
 val messages = news.take(3).runToList()
 ```
@@ -69,7 +69,7 @@ The plain `subscribe` returns the stream immediately and registers the subscript
 
 - **ZIO / Kyo**: `subscribeScoped`, a scoped effect.
 - **Cats Effect**: `subscribeResource`, a `Resource`.
-- **Ox**: plain `subscribe` already blocks until confirmed.
+- **Ox**: `subscribeScoped`, bound to the enclosing Ox scope.
 - **Pekko**: plain `subscribe` returns a `Source` whose materialized `Future[Done]` completes once registered; await it before publishing.
 
 The examples above use these. Confirmation closes the race on a standalone or master-replica server; in cluster mode it is best-effort, as on every backend. With the scoped and resource variants that scope owns the unsubscribe, so the subscription outlives the stream and is released when the scope closes; on Pekko, ending the `Source` (cancel, complete, or fail) unsubscribes.

--- a/examples/ox/src/main/scala/sage/examples/ox/PubSubExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/PubSubExample.scala
@@ -12,7 +12,8 @@ import sage.backend.*
 object PubSubExample {
 
   def run(client: SageClient)(using Ox): Unit = {
-    val news     = client.subscribe[String]("news")
+    // subscribeScoped confirms before returning, so the publishes below can't outrun the registration
+    val news     = client.subscribeScoped[String]("news")
     (1 to 3).foreach { i =>
       val _ = client.publish("news", s"item-$i")
     }

--- a/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
+++ b/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
@@ -74,13 +74,39 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
     withContainers { server =>
       supervised {
         val client   = SageClient.scoped(configOf(server))
-        val stream   = client.subscribe[String]("smoke")
+        val stream   = client.subscribeScoped[String]("smoke")
         (1 to 3).foreach { i =>
           val _ = client.publish("smoke", s"m$i")
         }
         val messages = stream.take(3).runToList()
         assertEquals(messages.map(_.channel).toSet, Set("smoke"))
         assertEquals(messages.map(_.payload), List("m1", "m2", "m3"))
+      }
+    }
+  }
+
+  test("a plain subscribe Flow resubscribes on every run instead of yielding an empty stream on re-run") {
+    withContainers { server =>
+      supervised {
+        val client    = SageClient.scoped(configOf(server))
+        val stream    = client.subscribe[String]("rerun")
+        // publish continuously so each run's subscription receives one; the second run must resubscribe, not complete empty
+        val running   = new java.util.concurrent.atomic.AtomicBoolean(true)
+        val publisher = fork {
+          while (running.get()) {
+            val _ = client.publish("rerun", "tick")
+            Thread.sleep(50)
+          }
+        }
+        try {
+          val first  = stream.take(1).runToList()
+          val second = stream.take(1).runToList()
+          assertEquals(first.map(_.payload), List("tick"))
+          assertEquals(second.map(_.payload), List("tick"))
+        } finally {
+          running.set(false)
+          publisher.join()
+        }
       }
     }
   }

--- a/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
@@ -166,6 +166,30 @@ abstract class MasterReplicaSuite(image: String, serverBinary: String) extends M
       program.unsafeRun
     }
   }
+
+  test("pub/sub works when a subscription is the client's first operation") {
+    withContainers { server =>
+      val host = server.host
+      val pm   = server.mappedPort(masterPort)
+      val pr   = server.mappedPort(replicaPort)
+
+      val program =
+        connectAndUse(standalone(host, pr))(ensureReplicating(_, host, pr)).flatMap { _ =>
+          connectAndUse(masterReplica(host, pm, ReadFrom.ReplicaPreferred)) { client =>
+            for {
+              sub     <- client.subscribeChannels[String]("mr:first")
+              count   <- client.publish("mr:first", "hello")
+              message <- sub.next
+              _       <- sub.close
+            } yield {
+              assertEquals(count, 1L)
+              assertEquals(message, Some(Message("mr:first", "hello")))
+            }
+          }
+        }
+      program.unsafeRun
+    }
+  }
 }
 
 /**

--- a/sage-client/ox/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/backend/SageClient.scala
@@ -157,9 +157,9 @@ extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]
     )
 
   /**
-    * Subscribes to one or more channels, returning once the server has confirmed the SUBSCRIBE so a publish issued after this call cannot
-    * race the registration. Ending the flow unsubscribes. Survives reconnects via auto-resubscribe, dropping messages published during the
-    * reconnect gap.
+    * Subscribes to one or more channels; the SUBSCRIBE is issued each time the returned flow is run, so a re-run resubscribes (an Ox `Flow`
+    * is a reusable description). Ending the flow unsubscribes. Survives reconnects via auto-resubscribe, dropping messages published during
+    * the reconnect gap. To confirm the SUBSCRIBE before a publish (so the publish cannot race the registration), use [[subscribeScoped]].
     */
   def subscribe[V: ValueCodec](channel: String, rest: String*): Ox ?=> Flow[Message[V]] =
     streamOf(client.subscribeChannels[V](channel, rest*))
@@ -177,8 +177,42 @@ extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]
   def sSubscribe[V: ValueCodec](channel: String, rest: String*): Ox ?=> Flow[Message[V]] =
     streamOf(client.subscribeShardChannels[V](channel, rest*))
 
-  // subscribe eagerly so the SUBSCRIBE is confirmed before returning; unsubscribe once, when the flow ends or (if never run) at scope close
-  private def streamOf[A](open: => Subscription[[X] =>> Ox ?=> X, A]): Ox ?=> Flow[A] = {
+  /**
+    * Like [[subscribe]], but subscribes eagerly and returns only once the server has confirmed the SUBSCRIBE, so a publish sequenced after
+    * this call cannot race the registration. The subscription is bound to the enclosing Ox scope and unsubscribes when it closes.
+    */
+  def subscribeScoped[V: ValueCodec](channel: String, rest: String*): Ox ?=> Flow[Message[V]] =
+    scopedStreamOf(client.subscribeChannels[V](channel, rest*))
+
+  /**
+    * Like [[pSubscribe]], but subscribes eagerly and returns only once the server has confirmed the PSUBSCRIBE. Bound to the enclosing Ox
+    * scope, which unsubscribes on close.
+    */
+  def pSubscribeScoped[V: ValueCodec](pattern: String, rest: String*): Ox ?=> Flow[PatternMessage[V]] =
+    scopedStreamOf(client.subscribePatterns[V](pattern, rest*))
+
+  /**
+    * Like [[sSubscribe]], but subscribes eagerly and returns only once the server has confirmed the SSUBSCRIBE. Bound to the enclosing Ox
+    * scope, which unsubscribes on close.
+    */
+  def sSubscribeScoped[V: ValueCodec](channel: String, rest: String*): Ox ?=> Flow[Message[V]] =
+    scopedStreamOf(client.subscribeShardChannels[V](channel, rest*))
+
+  // open per run, not once: an Ox Flow is reusable, so opening eagerly would leave a re-run empty (the first run's finally already unsubscribed)
+  private def streamOf[A](open: => Subscription[[X] =>> Ox ?=> X, A]): Ox ?=> Flow[A] =
+    Flow.usingEmit { emit =>
+      val sub = open
+      try {
+        var continue = true
+        while (continue)
+          sub.next match {
+            case Some(a) => emit(a)
+            case None    => continue = false
+          }
+      } finally sub.close
+    }
+
+  private def scopedStreamOf[A](open: => Subscription[[X] =>> Ox ?=> X, A]): Ox ?=> Flow[A] = {
     val sub                 = open
     val closed              = new AtomicBoolean(false)
     def unsubscribe(): Unit = if (closed.compareAndSet(false, true)) sub.close

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
@@ -137,8 +137,11 @@ final private[client] class ClusterSubscriptions(
         // would otherwise strand every classic sub: drop the dead connection and retry rather than wait for a termination that never comes
         var failed = false
         subs.foreach { sub =>
-          try conn.attach(sub.sink, sub.names, sub.kind)
-          catch { case NonFatal(_) => failed = true }
+          try {
+            conn.attach(sub.sink, sub.names, sub.kind)
+            // closed during attach: closeClassic couldn't detach a not-yet-attached sub, so detach here or its channels leak on `conn`
+            if (!locked(classicSubs.contains(sub))) { val _ = conn.detach(sub.sink, sub.names, sub.kind) }
+          } catch { case NonFatal(_) => failed = true }
         }
         if (failed) {
           locked(if (classicConn eq conn) classicConn = null)
@@ -222,7 +225,11 @@ final private[client] class ClusterSubscriptions(
     if (subs.nonEmpty) {
       if (subs.exists(sub => hasUnownedSlot(sub.channels))) refresh()
       var incomplete = false
-      subs.foreach(sub => if (sub.placement.reconcile(planFor(sub.channels), conns)) incomplete = true)
+      subs.foreach { sub =>
+        if (sub.placement.reconcile(planFor(sub.channels), conns)) incomplete = true
+        // closed during this pass: a racing closeShard may have detached before we re-attached, so reconcile back to empty
+        if (!locked(shardSubs.contains(sub))) { val _ = sub.placement.reconcile(Map.empty, conns) }
+      }
       evictEmptyShardConns()
       if (incomplete) scheduleRetry()
     }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -349,7 +349,8 @@ final private[client] class MasterReplicaLive(
             config.watchdog,
             config.connectTimeout.toMillis,
             config.pubsub.bufferSize,
-            () => masterPool.existingLive(masterNodeRef.get()).isDefined,
+            // the subscription opens its own socket, so gate on a resolved master, not a live pooled connection a pub/sub-only client never creates
+            () => !closed && masterNodeRef.get() != null,
             onReconnect = () => refreshRolesBeforeRehome()
           )
         }

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -60,6 +60,7 @@ final private[client] class SubscriptionConnection(
   private var watchdogHandle: Scheduler.Cancelable     = null
   @volatile private var readerBlocked: Boolean         = false
   @volatile private var lastReplyAtMillis: Long        = scheduler.nowMillis
+  @volatile private var lastBackpressureMillis: Long   = 0L
   @volatile private var pingSentAtMillis: Long         = 0L
   @volatile private var bootstrapWaiter: Frame => Unit = null
 
@@ -162,10 +163,12 @@ final private[client] class SubscriptionConnection(
   // bring a freshly-established socket Live, resubscribing everything registered (counters reset to this generation). In cluster mode it runs
   // once per connection with at most one Slot's worth of Shard channels registered, so the single SSUBSCRIBE never spans slots (CROSSSLOT).
   private def goLive(conn: Conn): Unit = {
-    var reconnect = false
-    var notify    = false
+    var reconnect      = false
+    var notify         = false
+    // conn.close() joins the reader whose onConnClosed needs `lock`, so tear down after releasing it (as closeOwned/close do)
+    var teardown: Conn = null
     locked {
-      if (state != State.Establishing && state != State.Reconnecting) conn.close()
+      if (state != State.Establishing && state != State.Reconnecting) teardown = conn
       else if (conn.isTerminated) {
         if (cluster) { stopWatchdog(); current = null; state = State.Closed; notify = true }
         else { state = State.Reconnecting; reconnect = true }
@@ -185,7 +188,7 @@ final private[client] class SubscriptionConnection(
         if (shards.nonEmpty) sendSubscribe(conn, Kind.Shard, shards)
         if (channels.isEmpty && patterns.isEmpty && shards.isEmpty) {
           // everything closed during the establish; tear back down rather than hold an idle socket open
-          conn.close()
+          teardown = conn
           current = null
           state = State.Idle
         } else {
@@ -197,6 +200,7 @@ final private[client] class SubscriptionConnection(
         confirmed.signalAll()
       }
     }
+    if (teardown != null) teardown.close()
     if (reconnect) scheduleReconnect(0)
     if (notify) onTerminated()
   }
@@ -319,8 +323,11 @@ final private[client] class SubscriptionConnection(
     val targets = locked(map.get(key).map(_.toVector).getOrElse(Vector.empty))
     if (targets.nonEmpty) {
       readerBlocked = true
-      try targets.foreach(_.offer(delivery))
-      finally readerBlocked = false
+      try {
+        var blocked = false
+        targets.foreach(sink => if (sink.offer(delivery)) blocked = true)
+        if (blocked) lastBackpressureMillis = scheduler.nowMillis
+      } finally readerBlocked = false
     }
   }
 
@@ -401,7 +408,9 @@ final private[client] class SubscriptionConnection(
     if (conn != null) {
       val now = scheduler.nowMillis
       if (pingSentAtMillis != 0L) {
-        if (now - pingSentAtMillis >= watchdog.pingTimeout.toMillis) scheduler.after(Duration.Zero)(conn.close())
+        // recent backpressure means the reader hasn't reached the queued PONG yet; a sink with room never blocks, so an unanswered PING there still kills
+        val backpressured = now - lastBackpressureMillis < watchdog.pingTimeout.toMillis
+        if (!backpressured && now - pingSentAtMillis >= watchdog.pingTimeout.toMillis) scheduler.after(Duration.Zero)(conn.close())
       } else if (now - lastReplyAtMillis >= watchdog.pingInterval.toMillis) {
         pingSentAtMillis = now
         conn.send(Connection.ping(None).encode)
@@ -502,8 +511,9 @@ private[client] object SubscriptionConnection {
       if (ready != null) callback(ready)
     }
 
-    def offer(delivery: Delivery): Unit = {
+    def offer(delivery: Delivery): Boolean = {
       var hungry: Option[Delivery] => Unit = null
+      var blocked                          = false
       lock.lock()
       try {
         var settled = false
@@ -511,9 +521,10 @@ private[client] object SubscriptionConnection {
           if (closed) settled = true
           else if (waiter != null) { hungry = waiter; waiter = null; settled = true }
           else if (backlog.size < cap) { backlog.add(delivery); settled = true }
-          else notFull.await() // backlog full, no consumer: backpressure the reader
+          else { blocked = true; notFull.await() } // backlog full, no consumer: backpressure the reader
       } finally lock.unlock()
       if (hungry != null) hungry(Some(delivery))
+      blocked
     }
 
     def terminate(): Unit = {


### PR DESCRIPTION
Fixes five pub/sub bugs across the subscription connection, cluster/master-replica managers, and the Ox backend.

## 1. Master-replica pub/sub fails when a subscription is the first operation
`MasterReplicaLive` gated the subscription's liveness on `masterPool.existingLive(...)`, but bootstrap role-probing uses throwaway node clients and never populates the pool — only running a command does. `connect` then `subscribeChannels` hit `State.Idle` with `isLive()` false and threw `NotConnected`, so a pub/sub-only client could never subscribe. The subscription opens its own socket via the rehoming factory, so it now gates on a resolved master (`!closed && masterNodeRef.get() != null`); its own establish reconnects if the master is down.

## 2. Deadlock: `goLive` closed the socket while holding the lock
`SubscriptionConnection.goLive` called `conn.close()` inside `locked {}`. `close()` joins the reader thread, whose `onConnClosed` path needs the same lock, so a peer drop during teardown parked both threads forever. It now captures the socket and closes it after releasing the lock, matching `closeOwned`/`close`.

## 3. Rehome/reconcile races with a concurrent unsubscribe
`rehomeClassic`/`reconcileShard` snapshot the sub list and attach outside the lock. A close after the snapshot re-attached the closed sub's channels with nothing left to detach them, leaking the server-side subscription onto a terminated sink and keeping shard connections permanently non-empty (eviction never fires). Each pass now re-checks membership after attaching and detaches/reconciles-to-empty any sub closed during the pass.

## 4. Watchdog killed a healthy connection under consumer backpressure
The `readerBlocked` skip is cleared between deliveries, so a watchdog tick in the parse/dispatch gap during a flood saw an expired PING (the PONG queued behind buffered messages) and closed a healthy connection. `Sink.offer` now reports whether it actually blocked; the watchdog skips the kill when a real block occurred within the last `pingTimeout`. Push traffic to a sink with spare room never blocks, so an unanswered PING there still kills as before.

## 5. Ox `subscribe` Flow was silently empty on a second run
`streamOf` opened the subscription once and eagerly; the first run's `finally` unsubscribed, so re-running the reusable Flow completed with no elements. Plain `subscribe`/`pSubscribe`/`sSubscribe` now open per run (resubscribing, matching the other backends). Added eager `subscribeScoped`/`pSubscribeScoped`/`sSubscribeScoped` for confirm-before-publish parity; docs and the Ox `PubSubExample` updated to use them.

## Tests
- New `MasterReplicaSuite` test: subscribe as the client's first operation (issue 1) — passing on Valkey.
- New `OxSmokeSuite` test: a plain `subscribe` Flow resubscribes on re-run (issue 5); existing subscribe smoke test switched to `subscribeScoped` — both passing.
- Existing watchdog "push proves only the read path" test preserved; full 141-test shared suite and the Valkey cluster pub/sub test pass.