### PR TITLE
Fix WAIT/WAITAOF connection affinity and cluster broadcast

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -15,7 +15,7 @@ import sage.SageException.{ConnectionLost, CrossSlot, NotConnected, ServerError}
 import sage.client.{BackoffConfig, ClusterConfig, DedicatedPoolConfig, ReadFrom, SageConfig, WatchdogConfig}
 import sage.cluster.{ClusterTopology, Node, NodeGroup, Redirect, RedirectKind, Rejected, Route, Shard, Slot, SplitPlan}
 import sage.codec.{KeyCodec, ValueCodec}
-import sage.commands.{Cluster, Command, Connection, Pipeline, Reply}
+import sage.commands.{BroadcastReduce, Cluster, Command, Connection, Pipeline, Reply}
 import sage.protocol.Frame
 
 /**
@@ -199,8 +199,11 @@ final private[client] class ClusterLive(
     else {
       val topology = topologyRef.get()
       if (command.allMasters)
-        if (command.aggregate) sendToAllMastersAggregated(topology, command, complete)
-        else sendToAllMasters(topology, command, complete)
+        command.broadcast match {
+          case BroadcastReduce.First      => sendToAllMasters(topology, command, complete)
+          case BroadcastReduce.Concat     => broadcastCombine(topology, command, concatFrames, complete)
+          case BroadcastReduce.Fold(fold) => broadcastCombine(topology, command, _.reduce(fold), complete)
+        }
       else
         topology.route(command) match {
           case Route.ToNode(node, slot) =>
@@ -313,9 +316,15 @@ final private[client] class ClusterLive(
     }
   }
 
-  // an aggregating broadcast (KEYS): every slot-owning master returns its node-local slice, which we merge as raw frames and decode once,
-  // since no single node sees the whole keyspace; any node failing fails the command
-  private def sendToAllMastersAggregated[A](topology: ClusterTopology, command: Command[A], complete: Try[A] => Unit): Unit = {
+  // an all-masters broadcast whose per-node replies fold into one: KEYS concatenates each node's node-local slice (no single node sees the
+  // whole keyspace), WAIT/WAITAOF reduce to the weakest shard. Frames are collected raw and combined before a single decode; any node
+  // failing fails the command
+  private def broadcastCombine[A](
+    topology: ClusterTopology,
+    command: Command[A],
+    combine: Vector[Frame] => Frame,
+    complete: Try[A] => Unit
+  ): Unit = {
     val masters = slotOwningMasters(topology)
     if (masters.isEmpty) sendToAny(topology, command, cluster.maxRedirects, complete)
     else {
@@ -331,7 +340,7 @@ final private[client] class ClusterLive(
         if (remaining.decrementAndGet() == 0)
           Option(firstError.get()) match {
             case Some(e) => complete(Failure(e))
-            case None    => complete(decodeMerged(command, mergeFrames(frames, masters.size)))
+            case None    => complete(Try(combine(collectFrames(frames, masters.size))).flatMap(decodeMerged(command, _)))
           }
       }
       masters.iterator.zipWithIndex.foreach { case (node, index) =>
@@ -344,19 +353,19 @@ final private[client] class ClusterLive(
     }
   }
 
-  private def mergeFrames(frames: java.util.concurrent.atomic.AtomicReferenceArray[Frame], size: Int): Frame = {
-    val merged = Vector.newBuilder[Frame]
-    var i      = 0
-    while (i < size) {
-      frames.get(i) match {
-        case Frame.Array(elements) => merged ++= elements
-        case Frame.Set(elements)   => merged ++= elements
-        case other                 => merged += other
-      }
-      i += 1
-    }
-    Frame.Array(merged.result())
+  private def collectFrames(frames: java.util.concurrent.atomic.AtomicReferenceArray[Frame], size: Int): Vector[Frame] = {
+    val out = Vector.newBuilder[Frame]
+    var i   = 0
+    while (i < size) { out += frames.get(i); i += 1 }
+    out.result()
   }
+
+  private def concatFrames(frames: Vector[Frame]): Frame =
+    Frame.Array(frames.flatMap {
+      case Frame.Array(elements) => elements
+      case Frame.Set(elements)   => elements
+      case other                 => Vector(other)
+    })
 
   private def decodeMerged[A](command: Command[A], merged: Frame): Try[A] = Reply.decode(command, merged)
 

--- a/sage-client/shared/src/main/scala/sage/exports.scala
+++ b/sage-client/shared/src/main/scala/sage/exports.scala
@@ -129,6 +129,6 @@ export sage.commands.{
   ZRange
 }
 export sage.commands.{as, asArray, asArrayOf, asLong, asString}
-export sage.commands.{Attempt, Command, Commands, Execution}
+export sage.commands.{Attempt, BroadcastReduce, Command, Commands, Execution}
 // raw-Frame escape hatch for eval/fcall replies
 export sage.protocol.Frame

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -7,10 +7,10 @@ import scala.concurrent.duration.*
 import kyo.compat.*
 
 import sage.Bytes
-import sage.SageException.{CrossSlot, NotConnected, ServerError}
+import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, NotConnected, ServerError}
 import sage.client.internal.{ClusterLive, FakeTransport, MultiplexedConnection, Scheduler}
 import sage.cluster.{Node, Slot}
-import sage.commands.{Command, Connection, Keys, Strings}
+import sage.commands.{BroadcastReduce, Command, Connection, Keys, Server, Strings}
 import sage.protocol.Frame
 
 class ClusterClientSpec extends munit.FunSuite {
@@ -109,6 +109,17 @@ class ClusterClientSpec extends munit.FunSuite {
       transports.values.flatten
         .find(_.written.exists(_.asUtf8String.contains("\r\nSUBSCRIBE\r\n")))
         .foreach(_.close())
+
+    def drop(node: Node): Unit = transports.getOrElse(node, mutable.ArrayBuffer.empty).foreach(_.close())
+
+    def deliver(node: Node, frame: Frame): Unit =
+      transports.getOrElse(node, mutable.ArrayBuffer.empty).lastOption.foreach(_.emit(frame))
+  }
+
+  private def awaitWritten(fixture: Fixture, node: Node, token: String): Unit = {
+    val deadline = System.nanoTime() + 2000000000L
+    while (!fixture.written(node).exists(_.contains(token)) && System.nanoTime() < deadline) Thread.sleep(5)
+    assert(fixture.written(node).exists(_.contains(token)), s"$node never received $token")
   }
 
   private def wholeClusterOn(node: Node): Frame = slotsFrame((node, 0, Slot.Count - 1))
@@ -148,6 +159,112 @@ class ClusterClientSpec extends munit.FunSuite {
       assertEquals(result.toSet, (aKeys ++ bKeys).toSet)
       assert(fixture.written(nodeA).exists(_.contains("KEYS")), "nodeA did not receive KEYS")
       assert(fixture.written(nodeB).exists(_.contains("KEYS")), "nodeB did not receive KEYS")
+    }
+  }
+
+  test("WAIT broadcasts to every slot-owning master and returns the weakest shard's count") {
+    val mid       = Slot.Count / 2
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else if (text.contains("WAIT")) Seq(Frame.Integer(if (node == nodeA) 2L else 1L))
+      else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Server.waitReplicas(1L, 100.millis)).unsafeRun.map { result =>
+      assertEquals(result, 1L)
+      assert(fixture.written(nodeA).exists(_.contains("WAIT")), "nodeA did not receive WAIT")
+      assert(fixture.written(nodeB).exists(_.contains("WAIT")), "nodeB did not receive WAIT")
+    }
+  }
+
+  test("WAIT fails when any master fails, rather than reporting a partial durability signal") {
+    val mid       = Slot.Count / 2
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else if (text.contains("WAIT")) Seq(if (node == nodeA) Frame.Integer(2L) else Frame.SimpleError("ERR replication offset unavailable"))
+      else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Server.waitReplicas(1L, 100.millis)).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[ServerError], s"expected ServerError, got $error")
+    }
+  }
+
+  test("WAIT surfaces a malformed master reply rather than hiding it behind a valid one") {
+    val mid       = Slot.Count / 2
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else if (text.contains("WAIT")) Seq(if (node == nodeA) Frame.Integer(2L) else Frame.BulkString(Bytes.utf8("nonsense")))
+      else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Server.waitReplicas(1L, 100.millis)).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[DecodeError], s"expected DecodeError, got $error")
+    }
+  }
+
+  test("WAIT fails when a master's connection cannot be established, not only on a server error") {
+    val mid       = Slot.Count / 2
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else if (text.contains("WAIT")) Seq(Frame.Integer(2L))
+      else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA), unreachable = Set(nodeB))
+
+    fixture.live.run(Server.waitReplicas(1L, 100.millis)).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[NotConnected], s"expected NotConnected, got $error")
+    }
+  }
+
+  test("a broadcast fold that throws on a reply arriving after dispatch fails the command rather than hanging the caller") {
+    val mid       = Slot.Count / 2
+    val behaviour =
+      (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1))) else Nil
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+    val throwing  = Command[Long](
+      "WAIT",
+      Command.NoKeys,
+      Vector(Bytes.utf8("0"), Bytes.utf8("0")),
+      _ => Right(0L),
+      allMasters = true,
+      broadcast = BroadcastReduce.Fold((_, _) => throw new RuntimeException("boom"))
+    )
+
+    val running = fixture.live.run(throwing).unsafeRun.failed
+    awaitWritten(fixture, nodeA, "WAIT")
+    awaitWritten(fixture, nodeB, "WAIT")
+    fixture.deliver(nodeA, Frame.Integer(1L))
+    fixture.deliver(nodeB, Frame.Integer(1L))
+    running.map(error => assertEquals(error.getMessage, "boom"))
+  }
+
+  test("WAIT fails when a master's connection drops while the barrier is pending, rather than returning partially or hanging") {
+    val mid       = Slot.Count / 2
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else if (text.contains("WAIT")) if (node == nodeA) Seq(Frame.Integer(2L)) else Nil
+      else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    val running = fixture.live.run(Server.waitReplicas(1L, 5.seconds)).unsafeRun.failed
+    awaitWritten(fixture, nodeB, "WAIT")
+    fixture.drop(nodeB)
+    running.map(error => assert(error.isInstanceOf[ConnectionLost], s"expected ConnectionLost, got $error"))
+  }
+
+  test("WAITAOF broadcasts to every slot-owning master and returns component-wise minimums") {
+    val mid                               = Slot.Count / 2
+    def pair(local: Long, replicas: Long) = Frame.Array(Vector(Frame.Integer(local), Frame.Integer(replicas)))
+    val behaviour                         = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else if (text.contains("WAITAOF")) Seq(if (node == nodeA) pair(2L, 2L) else pair(1L, 3L))
+      else Seq(Frame.Null)
+    val fixture                           = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Server.waitAof(1L, 1L, 100.millis)).unsafeRun.map { result =>
+      assertEquals(result, (1L, 2L))
+      assert(fixture.written(nodeA).exists(_.contains("WAITAOF")), "nodeA did not receive WAITAOF")
+      assert(fixture.written(nodeB).exists(_.contains("WAITAOF")), "nodeB did not receive WAITAOF")
     }
   }
 

--- a/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
@@ -11,7 +11,7 @@ import kyo.compat.*
 import sage.{Bytes, Outcome, SageEvent, SageListener}
 import sage.SageException.{ConnectionFailed, NotConnected, UnsupportedServer}
 import sage.client.internal.{Client, Events, FakeTransport, ManualScheduler, MultiplexedConnection}
-import sage.commands.{Command, Execution}
+import sage.commands.{Command, Execution, Server}
 import sage.protocol.Frame
 
 class ConnectSpec extends munit.FunSuite {
@@ -120,6 +120,41 @@ class ConnectSpec extends munit.FunSuite {
     val (factory, _)                            = scripted(helloThenPong)
     val native: zio.ZIO[Any, Throwable, String] = Client.connectWith(factory).flatMap(client => client.ping()).lower
     CIO.lift(native).unsafeRun.map(result => assertEquals(result, "PONG"))
+  }
+
+  private def assertBarrierRidesMux(barrier: Command[?], barrierReply: Frame, token: String): scala.concurrent.Future[Unit] = {
+    val transports                                      = new ConcurrentLinkedQueue[FakeTransport]()
+    val reply: Bytes => Seq[Frame]                      = payload =>
+      if (payload.asUtf8String.contains("HELLO")) Seq(helloReply)
+      else if (payload.asUtf8String.contains(token)) Seq(barrierReply)
+      else Seq(Frame.SimpleString("OK"))
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
+      val transport = new FakeTransport(onFrame, onClosed, reply)
+      transports.add(transport)
+      transport
+    }
+    val write                                           =
+      Command("SET", Command.NoKeys, Vector(Bytes.utf8("k"), Bytes.utf8("v")), (_: Frame) => Right(()), Execution.Ordinary)
+    Client
+      .connectWith(factory)
+      .flatMap(client => client.run(write).flatMap(_ => client.run(barrier)))
+      .unsafeRun
+      .map { _ =>
+        assertEquals(transports.size, 1)
+        val payloads   = transports.peek().written.map(_.asUtf8String).toVector
+        val setIdx     = payloads.indexWhere(_.contains("SET"))
+        val barrierIdx = payloads.indexWhere(_.contains(token))
+        assert(setIdx >= 0 && barrierIdx >= 0, s"SET and $token must both ride the multiplexed transport, got $payloads")
+        assert(setIdx < barrierIdx, s"$token must follow the SET on the same transport, got $payloads")
+      }
+  }
+
+  test("WAIT rides the multiplexed connection carrying the preceding writes, never a dedicated connection") {
+    assertBarrierRidesMux(Server.waitReplicas(0L, 100.millis), Frame.Integer(0L), "WAIT")
+  }
+
+  test("WAITAOF rides the multiplexed connection carrying the preceding writes, never a dedicated connection") {
+    assertBarrierRidesMux(Server.waitAof(0L, 0L, 100.millis), Frame.Array(Vector(Frame.Integer(0L), Frame.Integer(0L))), "WAITAOF")
   }
 
   test("a pipeline carrying a blocking command fails fast without reaching the socket") {

--- a/sage-core/src/main/scala/sage/commands/Command.scala
+++ b/sage-core/src/main/scala/sage/commands/Command.scala
@@ -14,6 +14,18 @@ enum Execution {
 }
 
 /**
+  * How a keyless `allMasters` broadcast folds its per-node replies into one. `First` keeps the first node's reply (identical
+  * acknowledgements like `SCRIPT LOAD`'s SHA); `Concat` appends each node's array slice (`KEYS`); `Fold` reduces pairwise (a durability
+  * barrier down to its weakest shard). A single policy rather than separate flags, so `Concat` and `Fold` cannot both be requested. Inert
+  * unless `allMasters`.
+  */
+enum BroadcastReduce {
+  case First
+  case Concat
+  case Fold(combine: (Frame, Frame) => Frame)
+}
+
+/**
   * A pure value describing one server command. `keyIndices` marks which `args` positions are keys, for cluster routing. `decode` never
   * sees top-level error frames — [[Reply.run]] intercepts them.
   *
@@ -26,15 +38,14 @@ enum Execution {
   * slot-owning master rather than one (`SCRIPT LOAD`, `FUNCTION LOAD` and their `FLUSH`/`DELETE`/`RESTORE` mutations, and `FLUSHALL`/
   * `FLUSHDB`). Inert on a standalone server.
   *
-  * `aggregate` refines an `allMasters` command whose reply is a per-node *view* rather than an identical acknowledgement (`KEYS`): the
-  * cluster broadcasts it to every slot-owning master and concatenates the array replies into one, since no single node sees the whole
-  * keyspace. The broadcast always targets masters regardless of the `ReadFrom` policy (a single replica would only see one shard's slice).
-  * An `allMasters` command without `aggregate` keeps the first node's reply (every node returns the same `OK`/SHA). Inert on a standalone
-  * server.
-  *
   * `cursorBound` marks a command whose reply carries a continuation cursor valid only on the node that issued it (`SCAN`/`HSCAN`/`SSCAN`/
   * `ZSCAN`). Such a read is excluded from replica round-robin routing: iterating its pages across different replicas would feed a cursor to
   * a node that never minted it, skipping or duplicating entries.
+  *
+  * `broadcast` chooses how an `allMasters` command's per-node replies fold into one: `First` keeps one node's identical acknowledgement,
+  * `Concat` appends each node's array slice (`KEYS`, since no single node sees the whole keyspace), `Fold` reduces pairwise (a durability
+  * barrier down to its weakest shard). The broadcast always targets masters regardless of the `ReadFrom` policy (a single replica would only
+  * see one shard's slice). Inert on a standalone server.
   */
 final case class Command[+Out](
   name: String,
@@ -46,14 +57,14 @@ final case class Command[+Out](
   cacheable: Boolean = false,
   allMasters: Boolean = false,
   cursorBound: Boolean = false,
-  aggregate: Boolean = false
+  broadcast: BroadcastReduce = BroadcastReduce.First
 ) {
 
   /**
     * Transforms the decoded result, leaving the wire encoding and routing metadata untouched.
     */
   def map[B](f: Out => B): Command[B] =
-    Command(name, keyIndices, args, frame => decode(frame).map(f), execution, isReadOnly, cacheable, allMasters, cursorBound, aggregate)
+    Command(name, keyIndices, args, frame => decode(frame).map(f), execution, isReadOnly, cacheable, allMasters, cursorBound, broadcast)
 
   /**
     * Whether this command blocks its connection and so needs a Dedicated Connection.
@@ -77,10 +88,10 @@ final case class Command[+Out](
 
   /**
     * This command's wire form with decoding replaced by the raw reply frame, preserving routing metadata. The cluster runtime uses it to
-    * collect an `aggregate` broadcast's per-node replies and merge them before decoding once.
+    * collect a broadcast's per-node replies and fold them before decoding once.
     */
   def rawFrame: Command[Frame] =
-    Command(name, keyIndices, args, frame => Right(frame), execution, isReadOnly, cacheable, allMasters, cursorBound, aggregate)
+    Command(name, keyIndices, args, frame => Right(frame), execution, isReadOnly, cacheable, allMasters, cursorBound, broadcast)
 }
 
 object Command {

--- a/sage-core/src/main/scala/sage/commands/Keys.scala
+++ b/sage-core/src/main/scala/sage/commands/Keys.scala
@@ -185,7 +185,7 @@ private[sage] object Keys {
   def pExpireTime[K](key: K)(using keyCodec: KeyCodec[K]): Command[ExpiryTime] =
     Command.readUncacheable("PEXPIRETIME", Command.FirstKey, Vector(keyCodec.encode(key)), expiryTimeDecode(Instant.ofEpochMilli))
 
-  // KEYS is node-local; `allMasters` + `aggregate` makes a cluster sweep every master and merge the slices. Prefer `scanAll` in production.
+  // KEYS is node-local; `allMasters` + `Concat` makes a cluster sweep every master and merge the slices. Prefer `scanAll` in production.
   def keys[K](pattern: String)(using keyCodec: KeyCodec[K]): Command[Vector[K]] =
     Command(
       "KEYS",
@@ -194,7 +194,7 @@ private[sage] object Keys {
       Decode.vector(Decode.key),
       isReadOnly = true,
       allMasters = true,
-      aggregate = true
+      broadcast = BroadcastReduce.Concat
     )
 
   def persist[K](key: K)(using keyCodec: KeyCodec[K]): Command[Boolean] =

--- a/sage-core/src/main/scala/sage/commands/Server.scala
+++ b/sage-core/src/main/scala/sage/commands/Server.scala
@@ -185,8 +185,30 @@ private[sage] object Server {
   def flushDb(mode: Option[FlushMode] = None): Command[Unit]  =
     Command("FLUSHDB", Command.NoKeys, FlushMode.args(mode), Decode.ok, allMasters = true)
 
+  private val waitMinReplicas: (Frame, Frame) => Frame = (a, b) =>
+    (a, b) match {
+      case (Frame.Integer(x), Frame.Integer(y)) => Frame.Integer(math.min(x, y))
+      case (Frame.Integer(_), bad)              => bad
+      case (bad, _)                             => bad
+    }
+
+  private val waitAofMin: (Frame, Frame) => Frame = (a, b) =>
+    (a, b) match {
+      case (Frame.Array(Vector(Frame.Integer(l1), Frame.Integer(r1))), Frame.Array(Vector(Frame.Integer(l2), Frame.Integer(r2)))) =>
+        Frame.Array(Vector(Frame.Integer(math.min(l1, l2)), Frame.Integer(math.min(r1, r2))))
+      case (Frame.Array(Vector(Frame.Integer(_), Frame.Integer(_))), bad)                                                         => bad
+      case (bad, _)                                                                                                               => bad
+    }
+
   def waitReplicas(numReplicas: Long, timeout: FiniteDuration): Command[Long] =
-    Command("WAIT", Command.NoKeys, Vector(Bytes.utf8(numReplicas.toString), Bytes.utf8(timeout.toMillis.toString)), Decode.long, Execution.Blocking)
+    Command(
+      "WAIT",
+      Command.NoKeys,
+      Vector(Bytes.utf8(numReplicas.toString), Bytes.utf8(timeout.toMillis.toString)),
+      Decode.long,
+      allMasters = true,
+      broadcast = BroadcastReduce.Fold(waitMinReplicas)
+    )
 
   def waitAof(numLocal: Long, numReplicas: Long, timeout: FiniteDuration): Command[(Long, Long)] =
     Command(
@@ -197,7 +219,8 @@ private[sage] object Server {
         case Frame.Array(Vector(Frame.Integer(local), Frame.Integer(replicas))) => Right((local, replicas))
         case other                                                              => Left(DecodeError("WAITAOF [numlocal, numreplicas]", Frame.describe(other)))
       },
-      Execution.Blocking
+      allMasters = true,
+      broadcast = BroadcastReduce.Fold(waitAofMin)
     )
 
   def memoryUsage[K](key: K, samples: Option[Long] = None)(using keyCodec: sage.codec.KeyCodec[K]): Command[Option[Long]] =

--- a/sage-core/src/test/scala/sage/commands/KeysSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/KeysSpec.scala
@@ -97,13 +97,13 @@ class KeysSpec extends munit.FunSuite {
     assertEquals(Keys.randomKey[String].keyIndices, Vector.empty[Int])
   }
 
-  test("KEYS is an aggregating all-masters read, so a cluster sweeps every master and merges the slices") {
+  test("KEYS is a concatenating all-masters read, so a cluster sweeps every master and merges the slices") {
     val command = Keys.keys[String]("*")
     assert(command.allMasters)
-    assert(command.aggregate)
+    assertEquals(command.broadcast, BroadcastReduce.Concat)
     assert(command.isReadOnly)
     assertEquals(command.rawFrame.allMasters, true)
-    assertEquals(command.rawFrame.aggregate, true)
+    assertEquals(command.rawFrame.broadcast, BroadcastReduce.Concat)
   }
 
   test("expire picks the wire command from the duration's precision") {

--- a/sage-core/src/test/scala/sage/commands/ServerSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ServerSpec.scala
@@ -76,10 +76,46 @@ class ServerSpec extends munit.FunSuite {
     )
   }
 
-  test("WAITAOF decodes the [numlocal, numreplicas] pair and is blocking") {
+  test("WAITAOF decodes the [numlocal, numreplicas] pair; WAIT/WAITAOF ride the multiplexed connection and broadcast per master") {
     assertEquals(Reply.run(Server.waitAof(1L, 0L, 1.second), Frame.Array(Vector(Frame.Integer(1L), Frame.Integer(2L)))), Right((1L, 2L)))
-    assert(Server.waitAof(1L, 0L, 1.second).isBlocking)
-    assert(Server.waitReplicas(1L, 1.second).isBlocking)
+    assert(!Server.waitAof(1L, 0L, 1.second).isBlocking)
+    assert(!Server.waitReplicas(1L, 1.second).isBlocking)
+    assert(Server.waitAof(1L, 0L, 1.second).allMasters)
+    assert(Server.waitReplicas(1L, 1.second).allMasters)
+  }
+
+  private def fold(command: Command[?]): (Frame, Frame) => Frame =
+    command.broadcast match {
+      case BroadcastReduce.Fold(f) => f
+      case other                   => fail(s"expected a Fold broadcast, got $other")
+    }
+
+  test("WAIT/WAITAOF fold differing multi-master replies to the weakest shard") {
+    val waitFold = fold(Server.waitReplicas(1L, 1.second))
+    assertEquals(waitFold(Frame.Integer(2L), Frame.Integer(1L)), Frame.Integer(1L))
+    assertEquals(waitFold(Frame.Integer(0L), Frame.Integer(3L)), Frame.Integer(0L))
+    assertEquals(Reply.run(Server.waitReplicas(1L, 1.second), Frame.Integer(1L)), Right(1L))
+
+    val aofFold = fold(Server.waitAof(1L, 0L, 1.second))
+    assertEquals(
+      aofFold(Frame.Array(Vector(Frame.Integer(1L), Frame.Integer(2L))), Frame.Array(Vector(Frame.Integer(0L), Frame.Integer(3L)))),
+      Frame.Array(Vector(Frame.Integer(0L), Frame.Integer(2L)))
+    )
+  }
+
+  test("WAIT/WAITAOF folds pass a malformed reply through in either operand position, so it never hides behind a valid one") {
+    val waitFold = fold(Server.waitReplicas(1L, 1.second))
+    val badInt   = Frame.SimpleString("nonsense")
+    assertEquals(waitFold(Frame.Integer(2L), badInt), badInt)
+    assertEquals(waitFold(badInt, Frame.Integer(2L)), badInt)
+    assert(Reply.run(Server.waitReplicas(1L, 1.second), waitFold(Frame.Integer(2L), badInt)).isLeft)
+
+    val aofFold   = fold(Server.waitAof(1L, 0L, 1.second))
+    val validPair = Frame.Array(Vector(Frame.Integer(1L), Frame.Integer(2L)))
+    val badPair   = Frame.Array(Vector(Frame.Integer(1L)))
+    assertEquals(aofFold(validPair, badPair), badPair)
+    assertEquals(aofFold(badPair, validPair), badPair)
+    assert(Reply.run(Server.waitAof(1L, 0L, 1.second), aofFold(validPair, badPair)).isLeft)
   }
 
   test("MEMORY USAGE decodes a present count and a missing key as None, and is keyed") {


### PR DESCRIPTION
## Problem

`WAIT`/`WAITAOF` were marked `Execution.Blocking`, so they ran on a fresh **dedicated** pool connection that had issued no writes. Redis scopes their guarantee to the *calling connection's* write offset, so on a connection that carried no writes the offset covered nothing and the barrier returned a **false durability signal**. In a cluster the problem compounded: a single arbitrary node was contacted, and even the reply aggregation kept whichever master answered first, so a caller could see a replicated count while another shard lagged.

## Changes

- **Connection affinity:** route `WAIT`/`WAITAOF` as `Ordinary` so they ride the multiplexed connection carrying the preceding writes (as Lettuce does), and mark them `allMasters` so a cluster reaches every slot-owning master on its own connection.
- **Broadcast policy:** replace the `Command` `aggregate: Boolean` + `combine: Option[fn]` pair with a single sealed `BroadcastReduce` (`First | Concat | Fold`), so contradictory states are unrepresentable. `KEYS` uses `Concat`; `WAIT`/`WAITAOF` use `Fold`, reducing per-master replies to the **weakest shard** (`WAIT` the minimum, `WAITAOF` component-wise minimums).
- **Malformed replies:** the fold passes an unexpected-shape frame through in either operand position, so the final decode surfaces it rather than a valid reply masking it.
- **Exception boundary:** the fold + decode run inside a `Try` in the broadcast, so a throwing fold fails the caller instead of escaping on the reply thread and hanging.
- **MULTI:** left legal, matching Redis (WAIT returns ASAP inside a transaction rather than blocking); no artificial rejection.

## Tests

- Transport affinity for both `WAIT` and `WAITAOF` (single multiplexed transport, write-before-barrier ordering; verified it fails if reverted to `Blocking`).
- Cluster broadcast to every master, weakest-shard reduction, and `WAITAOF` component-wise minimums.
- Malformed replies in either operand position.
- A mid-flight connection drop while the barrier is pending (fails with `ConnectionLost`, no partial result, no hang).
- A throwing fold on a reply arriving **after** dispatch (verified it fails if the `Try` boundary is removed).

Full core and clientZio suites pass; scalafmt clean.