### PR TITLE
Fix pub/sub orphan, extreme-instant expiry, and opaque reconnect failures

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -212,7 +212,8 @@ final private[client] class MultiplexedConnection private (
           locked(if (state == State.Reconnecting) scheduleReconnect(attempt + 1))
         }
       } catch {
-        case NonFatal(_) => locked(if (state == State.Reconnecting) scheduleReconnect(attempt + 1))
+        case NonFatal(error) =>
+          locked(if (state == State.Reconnecting) { events.emit(SageEvent.Connection.ReconnectFailed(node, error)); scheduleReconnect(attempt + 1) })
       }
   }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -162,10 +162,11 @@ final private[client] class SubscriptionConnection(
   // bring a freshly-established socket Live, resubscribing everything registered (counters reset to this generation). In cluster mode it runs
   // once per connection with at most one Slot's worth of Shard channels registered, so the single SSUBSCRIBE never spans slots (CROSSSLOT).
   private def goLive(conn: Conn): Unit = {
-    var reconnect      = false
-    var notify         = false
+    var reconnect          = false
+    var notify             = false
     // conn.close() joins the reader whose onConnClosed needs `lock`, so tear down after releasing it (as closeOwned/close do)
-    var teardown: Conn = null
+    var teardown: Conn     = null
+    var failure: Throwable = null
     locked {
       if (state != State.Establishing && state != State.Reconnecting) teardown = conn
       else if (conn.isTerminated) {
@@ -182,19 +183,25 @@ final private[client] class SubscriptionConnection(
         val channels = channelSinks.keys.toVector
         val patterns = patternSinks.keys.toVector
         val shards   = shardSinks.keys.toVector
-        if (channels.nonEmpty) sendSubscribe(conn, Kind.Channel, channels)
-        if (patterns.nonEmpty) sendSubscribe(conn, Kind.Pattern, patterns)
-        if (shards.nonEmpty) sendSubscribe(conn, Kind.Shard, shards)
-        if (channels.isEmpty && patterns.isEmpty && shards.isEmpty) {
-          // everything closed during the establish; tear back down rather than hold an idle socket open
-          teardown = conn
-          current = null
-          state = State.Idle
-        } else {
-          state = State.Live
-          startWatchdog()
-          liveTarget = subscribeSent
+        try {
+          if (channels.nonEmpty) sendSubscribe(conn, Kind.Channel, channels)
+          if (patterns.nonEmpty) sendSubscribe(conn, Kind.Pattern, patterns)
+          if (shards.nonEmpty) sendSubscribe(conn, Kind.Shard, shards)
+        } catch {
+          // resubscribe write failed: drop this socket and clear current so a superseded generation can't keep dispatching, then rethrow
+          case e: Throwable => current = null; teardown = conn; failure = e
         }
+        if (failure == null)
+          if (channels.isEmpty && patterns.isEmpty && shards.isEmpty) {
+            // everything closed during the establish; tear back down rather than hold an idle socket open
+            teardown = conn
+            current = null
+            state = State.Idle
+          } else {
+            state = State.Live
+            startWatchdog()
+            liveTarget = subscribeSent
+          }
         established.signalAll()
         confirmed.signalAll()
       }
@@ -202,6 +209,7 @@ final private[client] class SubscriptionConnection(
     if (teardown != null) teardown.close()
     if (reconnect) scheduleReconnect(0)
     if (notify) onTerminated()
+    if (failure != null) throw failure
   }
 
   private def sendSubscribe(conn: Conn, kind: Kind, names: Vector[String]): Unit = {

--- a/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
@@ -220,6 +220,57 @@ class EventsSpec extends munit.FunSuite {
     )
   }
 
+  test("a failed reconnect establish surfaces the cause as ReconnectFailed instead of retrying opaquely") {
+    val node                                            = Some(Node("shard-a", 6379))
+    val rec                                             = new Recording
+    val scheduler                                       = new ManualScheduler
+    var healthy                                         = true // first establish's PING succeeds; the reconnect's is rejected, as a rotated password would be
+    val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
+      val respond: Bytes => Seq[Frame] = _ => Seq(if (healthy) Frame.SimpleString("PONG") else Frame.SimpleError("WRONGPASS invalid password"))
+      val t                            = new FakeTransport(onFrame, onClosed, respond)
+      transports += t
+      t
+    }
+    val connection                                      =
+      MultiplexedConnection
+        .connect(factory, scheduler, Vector(Connection.ping()), fixedBackoff, noWatchdog, 1.second, Duration.Zero, 1L << 20, node, rec)
+    val _                                               = connection
+
+    healthy = false
+    transports.head.close()
+    scheduler.advance(1.milli)
+    assert(
+      rec.events.exists { case SageEvent.Connection.ReconnectFailed(`node`, _: sage.SageException.ServerError) => true; case _ => false },
+      rec.events
+    )
+  }
+
+  test("a reconnect establish aborted by close() is silent: shutdown is intentional, not a reconnect failure") {
+    val node                                            = Some(Node("shard-a", 6379))
+    val rec                                             = new Recording
+    val scheduler                                       = new ManualScheduler
+    var attempt                                         = 0
+    var connection: MultiplexedConnection               = null
+    val first                                           = new java.util.concurrent.atomic.AtomicReference[FakeTransport]()
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
+      attempt += 1
+      if (attempt == 1) { val t = new FakeTransport(onFrame, onClosed, _ => Seq(Frame.SimpleString("PONG"))); first.set(t); t }
+      else
+        new Transport {
+          def start(): Unit                    = { connection.close(); throw new RuntimeException("aborted by close") }
+          def send(item: Transport.Item): Unit = ()
+          def close(): Unit                    = ()
+        }
+    }
+    connection = MultiplexedConnection
+      .connect(factory, scheduler, Vector(Connection.ping()), fixedBackoff, noWatchdog, 1.second, Duration.Zero, 1L << 20, node, rec)
+
+    first.get().close()
+    scheduler.advance(1.milli)
+    assert(!rec.events.exists { case _: SageEvent.Connection.ReconnectFailed => true; case _ => false }, rec.events)
+  }
+
   // --- cache -----------------------------------------------------------------------------------------------------------------------------
 
   test("a cached read misses then hits") {

--- a/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
@@ -362,4 +362,27 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
     sink.cancelNext(_ => ())
     intercept[IllegalStateException](sink.next(_ => ()))
   }
+
+  test("a resubscribe write that fails during goLive tears the socket down instead of orphaning a subscribed connection") {
+    final class FailingSubscribe(onFrame: Frame => Unit, onClosed: () => Unit) extends Transport {
+      var closeCount                       = 0
+      def start(): Unit                    = ()
+      def send(item: Transport.Item): Unit = {
+        if (item.payload.asUtf8String.contains("\r\nSUBSCRIBE\r\n")) throw new RuntimeException("write failed")
+        item.writeAttempted()
+        serverResponder(item.payload).foreach(onFrame)
+      }
+      def close(): Unit                    = { closeCount += 1; onClosed() }
+    }
+    val transports = mutable.ArrayBuffer.empty[FailingSubscribe]
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
+      val t = new FailingSubscribe(onFrame, onClosed); transports += t; t
+    }
+    val connection                                      =
+      new SubscriptionConnection(factory, Vector(Connection.ping()), new ManualScheduler, fixedBackoff, noWatchdog, 1000L, 16, () => true)
+
+    intercept[RuntimeException](connection.subscribeChannels(Vector("news")))
+    assertEquals(transports.head.closeCount, 1, "the socket whose resubscribe failed must be closed, not left dispatching")
+    assert(connection.isEmpty, "the phantom sink is deregistered so the connection holds nothing")
+  }
 }

--- a/sage-core/src/main/scala/sage/SageEvent.scala
+++ b/sage-core/src/main/scala/sage/SageEvent.scala
@@ -35,6 +35,14 @@ object SageEvent {
   object Connection {
     final case class Connected(node: Option[Node])    extends Connection
     final case class Disconnected(node: Option[Node]) extends Connection
+
+    /**
+      * A reconnect attempt failed to establish, carrying the cause so a permanent failure (a rejected password, an unsupported server, bad
+      * TLS material) is visible rather than looking like an endless generic reconnect. The runtime still backs off and retries — the server
+      * side may recover. The error carries no credentials (a `WRONGPASS` names no password). Not fired for the initial connect, whose failure
+      * the caller already sees.
+      */
+    final case class ReconnectFailed(node: Option[Node], error: Throwable) extends Connection
   }
 
   /**

--- a/sage-core/src/main/scala/sage/commands/Decode.scala
+++ b/sage-core/src/main/scala/sage/commands/Decode.scala
@@ -326,8 +326,17 @@ private[commands] object TimeArgs {
   // an expiry must never land earlier than asked, and truncation would turn a sub-millisecond expiry into 0 (immediate)
   def millis(duration: FiniteDuration): Long = Math.ceilDiv(duration.toNanos, 1000000L)
 
+  // saturate rather than overflow: an extreme Instant must not throw while building a command, and clamping up never lands earlier than asked
   def millis(timestamp: Instant): Long =
-    Math.addExact(Math.multiplyExact(timestamp.getEpochSecond, 1000L), Math.ceilDiv(timestamp.getNano.toLong, 1000000L))
+    satAdd(satMul(timestamp.getEpochSecond, 1000L), Math.ceilDiv(timestamp.getNano.toLong, 1000000L))
+
+  private def satMul(a: Long, b: Long): Long =
+    try Math.multiplyExact(a, b)
+    catch { case _: ArithmeticException => if ((a ^ b) < 0L) Long.MinValue else Long.MaxValue }
+
+  private def satAdd(a: Long, b: Long): Long =
+    try Math.addExact(a, b)
+    catch { case _: ArithmeticException => if (a < 0L) Long.MinValue else Long.MaxValue }
 
   def relative(duration: FiniteDuration): Vector[Bytes] =
     if (wholeSeconds(duration)) Vector(Ex, Bytes.utf8(duration.toSeconds.toString))

--- a/sage-core/src/test/scala/sage/commands/CommandSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/CommandSpec.scala
@@ -1,9 +1,17 @@
 package sage.commands
 
+import java.time.Instant
+
 import sage.{Bytes, SageException}
 import sage.protocol.{Frame, RespParser}
 
 class CommandSpec extends munit.FunSuite {
+
+  test("expireAt with an extreme instant saturates instead of throwing while building the command") {
+    val command = Keys.expireAt("k", Instant.MAX)
+    assertEquals(command.name, "PEXPIREAT")
+    assert(command.args.exists(_.sameBytes(Bytes.utf8(Long.MaxValue.toString))), command.args.map(_.asUtf8String))
+  }
 
   test("GET encodes against the golden wire frame") {
     assertEquals(Strings.get[String, String]("foo").encode.asUtf8String, "*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n")


### PR DESCRIPTION
Three robustness fixes.

## A pub/sub reconnect can orphan a subscribed socket
`goLive` set `current = conn` before the interruptible resubscribe writes with no rollback. If `conn.send` threw (e.g. an interrupt), the block unwound leaving the socket open and `current` pointing at it — and since message `dispatch` isn't gated on `current`, that stale reader kept delivering pushes after a later generation resubscribed on a new socket. The resubscribe is now wrapped: on any throw it clears `current`, tears the socket down (after the lock), and rethrows so the caller unwinds/reconnects.

## Extreme-instant expiry builders threw while building the command
`TimeArgs.millis` used `multiplyExact`/`addExact`, so `expireAt` / `pexpireAt` / `RESTORE ABSTTL` with an extreme `Instant` (e.g. `Instant.MAX`) threw `ArithmeticException` during command construction. It now saturates to `Long.MaxValue`, which keeps the invariant that an expiry never lands earlier than asked.

## Permanent auth/bootstrap failure during reconnect was opaque
A failed reconnect establish was swallowed and silently retried, so a rotated password looked like generic reconnecting (the initial connect reports auth errors, later reconnects didn't). Added `SageEvent.Connection.ReconnectFailed(node, error)` and emit it from the reconnect failure path, carrying the cause (e.g. `WRONGPASS`) so listeners can see it. The emit is gated on the connection still being in `Reconnecting`, so a `close()` that aborts an in-flight establish stays silent — shutdown is intentional, not a reconnect failure. The error carries no credentials.

## Tests
- `SubscriptionConnectionSpec`: a failing resubscribe write closes the socket and leaves the connection empty (fails if the rollback is removed).
- `CommandSpec`: `expireAt(Instant.MAX)` saturates to `PEXPIREAT Long.MaxValue` instead of throwing.
- `EventsSpec`: a failed reconnect establish emits `ReconnectFailed` with the cause; a `close()`-aborted establish emits nothing. Both mutation-verified.

All backend cells compile; affected suites green; scalafmt clean.