### PR TITLE
Harden subscription cleanup, URI redaction, and subscription observability

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
+++ b/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
@@ -224,21 +224,17 @@ object SageConfig {
   }
 
   private def redactCredentials(uri: String): String =
-    uri.split("://", 2) match {
-      case Array(scheme, rest) =>
-        val slash     = rest.indexOf('/')
-        val authority = if (slash < 0) rest else rest.substring(0, slash)
-        val tail      = if (slash < 0) "" else rest.substring(slash)
-        authority.lastIndexOf('@') match {
-          case -1 => uri
-          case at =>
-            val redacted = authority.substring(0, at).indexOf(':') match {
-              case -1 => "<redacted>"
-              case i  => s"${authority.substring(0, i)}:<redacted>"
-            }
-            s"$scheme://$redacted${authority.substring(at)}$tail"
+    uri.lastIndexOf('@') match {
+      case -1 => uri
+      case at =>
+        val prefix    = uri.substring(0, at)
+        val schemeEnd = prefix.indexOf("://") match { case -1 => 0; case i => i + 3 }
+        val userinfo  = prefix.substring(schemeEnd)
+        val redacted  = userinfo.indexOf(':') match {
+          case -1 => "<redacted>"
+          case i  => s"${userinfo.substring(0, i)}:<redacted>"
         }
-      case _                   => uri
+        s"${prefix.substring(0, schemeEnd)}$redacted${uri.substring(at)}"
     }
 
   // split on the first literal ':' (a ':' inside a credential is percent-encoded as %3A), then decode each half

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2298,7 +2298,8 @@ object Client {
           watchdog,
           connectTimeout.toMillis,
           pubsub.bufferSize,
-          () => connection.isLive
+          () => connection.isLive,
+          events = events
         )
         new Live(connection, pool, subscriptions, cachingEnabled, events)
       }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -357,7 +357,8 @@ final private[client] class MasterReplicaLive(
             config.pubsub.bufferSize,
             // the subscription opens its own socket, so gate on a resolved master, not a live pooled connection a pub/sub-only client never creates
             () => !closed && masterNodeRef.get() != null,
-            onReconnect = () => refreshRolesBeforeRehome()
+            onReconnect = () => refreshRolesBeforeRehome(),
+            events = events
           )
         }
         s = subscriptions

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -8,9 +8,10 @@ import scala.collection.mutable
 import scala.concurrent.duration.*
 import scala.util.control.NonFatal
 
-import sage.Bytes
-import sage.SageException.NotConnected
+import sage.{Bytes, SageEvent, SageException}
+import sage.SageException.{ConnectionFailed, NotConnected}
 import sage.client.{BackoffConfig, WatchdogConfig}
+import sage.cluster.Node
 import sage.commands.{Command, Connection, Pubsub, Reply}
 import sage.protocol.Frame
 
