### PR TITLE
Release an interrupted blocking command's pooled slot

### DIFF
--- a/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
+++ b/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
@@ -1,5 +1,9 @@
 package sage.integration
 
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.FiniteDuration
+
 import zio.*
 
 import sage.*
@@ -65,6 +69,24 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
                         } yield res
                       }
           } yield assertEquals(out, Some((2L, 6L)))
+        }
+
+      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    }
+  }
+
+  test("an interrupted blocking command releases its pooled slot instead of leaking it") {
+    withContainers { server =>
+      val config              = configOf(server).copy(dedicatedPool =
+        sage.client.DedicatedPoolConfig(maxConnections = 2, acquireTimeout = FiniteDuration(1L, TimeUnit.SECONDS))
+      )
+      val program: Task[Unit] =
+        ZIO.scoped {
+          for {
+            client <- SageClient.scoped(config)
+            _      <- ZIO.foreachDiscard(1 to 4)(_ => client.blPop[String]("leak:empty")(BlockTimeout.Forever).timeout(Duration.fromMillis(150)))
+            none   <- client.blPop[String]("leak:empty")(BlockTimeout.After(FiniteDuration(100L, TimeUnit.MILLISECONDS)))
+          } yield assertEquals(none, None)
         }
 
       Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2331,12 +2331,20 @@ object Client {
   ) extends Client[CIO, String] {
 
     def run[A](command: Command[A]): CIO[A] =
-      CIO.async { callback =>
-        val tracked = Events.trackCommand(events, command, callback)
-        command.execution match {
-          case Execution.Ordinary => Client.completing(tracked)(connection.submit(command, tracked))
-          case Execution.Blocking => Client.completing(tracked)(pool.use(command, tracked))
-        }
+      command.execution match {
+        case Execution.Ordinary =>
+          CIO.async { callback =>
+            val tracked = Events.trackCommand(events, command, callback)
+            Client.completing(tracked)(connection.submit(command, tracked))
+          }
+        case Execution.Blocking =>
+          val lease = new DedicatedPool.Lease
+          CIO.ensure(CIO.blocking(lease.cancel())) {
+            CIO.async { callback =>
+              val tracked = Events.trackCommand(events, command, callback)
+              Client.completing(tracked)(pool.use(command, tracked, lease))
+            }
+          }
       }
 
     def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -111,14 +111,18 @@ final private[client] class ClusterLive(
     throw lastError
   }
 
-  def run[A](command: Command[A]): CIO[A] =
-    CIO.async[A] { complete =>
-      val span = Events.startSpan(events, command)
-      offload {
-        val tracked = Events.trackCommand(events, command, complete, span)
-        Client.completing(tracked)(dispatch(command, cluster.maxRedirects, tracked))
+  def run[A](command: Command[A]): CIO[A] = {
+    val lease = if (command.isBlocking) new DedicatedPool.Lease else null
+    val body  =
+      CIO.async[A] { complete =>
+        val span = Events.startSpan(events, command)
+        offload {
+          val tracked = Events.trackCommand(events, command, complete, span)
+          Client.completing(tracked)(dispatch(command, cluster.maxRedirects, tracked, lease = lease))
+        }
       }
-    }
+    if (lease != null) CIO.ensure(CIO.blocking(lease.cancel()))(body) else body
+  }
 
   // caching is not applied in cluster mode (per-node tracking through redirects/failover is unsupported): the read runs uncached but on the
   // master (allowReplica = false), so it never honors ReadFrom and the call stays portable; the cacheability guard still applies
@@ -179,7 +183,13 @@ final private[client] class ClusterLive(
 
   // --- routing -------------------------------------------------------------------------------------------------------------------------
 
-  private def dispatch[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit, allowReplica: Boolean = true): Unit =
+  private def dispatch[A](
+    command: Command[A],
+    redirectsLeft: Int,
+    complete: Try[A] => Unit,
+    allowReplica: Boolean = true,
+    lease: DedicatedPool.Lease = null
+  ): Unit =
     if (closed) complete(Failure(NotConnected()))
     else {
       val topology = topologyRef.get()
@@ -191,12 +201,12 @@ final private[client] class ClusterLive(
           case Route.ToNode(node, slot) =>
             if (allowReplica && readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command))
               sendRead(command, node, slot, redirectsLeft, complete)
-            else sendTo(node, command, asking = false, redirectsLeft, complete)
+            else sendTo(node, command, asking = false, redirectsLeft, complete, lease)
           case Route.Keyless            =>
             if (allowReplica && readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command))
               sendKeylessRead(topology, command, redirectsLeft, complete)
-            else sendToAny(topology, command, redirectsLeft, complete)
-          case Route.Unowned(_)         => onUnowned(command, redirectsLeft, complete)
+            else sendToAny(topology, command, redirectsLeft, complete, lease)
+          case Route.Unowned(_)         => onUnowned(command, redirectsLeft, complete, lease)
           case Route.CrossSlot(slots)   => complete(Failure(crossSlot(command.name, slots)))
           case Route.Malformed          =>
             complete(Failure(malformedKeys(command.name)))
@@ -345,70 +355,98 @@ final private[client] class ClusterLive(
 
   private def decodeMerged[A](command: Command[A], merged: Frame): Try[A] = Reply.decode(command, merged)
 
-  private def sendToAny[A](topology: ClusterTopology, command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit =
+  private def sendToAny[A](
+    topology: ClusterTopology,
+    command: Command[A],
+    redirectsLeft: Int,
+    complete: Try[A] => Unit,
+    lease: DedicatedPool.Lease = null
+  ): Unit =
     pickNode(topology) match {
-      case Some(node) => sendTo(node, command, asking = false, redirectsLeft, complete)
+      case Some(node) => sendTo(node, command, asking = false, redirectsLeft, complete, lease)
       case None       => complete(Failure(NotConnected()))
     }
 
-  private def sendTo[A](node: Node, command: Command[A], asking: Boolean, redirectsLeft: Int, complete: Try[A] => Unit): Unit = {
+  private def sendTo[A](
+    node: Node,
+    command: Command[A],
+    asking: Boolean,
+    redirectsLeft: Int,
+    complete: Try[A] => Unit,
+    lease: DedicatedPool.Lease = null
+  ): Unit = {
     val nc =
       try getOrEstablish(node)
       catch { case NonFatal(_) => null }
-    if (nc == null) onUnreachable(command, redirectsLeft, complete)
+    if (nc == null) onUnreachable(command, redirectsLeft, complete, lease)
     else
       nc.submit[A](
         command,
         asking,
         {
           case Success(value) => Events.attributeNode(complete, node); complete(Success(value))
-          case Failure(error) => offload(onFailure(node, command, error, redirectsLeft, complete))
-        }
+          case Failure(error) => offload(onFailure(node, command, error, redirectsLeft, complete, lease))
+        },
+        lease
       )
   }
 
-  private def onFailure[A](node: Node, command: Command[A], error: Throwable, redirectsLeft: Int, complete: Try[A] => Unit): Unit =
+  private def onFailure[A](
+    node: Node,
+    command: Command[A],
+    error: Throwable,
+    redirectsLeft: Int,
+    complete: Try[A] => Unit,
+    lease: DedicatedPool.Lease
+  ): Unit =
     Fault.categorize(error) match {
-      case Fault.Redirected(redirect)       => onRedirect(node, redirect, command, redirectsLeft, complete)
-      case Fault.Lost(false)                => onUnreachable(command, redirectsLeft, complete)
+      case Fault.Redirected(redirect)       => onRedirect(node, redirect, command, redirectsLeft, complete, lease)
+      case Fault.Lost(false)                => onUnreachable(command, redirectsLeft, complete, lease)
       case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error))
       case Fault.Fatal                      => Events.attributeNode(complete, node); complete(Failure(error))
     }
 
-  private def onRedirect[A](from: Node, redirect: Redirect, command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit =
+  private def onRedirect[A](
+    from: Node,
+    redirect: Redirect,
+    command: Command[A],
+    redirectsLeft: Int,
+    complete: Try[A] => Unit,
+    lease: DedicatedPool.Lease = null
+  ): Unit =
     if (redirectsLeft <= 0)
       complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
     else {
       val target = resolve(redirect.target, from)
       redirect.kind match {
-        case RedirectKind.Moved => triggerRefresh(); sendTo(target, command, asking = false, redirectsLeft - 1, complete)
-        case RedirectKind.Ask   => sendTo(target, command, asking = true, redirectsLeft - 1, complete)
+        case RedirectKind.Moved => triggerRefresh(); sendTo(target, command, asking = false, redirectsLeft - 1, complete, lease)
+        case RedirectKind.Ask   => sendTo(target, command, asking = true, redirectsLeft - 1, complete, lease)
       }
     }
 
   // the command provably never executed: refresh to adopt the promoted master, then re-route. Jittered backoff paces retries so an in-progress
   // failover is not hammered; redirectsLeft bounds it.
-  private def onUnreachable[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit =
+  private def onUnreachable[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit, lease: DedicatedPool.Lease = null): Unit =
     if (redirectsLeft <= 0) complete(Failure(NotConnected()))
     else {
       refresh(force = true)
       val attempt = (cluster.maxRedirects - redirectsLeft).max(0)
-      scheduler.after(Backoff.jitteredMillis(reconnect, attempt, scheduler).millis)(dispatch(command, redirectsLeft - 1, complete))
+      scheduler.after(Backoff.jitteredMillis(reconnect, attempt, scheduler).millis)(dispatch(command, redirectsLeft - 1, complete, lease = lease))
     }
 
-  private def onUnowned[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit): Unit = {
+  private def onUnowned[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit, lease: DedicatedPool.Lease): Unit = {
     refresh(force = false)
     val topology = topologyRef.get()
     topology.route(command) match {
       // re-apply the read policy: an eligible read must still go to a replica once the slot resolves, not be pinned to its master
       case Route.ToNode(node, slot)                                                  =>
         if (readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command)) sendRead(command, node, slot, redirectsLeft, complete)
-        else sendTo(node, command, asking = false, redirectsLeft, complete)
+        else sendTo(node, command, asking = false, redirectsLeft, complete, lease)
       // strict Replica must not fall back to a master: refresh and retry (bounded), never sendToAny
       case _ if readFrom == ReadFrom.Replica && ReadRouting.replicaEligible(command) =>
-        onUnreachable(command, redirectsLeft, complete)
+        onUnreachable(command, redirectsLeft, complete, lease)
       // still unowned after refresh: any master, trusting its reply (a MOVED to follow, or CLUSTERDOWN)
-      case _                                                                         => sendToAny(topology, command, redirectsLeft, complete)
+      case _                                                                         => sendToAny(topology, command, redirectsLeft, complete, lease)
     }
   }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -1,5 +1,6 @@
 package sage.client.internal
 
+import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.collection.mutable
@@ -49,15 +50,21 @@ final private[client] class DedicatedPool(
     * Runs a blocking command on a borrowed Dedicated Connection, releasing it when the reply (or a failure) arrives. Returns immediately;
     * the acquire — which may wait for a slot or open a socket — is offloaded so the calling fiber is never blocked.
     */
-  def use[A](command: Command[A], callback: Try[A] => Unit): Unit = lease(command, asking = false, callback)
+  def use[A](command: Command[A], callback: Try[A] => Unit): Unit = leaseAndSubmit(command, asking = false, callback, new DedicatedPool.Lease)
+
+  def use[A](command: Command[A], callback: Try[A] => Unit, lease: DedicatedPool.Lease): Unit =
+    leaseAndSubmit(command, asking = false, callback, lease)
 
   /**
     * Runs a blocking command redirected by `ASK`: `ASKING` then the command, back-to-back on one exclusively-leased connection, so their
     * wire adjacency is automatic. The `ASKING` reply is discarded; the command's reply releases the connection.
     */
-  def useAsking[A](command: Command[A], callback: Try[A] => Unit): Unit = lease(command, asking = true, callback)
+  def useAsking[A](command: Command[A], callback: Try[A] => Unit): Unit = leaseAndSubmit(command, asking = true, callback, new DedicatedPool.Lease)
 
-  private def lease[A](command: Command[A], asking: Boolean, callback: Try[A] => Unit): Unit =
+  def useAsking[A](command: Command[A], callback: Try[A] => Unit, lease: DedicatedPool.Lease): Unit =
+    leaseAndSubmit(command, asking = true, callback, lease)
+
+  private def leaseAndSubmit[A](command: Command[A], asking: Boolean, callback: Try[A] => Unit, lease: DedicatedPool.Lease): Unit =
     if (!isLive()) callback(scala.util.Failure(NotConnected()))
     else
       scheduler.after(Duration.Zero) {
@@ -70,15 +77,12 @@ final private[client] class DedicatedPool(
           }
         acquired match {
           case Left(error) => callback(scala.util.Failure(error))
+          // attach fails only if the caller was already interrupted; the connection is discarded, so skip the submit
           case Right(conn) =>
-            if (asking) conn.submit[Unit](Connection.asking, _ => ())
-            conn.submit(
-              command,
-              result => {
-                release(conn)
-                callback(result)
-              }
-            )
+            if (lease.attach(this, conn)) {
+              if (asking) conn.submit[Unit](Connection.asking, _ => ())
+              conn.submit(command, result => if (lease.finish(conn)) { release(conn); callback(result) })
+            }
         }
       }
 
@@ -257,4 +261,31 @@ private[client] object DedicatedPool {
   }
 
   final case class Idle(connection: DedicatedConnection, idleSinceMillis: Long)
+
+  /**
+    * Tracks the one Dedicated Connection a single (possibly ASK/MOVED-redirected) blocking command currently holds, so an interrupted caller
+    * can release it. `attach` records a freshly leased connection; `finish` clears it when the reply lands; `cancel` discards whatever is held
+    * and, via the terminal state, makes any later `attach` (a redirect leasing again after the interrupt) discard immediately instead of leak.
+    */
+  final class Lease {
+    private val state = new AtomicReference[AnyRef]() // null idle, a Held while leased, Cancelled terminal
+
+    private[internal] def attach(pool: DedicatedPool, conn: DedicatedConnection): Boolean =
+      if (state.compareAndSet(null, Held(pool, conn))) true
+      else { pool.releaseTransaction(conn, reusable = false); false }
+
+    private[internal] def finish(conn: DedicatedConnection): Boolean =
+      state.get() match {
+        case h: Held if h.conn eq conn => state.compareAndSet(h, null)
+        case _                         => false
+      }
+
+    def cancel(): Unit = state.getAndSet(Cancelled) match {
+      case h: Held => h.pool.releaseTransaction(h.conn, reusable = false)
+      case _       => ()
+    }
+  }
+
+  final private case class Held(pool: DedicatedPool, conn: DedicatedConnection)
+  private case object Cancelled
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -152,16 +152,21 @@ final private[client] class MasterReplicaLive(
 
   // --- routing -------------------------------------------------------------------------------------------------------------------------
 
-  def run[A](command: Command[A]): CIO[A] =
-    CIO.async[A] { complete =>
-      val span = Events.startSpan(events, command)
-      offload {
-        val tracked = Events.trackCommand(events, command, complete, span)
-        Client.completing(tracked) {
-          if (readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command)) sendRead(command, tracked) else sendMaster(command, tracked)
+  def run[A](command: Command[A]): CIO[A] = {
+    val lease = if (command.isBlocking) new DedicatedPool.Lease else null
+    val body  =
+      CIO.async[A] { complete =>
+        val span = Events.startSpan(events, command)
+        offload {
+          val tracked = Events.trackCommand(events, command, complete, span)
+          Client.completing(tracked) {
+            if (readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command)) sendRead(command, tracked)
+            else sendMaster(command, tracked, lease)
+          }
         }
       }
-    }
+    if (lease != null) CIO.ensure(CIO.blocking(lease.cancel()))(body) else body
+  }
 
   def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =
     if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command))
@@ -179,8 +184,8 @@ final private[client] class MasterReplicaLive(
         offload(Client.completing(complete)(sendMasterCached(command, ttl.toMillis, complete, deferred)))
       }
 
-  private def sendMaster[A](command: Command[A], complete: Try[A] => Unit): Unit =
-    onMaster(complete)((nc, _, cb) => nc.submit[A](command, asking = false, cb))
+  private def sendMaster[A](command: Command[A], complete: Try[A] => Unit, lease: DedicatedPool.Lease = null): Unit =
+    onMaster(complete)((nc, _, cb) => nc.submit[A](command, asking = false, cb, lease))
 
   private def sendMasterCached[A](command: Command[A], ttlMillis: Long, complete: Try[A] => Unit, deferred: () => CommandSpan): Unit = {
     var reached = false

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
@@ -14,9 +14,12 @@ import sage.commands.Command
   */
 final private[client] class NodeClient(connection: MultiplexedConnection, pool: DedicatedPool) {
 
-  def submit[A](command: Command[A], asking: Boolean, callback: Try[A] => Unit): Unit =
-    if (command.isBlocking) { if (asking) pool.useAsking(command, callback) else pool.use(command, callback) }
-    else if (asking) connection.submitAsking(command, callback)
+  // `lease` (blocking only) lets an interrupted caller release the leased slot; null falls back to a private, uncancellable lease
+  def submit[A](command: Command[A], asking: Boolean, callback: Try[A] => Unit, lease: DedicatedPool.Lease = null): Unit =
+    if (command.isBlocking) {
+      val l = if (lease != null) lease else new DedicatedPool.Lease
+      if (asking) pool.useAsking(command, callback, l) else pool.use(command, callback, l)
+    } else if (asking) connection.submitAsking(command, callback)
     else connection.submit(command, callback)
 
   def cachedSubmit[A](command: Command[A], ttlMillis: Long, callback: Try[A] => Unit, deferred: () => CommandSpan): Unit =


### PR DESCRIPTION
Blocking commands submit via `CIO.async` with no cancellation hook and release the leased dedicated connection only in the reply callback. Interrupting one — e.g. wrapping `blPop(...)(BlockTimeout.Forever)` in the backend timeout combinator `docs/error-handling.md` recommends — abandoned the slot waiting for a reply that never comes. After `maxConnections` such timeouts, every blocking command and transaction failed `TimedOut` until `close()`. The **standalone, cluster, and master-replica** runtimes all had this leak.

## Fix
`DedicatedPool` gains a cancellable **`Lease`** (an atomic state machine: idle → held → cleared, or → cancelled). The blocking submit still runs through the pool's callback:
- an **acquire failure** flows through the callback, so a tracked command's span still settles (**this addresses the P2 observability regression** from the earlier bracket approach — no `CommandCompleted` was emitted for exhausted-pool failures);
- on a successful acquire the connection is recorded in the lease; the reply clears it and releases normally;
- **`cancel()`** discards whatever connection is currently held and moves the lease to a terminal state, so a redirect that re-leases *after* the interrupt (cluster ASK/MOVED) discards immediately instead of leaking.

Each runtime's blocking `run` wraps the submit in `CIO.ensure(CIO.blocking(lease.cancel()))`, threading the lease into the pool: directly (standalone), through `sendMaster` (master-replica — blocking always targets the master), and through the keyed dispatch + redirect path (cluster: `dispatch → sendTo → onFailure → onRedirect / onUnreachable / onUnowned`).

## Tests
- New ZIO integration test: with `maxConnections = 2`, interrupt four `BLPOP … Forever` via `.timeout`, then assert a fresh blocking command still acquires a slot (`None`) instead of failing `TimedOut`. Confirmed it fails without the fix.
- Full shared client (193) and core unit suites pass; the Valkey cluster and master-replica integration suites pass unchanged (no routing/redirect regression); all backend bindings compile.