### PR TITLE
Fix subscription and cluster concurrency edge cases

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -153,13 +153,17 @@ final private[client] class ClusterLive(
   def runOn[A](target: ScanTarget, command: Command[A]): CIO[A] =
     target.node match {
       case Some(node) =>
-        CIO.async[A] { complete =>
-          val span = Events.startSpan(events, command)
-          offload {
-            val tracked = Events.trackCommand(events, command, complete, span)
-            Client.completing(tracked)(sendTo(node, command, asking = false, redirectsLeft = 0, tracked))
+        def body(lease: DedicatedPool.Lease): CIO[A] =
+          CIO.async[A] { complete =>
+            val span = Events.startSpan(events, command)
+            offload {
+              val tracked = Events.trackCommand(events, command, complete, span)
+              Client.completing(tracked)(sendTo(node, command, asking = false, redirectsLeft = 0, tracked, lease))
+            }
           }
-        }
+        // mirror run: a blocking command needs a cancelable lease so an interrupt releases the slot instead of leaking it
+        if (!command.isBlocking) body(null)
+        else CIO.acquireReleaseWith(CIO.defer(new DedicatedPool.Lease))(lease => CIO.blocking(lease.cancel()))(body)
       case None       => run(command)
     }
 
@@ -374,7 +378,7 @@ final private[client] class ClusterLive(
     asking: Boolean,
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    lease: DedicatedPool.Lease = null
+    lease: DedicatedPool.Lease
   ): Unit = {
     val nc =
       try getOrEstablish(node)

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -697,40 +697,63 @@ final private[client] class ClusterLive(
           }
 
     // validates the whole pipeline's slots against the pin *before* sending MULTI, so a cross-slot transaction is rejected with nothing on the wire
-    private def submitExec[Out, R](p: Pipeline[Out, R], complete: Try[Vector[Frame]] => Unit): Unit = {
-      lock.lock()
-      try
-        if (released) complete(Failure(TxSupport.scopeReleasedError))
-        else
-          pipelineSlot(p).flatMap(ensureConn) match {
-            case Left(error) => refreshOnFault(error); complete(Failure(error))
-            case Right(_)    => Client.completing(complete)(conn.submitRaw(Connection.multi +: p.commands :+ Connection.exec, faulting(complete)))
+    private def submitExec[Out, R](p: Pipeline[Out, R], complete: Try[Vector[Frame]] => Unit): Unit =
+      onConn(pipelineSlot(p), complete)(c => c.submitRaw(Connection.multi +: p.commands :+ Connection.exec, faulting(complete)))
+
+    private def withConn[A](command: Command[?], complete: Try[A] => Unit)(use: DedicatedConnection => Unit): Unit =
+      onConn(commandSlot(command), complete)(use)
+
+    // checks and submits stay under `lock` (release-vs-late-submit is atomic); the slow acquire runs outside it so release() never stalls behind it
+    private def onConn[A](slotResult: Either[Throwable, Option[Slot]], complete: Try[A] => Unit)(use: DedicatedConnection => Unit): Unit = {
+      var retry = true
+      while (retry) {
+        retry = false
+        var fault: Throwable   = null
+        var acquire            = false
+        var slot: Option[Slot] = None
+        lock.lock()
+        try
+          if (released) complete(Failure(TxSupport.scopeReleasedError))
+          else
+            slotResult match {
+              case Left(error) => fault = error; complete(Failure(error))
+              case Right(s)    =>
+                if (conn == null) { acquire = true; slot = s }
+                else
+                  checkPin(s) match {
+                    case Left(error) => fault = error; complete(Failure(error))
+                    case Right(())   => Client.completing(complete)(use(conn))
+                  }
+            }
+        finally lock.unlock()
+        if (fault != null) refreshOnFault(fault)
+        else if (acquire)
+          acquireConn(slot) match {
+            case Left(error)               => refreshOnFault(error); complete(Failure(error))
+            case Right((nc, c, node, pin)) =>
+              var giveBack = false
+              lock.lock()
+              try
+                if (released) { giveBack = true; complete(Failure(TxSupport.scopeReleasedError)) }
+                else if (conn != null) { giveBack = true; retry = true } // lost the acquire race; re-validate against the winner's pin
+                else {
+                  nodeClient = nc
+                  conn = c
+                  pinnedNode = node
+                  pinnedSlot = pin
+                  Client.completing(complete)(use(conn))
+                }
+              finally lock.unlock()
+              if (giveBack) nc.releaseTransaction(c, reusable = true)
           }
-      finally lock.unlock()
+      }
     }
 
-    private def withConn[A](command: Command[?], complete: Try[A] => Unit)(use: DedicatedConnection => Unit): Unit = {
-      lock.lock()
-      try
-        if (released) complete(Failure(TxSupport.scopeReleasedError))
-        else
-          commandSlot(command).flatMap(ensureConn) match {
-            case Left(error) => refreshOnFault(error); complete(Failure(error))
-            case Right(_)    => Client.completing(complete)(use(conn))
-          }
-      finally lock.unlock()
-    }
-
-    // called under `lock`; the blocking acquire is safe here — the finalizer never runs concurrently with a live block. With a slot: pin its
-    // owner on the first key, then require every later key to match; a keyless-acquired pin adopts the slot only if its node already owns it.
-    private def ensureConn(slot: Option[Slot]): Either[Throwable, Unit] =
+    // must hold `lock`, conn != null; a keyless-acquired pin adopts the first keyed slot only if its node already owns it
+    private def checkPin(slot: Option[Slot]): Either[Throwable, Unit] =
       slot match {
-        case Some(s) if conn == null =>
-          nodeForSlotRefreshing(s) match {
-            case Some(node) => acquireOn(node).map(_ => pinnedSlot = Some(s))
-            case None       => Left(NotConnected())
-          }
-        case Some(s)                 =>
+        case None    => Right(())
+        case Some(s) =>
           pinnedSlot match {
             case Some(ps) if ps == s => Right(())
             case Some(ps)            =>
@@ -739,28 +762,29 @@ final private[client] class ClusterLive(
               if (topologyRef.get().nodeForSlot(s).contains(pinnedNode)) { pinnedSlot = Some(s); Right(()) }
               else Left(CrossSlot(s"transaction touches slot ${s.value} on a node other than its pinned one; MULTI/EXEC requires a single slot"))
           }
-        case None if conn != null    => Right(())
-        case None                    =>
-          pickNode(topologyRef.get()) match {
-            case Some(node) => acquireOn(node)
-            case None       => Left(NotConnected())
+      }
+
+    // runs outside `lock`: may force a topology refresh, connect, or wait for a pool slot
+    private def acquireConn(slot: Option[Slot]): Either[Throwable, (NodeClient, DedicatedConnection, Node, Option[Slot])] = {
+      val target = slot match {
+        case Some(s) => nodeForSlotRefreshing(s).map(_ -> slot)
+        case None    => pickNode(topologyRef.get()).map(_ -> None)
+      }
+      target match {
+        case None              => Left(NotConnected())
+        case Some((node, pin)) =>
+          try {
+            val nc = getOrEstablish(node)
+            Right((nc, nc.acquireForTransaction(), node, pin))
+          } catch {
+            case error: SageException => Left(error)
+            case NonFatal(_)          => Left(ConnectionLost(mayHaveExecuted = false))
           }
       }
+    }
 
     private def nodeForSlotRefreshing(slot: Slot): Option[Node] =
       topologyRef.get().nodeForSlot(slot).orElse { refresh(force = true); topologyRef.get().nodeForSlot(slot) }
-
-    private def acquireOn(node: Node): Either[Throwable, Unit] =
-      try {
-        val nc = getOrEstablish(node)
-        conn = nc.acquireForTransaction()
-        nodeClient = nc
-        pinnedNode = node
-        Right(())
-      } catch {
-        case error: SageException => Left(error)
-        case NonFatal(_)          => Left(ConnectionLost(mayHaveExecuted = false))
-      }
 
     private def commandSlot(command: Command[?]): Either[Throwable, Option[Slot]] =
       if (command.hasMalformedKeys)

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -135,8 +135,8 @@ final private[client] class SubscriptionConnection(
       try goLive(establish())
       catch {
         case e: Throwable =>
-          // establish failed after the sink was registered; drop it so a later reconnect doesn't resubscribe a phantom name
-          locked { deregister(sink, names, kind); state = State.Idle; established.signalAll() }
+          // drop the phantom sink, but only if a concurrent close/goLive hasn't already moved us off Establishing
+          locked { if (state == State.Establishing) { deregister(sink, names, kind); state = State.Idle; established.signalAll() } }
           throw e
       }
     awaitActive(failIfUnconfirmed, confirmTarget)
@@ -307,7 +307,9 @@ final private[client] class SubscriptionConnection(
           case Some(Pubsub.Event.Message(channel, payload))            => dispatch(channelSinks, channel, Delivery.Channel(channel, payload))
           case Some(Pubsub.Event.ShardMessage(channel, payload))       => dispatch(shardSinks, channel, Delivery.Channel(channel, payload))
           case Some(Pubsub.Event.PatternMessage(pattern, ch, payload)) => dispatch(patternSinks, pattern, Delivery.Pattern(pattern, ch, payload))
-          case Some(_: Pubsub.Event.Subscribed)                        => locked { subscribeConfirmed += 1; confirmed.signalAll() }
+          case Some(_: Pubsub.Event.Subscribed)                        =>
+            // conn eq current: a late ack from a superseded generation must not advance this generation's count
+            locked { if (conn eq current) { subscribeConfirmed += 1; confirmed.signalAll() } }
           case _                                                       => () // an Unsubscribed ack is informational; re-homing is disconnect-driven
         }
       case reply                => // non-push reply: bootstrap HELLO, watchdog PONG, or an unexpected error
@@ -544,6 +546,8 @@ private[client] object SubscriptionConnection {
       var ready: Option[Delivery] = null // null = parked on the waiter; non-null = deliver synchronously
       lock.lock()
       try {
+        // an existing waiter means a concurrent consumer; fail loud rather than silently evict it
+        if (waiter != null) throw new IllegalStateException("a subscription is single-consumer; concurrent next is not supported")
         val head = backlog.poll()
         if (head != null) { notFull.signal(); ready = Some(head) }
         else if (closed) ready = None

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -136,7 +136,7 @@ final private[client] class SubscriptionConnection(
       catch {
         case e: Throwable =>
           // drop the phantom sink, but only if a concurrent close/goLive hasn't already moved us off Establishing
-          locked { if (state == State.Establishing) { deregister(sink, names, kind); state = State.Idle; established.signalAll() } }
+          locked(if (state == State.Establishing) { deregister(sink, names, kind); state = State.Idle; established.signalAll() })
           throw e
       }
     awaitActive(failIfUnconfirmed, confirmTarget)
@@ -309,7 +309,7 @@ final private[client] class SubscriptionConnection(
           case Some(Pubsub.Event.PatternMessage(pattern, ch, payload)) => dispatch(patternSinks, pattern, Delivery.Pattern(pattern, ch, payload))
           case Some(_: Pubsub.Event.Subscribed)                        =>
             // conn eq current: a late ack from a superseded generation must not advance this generation's count
-            locked { if (conn eq current) { subscribeConfirmed += 1; confirmed.signalAll() } }
+            locked(if (conn eq current) { subscribeConfirmed += 1; confirmed.signalAll() })
           case _                                                       => () // an Unsubscribed ack is informational; re-homing is disconnect-driven
         }
       case reply                => // non-push reply: bootstrap HELLO, watchdog PONG, or an unexpected error

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -50,7 +50,8 @@ class ClusterClientSpec extends munit.FunSuite {
     behaviour: (Node, String) => Seq[Frame],
     seeds: Vector[Node],
     unreachable: Set[Node] = Set.empty,
-    readFrom: ReadFrom = ReadFrom.Master
+    readFrom: ReadFrom = ReadFrom.Master,
+    connectGate: (Node, Int) => Unit = (_, _) => () // blocks a node's nth transport creation, to park an establish mid-flight
   ) {
 
     // accumulate every transport per node (a node has both a Multiplexed and, once a transaction pins, a Dedicated connection) so a refresh
@@ -62,6 +63,7 @@ class ClusterClientSpec extends munit.FunSuite {
 
     private val factory: Node => MultiplexedConnection.TransportFactory = node =>
       (onFrame, onClosed) => {
+        connectGate(node, transports.get(node).map(_.size).getOrElse(0))
         val respond: Bytes => Seq[Frame] = payload => {
           val text = payload.asUtf8String
           if (text.contains("HELLO"))
@@ -372,6 +374,31 @@ class ClusterClientSpec extends munit.FunSuite {
       Thread.sleep(150)
       val clusterCalls = fixture.written(nodeA).count(_.contains("CLUSTER"))
       assert(clusterCalls >= 3, s"each tx fault must force a refresh despite the throttle; CLUSTER calls: $clusterCalls")
+    }
+  }
+
+  test("an interrupted transaction releases promptly while its first acquire is mid-connect, and the acquired connection is recycled") {
+    val gate      = new java.util.concurrent.CountDownLatch(1)
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (text.contains("MULTI"))
+        Seq(Frame.SimpleString("OK"), Frame.SimpleString("QUEUED"), Frame.Array(Vector(Frame.BulkString(Bytes.utf8("v")))))
+      else Seq(Frame.SimpleString("OK"))
+    // gate the dedicated (second) transport of nodeA so the transaction's first acquire parks mid-connect
+    val fixture   = new Fixture(behaviour, Vector(nodeA), connectGate = (node, index) => if (node == nodeA && index == 1) gate.await())
+
+    val started = System.nanoTime()
+    CIO.timeout(500.millis)(fixture.live.transaction(_.exec(Vector(Strings.get[String, String]("{a}1"))))).unsafeRun.flatMap { result =>
+      val elapsedMs = (System.nanoTime() - started) / 1000000L
+      assert(result.isEmpty, s"expected the timeout to win, got $result")
+      assert(elapsedMs < 3000L, s"the finalizer stalled behind the parked acquire: ${elapsedMs}ms")
+      gate.countDown()
+      Thread.sleep(300) // let the orphaned acquire finish and hand its never-used connection back
+      fixture.live.transaction(_.exec(Vector(Strings.get[String, String]("{a}1")))).unsafeRun.map { committed =>
+        assertEquals(committed, Some(Vector(Some("v"))))
+        val hellos = fixture.written(nodeA).count(_.contains("HELLO"))
+        assertEquals(hellos, 2, "the recycled dedicated connection must be reused, not re-established")
+      }
     }
   }
 


### PR DESCRIPTION
Five concurrency edge cases surfaced by review, all confirmed real.

### `SubscriptionConnection`

- **Establish-failure state clobber.** `close()`/`shutdown()`/`closeIfEmpty()` can set `state = Closed` while `establish()` runs holding no lock. If `establish()` then threw, the catch unconditionally reset to `Idle`, resurrecting a dropped connection (or orphaning a socket a concurrent `goLive` had already brought Live). Now only resets when still `Establishing`.
- **Cross-generation SUBSCRIBE ack.** `onFrame` bumped `subscribeConfirmed` without the `conn eq current` check `onConnClosed` already has, so a late ack from a superseded generation's still-running reader could satisfy the new generation's `awaitActive` and let `subscribe` return before the server confirmed. Now gated on `conn eq current`.
- **`Sink.next` waiter eviction.** Ox's scoped subscription opens the sink once and hands back a reusable `Flow`, so two concurrent runs pull one shared `Sink`; the old code silently evicted the first parked waiter (hang + nondeterministic split). Now enforces the documented single-consumer invariant and fails loud.

### `ClusterLive`

- **`runOn` lease bracket.** The node-pinned path called `sendTo` with no lease, so a blocking command would fall back to `NodeClient`'s uncancellable private lease and leak the pool slot on interrupt. Now brackets a cancelable lease exactly like `run`.
- **Transaction finalizer stall.** `ClusterTxScope` held its lock across `ensureConn`, whose owner resolution can force a synchronous `CLUSTER SLOTS` sweep (with an uninterruptible single-flight collapse in `RefreshThrottle`) and whose acquire connects or waits for a pool slot. An interrupted transaction's finalizer blocks on that same lock, so mid-failover it could stall for candidates × connectTimeout, and anything sequenced after the bracket (including `close`) stalled with it. `onConn` now keeps the released check, pin validation, and submit under the lock (release-vs-late-submit stays atomic) and runs the slow acquire outside it: a scope sealed mid-acquire hands the never-used connection straight back to the pool, and losing an acquire race to a concurrent op retries against the winner's pin. The regression test parks the first acquire mid-connect, interrupts the transaction, and asserts the finalizer returns promptly and a later transaction reuses the handed-back connection (it hangs on the previous code).