### PR TITLE
Fix multiplexed watchdog never starting after an initial dead connect

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -202,6 +202,7 @@ final private[client] class MultiplexedConnection private (
             current = conn
             generation = generation.next
             transition(State.Live)
+            startWatchdog()
             events.emit(SageEvent.Connection.Connected(node))
             true
           } else false

--- a/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
@@ -512,6 +512,35 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     assertEquals(ts.size, 1)
   }
 
+  test("the watchdog starts even when the initial connection dies in the establish window") {
+    val watchdog                                        = WatchdogConfig(pingInterval = 10.millis, pingTimeout = 5.millis, enabled = true)
+    val scheduler                                       = new ManualScheduler
+    val live                                            = mutable.ArrayBuffer.empty[FakeTransport]
+    var first                                           = true
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) =>
+      if (first) {
+        first = false
+        new Transport {
+          def start(): Unit                    = onClosed()
+          def send(item: Transport.Item): Unit = ()
+          def close(): Unit                    = ()
+        }
+      } else {
+        val t = new FakeTransport(onFrame, onClosed, _ => Nil, autoWrite = true)
+        live += t
+        t
+      }
+    val connection                                      =
+      MultiplexedConnection.connect(factory, scheduler, Vector.empty[Command[?]], fixedBackoff, watchdog, 1.second, Duration.Zero)
+
+    scheduler.advance(1.milli)
+    assertEquals(connection.currentState, MultiplexedConnection.State.Live)
+    assertEquals(live.size, 1)
+
+    scheduler.advance(10.millis)
+    assertEquals(live.head.written.count(_.asUtf8String.contains("PING")), 1)
+  }
+
   test("graceful drain lets an in-flight reply complete before close finishes") {
     val (connection, _, transports) = make(autoWrite = false, closeTimeout = 2.seconds)
     var result: Option[Try[String]] = None


### PR DESCRIPTION
`startWatchdog()` had exactly one call site — the happy branch of `connectInitial`. If the first connection landed terminated in the establish window, recovery went through `attemptReconnect`, which transitions to `Live` without ever starting the watchdog. The client then ran its whole lifetime without idle-PING liveness, so a later half-open TCP connection would hang commands instead of triggering a reconnect.

`attemptReconnect` now starts the watchdog on its `Live` transition. `startWatchdog` is idempotent (guards on `watchdogHandle == null`) and the watchdog is a single recurring handle that checks whatever is live each tick, so a normal reconnect — where it is already running — is unaffected.

Regression test: the first transport dies during establish, forcing recovery via `attemptReconnect`; the test then asserts an idle interval injects a PING on the recovered socket. Full `MultiplexedConnectionSpec` (38) passes.