### PR TITLE
Fix cluster pub/sub eviction and re-home races

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
@@ -159,7 +159,9 @@ final private[client] class ClusterSubscriptions(
           } catch { case NonFatal(_) => failed = true }
         }
         if (failed) {
+          // conn may be Live with re-attached subs: shut it down or the retry double-delivers and leaks the socket
           locked(if (classicConn eq conn) classicConn = null)
+          conn.shutdown()
           scheduleRehomeRetry()
         }
       }
@@ -276,11 +278,10 @@ final private[client] class ClusterSubscriptions(
   }
 
   private def evictEmptyShardConns(): Unit = {
-    val gone = locked {
-      val empties = shardConns.iterator.collect { case (node, conn) if conn.isEmpty => node }.toVector
-      empties.flatMap(node => shardConns.remove(node).map(node -> _))
+    val candidates = locked(shardConns.iterator.collect { case (node, conn) if conn.isEmpty => node -> conn }.toVector)
+    candidates.foreach { case (node, conn) =>
+      if (conn.closeIfEmpty()) locked(if (shardConns.get(node).contains(conn)) shardConns -= node)
     }
-    gone.foreach { case (_, conn) => conn.close() }
   }
 
   // --- shared ------------------------------------------------------------------------------------------------------------------------------

--- a/sage-client/shared/src/main/scala/sage/client/internal/Placement.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Placement.scala
@@ -72,8 +72,8 @@ final private[internal] class Placement(sink: Sink, requested: Vector[String]) {
       incomplete
     }
 
-  // every requested channel is placed on some owner; false means an unowned Slot or unreachable owner is still outstanding
-  def fullyPlaced: Boolean = locked(placedAt.valuesIterator.map(_.size).sum) >= requested.distinct.size
+  // distinct union, not a sum of per-node sizes: a double-recorded channel must not mask an unplaced one
+  def fullyPlaced: Boolean = locked(placedAt.valuesIterator.flatten.toSet.size) >= requested.distinct.size
 }
 
 private[internal] object Placement {

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -312,11 +312,23 @@ final private[client] class SubscriptionConnection(
           case Some(_: Pubsub.Event.Subscribed)                        => locked { subscribeConfirmed += 1; confirmed.signalAll() }
           case _                                                       => () // an Unsubscribed ack is informational; re-homing is disconnect-driven
         }
-      case reply                => // a non-push reply is the bootstrap HELLO or the watchdog's PONG
+      case reply                => // non-push reply: bootstrap HELLO, watchdog PONG, or an unexpected error
         lastReplyAtMillis = scheduler.nowMillis
         val waiter = bootstrapWaiter
-        if (waiter != null) waiter(reply) else pingSentAtMillis = 0L
+        if (waiter != null) waiter(reply)
+        else
+          reply match {
+            // an error (e.g. MOVED on SSUBSCRIBE) isn't a PONG: drop the connection so re-home/reconnect re-plans
+            case _: Frame.SimpleError | _: Frame.BulkError => dropOnUnexpectedError()
+            case _                                         => pingSentAtMillis = 0L
+          }
     }
