### PR TITLE
Keep TLS/auth failures diagnosable and stop leaking URI credentials

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
+++ b/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
@@ -189,7 +189,8 @@ object SageConfig {
     * is intentionally no way to select insecure TLS from a URI.
     */
   def fromUri(uri: String): Either[String, SageConfig] = {
-    def fail[A](msg: String): Either[String, A] = Left(s"invalid redis URI '$uri': $msg")
+    val shown                                   = redactCredentials(uri)
+    def fail[A](msg: String): Either[String, A] = Left(s"invalid redis URI '$shown': $msg")
 
     uri.split("://", 2) match {
       case Array(scheme, rest) =>
@@ -205,10 +206,10 @@ object SageConfig {
           pathPart   = if (slash < 0) "" else rest.substring(slash + 1)
           at         = authority.lastIndexOf('@')
           userinfo   = if (at < 0) "" else authority.substring(0, at)
-          auth      <- if (userinfo.isEmpty) Right(None) else parseAuth(uri, userinfo)
-          endpoints <- parseEndpoints(uri, if (at < 0) authority else authority.substring(at + 1))
+          auth      <- if (userinfo.isEmpty) Right(None) else parseAuth(shown, userinfo)
+          endpoints <- parseEndpoints(shown, if (at < 0) authority else authority.substring(at + 1))
           db        <- if (pathPart.isEmpty) Right(0)
-                       else pathPart.toIntOption.filter(_ >= 0).toRight(s"invalid redis URI '$uri': invalid database '$pathPart'")
+                       else pathPart.toIntOption.filter(_ >= 0).toRight(s"invalid redis URI '$shown': invalid database '$pathPart'")
           topology   = endpoints match {
                          case Vector(one) => Topology.Standalone(one)
                          case seeds       => Topology.Cluster(seeds)
@@ -221,6 +222,24 @@ object SageConfig {
       case _                   => fail("expected redis:// or rediss://")
     }
   }
+
+  private def redactCredentials(uri: String): String =
+    uri.split("://", 2) match {
+      case Array(scheme, rest) =>
+        val slash     = rest.indexOf('/')
+        val authority = if (slash < 0) rest else rest.substring(0, slash)
+        val tail      = if (slash < 0) "" else rest.substring(slash)
+        authority.lastIndexOf('@') match {
+          case -1 => uri
+          case at =>
+            val redacted = authority.substring(0, at).indexOf(':') match {
+              case -1 => "<redacted>"
+              case i  => s"${authority.substring(0, i)}:<redacted>"
+            }
+            s"$scheme://$redacted${authority.substring(at)}$tail"
+        }
+      case _                   => uri
+    }
 
   // split on the first literal ':' (a ':' inside a credential is percent-encoded as %3A), then decode each half
   private def parseAuth(uri: String, userinfo: String): Either[String, Option[AuthConfig]] =

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2372,9 +2372,8 @@ object Client {
       CIO.blocking {
         try new TxScope(pool.acquireForTransaction(), events = events)
         catch {
-          case e: NotConnected => throw e
-          case e: TimedOut     => throw e
-          case NonFatal(_)     => throw ConnectionLost(mayHaveExecuted = false)
+          case e: SageException => throw e
+          case NonFatal(_)      => throw ConnectionLost(mayHaveExecuted = false)
         }
       }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -8,6 +8,7 @@ import scala.concurrent.duration.*
 import scala.util.Try
 import scala.util.control.NonFatal
 
+import sage.SageException
 import sage.SageException.{ConnectionLost, NotConnected, TimedOut}
 import sage.client.DedicatedPoolConfig
 import sage.commands.{Command, Connection}
@@ -71,9 +72,8 @@ final private[client] class DedicatedPool(
         val acquired =
           try Right(acquire())
           catch {
-            case e: NotConnected => Left(e)
-            case e: TimedOut     => Left(e)
-            case NonFatal(_)     => Left(ConnectionLost(mayHaveExecuted = false)) // never reached the wire
+            case e: SageException => Left(e)
+            case NonFatal(_)      => Left(ConnectionLost(mayHaveExecuted = false)) // never reached the wire
           }
         acquired match {
           case Left(error) => callback(scala.util.Failure(error))

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -322,14 +322,14 @@ final private[client] class MasterReplicaLive(
       val nc =
         try masterPool.getOrEstablish(masterNodeRef.get())
         catch {
-          case e: NotConnected => triggerRefresh(); throw e
-          case NonFatal(_)     => triggerRefresh(); throw ConnectionLost(mayHaveExecuted = false)
+          case e: SageException => triggerRefresh(); throw e
+          case NonFatal(_)      => triggerRefresh(); throw ConnectionLost(mayHaveExecuted = false)
         }
       try new MasterReplicaLive.TxLease(new Client.TxScope(nc.acquireForTransaction(), refreshOnTxFault, events), nc)
       catch {
-        case e: NotConnected => triggerRefresh(); throw e
-        case e: TimedOut     => throw e
-        case NonFatal(_)     => triggerRefresh(); throw ConnectionLost(mayHaveExecuted = false)
+        case e: TimedOut      => throw e
+        case e: SageException => triggerRefresh(); throw e
+        case NonFatal(_)      => triggerRefresh(); throw ConnectionLost(mayHaveExecuted = false)
       }
     }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/Tls.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Tls.scala
@@ -28,16 +28,23 @@ private[client] object Tls {
       case Some(config) =>
         val (context, verifyHostname) = contextFor(config.trust)
         val factory                   = context.getSocketFactory
-        plain => {
-          val ssl = factory.createSocket(plain, host, port, /*autoClose*/ true).asInstanceOf[SSLSocket]
-          if (verifyHostname) {
-            val params = ssl.getSSLParameters
-            params.setEndpointIdentificationAlgorithm("HTTPS")
-            ssl.setSSLParameters(params)
+        plain =>
+          try {
+            val ssl = factory.createSocket(plain, host, port, /*autoClose*/ true).asInstanceOf[SSLSocket]
+            if (verifyHostname) {
+              val params = ssl.getSSLParameters
+              params.setEndpointIdentificationAlgorithm("HTTPS")
+              ssl.setSSLParameters(params)
+            }
+            ssl.startHandshake()
+            ssl
+          } catch {
+            case e: TlsError => throw e
+            case NonFatal(e) =>
+              val wrapped = TlsError(s"TLS handshake with $host:$port failed: $e")
+              wrapped.initCause(e)
+              throw wrapped
           }
-          ssl.startHandshake()
-          ssl
-        }
     }
 
   private def contextFor(trust: TrustSource): (SSLContext, Boolean) =

--- a/sage-client/shared/src/test/scala/sage/client/SageConfigSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/SageConfigSpec.scala
@@ -77,4 +77,12 @@ class SageConfigSpec extends munit.FunSuite {
     assert(SageConfig.fromUri("redis://h/x").isLeft)        // non-numeric database
     assert(SageConfig.fromUri("redis://h?ssl=true").isLeft) // query params unsupported
   }
+
+  test("a parse error never echoes the password back") {
+    def problem(uri: String): String = SageConfig.fromUri(uri).swap.getOrElse(fail(s"expected a Left for $uri"))
+    assert(!problem("redis://alice:hunter2@h:0").contains("hunter2"))
+    assert(!problem("redis://:hunter2@h:0").contains("hunter2"))
+    assert(!problem("redis://:p%40ss@h?x=1").contains("p%40ss"))
+    assertEquals(problem("redis://alice:hunter2@h:0"), "invalid redis URI 'redis://alice:<redacted>@h:0': invalid port in 'h:0'")
+  }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/TlsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/TlsSpec.scala
@@ -1,0 +1,96 @@
+package sage.client.internal
+
+import java.net.{InetAddress, InetSocketAddress, Socket}
+import java.nio.file.{Files, Path}
+import java.security.KeyStore
+import javax.net.ssl.{KeyManagerFactory, SSLContext, SSLServerSocket, TrustManagerFactory}
+
+import sage.SageException.TlsError
+import sage.client.{TlsConfig, TrustSource}
+
+class TlsSpec extends munit.FunSuite {
+
+  // one self-signed cert whose only SAN is dns:localhost: the server presents it, the client trusts it, so only the connect host varies
+  private lazy val material = certMaterial()
+
+  private def certMaterial(): (SSLContext, SSLContext) = {
+    val dir     = Files.createTempDirectory("sage-tls-unit")
+    val store   = dir.resolve("server.p12")
+    val pass    = "changeit".toCharArray
+    val keytool = Path.of(System.getProperty("java.home"), "bin", "keytool").toString
+    val proc    = new ProcessBuilder(
+      keytool,
+      "-genkeypair",
+      "-alias",
+      "server",
+      "-keyalg",
+      "RSA",
+      "-keysize",
+      "2048",
+      "-validity",
+      "3650",
+      "-storetype",
+      "PKCS12",
+      "-keystore",
+      store.toString,
+      "-storepass",
+      "changeit",
+      "-dname",
+      "CN=localhost",
+      "-ext",
+      "san=dns:localhost"
+    ).redirectErrorStream(true).start()
+    val out     = new String(proc.getInputStream.readAllBytes())
+    assert(proc.waitFor() == 0, s"keytool failed: $out")
+
+    val ks = KeyStore.getInstance("PKCS12")
+    val in = Files.newInputStream(store)
+    try ks.load(in, pass)
+    finally in.close()
+
+    val kmf    = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
+    kmf.init(ks, pass)
+    val server = SSLContext.getInstance("TLS")
+    server.init(kmf.getKeyManagers, null, null)
+
+    val trust  = KeyStore.getInstance(KeyStore.getDefaultType)
+    trust.load(null, null)
+    trust.setCertificateEntry("server", ks.getCertificate("server"))
+    val tmf    = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+    tmf.init(trust)
+    val client = SSLContext.getInstance("TLS")
+    client.init(null, tmf.getTrustManagers, null)
+    (server, client)
+  }
+
+  private def withServer(body: Int => Unit): Unit = {
+    val socket = material._1.getServerSocketFactory
+      .createServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))
+      .asInstanceOf[SSLServerSocket]
+    socket.setSoTimeout(10000)
+    val accept = Thread.ofVirtual().start { () =>
+      try { val s = socket.accept(); s.getInputStream.read(); s.close() }
+      catch { case _: Throwable => () }
+    }
+    try body(socket.getLocalPort)
+    finally { socket.close(); accept.join() }
+  }
+
+  private def upgrade(host: String, port: Int): Unit = {
+    val plain = new Socket()
+    plain.connect(new InetSocketAddress("127.0.0.1", port), 5000)
+    try { val _ = Tls.buildUpgrade(Some(TlsConfig(TrustSource.Custom(material._2))), host, port)(plain) }
+    finally plain.close()
+  }
+
+  test("hostname verification accepts a certificate whose SAN matches the connect host") {
+    withServer(port => upgrade("localhost", port))
+  }
+
+  test("hostname verification rejects a certificate whose SAN does not match the connect host") {
+    withServer { port =>
+      intercept[TlsError](upgrade("sage-mismatch.invalid", port))
+      ()
+    }
+  }
+}


### PR DESCRIPTION
Four fixes in the TLS/auth/config lane.

## TLS handshake failures escape the sealed hierarchy
`Tls.buildUpgrade` ran the handshake inside the returned upgrade closure without wrapping it, so a rejected certificate or hostname mismatch threw a raw `SSLException`. Depending on the caller it either escaped a subscription establish as an unmodeled defect (contradicting the error-handling docs) or collapsed to a bare `ConnectionLost`. The closure now catches the handshake failure and throws `TlsError` with the original cause attached — one seam that fixes both callers.

## Runtime-opened dedicated connections collapse TLS/auth to `ConnectionLost`
The blocking-command pool (`DedicatedPool.leaseAndSubmit`) and the standalone / master-replica transaction acquires caught everything as `NonFatal` and flattened it to `ConnectionLost`, discarding the cause — so a rotated cert or password (`WRONGPASS`) became undiagnosable. They now let a `SageException` through before the `NonFatal` fallback, matching the cluster path which already did this.

## `SageConfig.fromUri` parse errors leak the password
Every parse error interpolated the full URI, including `redis://user:pass@…` — the one credential-leak path (everything else redacts). Added `redactCredentials`, which masks the userinfo password (mirroring the parser's own tokenisation), and routed all error messages through it.

## Hostname verification had zero negative coverage
Hostname verification was correctly implemented but untested — deleting it passed the whole suite. Added `TlsSpec` (a unit test, no container): one self-signed cert with `SAN=dns:localhost`, a loopback `SSLServerSocket`, and two cases driving `Tls.buildUpgrade` — a matching host connects, a mismatched host fails with `TlsError`. Mutation-checked: disabling the verification block makes the negative case fail.

## Verified
All backend cells compile; `SageConfigSpec` (12) and `TlsSpec` (2) pass; related suites (`DedicatedPoolSpec`, `FaultSpec`) still green; scalafmt clean.