### PR TITLE
Fix DBSIZE in cluster mode and reject cluster-wide-result commands in cluster transactions

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -638,6 +638,12 @@ final private[client] class ClusterLive(
     def run[A](command: Command[A]): CIO[A] =
       if (command.isBlocking)
         CIO.fail(new IllegalArgumentException("a Transaction cannot run blocking commands; run them individually on the client"))
+      else if (command.requiresClusterWideTxResult)
+        CIO.fail(
+          new IllegalArgumentException(
+            s"${command.name} returns a cluster-wide result that a single-node Transaction cannot produce; run it individually on the client"
+          )
+        )
       else
         CIO.async[A] { complete =>
           val tracked = Events.trackSpan(events, command, complete)
@@ -693,6 +699,12 @@ final private[client] class ClusterLive(
         CIO.value(Some(Vector.empty))
       else if (p.commands.exists(_.isBlocking))
         CIO.fail(new IllegalArgumentException("a Transaction cannot carry blocking commands; run them individually on the client"))
+      else if (p.commands.exists(_.requiresClusterWideTxResult))
+        CIO.fail(
+          new IllegalArgumentException(
+            "a Transaction cannot carry a command that returns a cluster-wide result; run it individually on the client"
+          )
+        )
       else
         CIO
           .async[Vector[Frame]] { complete =>

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -562,6 +562,84 @@ class ClusterClientSpec extends munit.FunSuite {
       .map(result => assertEquals(result, Some(Vector(Some("v")))))
   }
 
+  test("a cluster transaction rejects DBSIZE on the immediate-run path, with no MULTI sent") {
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live
+      .transaction(_.dbSize)
+      .unsafeRun
+      .failed
+      .map { error =>
+        assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+        assert(!fixture.written(nodeA).exists(_.contains("DBSIZE")), "a rejected DBSIZE must not reach the wire")
+      }
+  }
+
+  test("a cluster transaction rejects DBSIZE inside exec, with no MULTI sent") {
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live
+      .transaction(_.exec(Vector(Server.dbSize)))
+      .unsafeRun
+      .failed
+      .map { error =>
+        assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+        assert(!fixture.written(nodeA).exists(_.contains("MULTI")), "a rejected exec must not open MULTI")
+      }
+  }
+
+  test("a cluster transaction still accepts WAIT inside exec, whose node-local reply is a valid transaction result") {
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (text.contains("MULTI")) Seq(Frame.SimpleString("OK"), Frame.SimpleString("QUEUED"), Frame.Array(Vector(Frame.Integer(1L))))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live
+      .transaction(_.exec(Vector(Server.waitReplicas(1L, 100.millis))))
+      .unsafeRun
+      .map { result =>
+        assertEquals(result, Some(Vector(1L)))
+        assert(fixture.written(nodeA).exists(_.contains("WAIT")), "WAIT should ride the pinned transaction connection")
+      }
+  }
+
+  test("a cluster transaction accepts immediate WAIT and WAITAOF on the run path, whose node-local replies are valid results") {
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (text.contains("WAITAOF")) Seq(Frame.Array(Vector(Frame.Integer(1L), Frame.Integer(1L))))
+      else if (text.contains("WAIT")) Seq(Frame.Integer(1L))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live
+      .transaction(tx => tx.run(Server.waitReplicas(1L, 100.millis)).flatMap(_ => tx.run(Server.waitAof(1L, 1L, 100.millis))))
+      .unsafeRun
+      .map { result =>
+        assertEquals(result, (1L, 1L))
+        assert(fixture.written(nodeA).exists(_.contains("WAIT\r\n")), "WAIT should ride the pinned transaction connection")
+        assert(fixture.written(nodeA).exists(_.contains("WAITAOF")), "WAITAOF should ride the pinned transaction connection")
+      }
+  }
+
+  test("a cluster transaction still accepts KEYS, an existing broadcast command, returning the pinned node's keys") {
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (text.contains("KEYS")) Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("k1")))))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live
+      .transaction(_.run(Keys.keys[String]("*")))
+      .unsafeRun
+      .map { result =>
+        assertEquals(result, Vector("k1"))
+        assert(fixture.written(nodeA).exists(_.contains("KEYS")), "KEYS should ride the pinned transaction connection")
+      }
+  }
+
   test("a sharded subscribe routes SSUBSCRIBE to the channel's slot owner, not other nodes") {
     val behaviour = (_: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(splitOn(slotB))

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -268,6 +268,34 @@ class ClusterClientSpec extends munit.FunSuite {
     }
   }
 
+  test("DBSIZE broadcasts to every slot-owning master and sums shard counts into the cluster total") {
+    val mid       = Slot.Count / 2
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else if (text.contains("DBSIZE")) Seq(Frame.Integer(if (node == nodeA) 2L else 3L))
+      else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Server.dbSize).unsafeRun.map { result =>
+      assertEquals(result, 5L)
+      assert(fixture.written(nodeA).exists(_.contains("DBSIZE")), "nodeA did not receive DBSIZE")
+      assert(fixture.written(nodeB).exists(_.contains("DBSIZE")), "nodeB did not receive DBSIZE")
+    }
+  }
+
+  test("DBSIZE fails when any master fails, rather than reporting a partial count") {
+    val mid       = Slot.Count / 2
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else if (text.contains("DBSIZE")) Seq(if (node == nodeA) Frame.Integer(2L) else Frame.SimpleError("ERR unavailable"))
+      else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Server.dbSize).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[ServerError], s"expected ServerError, got $error")
+    }
+  }
+
   test("under a Replica policy an eligible read routes to the shard's replica, which gets READONLY at setup") {
     val nodeR                   = Node("r", 6379)
     // CLUSTER SLOTS lists nodeR as nodeA's replica for the whole keyspace

--- a/sage-core/src/main/scala/sage/commands/Command.scala
+++ b/sage-core/src/main/scala/sage/commands/Command.scala
@@ -46,6 +46,11 @@ enum BroadcastReduce {
   * `Concat` appends each node's array slice (`KEYS`, since no single node sees the whole keyspace), `Fold` reduces pairwise (a durability
   * barrier down to its weakest shard). The broadcast always targets masters regardless of the `ReadFrom` policy (a single replica would only
   * see one shard's slice). Inert on a standalone server.
+  *
+  * `requiresClusterWideTxResult` marks a command whose result is correct only when aggregated across every master, so a cluster `MULTI`/
+  * `EXEC` — pinned to a single node — cannot produce it and rejects it before the wire. Only `DBSIZE` sets it: its contract is the cluster-wide
+  * key count, which one shard cannot give. Other broadcasts (`KEYS`, `FLUSHALL`, `SCRIPT LOAD`, `WAIT`) stay transaction-legal with node-local
+  * semantics, matching Redis, which does not flag them `no-multi`. Inert on a standalone server.
   */
 final case class Command[+Out](
   name: String,
@@ -57,19 +62,35 @@ final case class Command[+Out](
   cacheable: Boolean = false,
   allMasters: Boolean = false,
   cursorBound: Boolean = false,
-  broadcast: BroadcastReduce = BroadcastReduce.First
+  broadcast: BroadcastReduce = BroadcastReduce.First,
+  requiresClusterWideTxResult: Boolean = false
 ) {
 
   /**
     * Transforms the decoded result, leaving the wire encoding and routing metadata untouched.
     */
-  def map[B](f: Out => B): Command[B] =
-    Command(name, keyIndices, args, frame => decode(frame).map(f), execution, isReadOnly, cacheable, allMasters, cursorBound, broadcast)
+  def map[B](f: Out => B): Command[B] = withDecode(frame => decode(frame).map(f))
 
   /**
     * Whether this command blocks its connection and so needs a Dedicated Connection.
     */
   def isBlocking: Boolean = execution == Execution.Blocking
+
+  // rebuilds the command with a new (possibly re-typed) decoder, carrying every field by name so a future field can't be dropped or misordered
+  private def withDecode[B](decode: Frame => Either[DecodeError, B]): Command[B] =
+    Command(
+      name = name,
+      keyIndices = keyIndices,
+      args = args,
+      decode = decode,
+      execution = execution,
+      isReadOnly = isReadOnly,
+      cacheable = cacheable,
+      allMasters = allMasters,
+      cursorBound = cursorBound,
+      broadcast = broadcast,
+      requiresClusterWideTxResult = requiresClusterWideTxResult
+    )
 
   /**
     * The key bytes the server tracks for this command, in arg order — the keys a cache invalidation evicts by.
@@ -90,8 +111,7 @@ final case class Command[+Out](
     * This command's wire form with decoding replaced by the raw reply frame, preserving routing metadata. The cluster runtime uses it to
     * collect a broadcast's per-node replies and fold them before decoding once.
     */
-  def rawFrame: Command[Frame] =
-    Command(name, keyIndices, args, frame => Right(frame), execution, isReadOnly, cacheable, allMasters, cursorBound, broadcast)
+  def rawFrame: Command[Frame] = withDecode(frame => Right(frame))
 }
 
 object Command {

--- a/sage-core/src/main/scala/sage/commands/Server.scala
+++ b/sage-core/src/main/scala/sage/commands/Server.scala
@@ -143,7 +143,15 @@ private[sage] object Server {
     }
 
   val dbSize: Command[Long] =
-    Command("DBSIZE", Command.NoKeys, Vector.empty, Decode.long, allMasters = true, broadcast = BroadcastReduce.Fold(dbSizeSum))
+    Command(
+      "DBSIZE",
+      Command.NoKeys,
+      Vector.empty,
+      Decode.long,
+      allMasters = true,
+      broadcast = BroadcastReduce.Fold(dbSizeSum),
+      requiresClusterWideTxResult = true
+    )
 
   val time: Command[Instant] =
     Command(

--- a/sage-core/src/main/scala/sage/commands/Server.scala
+++ b/sage-core/src/main/scala/sage/commands/Server.scala
@@ -135,7 +135,15 @@ private[sage] object Server {
   def info(sections: String*): Command[String] =
     Command("INFO", Command.NoKeys, sections.iterator.map(Bytes.utf8).toVector, Decode.text)
 
-  val dbSize: Command[Long] = Command("DBSIZE", Command.NoKeys, Vector.empty, Decode.long)
+  private val dbSizeSum: (Frame, Frame) => Frame = (a, b) =>
+    (a, b) match {
+      case (Frame.Integer(x), Frame.Integer(y)) => Frame.Integer(math.addExact(x, y))
+      case (Frame.Integer(_), bad)              => bad
+      case (bad, _)                             => bad
+    }
+
+  val dbSize: Command[Long] =
+    Command("DBSIZE", Command.NoKeys, Vector.empty, Decode.long, allMasters = true, broadcast = BroadcastReduce.Fold(dbSizeSum))
 
   val time: Command[Instant] =
     Command(

--- a/sage-core/src/test/scala/sage/commands/ServerSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ServerSpec.scala
@@ -118,6 +118,18 @@ class ServerSpec extends munit.FunSuite {
     assert(Reply.run(Server.waitAof(1L, 0L, 1.second), aofFold(validPair, badPair)).isLeft)
   }
 
+  test("DBSIZE broadcasts per master and folds shard counts into the cluster total, with checked overflow and malformed passthrough") {
+    assert(Server.dbSize.allMasters)
+    val sum    = fold(Server.dbSize)
+    assertEquals(sum(Frame.Integer(10L), Frame.Integer(20L)), Frame.Integer(30L))
+    assertEquals(Reply.run(Server.dbSize, Frame.Integer(30L)), Right(30L))
+    intercept[ArithmeticException](sum(Frame.Integer(Long.MaxValue), Frame.Integer(1L)))
+    val badInt = Frame.SimpleString("nonsense")
+    assertEquals(sum(Frame.Integer(10L), badInt), badInt)
+    assertEquals(sum(badInt, Frame.Integer(10L)), badInt)
+    assert(Reply.run(Server.dbSize, sum(Frame.Integer(10L), badInt)).isLeft)
+  }
+
   test("MEMORY USAGE decodes a present count and a missing key as None, and is keyed") {
     assertEquals(Reply.run(Server.memoryUsage("k"), Frame.Integer(64L)), Right(Some(64L)))
     assertEquals(Reply.run(Server.memoryUsage("k"), Frame.Null), Right(None))

--- a/sage-core/src/test/scala/sage/commands/ServerSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ServerSpec.scala
@@ -84,6 +84,16 @@ class ServerSpec extends munit.FunSuite {
     assert(Server.waitReplicas(1L, 1.second).allMasters)
   }
 
+  test(
+    "only DBSIZE requires a cluster-wide transaction result; other broadcasts stay transaction-legal like Redis, which never flags them no-multi"
+  ) {
+    assert(!Server.waitReplicas(1L, 1.second).requiresClusterWideTxResult, "WAIT stays legal in a cluster transaction with node-local semantics")
+    assert(!Server.waitAof(1L, 0L, 1.second).requiresClusterWideTxResult, "WAITAOF stays legal in a cluster transaction with node-local semantics")
+    assert(!Keys.keys[String]("*").requiresClusterWideTxResult, "KEYS stays legal in a cluster transaction, returning the pinned node's keys")
+    assert(!Server.flushAll().requiresClusterWideTxResult, "FLUSHALL stays legal in a cluster transaction")
+    assert(!Server.flushDb().requiresClusterWideTxResult, "FLUSHDB stays legal in a cluster transaction")
+  }
+
   private def fold(command: Command[?]): (Frame, Frame) => Frame =
     command.broadcast match {
       case BroadcastReduce.Fold(f) => f
@@ -120,6 +130,10 @@ class ServerSpec extends munit.FunSuite {
 
   test("DBSIZE broadcasts per master and folds shard counts into the cluster total, with checked overflow and malformed passthrough") {
     assert(Server.dbSize.allMasters)
+    assert(
+      Server.dbSize.requiresClusterWideTxResult,
+      "DBSIZE only produces a total when broadcast, so a single-node cluster transaction must reject it"
+    )
     val sum    = fold(Server.dbSize)
     assertEquals(sum(Frame.Integer(10L), Frame.Integer(20L)), Frame.Integer(30L))
     assertEquals(Reply.run(Server.dbSize, Frame.Integer(30L)), Right(30L))


### PR DESCRIPTION
## Summary

Two related cluster-correctness fixes for `DBSIZE`.

### 1. DBSIZE returned one arbitrary shard's count in cluster mode
`Server.dbSize` was keyless and not `allMasters`, so the cluster runtime sent it to a single master and returned that shard's count instead of the logical cluster total. With shards of 10 and 20 keys, callers saw either instead of 30.

- Mark `dbSize` `allMasters` with a summing `BroadcastReduce.Fold` (checked overflow via `math.addExact`; a malformed reply is passed through so decode surfaces it rather than hiding behind a valid one).
- Broadcasts to every distinct slot-owning master and sums the integer replies; a node failure or malformed reply fails the whole call.
- Standalone is unchanged (`allMasters` is inert on a single node).

This matches Lettuce, whose cluster `dbsize()` fans out to all upstreams and aggregates.

### 2. DBSIZE inside a cluster transaction silently returned a shard-local count
A cluster `MULTI`/`EXEC` is pinned to one node, so `tx.dbSize` / `tx.exec(DBSIZE)` executed on that one master and returned a shard-local count while the command's contract promises the cluster-wide total.

- Add `Command.requiresClusterWideTxResult`, set **only** on `DBSIZE`, and reject such commands on both cluster transaction paths (immediate `run` and `exec`) before anything reaches the wire.
- The flag is targeted, not derived from `allMasters`: `KEYS`, `FLUSHALL`, `FLUSHDB`, `SCRIPT`/`FUNCTION` operations and `WAIT`/`WAITAOF` carry no `no-multi` flag in Redis and remain transaction-legal with node-local semantics, matching Redis and Lettuce (a cluster transaction is a single-node connection).

### Housekeeping
`Command.map`/`rawFrame` now rebuild through one named-argument helper (`withDecode`) instead of two positional constructor calls, so a future field cannot be dropped or misordered.

## Tests
- Core: DBSIZE broadcast fold (sum, checked overflow, malformed passthrough); only DBSIZE carries `requiresClusterWideTxResult` (WAIT/WAITAOF/KEYS/FLUSHALL/FLUSHDB do not).
- Cluster: DBSIZE sums shard counts (2 + 3 = 5) with both masters contacted; DBSIZE fails on a master error; DBSIZE rejected pre-wire on both the run and exec transaction paths; immediate WAIT and WAITAOF accepted in a cluster transaction; KEYS remains transaction-legal (returns the pinned node's keys).

## Note
With the targeted policy, `tx.keys("*")` / `tx.flushDb()` inside a cluster transaction act on the pinned node only (node-local partial view), consistent with Redis/Lettuce cluster-transaction semantics. Only `DBSIZE` is rejected, because only its contract promises a cluster-wide aggregate.