### PR TITLE
Fix cluster pub/sub reliability bugs

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -805,7 +805,8 @@ final private[client] class ClusterLive(
   // means "the node I queried", so substitute `from` as redirects do
   private def adopt(from: Node, shards: Vector[Shard]): Unit = {
     val resolved     = shards.map(shard => shard.copy(master = resolve(shard.master, from), replicas = shard.replicas.map(resolve(_, from))))
-    val previous     = if (events.emitsEvents) slotOwningMasters(topologyRef.get()).toSet else Set.empty[Node]
+    val oldTopology  = topologyRef.get()
+    val previous     = if (events.emitsEvents) slotOwningMasters(oldTopology).toSet else Set.empty[Node]
     val newTopology  = ClusterTopology.from(resolved)
     topologyRef.set(newTopology)
     // skip the empty -> populated bootstrap transition: discovering the topology at connect is not a change
@@ -819,9 +820,9 @@ final private[client] class ClusterLive(
     val replicaNodes = resolved.iterator.flatMap(_.replicas).toSet
     replicaPool.retain(replicaNodes.contains)
     replicaCursors.keySet.removeIf(node => !masters.contains(node))
-    // re-home Shard Channel subscriptions onto the new slot owners; a classic subscription follows the cluster bus, so it only re-homes when
-    // its pinned master's socket actually drops, not on every topology change
-    subscriptions.onTopologyChanged()
+    // re-home shard subscriptions only when slot ownership changed; else a forced refresh mid-failover loops (refresh -> adopt -> reconcile ->
+    // refresh) at RTT. A classic subscription follows the cluster bus, so it re-homes only when its pinned master's socket drops, never here.
+    if (!newTopology.sameOwnership(oldTopology)) subscriptions.onTopologyChanged()
   }
 
   private def closeAll(): Unit = {

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
@@ -43,12 +43,14 @@ final private[client] class ClusterSubscriptions(
   // --- classic state (guarded by lock) ---
   private var classicConn: SubscriptionConnection = null
   private val classicSubs                         = mutable.LinkedHashSet.empty[ClassicSub]
-  private var rehomePending                       = false
+  private var rehomeRunning                       = false
+  private var rehomeQueued                        = false
 
   // --- sharded state (guarded by lock) ---
   private val shardConns       = mutable.HashMap.empty[Node, SubscriptionConnection]
   private val shardSubs        = mutable.LinkedHashSet.empty[ShardSub]
-  private var reconcilePending = false
+  private var reconcileRunning = false
+  private var reconcileQueued  = false
 
   private var closed = false
 
@@ -114,11 +116,24 @@ final private[client] class ClusterSubscriptions(
     scheduleRehomeClassic()
   }
 
-  // coalesce passes: at most one queued plus one running. Refresh the topology first — the master may be gone, so the re-home target comes
-  // from the current topology, not the stale one.
+  // single-flight (one running, at most one queued): a mid-pass trigger queues a follow-up rather than racing a concurrent pass. Refresh the
+  // topology first — the master may be gone, so the re-home target comes from the current topology, not the stale one.
   private def scheduleRehomeClassic(): Unit = {
-    val go = locked(if (rehomePending || closed) false else { rehomePending = true; true })
-    if (go) offload { locked { rehomePending = false }; refresh(); rehomeClassic() }
+    val go = locked {
+      if (closed) false
+      else if (rehomeRunning) { rehomeQueued = true; false }
+      else { rehomeRunning = true; true }
+    }
+    if (go) offload(runRehomeClassicPass())
+  }
+
+  private def runRehomeClassicPass(): Unit = {
+    refresh()
+    rehomeClassic()
+    val again = locked(if (!closed && rehomeQueued) {
+      rehomeQueued = false; true
+    } else { rehomeRunning = false; false })
+    if (again) offload(runRehomeClassicPass())
   }
 
   private def rehomeClassic(): Unit = {
@@ -213,10 +228,22 @@ final private[client] class ClusterSubscriptions(
 
   def onTopologyChanged(): Unit = scheduleReconcile()
 
-  // coalesce passes: at most one queued plus one running, so a burst of triggers collapses into a single pass
+  // single-flight (one running, at most one queued): a mid-pass trigger queues a follow-up rather than racing a concurrent pass that would corrupt the ledger
   private def scheduleReconcile(): Unit = {
-    val go = locked(if (reconcilePending || closed) false else { reconcilePending = true; true })
-    if (go) offload { locked { reconcilePending = false }; reconcileShard() }
+    val go = locked {
+      if (closed) false
+      else if (reconcileRunning) { reconcileQueued = true; false }
+      else { reconcileRunning = true; true }
+    }
+    if (go) offload(runReconcilePass())
+  }
+
+  private def runReconcilePass(): Unit = {
+    reconcileShard()
+    val again = locked(if (!closed && reconcileQueued) {
+      reconcileQueued = false; true
+    } else { reconcileRunning = false; false })
+    if (again) offload(runReconcilePass())
   }
 
   // re-home each sub onto its channels' current owners. One refresh per pass; an incomplete pass retries so a transient failover failure converges.

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
@@ -253,9 +253,11 @@ final private[client] class ClusterSubscriptions(
       if (subs.exists(sub => hasUnownedSlot(sub.channels))) refresh()
       var incomplete = false
       subs.foreach { sub =>
-        if (sub.placement.reconcile(planFor(sub.channels), conns)) incomplete = true
+        val failed = sub.placement.reconcile(planFor(sub.channels), conns)
         // closed during this pass: a racing closeShard may have detached before we re-attached, so reconcile back to empty
         if (!locked(shardSubs.contains(sub))) { val _ = sub.placement.reconcile(Map.empty, conns) }
+        // an unowned slot is dropped from the plan, so reconcile reports no failure though the sub isn't placed; retry until fullyPlaced
+        else if (failed || !sub.placement.fullyPlaced) incomplete = true
       }
       evictEmptyShardConns()
       if (incomplete) scheduleRetry()

--- a/sage-client/shared/src/main/scala/sage/client/internal/Placement.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Placement.scala
@@ -14,7 +14,8 @@ import sage.cluster.Node
   * is the single place that keeps that record in step with the wire. A Node owning several slot ranges needs one `SSUBSCRIBE` per Slot (a
   * batched cross-slot subscribe returns `CROSSSLOT`), so a plan groups a Node's channels into the groups that each become one `SSUBSCRIBE`.
   *
-  * Two ways to apply a plan:
+  * Two ways to apply a plan, each applied atomically under the ledger lock so a concurrent unsubscribe/re-home of the same subscription can't
+  * interleave and strand an SSUBSCRIBE on an old owner:
   *   - [[place]] is the initial subscribe: it records each group as it lands and leaves a failed attach unplaced for the caller to retry
   *     (see `fullyPlaced`), so a transient owner/connection failure converges instead of surfacing to the subscriber; `placedAt` still
   *     reflects exactly what landed, so a roll-back ([[reconcile]] to the empty plan) detaches it.
@@ -33,40 +34,43 @@ final private[internal] class Placement(sink: Sink, requested: Vector[String]) {
   }
 
   def place(plan: Placement.Plan, conns: Placement.Conns): Unit =
-    plan.foreach { case (node, groups) =>
-      conns.ensure(node).foreach { conn =>
-        groups.foreach { group =>
-          // a concurrent eviction can close `conn` before attach; leave it unplaced to retry, don't propagate
-          try {
-            conn.attach(sink, group, Kind.Shard)
-            locked { placedAt = placedAt.updatedWith(node)(prev => Some(prev.getOrElse(Set.empty) ++ group)) }
-          } catch { case NonFatal(_) => () }
+    locked {
+      plan.foreach { case (node, groups) =>
+        conns.ensure(node).foreach { conn =>
+          groups.foreach { group =>
+            // a concurrent eviction can close `conn` before attach; leave it unplaced to retry, don't propagate
+            try {
+              conn.attach(sink, group, Kind.Shard)
+              placedAt = placedAt.updatedWith(node)(prev => Some(prev.getOrElse(Set.empty) ++ group))
+            } catch { case NonFatal(_) => () }
+          }
         }
       }
     }
 
   // true when some attach failed (an unowned Slot is dropped from the plan by the caller, not reported here); the caller retries until it converges
-  def reconcile(plan: Placement.Plan, conns: Placement.Conns): Boolean = {
-    val desired    = plan.view.mapValues(_.flatten.toSet).toMap
-    var incomplete = false
-    locked(placedAt).foreach { case (node, had) =>
-      val gone = (had -- desired.getOrElse(node, Set.empty)).toVector
-      if (gone.nonEmpty) conns.get(node).foreach(_.detach(sink, gone, Kind.Shard))
-    }
-    val actual     = mutable.HashMap.empty[Node, Set[String]]
-    plan.foreach { case (node, groups) =>
-      conns.ensure(node) match {
-        case None       => incomplete = true
-        case Some(conn) =>
-          groups.foreach { group =>
-            try { conn.attach(sink, group, Kind.Shard); actual.update(node, actual.getOrElse(node, Set.empty) ++ group) }
-            catch { case NonFatal(_) => incomplete = true }
-          }
+  def reconcile(plan: Placement.Plan, conns: Placement.Conns): Boolean =
+    locked {
+      val desired    = plan.view.mapValues(_.flatten.toSet).toMap
+      var incomplete = false
+      placedAt.foreach { case (node, had) =>
+        val gone = (had -- desired.getOrElse(node, Set.empty)).toVector
+        if (gone.nonEmpty) conns.get(node).foreach(_.detach(sink, gone, Kind.Shard))
       }
+      val actual     = mutable.HashMap.empty[Node, Set[String]]
+      plan.foreach { case (node, groups) =>
+        conns.ensure(node) match {
+          case None       => incomplete = true
+          case Some(conn) =>
+            groups.foreach { group =>
+              try { conn.attach(sink, group, Kind.Shard); actual.update(node, actual.getOrElse(node, Set.empty) ++ group) }
+              catch { case NonFatal(_) => incomplete = true }
+            }
+        }
+      }
+      placedAt = actual.toMap
+      incomplete
     }
-    locked { placedAt = actual.toMap }
-    incomplete
-  }
 
   // every requested channel is placed on some owner; false means an unowned Slot or unreachable owner is still outstanding
   def fullyPlaced: Boolean = locked(placedAt.valuesIterator.map(_.size).sum) >= requested.distinct.size

--- a/sage-core/src/main/scala/sage/cluster/Topology.scala
+++ b/sage-core/src/main/scala/sage/cluster/Topology.scala
@@ -22,9 +22,13 @@ final private[sage] case class Shard(master: Node, replicas: Vector[Node], slots
   * A pure snapshot of which masters own which slots. Routing and splitting are total classifications over it — they never raise, choose a
   * connection, or decide a retry.
   */
-final private[sage] class ClusterTopology private (val shards: Vector[Shard], owners: Array[Node], shardOwners: Array[Shard]) {
+final private[sage] class ClusterTopology private (val shards: Vector[Shard], private val owners: Array[Node], shardOwners: Array[Shard]) {
 
   def nodeForSlot(slot: Slot): Option[Node] = Option(owners(slot.value))
+
+  // same slot -> owning master mapping; lets a refresh that adopts an unchanged topology skip re-homing shard subscriptions
+  def sameOwnership(other: ClusterTopology): Boolean =
+    java.util.Arrays.equals(owners.asInstanceOf[Array[AnyRef]], other.owners.asInstanceOf[Array[AnyRef]])
 
   // the core only locates the owning shard; selecting a live replica and applying the read policy is the runtime's job
   def shardForSlot(slot: Slot): Option[Shard] = Option(shardOwners(slot.value))

--- a/sage-core/src/test/scala/sage/cluster/TopologySpec.scala
+++ b/sage-core/src/test/scala/sage/cluster/TopologySpec.scala
@@ -67,4 +67,13 @@ class TopologySpec extends munit.FunSuite {
     assertEquals(whole.route(Command("BAD", Vector(5), Vector(Bytes.utf8("k")), _ => Right(0L))), Route.Malformed)
     assertEquals(whole.route(Command("BAD", Vector(-1), Vector(Bytes.utf8("k")), _ => Right(0L))), Route.Malformed)
   }
+
+  test("sameOwnership compares the slot->owner mapping, ignoring shard order but catching a migration") {
+    val ab        = ClusterTopology.from(Vector(covering(a, 0, 100), covering(b, 101, 200)))
+    val reordered = ClusterTopology.from(Vector(covering(b, 101, 200), covering(a, 0, 100)))
+    val migrated  = ClusterTopology.from(Vector(covering(a, 0, 150), covering(b, 151, 200)))
+    assert(ab.sameOwnership(reordered), "same slot ownership regardless of shard order")
+    assert(!ab.sameOwnership(migrated), "a slot moving from b to a is a change")
+    assert(!whole.sameOwnership(ab), "differing covered ranges are a change")
+  }
 }


### PR DESCRIPTION
Fixes three interrelated cluster pub/sub bugs in `ClusterSubscriptions`, `Placement`, and the topology adopt path.

## 1. Unthrottled `CLUSTER SLOTS` loop while a shard-subscription slot is unowned
`reconcileShard` force-refreshes (bypassing the throttle) when any subscribed slot is unowned, and `adopt` ended with an unconditional `subscriptions.onTopologyChanged()` even when the adopted topology was identical. During a mid-failover window that formed a tight loop — unowned slot → forced refresh → adopt → immediate reconcile → unowned slot → … — paced only by network RTT, hammering the cluster precisely while it was degraded; the intended `scheduleRetry` backoff never got to pace it.

`adopt` now re-homes shard subscriptions only when slot ownership actually changed, via a new `ClusterTopology.sameOwnership` (an order-independent slot→owner comparison). An unchanged topology no longer triggers a reconcile, so the loop is paced by the reconcile backoff. A classic subscription still re-homes only when its pinned master's socket drops.

## 2. Concurrent reconcile passes could corrupt the shard-placement ledger
`scheduleReconcile` cleared its pending flag *before* running the pass, so a trigger arriving mid-pass started a second concurrent pass (each offload is a fresh virtual thread — the "one queued plus one running" comment didn't hold). Since `Placement.reconcile` is a read-detach-attach-write, interleaved passes could lose ledger records and strand an `SSUBSCRIBE` on an old owner. Same pattern in `scheduleRehomeClassic`.

Both are now true single-flight: a `running` flag held across the whole pass, and a trigger during a pass queues exactly one follow-up.

## 3. Placement ledger read-detach-attach-write was non-atomic
Even with passes serialized, a concurrent unsubscribe/re-home of the *same* subscription (from a user thread) could interleave with a pass on that subscription's `Placement`. `place` and `reconcile` now hold the ledger lock for the entire operation, so those can't interleave and lose a record. Deadlock-free: nothing holds the manager lock while calling into a placement, so the only lock nesting is placement→manager (via `ensure`/`get`).

## Tests
- New `TopologySpec` test for `sameOwnership` (order-independent, catches a slot migration).
- Full core (697) and client (193) unit suites pass, including `PlacementSpec`; the Valkey cluster suite (routing + pub/sub) passes.