### PR TITLE
Unsubscribe an Ox scoped subscription on scope close, not flow-run end

### DIFF
--- a/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
+++ b/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
@@ -85,6 +85,21 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
     }
   }
 
+  test("a scoped subscription survives a flow run ending — take(1) must not unsubscribe, only scope close does") {
+    withContainers { server =>
+      supervised {
+        val client = SageClient.scoped(configOf(server))
+        val stream = client.subscribeScoped[String]("scoped-live")
+        val _      = client.publish("scoped-live", "a")
+        val first  = stream.take(1).runToList()
+        val _      = client.publish("scoped-live", "b")
+        val second = stream.take(1).runToList()
+        assertEquals(first.map(_.payload), List("a"))
+        assertEquals(second.map(_.payload), List("b"))
+      }
+    }
+  }
+
   test("a plain subscribe Flow resubscribes on every run instead of yielding an empty stream on re-run") {
     withContainers { server =>
       supervised {

--- a/sage-client/ox/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/backend/SageClient.scala
@@ -218,14 +218,12 @@ extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]
     def unsubscribe(): Unit = if (closed.compareAndSet(false, true)) sub.close
     val _                   = useInScope(sub)(_ => unsubscribe())
     Flow.usingEmit { emit =>
-      try {
-        var continue = true
-        while (continue)
-          sub.next match {
-            case Some(a) => emit(a)
-            case None    => continue = false
-          }
-      } finally unsubscribe()
+      var continue = true
+      while (continue)
+        sub.next match {
+          case Some(a) => emit(a)
+          case None    => continue = false
+        }
     }
   }
 }


### PR DESCRIPTION
`scopedStreamOf`'s emit loop unsubscribed in a `finally`, so **any single run ending** closed the subscription — `take(1)` aborts through the emit loop's `finally`, unsubscribing. This contradicts the scaladoc ("unsubscribes when the scope closes") and diverges from the zio/ce backends, which close the subscription only as a scope finalizer (`ZIO.acquireRelease(open)(_.close)`), never on stream-run termination. Everything published after the first run was silently dropped.

**Fix:** drop the `finally unsubscribe()`. The `useInScope(sub)(_ => unsubscribe())` binding already unsubscribes on scope close — the subscription's defined lifetime — so a flow run ending just stops emitting and leaves the subscription live. (The non-scoped `streamOf` still unsubscribes per run, which is correct: it opens its subscription per run.)

## Test
`OxSmokeSuite`: a scoped subscription consumed with `take(1)`, then a publish, then another `take(1)` — the second run must receive the later message. Confirmed to fail against the pre-fix code (second run got nothing) and pass after.