+
+  // off the reader thread, since close() joins the reader
+  private def dropOnUnexpectedError(): Unit = {
+    val conn = locked(current)
+    if (conn != null) scheduler.after(Duration.Zero)(conn.close())
+  }
 
   // snapshot the sinks under the lock, then deliver outside it: a blocking put (backpressure) must never hold the registry lock
   private def dispatch(map: mutable.HashMap[String, mutable.LinkedHashSet[Sink]], key: String, delivery: Delivery): Unit = {
@@ -346,6 +358,42 @@ final private[client] class SubscriptionConnection(
     }
     sink.terminate()
     if (teardown != null) teardown.close()
+  }
+
+  // atomic empty-check + Closed transition, so a racing attach can't bind a sink to a connection about to close
+  def closeIfEmpty(): Boolean = {
+    var conn: Conn = null
+    val closing    = locked {
+      if (!isEmptyUnlocked) false
+      else {
+        conn = current
+        state = State.Closed
+        stopWatchdog()
+        current = null
+        established.signalAll()
+        confirmed.signalAll()
+        true
+      }
+    }
+    if (conn != null) conn.close()
+    closing
+  }
+
+  // close socket/watchdog but keep the sinks (unlike close), so a re-home re-attaches them
+  def shutdown(): Unit = {
+    var conn: Conn = null
+    locked {
+      conn = current
+      state = State.Closed
+      stopWatchdog()
+      current = null
+      channelSinks.clear()
+      patternSinks.clear()
+      shardSinks.clear()
+      established.signalAll()
+      confirmed.signalAll()
+    }
+    if (conn != null) conn.close()
   }
 
   def close(): Unit = {

--- a/sage-client/shared/src/test/scala/sage/client/internal/PlacementSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/PlacementSpec.scala
@@ -100,6 +100,16 @@ class PlacementSpec extends munit.FunSuite {
     assert(placement.fullyPlaced)
   }
 
+  test("fullyPlaced counts distinct channels, so one double-recorded across owners cannot mask an unplaced channel") {
+    val pool      = new FakePool
+    val placement = new Placement(sink("a", "b"), Vector("a", "b"))
+
+    placement.reconcile(Map(n2 -> groups(Vector("a"))), pool) // fresh topology records a on n2
+    placement.place(Map(n1 -> groups(Vector("a"))), pool) // a stale concurrent place re-records a on n1, never touching b
+
+    assert(!placement.fullyPlaced, "b never landed; the duplicate a on n1 and n2 must not count as full coverage")
+  }
+
   test("a partial attach followed by a topology shift never duplicates a channel across owners") {
     val pool      = new FakePool
     val placement = new Placement(sink("a", "b"), Vector("a", "b"))

--- a/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
@@ -80,6 +80,14 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
     box.get()
   }
 
+  private def nextBlocking(sink: SubscriptionConnection.Sink): Option[SubscriptionConnection.Delivery] = {
+    val box   = new AtomicReference[Option[SubscriptionConnection.Delivery]]()
+    val latch = new CountDownLatch(1)
+    sink.next { delivery => box.set(delivery); latch.countDown() }
+    latch.await()
+    box.get()
+  }
+
   // Bytes has no structural `==` (CONTEXT: compare with sameBytes), so destructure and compare the payload as text
   private def assertChannel(delivery: Option[SubscriptionConnection.Delivery], channel: String, payload: String)(using munit.Location): Unit =
     delivery match {
@@ -232,6 +240,65 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
     assertChannel(nextBlocking(sub), "b", "from-b")
     transports.head.emit(message("a", "from-a"))
     assertChannel(nextBlocking(sub), "a", "from-a")
+  }
+
+  test("closeIfEmpty keeps a connection holding a sink, closes it once empty, and then rejects a racing attach") {
+    val (connection, _, transports) = make()
+    val sink                        = new SubscriptionConnection.Sink(Vector("orders"), SubscriptionConnection.Kind.Shard, 16)
+    connection.attach(sink, Vector("orders"), SubscriptionConnection.Kind.Shard)
+
+    assert(!connection.closeIfEmpty(), "a connection carrying a live sink must not be evicted")
+    assertEquals(transports.head.closeCount, 0)
+
+    val _ = connection.detach(sink, Vector("orders"), SubscriptionConnection.Kind.Shard)
+    assert(connection.closeIfEmpty(), "with its last sink gone the connection is empty and closes")
+    assertEquals(transports.head.closeCount, 1)
+
+    val late = new SubscriptionConnection.Sink(Vector("late"), SubscriptionConnection.Kind.Shard, 16)
+    intercept[NotConnected](connection.attach(late, Vector("late"), SubscriptionConnection.Kind.Shard))
+  }
+
+  test("shutdown drops the socket but leaves the sink usable, so a re-home can re-attach it to a fresh connection") {
+    val (conn1, _, transports1) = make()
+    val sink                    = new SubscriptionConnection.Sink(Vector("news"), SubscriptionConnection.Kind.Channel, 16)
+    conn1.attach(sink, Vector("news"), SubscriptionConnection.Kind.Channel)
+
+    conn1.shutdown()
+    assertEquals(transports1.head.closeCount, 1, "the abandoned socket is closed")
+
+    val (conn2, _, transports2) = make()
+    conn2.attach(sink, Vector("news"), SubscriptionConnection.Kind.Channel)
+    transports2.head.emit(message("news", "after-rehome"))
+    assertChannel(nextBlocking(sink), "news", "after-rehome")
+  }
+
+  test("an unexpected error reply (e.g. MOVED on a subscribe) drops the connection instead of being swallowed as a PONG") {
+    var terminated                                      = false
+    val scheduler                                       = new ManualScheduler
+    val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
+      val t = new FakeTransport(onFrame, onClosed, serverResponder); transports += t; t
+    }
+    val connection                                      = new SubscriptionConnection(
+      factory,
+      Vector(Connection.ping()),
+      scheduler,
+      fixedBackoff,
+      noWatchdog,
+      1000L,
+      16,
+      () => true,
+      cluster = true,
+      onTerminated = () => terminated = true
+    )
+    val sink                                            = new SubscriptionConnection.Sink(Vector("orders"), SubscriptionConnection.Kind.Shard, 16)
+    connection.attach(sink, Vector("orders"), SubscriptionConnection.Kind.Shard)
+    assertEquals(transports.size, 1)
+
+    transports.head.emit(Frame.SimpleError("MOVED 1234 10.0.0.2:6379"))
+    scheduler.advance(Duration.Zero) // the close is scheduled off the reader thread
+    assert(terminated, "a MOVED error on the subscribe connection must drop it so the manager re-homes")
+    assertEquals(transports.head.closeCount, 1)
   }
 
   test("a socket dying in the establish->live window fires onTerminated in cluster mode instead of going silently Live") {


### PR DESCRIPTION
Three cluster pub/sub concurrency bugs in the shard-subscription manager and its placement ledger.

## H3 — eviction racing an in-flight subscribe silently kills the stream (reported healthy)

`evictEmptyShardConns` snapshotted empty connections under the lock but closed them **outside** it. A concurrent `place`/`reconcile` holding a stale connection reference (from an earlier `ensure`) could bind a sink in that window; the close then terminated the just-registered sink (stream ends as if complete) while `awaitActive` returned normally on `Closed` (cluster attaches don't use `failIfUnconfirmed`). `Placement` recorded the phantom, `fullyPlaced` passed, no retry was scheduled — a dead subscription reported healthy.

**Fix:** `SubscriptionConnection.closeIfEmpty()` decides emptiness and the `Closed` transition in **one** critical section. A racing attach either registers first (connection stays non-empty, kept) or observes `Closed` and throws *before* registering — so its sink is never bound to the dying connection, and `place` leaves it unplaced to retry onto a fresh one. `evictEmptyShardConns` re-checks emptiness through `closeIfEmpty` at close time.

## M2 — `rehomeClassic` leaks the dropped connection on partial failure

It nulled `classicConn` and retried **without** closing `conn`, which by then can be Live carrying successfully re-attached subs: duplicate deliveries on two live sockets, plus a leaked socket and watchdog.

**Fix:** `SubscriptionConnection.shutdown()` closes the socket + watchdog **without** terminating the manager-owned sinks (so the retry re-attaches them; `transport.close()` interrupts the reader, so a backpressured sink can't hang the join). `rehomeClassic` calls it before retrying.

## M3 — `fullyPlaced` summed per-node set sizes

A channel double-recorded on two nodes (possible because `place` computes its plan outside the reconcile single-flight, against a stale topology) inflated the sum, masking another channel that never landed — stranded with no retry.

**Fix:** count the distinct union of placed channels. The double-placement then self-heals on the next reconcile.

**Contributing bug (also fixed):** an error reply to `SSUBSCRIBE` (e.g. `MOVED`) was misrouted by `onFrame` as a bootstrap/PONG reply and silently swallowed, so an unconfirmed subscribe was recorded as placed. A non-bootstrap error frame now drops the connection (off the reader thread) so the manager re-homes (cluster) or reconnects (standalone). Note: this also changes standalone behavior — an unexpected error on a subscription socket, previously ignored, now triggers a reconnect; a post-bootstrap error there is always abnormal.

## Tests
- `PlacementSpec`: `fullyPlaced` counts distinct channels, so a double-recorded one can't mask an unplaced channel.
- `SubscriptionConnectionSpec`: `closeIfEmpty` keeps a connection holding a sink / closes once empty / rejects a racing attach; `shutdown` drops the socket but leaves the sink usable for re-attach; an unexpected error reply drops the connection instead of being swallowed.

All six client backend cells compile; all 141 `sage.client.internal` unit tests pass; scalafmt clean. The M3 and MOVED tests were confirmed to fail against the pre-fix code.