### PR TITLE
expose `DecodeError.fromThrowable` publicly

### DIFF
--- a/sage-core/src/main/scala/sage/SageException.scala
+++ b/sage-core/src/main/scala/sage/SageException.scala
@@ -21,7 +21,7 @@ object SageException {
 
   object DecodeError {
 
-    private[sage] def fromThrowable(error: Throwable): DecodeError = {
+    def fromThrowable(error: Throwable): DecodeError = {
       val wrapped = DecodeError("a value the codec could decode", s"the codec threw $error")
       wrapped.initCause(error)
       wrapped


### PR DESCRIPTION
Exposes the `fromThrowable` constructor as a convenience function.