### PR TITLE
Serialize scaladoc during publish and fix opentelemetry doc links

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
 import _root_.io.getkyo.compat.CompatBackendAxis
 import sbt.VirtualAxis
 
+val scaladocTag = Tags.Tag("scaladoc")
+
 val scala3Version     = "3.3.8"
 val scala3NextVersion = "3.8.4"                             // Kyo requires Scala 3.8.x (Next)
 val scala3NextSuffix  = scala3NextVersion.replace('.', '_') // Kyo cells embed the Next Scala version in their project id
@@ -37,7 +39,8 @@ inThisBuild(
     scmInfo          := Some(ScmInfo(url("https://github.com/ghostdogpr/sage/"), "scm:git:git@github.com:ghostdogpr/sage.git")),
     developers       := List(Developer("ghostdogpr", "Pierre Ricadat", "ghostdogpr@gmail.com", url("https://github.com/ghostdogpr"))),
     resolvers += Resolver.sonatypeCentralSnapshots,
-    compatKyoVersion := kyoVersion
+    compatKyoVersion := kyoVersion,
+    concurrentRestrictions += Tags.limit(scaladocTag, 1)
   )
 )
 
@@ -72,7 +75,7 @@ addCommandAlias("exampleKyo", s"examplesKyo$scala3NextSuffix/run")
 
 addCommandAlias(
   "docAll",
-  s"all core/doc clientZio/doc clientCe/doc clientOx/doc clientPekko/doc clientKyo$scala3NextSuffix/doc"
+  s"all core/doc opentelemetry/doc clientZio/doc clientCe/doc clientOx/doc clientPekko/doc clientKyo$scala3NextSuffix/doc"
 )
 
 lazy val root = project
@@ -248,7 +251,8 @@ lazy val commonSettings = Def.settings(
     else base ++ Seq("-Xfatal-warnings", "-Ykind-projector", "-Yfuture-lazy-vals")
   },
   libraryDependencies += "org.scalameta" %% "munit" % munitVersion % Test,
-  Test / fork                            := true
+  Test / fork                            := true,
+  Compile / doc                          := (Compile / doc).tag(scaladocTag).value
 )
 
 // only for container-free cells: integration suites each boot their own container, so running them in

--- a/sage-opentelemetry/src/main/scala/sage/opentelemetry/OpenTelemetryCommandTracer.scala
+++ b/sage-opentelemetry/src/main/scala/sage/opentelemetry/OpenTelemetryCommandTracer.scala
@@ -56,14 +56,14 @@ object OpenTelemetryCommandTracer {
   private val ServerPort    = AttributeKey.longKey("server.port")
 
   /**
-    * Builds a tracer from an explicit [[OpenTelemetry]] (the testable form: inject an in-memory SDK), reading the thread-local current context
+    * Builds a tracer from an explicit `OpenTelemetry` (the testable form: inject an in-memory SDK), reading the thread-local current context
     * as each command's parent. `peerService` is the name every Redis node reports as, so a cluster shows as a single dependency; default `redis`.
     */
   def apply(openTelemetry: OpenTelemetry, peerService: String = "redis"): CommandTracer =
     new OpenTelemetryCommandTracer(openTelemetry.getTracer("sage"), peerService, () => Context.current())
 
   /**
-    * Builds a tracer from the globally-registered [[OpenTelemetry]] — the zero-configuration form for an APM agent (e.g. the Datadog Java agent
+    * Builds a tracer from the globally-registered `OpenTelemetry` — the zero-configuration form for an APM agent (e.g. the Datadog Java agent
     * with `dd.trace.otel.enabled=true`) that installs itself as the global instance.
     */
   def global(peerService: String = "redis"): CommandTracer =


### PR DESCRIPTION
## Problem

The `publish` job (`sbt ci-release`) fails with a scaladoc crash while documenting the `clientKyo` (Scala 3.8.4) cell:

```
Caused by: java.lang.NullPointerException: ... the return value of
"dotty.tools.scaladoc.translators.SignatureBuilder.content()" is null
    at ...SignatureBuilder.termParamList
(clientKyo3_8_4 / Compile / doc) java.lang.reflect.InvocationTargetException
```

The identical `clientKyo3_8_4/doc` task **succeeds** in the `docs` job of the same run and locally. dottydoc is not thread-safe, and `ci-release` runs `packageDoc` for every published cell in parallel in one JVM (far more than the `docs` gate's `docAll`), intermittently tripping the race.

## Changes

- Tag every `Compile / doc` task and cap the tag at 1 concurrent, serializing scaladoc during publish.
- Drop two unresolvable `[[OpenTelemetry]]` doc links (external type dottydoc can't resolve) in favor of monospace.
- Add `opentelemetry/doc` to `docAll` so the docs gate covers that module (it previously slipped past the gate).

## Verification

- `sbt docAll` passes with no `Couldn't resolve` / warning lines.
- Build reloads cleanly; the tagged doc task resolves on all cells.