@@ -37,7 +38,9 @@ final private[client] class SubscriptionConnection(
   isLive: () => Boolean,
   cluster: Boolean = false,
   onTerminated: () => Unit = () => (),
-  onReconnect: () => Unit = () => ()
+  onReconnect: () => Unit = () => (),
+  events: Events = Events.disabled,
+  node: Option[Node] = None
 ) extends Placement.ShardConn {
   import SubscriptionConnection.*
 
@@ -149,7 +152,10 @@ final private[client] class SubscriptionConnection(
   def detach(sink: Sink, names: Vector[String], kind: Kind): Boolean =
     locked {
       val emptied = deregister(sink, names, kind)
-      if (emptied.nonEmpty && state == State.Live) current.send(kind.unsubscribeWire(emptied))
+      // best-effort: swallow a failed (or interrupted) unsubscribe write so the caller still learns emptiness and terminates the sink
+      if (emptied.nonEmpty && state == State.Live)
+        try current.send(kind.unsubscribeWire(emptied))
+        catch { case NonFatal(_) | _: InterruptedException => () }
       isEmptyUnlocked
     }
 
@@ -250,7 +256,14 @@ final private[client] class SubscriptionConnection(
 
   private def establish(): Conn = {
     val conn = new Conn
-    conn.start()
+    try conn.start()
+    catch {
+      case e: SageException => throw e
+      case NonFatal(e)      =>
+        val failed = ConnectionFailed(s"could not open the subscription connection: $e")
+        failed.initCause(e)
+        throw failed
+    }
     runBootstrap(conn)
     conn
   }
@@ -277,7 +290,10 @@ final private[client] class SubscriptionConnection(
     if (proceed) {
       onReconnect()
       try goLive(establish())
-      catch { case NonFatal(_) => locked(if (state == State.Reconnecting) scheduleReconnect(attempt + 1)) }
+      catch {
+        case NonFatal(error) =>
+          locked(if (state == State.Reconnecting) { events.emit(SageEvent.Connection.ReconnectFailed(node, error)); scheduleReconnect(attempt + 1) })
+      }
     }
   }
 
@@ -347,10 +363,12 @@ final private[client] class SubscriptionConnection(
 
   // standalone: the connection owns the sink, so it both unsubscribes and terminates it; tears the socket down when its last sink closes
   private def closeOwned(sink: Sink): Unit = {
-    var teardown: Conn = null
+    var teardown: Conn     = null
+    var failure: Throwable = null
     locked {
       val emptied = deregister(sink, sink.names, sink.kind)
-      if (emptied.nonEmpty && state == State.Live) current.send(sink.kind.unsubscribeWire(emptied))
+      try if (emptied.nonEmpty && state == State.Live) current.send(sink.kind.unsubscribeWire(emptied))
+      catch { case e: Throwable => failure = e }
       if (isEmptyUnlocked && (state == State.Live || state == State.Reconnecting)) {
         stopWatchdog()
         teardown = current
@@ -360,6 +378,7 @@ final private[client] class SubscriptionConnection(
     }
     sink.terminate()
     if (teardown != null) teardown.close()
+    if (failure != null) throw failure
   }
 
   // atomic empty-check + Closed transition, so a racing attach can't bind a sink to a connection about to close

--- a/sage-client/shared/src/test/scala/sage/client/SageConfigSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/SageConfigSpec.scala
@@ -78,11 +78,14 @@ class SageConfigSpec extends munit.FunSuite {
     assert(SageConfig.fromUri("redis://h?ssl=true").isLeft) // query params unsupported
   }
 
-  test("a parse error never echoes the password back") {
+  test("a parse error never echoes the password back, even when the URI is the kind that fails to parse") {
     def problem(uri: String): String = SageConfig.fromUri(uri).swap.getOrElse(fail(s"expected a Left for $uri"))
     assert(!problem("redis://alice:hunter2@h:0").contains("hunter2"))
     assert(!problem("redis://:hunter2@h:0").contains("hunter2"))
     assert(!problem("redis://:p%40ss@h?x=1").contains("p%40ss"))
+    assert(!problem("memcache://alice:hunter2@h").contains("hunter2")) // unsupported scheme still parses far enough to leak
+    assert(!problem("alice:hunter2@h").contains("hunter2"))            // missing scheme
+    assert(!problem("redis://alice:hun/ter2@h").contains("hun/ter2"))  // unencoded '/' in the password
     assertEquals(problem("redis://alice:hunter2@h:0"), "invalid redis URI 'redis://alice:<redacted>@h:0': invalid port in 'h:0'")
   }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
@@ -385,4 +385,110 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
     assertEquals(transports.head.closeCount, 1, "the socket whose resubscribe failed must be closed, not left dispatching")
     assert(connection.isEmpty, "the phantom sink is deregistered so the connection holds nothing")
   }
+
+  test("a failed unsubscribe write during close still wakes the parked consumer and tears the socket down") {
+    final class FailingUnsubscribe(onFrame: Frame => Unit, onClosed: () => Unit) extends Transport {
+      var closeCount                       = 0
+      def start(): Unit                    = ()
+      def send(item: Transport.Item): Unit = {
+        if (item.payload.asUtf8String.contains("\r\nUNSUBSCRIBE\r\n")) throw new RuntimeException("write failed")
+        item.writeAttempted()
+        serverResponder(item.payload).foreach(onFrame)
+      }
+      def close(): Unit                    = { closeCount += 1; onClosed() }
+    }
+    val transports = mutable.ArrayBuffer.empty[FailingUnsubscribe]
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
+      val t = new FailingUnsubscribe(onFrame, onClosed); transports += t; t
+    }
+    val connection                                      =
+      new SubscriptionConnection(factory, Vector(Connection.ping()), new ManualScheduler, fixedBackoff, noWatchdog, 1000L, 16, () => true)
+
+    val sub   = connection.subscribeChannels(Vector("news"))
+    val box   = new AtomicReference[Option[SubscriptionConnection.Delivery]]()
+    val latch = new CountDownLatch(1)
+    sub.next { delivery => box.set(delivery); latch.countDown() }
+
+    intercept[RuntimeException](sub.close())
+    assert(latch.await(1, java.util.concurrent.TimeUnit.SECONDS), "the parked consumer must be woken, not left hanging")
+    assertEquals(box.get(), None)
+    assertEquals(transports.head.closeCount, 1)
+  }
+
+  test("a connect failure on the subscribe path surfaces as a modeled ConnectionFailed, not a raw defect") {
+    val factory: MultiplexedConnection.TransportFactory = (_, _) =>
+      new Transport {
+        def start(): Unit                    = throw new java.net.ConnectException("connection refused")
+        def send(item: Transport.Item): Unit = ()
+        def close(): Unit                    = ()
+      }
+    val connection                                      =
+      new SubscriptionConnection(factory, Vector(Connection.ping()), new ManualScheduler, fixedBackoff, noWatchdog, 1000L, 16, () => true)
+
+    intercept[sage.SageException.ConnectionFailed](connection.subscribeChannels(Vector("news")))
+  }
+
+  test("a failed subscription reconnect emits ReconnectFailed instead of retrying in silence") {
+    val recorded                                        = new java.util.concurrent.ConcurrentLinkedQueue[sage.SageEvent]()
+    val events                                          = new Events {
+      def enabled: Boolean                      = true
+      def emitsEvents: Boolean                  = true
+      def tracer: Option[sage.CommandTracer]    = None
+      def serverNode: Option[sage.cluster.Node] = None
+      def emit(event: sage.SageEvent): Unit     = { val _ = recorded.add(event) }
+      def close(): Unit                         = ()
+    }
+    var healthy                                         = true
+    val respond: Bytes => Seq[Frame]                    = payload =>
+      if (!healthy && payload.asUtf8String.contains("\r\nPING\r\n")) Seq(Frame.SimpleError("WRONGPASS invalid password"))
+      else serverResponder(payload)
+    val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
+      val t = new FakeTransport(onFrame, onClosed, respond); transports += t; t
+    }
+    val scheduler                                       = new ManualScheduler
+    val connection                                      =
+      new SubscriptionConnection(factory, Vector(Connection.ping()), scheduler, fixedBackoff, noWatchdog, 1000L, 16, () => true, events = events)
+
+    connection.subscribeChannels(Vector("news"))
+    healthy = false
+    transports.head.close()
+    scheduler.advance(1.milli)
+    assert(
+      recorded.toArray.exists {
+        case sage.SageEvent.Connection.ReconnectFailed(None, _: sage.SageException.ServerError) => true
+        case _                                                                                  => false
+      },
+      recorded.toArray.mkString(", ")
+    )
+  }
+
+  test("detach swallows an interrupted unsubscribe write so a cluster close can still terminate the sink") {
+    final class InterruptingUnsubscribe(onFrame: Frame => Unit, onClosed: () => Unit) extends Transport {
+      def start(): Unit                    = ()
+      def send(item: Transport.Item): Unit = {
+        if (item.payload.asUtf8String.contains("\r\nUNSUBSCRIBE\r\n")) throw new InterruptedException("interrupted")
+        item.writeAttempted()
+        serverResponder(item.payload).foreach(onFrame)
+      }
+      def close(): Unit                    = onClosed()
+    }
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => new InterruptingUnsubscribe(onFrame, onClosed)
+    val connection =
+      new SubscriptionConnection(
+        factory,
+        Vector(Connection.ping()),
+        new ManualScheduler,
+        fixedBackoff,
+        noWatchdog,
+        1000L,
+        16,
+        () => true,
+        cluster = true
+      )
+
+    val sink = new SubscriptionConnection.Sink(Vector("news"), SubscriptionConnection.Kind.Channel, 16)
+    connection.attach(sink, Vector("news"), SubscriptionConnection.Kind.Channel)
+    assert(connection.detach(sink, Vector("news"), SubscriptionConnection.Kind.Channel)) // must return, not throw the interrupt
+  }
 }


### PR DESCRIPTION
Four subscription/config robustness fixes.

## Interruptible unsubscribe write could hang a parked consumer
`closeOwned` and `detach` issued the unsubscribe write inside their locked block, before `sink.terminate()`. A synchronous throw there — notably an `InterruptedException` from `queue.put` on the calling fiber — unwound past `terminate()`, so a consumer parked in `next` hung forever, and for `closeOwned` the socket leaked too. Both now guard the write: `closeOwned` captures the failure, still runs terminate/teardown, and rethrows; `detach` swallows best-effort (`NonFatal` or `InterruptedException`, not genuine fatals) so the caller still learns emptiness and reaches `terminate()`. This covers the cluster/classic close paths (`closeClassic`) that call `detach` before terminating.

## `fromUri` redaction failed exactly on the URIs that leak
`redactCredentials` reused the parser's tokenization, so a missing scheme or an unencoded `/` in the password — the very inputs that fail to parse — defeated redaction, and the parse-error `Left` (the string most likely to be logged) still embedded the password. It now masks on the last `@` in the whole string, independent of whether the URI parses.

## Subscription connect failures escaped the sealed hierarchy
A raw `ConnectException`/`UnknownHostException` from the subscribe path's socket open surfaced as a ZIO defect / Kyo panic. `SubscriptionConnection.establish` now maps a non-`SageException` connect failure to `ConnectionFailed` (preserving `TlsError` and attaching the cause), matching the dedicated-pool path.

## Subscription reconnect loop was observability-blind
The reconnect loop had no `Events` plumbing, so a rotated password on a pub/sub-only client retried forever in total silence. Threaded `Events` into `SubscriptionConnection` (default disabled) and emit `SageEvent.Connection.ReconnectFailed` from the reconnect loop, gated on the connection still reconnecting so a `close()`-aborted establish stays silent. Wired at the standalone and master-replica construction sites.

## Tests (all mutation-verified)
- a failed unsubscribe write during close still wakes the parked consumer and tears the socket down;
- `detach` swallows an interrupted unsubscribe so a cluster close still terminates the sink;
- a connect failure on subscribe surfaces as `ConnectionFailed`;
- a failed subscription reconnect emits `ReconnectFailed`;
- parse errors never echo the password, including missing-scheme / unsupported-scheme / unencoded-`/` cases.

All backend cells compile; affected suites green; scalafmt clean.