### PR TITLE
Fix Future-carrier transaction leak and subscription waiter regression

### DIFF
--- a/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
@@ -4,7 +4,6 @@ import scala.annotation.unused
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success}
-import scala.util.control.NonFatal
 
 import kyo.compat.*
 import org.apache.pekko.{Done, NotUsed}
@@ -241,12 +240,14 @@ object SageClient {
     * `scoped`/`resource` helpers. Prefer this over `connect` + manual `close` unless you need to own the lifecycle yourself.
     */
   def use[A](config: SageConfig)(f: SageClient => Future[A])(using ExecutionContext): Future[A] =
-    connect(config).flatMap { client =>
-      val ran =
-        try f(client)
-        catch { case NonFatal(e) => Future.failed(e) }
-      ran.transformWith(result => client.close.transformWith(_ => Future.fromTry(result)))
-    }
+    connect(config).flatMap(client => useConnected(client)(f))
+
+  private[backend] def useConnected[A](client: SageClient)(f: SageClient => Future[A])(using ExecutionContext): Future[A] = {
+    val ran =
+      try f(client)
+      catch { case e: Throwable => Future.failed(e) }
+    ran.transformWith(result => client.close.transformWith(_ => Future.fromTry(result)))
+  }
 
   private[backend] def boundedPoll(block: BlockTimeout, method: String): Either[IllegalArgumentException, BlockTimeout] =
     block match {

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -1,7 +1,7 @@
 package sage.client.internal
 
 import java.time.Instant
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.util.concurrent.locks.ReentrantLock
 import javax.net.ssl.SSLException
 
@@ -2366,7 +2366,7 @@ object Client {
     // connection's WATCH/MULTI state, no reply outstanding) recycles the connection; a scope left armed or interrupted mid-command is
     // discarded rather than handed to the next borrower dirty.
     def transaction[A](body: TransactionScope[CIO, String] => CIO[A]): CIO[A] =
-      CIO.acquireReleaseWith(acquireScope)(releaseScope)(scope => body(scope))
+      CIO.acquireReleaseWith(acquireScope)(releaseScope)(scope => CIO.unit.flatMap(_ => body(scope)))
 
     private def acquireScope: CIO[TxScope] =
       CIO.blocking {
@@ -2410,10 +2410,18 @@ object Client {
   ): Subscription[CIO, M] =
     new Subscription[CIO, M] {
       // async, not blocking: the reader thread completes the callback, so a fiber parks instead of pinning a runtime worker
-      def next: CIO[Option[M]] = CIO.async { complete =>
-        raw.next {
-          case Some(delivery) => complete(Try(build(delivery)))
-          case None           => complete(Success(None))
+      def next: CIO[Option[M]] = {
+        // deregister the parked waiter if this next is interrupted, else a stale waiter trips the single-consumer guard
+        val registered = new AtomicReference[Option[SubscriptionConnection.Delivery] => Unit]()
+        CIO.ensure(CIO.defer { val cb = registered.getAndSet(null); if (cb ne null) raw.cancelNext(cb) }) {
+          CIO.async { complete =>
+            val cb: Option[SubscriptionConnection.Delivery] => Unit = {
+              case Some(delivery) => complete(Try(build(delivery)))
+              case None           => complete(Success(None))
+            }
+            registered.set(cb)
+            raw.next(cb)
+          }
         }
       }
       def close: CIO[Unit]     = CIO.blocking(raw.close())

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -171,7 +171,7 @@ final private[client] class ClusterLive(
   private[sage] def pipelineAttempt[Out, R](p: Pipeline[Out, R]): CIO[R] = submitPipeline(p).map(p.toResults)
 
   def transaction[A](body: TransactionScope[CIO, String] => CIO[A]): CIO[A] =
-    CIO.acquireReleaseWith(acquireScope)(releaseScope)(scope => body(scope))
+    CIO.acquireReleaseWith(acquireScope)(releaseScope)(scope => CIO.unit.flatMap(_ => body(scope)))
 
   // classic subscriptions ride one connection pinned to an arbitrary master (classic PUBLISH broadcasts cluster-wide); the manager re-homes it
   def subscribeChannels[V: ValueCodec](channel: String, rest: String*): CIO[Subscription[CIO, Message[V]]] =

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -313,7 +313,7 @@ final private[client] class MasterReplicaLive(
   // --- transactions (always on the master) ---------------------------------------------------------------------------------------------
 
   def transaction[A](body: TransactionScope[CIO, String] => CIO[A]): CIO[A] =
-    CIO.acquireReleaseWith(acquireScope)(releaseScope)(lease => body(lease.scope))
+    CIO.acquireReleaseWith(acquireScope)(releaseScope)(lease => CIO.unit.flatMap(_ => body(lease.scope)))
 
   private def refreshOnTxFault(error: Throwable): Unit = if (isOwnershipFault(error)) triggerRefresh()
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -556,6 +556,12 @@ private[client] object SubscriptionConnection {
       if (ready != null) callback(ready)
     }
 
+    def cancelNext(callback: Option[Delivery] => Unit): Unit = {
+      lock.lock()
+      try if (waiter eq callback) waiter = null
+      finally lock.unlock()
+    }
+
     def offer(delivery: Delivery): Boolean = {
       var hungry: Option[Delivery] => Unit = null
       var blocked                          = false
@@ -589,6 +595,8 @@ private[client] object SubscriptionConnection {
   final class RawSubscription private[internal] (sink: Sink, onClose: () => Unit) {
 
     def next(callback: Option[Delivery] => Unit): Unit = sink.next(callback)
+
+    def cancelNext(callback: Option[Delivery] => Unit): Unit = sink.cancelNext(callback)
 
     def close(): Unit = onClose()
   }

--- a/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
@@ -333,4 +333,33 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
 
     assert(terminatedCalled, "a connection that died in the establish->live window must notify the manager, not go silently Live")
   }
+
+  test("a concurrent consumer on one sink is rejected rather than silently evicting the parked waiter") {
+    val sink                                                    = new SubscriptionConnection.Sink(Vector("news"), SubscriptionConnection.Kind.Channel, 16)
+    val parked: Option[SubscriptionConnection.Delivery] => Unit = _ => ()
+    sink.next(parked)
+    intercept[IllegalStateException](sink.next(_ => ()))
+  }
+
+  test("deregistering an interrupted waiter lets the next poll re-arm instead of tripping the single-consumer guard") {
+    val sink                                                       = new SubscriptionConnection.Sink(Vector("news"), SubscriptionConnection.Kind.Channel, 16)
+    val abandoned: Option[SubscriptionConnection.Delivery] => Unit = _ => ()
+    sink.next(abandoned)
+    sink.cancelNext(abandoned)
+
+    val box   = new AtomicReference[Option[SubscriptionConnection.Delivery]]()
+    val latch = new CountDownLatch(1)
+    sink.next { delivery => box.set(delivery); latch.countDown() }
+    sink.offer(SubscriptionConnection.Delivery.Channel("news", Bytes.utf8("hello")))
+    latch.await()
+    assertChannel(box.get(), "news", "hello")
+  }
+
+  test("cancelNext is identity-checked and does not evict a live waiter registered by another call") {
+    val sink                                                  = new SubscriptionConnection.Sink(Vector("news"), SubscriptionConnection.Kind.Channel, 16)
+    val live: Option[SubscriptionConnection.Delivery] => Unit = _ => ()
+    sink.next(live)
+    sink.cancelNext(_ => ())
+    intercept[IllegalStateException](sink.next(_ => ()))
+  }
 }


### PR DESCRIPTION
Three related concurrency fixes in the client runtime.

## Future-carrier transaction connection leak

`transaction` applied the user's body strictly in the bracket's `use` position (`scope => body(scope)`). On the Future carrier, `acquireReleaseWith` wires release via `transformWith` *inside* the `flatMap` continuation, so a synchronous throw while constructing `body(scope)` fails the Future before release is attached — the leased connection is never returned and eight such throws exhaust the pool. The eager carriers (zio/ce/kyo/ox) were already safe.

Fix: suspend the body construction with `CIO.unit.flatMap(_ => body(scope))` so a strict throw becomes a failed effect inside the bracket. Applied to `Live`, `ClusterLive`, and `MasterReplicaLive`.

## pekko `use` helper hardening

Broadened the `use` body catch to `Throwable` and extracted `useConnected`, so the close-on-exit path runs for any failure of the user function, not just `NonFatal`.

## Subscription single-consumer false positive (regression from #161)

#161 made `Sink.next` fail loud when a waiter is already parked (concurrent-consumer guard). But no backend bridge has a canceler, so an interrupted `next` left its parked waiter registered; the next poll then threw the single-consumer `IllegalStateException` as a false positive and kept throwing until a message happened to clear the waiter — persistently breaking idle subscriptions.

Fix: a real waiter-unregister path. `next` wires a `CIO.ensure` finalizer that deregisters the exact callback it registered (identity-checked, so a live or superseding waiter is never evicted). The guard still correctly rejects genuine concurrent consumers. `ensure` runs its cleanup on interruption across ce/zio/ox/kyo; Future has no interrupt, so the finalizer is a harmless no-op there.

## Tests

Three unit tests on `Sink`: the guard rejects a genuine concurrent consumer; deregistering an interrupted waiter lets the next poll re-arm and receive; `cancelNext` with a non-matching callback does not evict a live waiter.

Verified: compiles on all backend cells (ce/zio/ox/kyo/pekko); `SubscriptionConnectionSpec` green (18/18).