### PR TITLE
Work around scaladoc JIT NPE on JDK 25

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,1 +1,5 @@
 -Dsbt.io.implicit.relative.glob.conversion=allow
+# Work around scala/scala3#24183: on JDK 25 the C2 JIT miscompiles a combinator in scaladoc's SignatureBuilder,
+# so content() returns null and doc generation NPEs once that method is JIT-compiled (after several doc runs in one
+# JVM). Excluding just that class from JIT sidesteps it; fixed upstream in Scala 3.9.0 (scala/scala3#25779).
+-XX:CompileCommand=exclude,dotty/tools/scaladoc/translators/SignatureBuilder.*

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,6 @@
 import _root_.io.getkyo.compat.CompatBackendAxis
 import sbt.VirtualAxis
 
-val scaladocTag = Tags.Tag("scaladoc")
-
 val scala3Version     = "3.3.8"
 val scala3NextVersion = "3.8.4"                             // Kyo requires Scala 3.8.x (Next)
 val scala3NextSuffix  = scala3NextVersion.replace('.', '_') // Kyo cells embed the Next Scala version in their project id
@@ -39,8 +37,7 @@ inThisBuild(
     scmInfo          := Some(ScmInfo(url("https://github.com/ghostdogpr/sage/"), "scm:git:git@github.com:ghostdogpr/sage.git")),
     developers       := List(Developer("ghostdogpr", "Pierre Ricadat", "ghostdogpr@gmail.com", url("https://github.com/ghostdogpr"))),
     resolvers += Resolver.sonatypeCentralSnapshots,
-    compatKyoVersion := kyoVersion,
-    concurrentRestrictions += Tags.limit(scaladocTag, 1)
+    compatKyoVersion := kyoVersion
   )
 )
 
@@ -251,8 +248,7 @@ lazy val commonSettings = Def.settings(
     else base ++ Seq("-Xfatal-warnings", "-Ykind-projector", "-Yfuture-lazy-vals")
   },
   libraryDependencies += "org.scalameta" %% "munit" % munitVersion % Test,
-  Test / fork                            := true,
-  Compile / doc                          := (Compile / doc).tag(scaladocTag).value
+  Test / fork                            := true
 )
 
 // only for container-free cells: integration suites each boot their own container, so running them in


### PR DESCRIPTION
## Root cause

The `publish` job (and, since #159 added `opentelemetry/doc`, the `docs` job) fails with a scaladoc crash:

```
java.lang.NullPointerException: ... the return value of
"dotty.tools.scaladoc.translators.SignatureBuilder.content()" is null
    at ...SignatureBuilder.termParamList
```

This is [scala/scala3#24183](https://github.com/scala/scala3/issues/24183): on **JDK 25** the C2 JIT miscompiles a combinator in scaladoc's `SignatureBuilder`, so `content()` returns null once that method gets JIT-compiled. That only happens after the method is warmed up by several doc runs in one JVM, which is why it hit a **random cell** and only in the many-cell `ci-release` / `docAll` runs, not standalone. Started when CI moved to Temurin 25. Fixed upstream in Scala 3.9.0 ([scala/scala3#25779](https://github.com/scala/scala3/pull/25779)).

Confirmed locally: with C2 disabled (`-XX:TieredStopAtLevel=1`) or the offending class excluded from JIT, `docAll` goes from reliably crashing to 0 crashes.

## Changes

- **`.jvmopts`**: exclude `dotty.tools.scaladoc.translators.SignatureBuilder` from JIT. sbt reads `.jvmopts` on every invocation, so this covers both the `docs` and `publish` jobs (and local `doc`/`publishLocal`) with C2 left on everywhere else. Harmless where scaladoc isn't loaded.
- **`build.sbt`**: remove the doc-task serialization from #159 (`scaladocTag`, `concurrentRestrictions`, the `Compile / doc` tag). It was based on a wrong concurrency hypothesis and had no effect — the crash reproduces with doc tasks run strictly serially.

## Verification

- `sbt docAll` on a clean fresh JVM: 0 crashes across two trials (previously ~reliably crashed), and the docs-gate warning grep passes.
- Confirmed via `RuntimeMXBean` that the `.jvmopts` flag actually reaches the sbt JVM.
- `scalafmtSbtCheck` passes.