### PR TITLE
Decode an unclassified TYPE reply as RedisType.Other

### DIFF
--- a/sage-core/src/main/scala/sage/commands/Keys.scala
+++ b/sage-core/src/main/scala/sage/commands/Keys.scala
@@ -22,26 +22,37 @@ enum ExpireCondition {
 }
 
 /**
-  * The data type a key holds, as reported by `TYPE`.
+  * The data type a key holds, as reported by `TYPE`. `Other` carries the wire name of any type this library does not classify as one of the
+  * six classic types — a preview type (Arrays, vector sets) or a module type — so `TYPE` never fails to decode.
   */
 enum RedisType {
   case String, List, Set, ZSet, Hash, Stream
+  case Other(name: java.lang.String)
 }
 
 object RedisType {
 
   private[commands] def wireName(tpe: RedisType): java.lang.String =
     tpe match {
-      case String => "string"
-      case List   => "list"
-      case Set    => "set"
-      case ZSet   => "zset"
-      case Hash   => "hash"
-      case Stream => "stream"
+      case String      => "string"
+      case List        => "list"
+      case Set         => "set"
+      case ZSet        => "zset"
+      case Hash        => "hash"
+      case Stream      => "stream"
+      case Other(name) => name
     }
 
-  private[commands] def fromWireName(name: java.lang.String): scala.Option[RedisType] =
-    RedisType.values.find(wireName(_) == name)
+  private[commands] def fromWireName(name: java.lang.String): RedisType =
+    name match {
+      case "string" => String
+      case "list"   => List
+      case "set"    => Set
+      case "zset"   => ZSet
+      case "hash"   => Hash
+      case "stream" => Stream
+      case other    => Other(other)
+    }
 }
 
 /**
@@ -229,8 +240,7 @@ private[sage] object Keys {
       Vector(keyCodec.encode(key)),
       decode = {
         case Frame.SimpleString("none") => Right(None)
-        case Frame.SimpleString(name)   =>
-          RedisType.fromWireName(name).map(Some(_)).toRight(DecodeError("key type", s"simple string '$name'"))
+        case Frame.SimpleString(name)   => Right(Some(RedisType.fromWireName(name)))
         case other                      => Left(DecodeError("key type simple string", Frame.describe(other)))
       }
     )

--- a/sage-core/src/test/scala/sage/commands/KeysSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/KeysSpec.scala
@@ -5,7 +5,6 @@ import java.time.Instant
 import scala.concurrent.duration.*
 
 import sage.Bytes
-import sage.SageException.DecodeError
 import sage.protocol.Frame
 
 class KeysSpec extends munit.FunSuite {
@@ -28,7 +27,7 @@ class KeysSpec extends munit.FunSuite {
     )
   }
 
-  test("TYPE decodes every key type, none as None, and rejects unknown types") {
+  test("TYPE decodes every key type, none as None, and an unclassified type as Other") {
     val expected = Map(
       "string" -> RedisType.String,
       "list"   -> RedisType.List,
@@ -41,10 +40,7 @@ class KeysSpec extends munit.FunSuite {
       assertEquals(Reply.run(Keys.typeOf("k"), Frame.SimpleString(wire)), Right(Some(tpe)))
     }
     assertEquals(Reply.run(Keys.typeOf("k"), Frame.SimpleString("none")), Right(None))
-    Reply.run(Keys.typeOf("k"), Frame.SimpleString("ReJSON-RL")) match {
-      case Left(error: DecodeError) => assertEquals(error.actual, "simple string 'ReJSON-RL'")
-      case other                    => fail(s"expected a DecodeError, got $other")
-    }
+    assertEquals(Reply.run(Keys.typeOf("k"), Frame.SimpleString("ReJSON-RL")), Right(Some(RedisType.Other("ReJSON-RL"))))
   }
 
   test("SCAN decodes a mid-iteration page with a next cursor") {


### PR DESCRIPTION
`RedisType` was a closed enum of the six classic types (string, list, set, zset, hash, stream), and `typeOf` turned any other wire name into a `DecodeError` — failing the whole `TYPE` call. That breaks `TYPE` on keys of:
- a preview type the library itself supports (the Arrays family, vector sets), and
- any module type (e.g. `ReJSON-RL`).

## Fix
Add an `Other(name)` case to `RedisType` and make `fromWireName` total: an unrecognized wire name now decodes to `RedisType.Other(name)` instead of erroring. `wireName` maps `Other(name)` back to its name, so it also round-trips as a `SCAN ... TYPE` filter argument.

## Test
Updated the `KeysSpec` TYPE test: it now asserts an unclassified reply (`ReJSON-RL`) decodes to `RedisType.Other("ReJSON-RL")` rather than failing. Full core suite (697) passes.