### PR TITLE
Fix single-shot blocking-command effect and unsettled span on interrupt

### DIFF
--- a/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
+++ b/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
@@ -93,6 +93,26 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
     }
   }
 
+  test("re-running the same blocking command value succeeds each round instead of hanging after the first") {
+    withContainers { server =>
+      val program: Task[Unit] =
+        ZIO.scoped {
+          for {
+            client <- SageClient.scoped(configOf(server))
+            blPop   = client.blPop[String]("h1:reuse")(BlockTimeout.After(FiniteDuration(100L, TimeUnit.MILLISECONDS)))
+            first  <- blPop
+            second <- blPop.timeout(Duration.fromSeconds(5))
+          } yield {
+            assertEquals(first, None)
+            assert(second.isDefined, "re-running the same blocking effect hung: its lease was captured and single-shot")
+            assertEquals(second.flatten, None)
+          }
+        }
+
+      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    }
+  }
+
   test("scanAll streams every key as a native ZStream") {
     withContainers { server =>
       val program: Task[Unit] =

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2338,8 +2338,8 @@ object Client {
             Client.completing(tracked)(connection.submit(command, tracked))
           }
         case Execution.Blocking =>
-          val lease = new DedicatedPool.Lease
-          CIO.ensure(CIO.blocking(lease.cancel())) {
+          // acquire a fresh lease per execution: a lease is single-shot (cancel is terminal), so a captured one would make a re-run of this value hang
+          CIO.acquireReleaseWith(CIO.defer(new DedicatedPool.Lease))(lease => CIO.blocking(lease.cancel())) { lease =>
             CIO.async { callback =>
               val tracked = Events.trackCommand(events, command, callback)
               Client.completing(tracked)(pool.use(command, tracked, lease))

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -112,8 +112,7 @@ final private[client] class ClusterLive(
   }
 
   def run[A](command: Command[A]): CIO[A] = {
-    val lease = if (command.isBlocking) new DedicatedPool.Lease else null
-    val body  =
+    def body(lease: DedicatedPool.Lease): CIO[A] =
       CIO.async[A] { complete =>
         val span = Events.startSpan(events, command)
         offload {
@@ -121,7 +120,9 @@ final private[client] class ClusterLive(
           Client.completing(tracked)(dispatch(command, cluster.maxRedirects, tracked, lease = lease))
         }
       }
-    if (lease != null) CIO.ensure(CIO.blocking(lease.cancel()))(body) else body
+    if (!command.isBlocking) body(null)
+    // acquire a fresh lease per execution: a lease is single-shot (cancel is terminal), so a captured one would make a re-run of this value hang
+    else CIO.acquireReleaseWith(CIO.defer(new DedicatedPool.Lease))(lease => CIO.blocking(lease.cancel()))(body)
   }
 
   // caching is not applied in cluster mode (per-node tracking through redirects/failover is unsupported): the read runs uncached but on the

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -77,12 +77,13 @@ final private[client] class DedicatedPool(
           }
         acquired match {
           case Left(error) => callback(scala.util.Failure(error))
-          // attach fails only if the caller was already interrupted; the connection is discarded, so skip the submit
           case Right(conn) =>
-            if (lease.attach(this, conn)) {
+            // attach fails only when already cancelled (interrupt before/between attaches); settle the callback here since cancel found no Held to settle
+            val onInterrupt = () => callback(scala.util.Failure(ConnectionLost(mayHaveExecuted = true)))
+            if (lease.attach(this, conn, onInterrupt)) {
               if (asking) conn.submit[Unit](Connection.asking, _ => ())
               conn.submit(command, result => if (lease.finish(conn)) { release(conn); callback(result) })
-            }
+            } else onInterrupt()
         }
       }
 
@@ -264,14 +265,15 @@ private[client] object DedicatedPool {
 
   /**
     * Tracks the one Dedicated Connection a single (possibly ASK/MOVED-redirected) blocking command currently holds, so an interrupted caller
-    * can release it. `attach` records a freshly leased connection; `finish` clears it when the reply lands; `cancel` discards whatever is held
-    * and, via the terminal state, makes any later `attach` (a redirect leasing again after the interrupt) discard immediately instead of leak.
+    * can release it. `attach` records a freshly leased connection and the action that settles the caller's tracked callback; `finish` clears it
+    * when the reply lands; `cancel` discards whatever is held, runs that settle action so an interrupted command's span/CommandCompleted still
+    * fire, and, via the terminal state, makes any later `attach` (a redirect leasing again after the interrupt) discard immediately instead of leak.
     */
   final class Lease {
     private val state = new AtomicReference[AnyRef]() // null idle, a Held while leased, Cancelled terminal
 
-    private[internal] def attach(pool: DedicatedPool, conn: DedicatedConnection): Boolean =
-      if (state.compareAndSet(null, Held(pool, conn))) true
+    private[internal] def attach(pool: DedicatedPool, conn: DedicatedConnection, onInterrupt: () => Unit): Boolean =
+      if (state.compareAndSet(null, Held(pool, conn, onInterrupt))) true
       else { pool.releaseTransaction(conn, reusable = false); false }
 
     private[internal] def finish(conn: DedicatedConnection): Boolean =
@@ -281,11 +283,11 @@ private[client] object DedicatedPool {
       }
 
     def cancel(): Unit = state.getAndSet(Cancelled) match {
-      case h: Held => h.pool.releaseTransaction(h.conn, reusable = false)
+      case h: Held => h.pool.releaseTransaction(h.conn, reusable = false); h.onInterrupt()
       case _       => ()
     }
   }
 
-  final private case class Held(pool: DedicatedPool, conn: DedicatedConnection)
+  final private case class Held(pool: DedicatedPool, conn: DedicatedConnection, onInterrupt: () => Unit)
   private case object Cancelled
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -153,8 +153,7 @@ final private[client] class MasterReplicaLive(
   // --- routing -------------------------------------------------------------------------------------------------------------------------
 
   def run[A](command: Command[A]): CIO[A] = {
-    val lease = if (command.isBlocking) new DedicatedPool.Lease else null
-    val body  =
+    def body(lease: DedicatedPool.Lease): CIO[A] =
       CIO.async[A] { complete =>
         val span = Events.startSpan(events, command)
         offload {
@@ -165,7 +164,9 @@ final private[client] class MasterReplicaLive(
           }
         }
       }
-    if (lease != null) CIO.ensure(CIO.blocking(lease.cancel()))(body) else body
+    if (!command.isBlocking) body(null)
+    // acquire a fresh lease per execution: a lease is single-shot (cancel is terminal), so a captured one would make a re-run of this value hang
+    else CIO.acquireReleaseWith(CIO.defer(new DedicatedPool.Lease))(lease => CIO.blocking(lease.cancel()))(body)
   }
 
   def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =

--- a/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
@@ -91,6 +91,43 @@ class DedicatedPoolSpec extends munit.FunSuite {
     assertEquals(transports.size, 2)
   }
 
+  test("interrupting an in-flight blocking command settles the tracked callback and discards the slot") {
+    val (pool, scheduler, transports)                 = make(replyWith(Nil)) // the BLPOP parks, never replying
+    val lease                                         = new DedicatedPool.Lease
+    var result: Option[Try[Option[(String, String)]]] = None
+    pool.use(blPop, r => result = Some(r), lease)
+    scheduler.advance(Duration.Zero)
+    assertEquals(result, None)
+
+    lease.cancel()
+    assertEquals(result, Some(Failure(ConnectionLost(mayHaveExecuted = true))))
+    scheduler.advance(Duration.Zero)
+    assertEquals(transports.head.closeCount, 1)
+  }
+
+  test("interrupting before the lease attaches (offloaded acquire window) still settles the tracked callback") {
+    val (pool, scheduler, transports)                 = make(replyWith(Seq(popReply)))
+    val lease                                         = new DedicatedPool.Lease
+    var result: Option[Try[Option[(String, String)]]] = None
+    pool.use(blPop, r => result = Some(r), lease)
+    lease.cancel()
+    scheduler.advance(Duration.Zero)
+    assertEquals(result, Some(Failure(ConnectionLost(mayHaveExecuted = true))))
+    scheduler.advance(Duration.Zero)
+    assertEquals(transports.headOption.map(_.closeCount), Some(1))
+  }
+
+  test("cancelling a lease after the blocking reply landed does not re-fire the callback") {
+    val (pool, scheduler, _) = make(replyWith(Seq(popReply)))
+    val lease                = new DedicatedPool.Lease
+    var count                = 0
+    pool.use(blPop, _ => count += 1, lease)
+    scheduler.advance(Duration.Zero)
+    assertEquals(count, 1)
+    lease.cancel()
+    assertEquals(count, 1)
+  }
+
   test("a dropped queued command marks the connection dead before failing the work, so the pool cannot recycle it") {
     val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
     val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {


### PR DESCRIPTION
Two regressions from #152 in the blocking-command path, across all three runtimes.

## H1 — a blocking-command effect is single-shot; re-running it hangs

`val lease = new DedicatedPool.Lease` was evaluated when `run(command)` was *called*, so one lease got captured inside the returned effect value. `CIO.ensure`'s finalizer runs `cancel()` on **every** exit — including success — driving that lease to the terminal `Cancelled` state. Re-executing the same value (`.retry`, `.repeat`, `.forever`, …) made `Lease.attach` fail its CAS, discard the freshly acquired connection, skip the submit, and never invoke the callback: the fiber hangs silently.

It was self-triggering in shipped code: `Paged.consume` re-runs its single `tailNew` effect value each poll round, so `xConsume` delivered one blocking round and then stalled forever on the zio/ce/kyo backends.

**Fix:** acquire a fresh lease **per execution** in the standalone, cluster, and master-replica runtimes, expressed as `acquireReleaseWith` with the lease as the acquired resource (`CIO.defer` for the acquire — `value` is strict on the CE backend and would allocate once).

## M1 — interrupting an in-flight blocking command never settles observability

The cancel path released the connection but never invoked the tracked callback, so the trace span settled zero times and no `CommandCompleted` fired.

**Fix:** thread an `onInterrupt` settle action through the lease. `cancel` runs it for a held connection; `leaseAndSubmit` runs it directly when `attach` finds the lease already cancelled — an interrupt in the offloaded acquire window or between redirect attempts, where `cancel` saw no held connection and so could not settle the callback itself. The `state` CAS keeps this exclusive with the reply's `finish`, so the callback fires exactly once. It uses `ConnectionLost(mayHaveExecuted = true)`, which in the cluster reply path terminally completes (`Fault.Lost(true)`) rather than triggering a retry.

## Tests
- `ZioSmokeSuite`: re-running the same blocking effect value twice succeeds each round (fails by hanging without the fix).
- `DedicatedPoolSpec`: interrupt of an in-flight command settles + discards the slot; interrupt before attach (offloaded-acquire window) still settles; a `cancel` after a normal reply does not re-fire.

All six client backend cells compile; `DedicatedPoolSpec` (20) and `ZioSmokeSuite` (12) pass; scalafmt clean.