### PR TITLE
Round sub-millisecond WAIT/WAITAOF timeouts up to 1ms

### DIFF
--- a/sage-core/src/main/scala/sage/commands/Server.scala
+++ b/sage-core/src/main/scala/sage/commands/Server.scala
@@ -216,11 +216,15 @@ private[sage] object Server {
       case (bad, _)                                                                                                               => bad
     }
 
+  // WAIT/WAITAOF read a wire 0 as block-forever, so only an explicit zero emits 0; any other duration rounds up to at least 1ms so a sub-millisecond (or negative) wait never truncates to 0 (mirrors BlockTimeout.millisWire)
+  private def waitTimeoutMillis(timeout: FiniteDuration): Long =
+    if (timeout == Duration.Zero) 0L else Math.max(1L, Math.ceilDiv(timeout.toNanos, 1000000L))
+
   def waitReplicas(numReplicas: Long, timeout: FiniteDuration): Command[Long] =
     Command(
       "WAIT",
       Command.NoKeys,
-      Vector(Bytes.utf8(numReplicas.toString), Bytes.utf8(timeout.toMillis.toString)),
+      Vector(Bytes.utf8(numReplicas.toString), Bytes.utf8(waitTimeoutMillis(timeout).toString)),
       Decode.long,
       allMasters = true,
       broadcast = BroadcastReduce.Fold(waitMinReplicas)
@@ -230,7 +234,7 @@ private[sage] object Server {
     Command(
       "WAITAOF",
       Command.NoKeys,
-      Vector(numLocal, numReplicas, timeout.toMillis).map(n => Bytes.utf8(n.toString)),
+      Vector(numLocal, numReplicas, waitTimeoutMillis(timeout)).map(n => Bytes.utf8(n.toString)),
       {
         case Frame.Array(Vector(Frame.Integer(local), Frame.Integer(replicas))) => Right((local, replicas))
         case other                                                              => Left(DecodeError("WAITAOF [numlocal, numreplicas]", Frame.describe(other)))

--- a/sage-core/src/main/scala/sage/commands/Server.scala
+++ b/sage-core/src/main/scala/sage/commands/Server.scala
@@ -216,7 +216,8 @@ private[sage] object Server {
       case (bad, _)                                                                                                               => bad
     }
 
-  // WAIT/WAITAOF read a wire 0 as block-forever, so only an explicit zero emits 0; any other duration rounds up to at least 1ms so a sub-millisecond (or negative) wait never truncates to 0 (mirrors BlockTimeout.millisWire)
+  // WAIT/WAITAOF read a wire 0 as block-forever, so only an explicit zero emits 0; any other duration (including a negative) rounds up to at
+  // least 1ms so a sub-millisecond wait never truncates to 0 (mirrors BlockTimeout.millisWire)
   private def waitTimeoutMillis(timeout: FiniteDuration): Long =
     if (timeout == Duration.Zero) 0L else Math.max(1L, Math.ceilDiv(timeout.toNanos, 1000000L))
 

--- a/sage-core/src/test/scala/sage/commands/ServerSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ServerSpec.scala
@@ -84,6 +84,19 @@ class ServerSpec extends munit.FunSuite {
     assert(Server.waitReplicas(1L, 1.second).allMasters)
   }
 
+  test("WAIT/WAITAOF round a sub-millisecond timeout up to 1ms, keep an explicit zero as block-forever, and clamp a negative to 1ms") {
+    def waitMs(d: FiniteDuration)    = Server.waitReplicas(1L, d).args(1).asUtf8String
+    def waitAofMs(d: FiniteDuration) = Server.waitAof(1L, 0L, d).args(2).asUtf8String
+    assertEquals(waitMs(500.microseconds), "1")
+    assertEquals(waitMs(Duration.Zero), "0")
+    assertEquals(waitMs(-5.milliseconds), "1")
+    assertEquals(waitMs(2.seconds), "2000")
+    assertEquals(waitAofMs(500.microseconds), "1")
+    assertEquals(waitAofMs(Duration.Zero), "0")
+    assertEquals(waitAofMs(-5.milliseconds), "1")
+    assertEquals(waitAofMs(2.seconds), "2000")
+  }
+
   test(
     "only DBSIZE requires a cluster-wide transaction result; other broadcasts stay transaction-legal like Redis, which never flags them no-multi"
   ) {


### PR DESCRIPTION
## Summary

`WAIT`/`WAITAOF` encoded their timeout with `timeout.toMillis`, which truncates. A positive sub-millisecond duration such as `500.microseconds` became `0`, and Redis reads a `0` timeout as **block forever** — so a caller asking for a bounded wait got an infinite one.

## Fix

Both commands now encode through a shared helper:

```scala
private def waitTimeoutMillis(timeout: FiniteDuration): Long =
  if (timeout == Duration.Zero) 0L else Math.max(1L, Math.ceilDiv(timeout.toNanos, 1000000L))
```

- Positive sub-millisecond durations round **up** to 1ms, so a bounded wait never truncates to 0.
- An **explicit zero** passes through as `0`, preserving Redis's intentional block-forever value.
- A **negative** duration clamps up to 1ms (a bounded wait), never landing on the wire `0`.

This mirrors the existing `BlockTimeout.millisWire` handling, which floors finite blocking timeouts at 1ms for the same reason (a `0` on the wire means infinite). Consistent with sage's no-throw-in-builders convention, an invalid (negative) duration is clamped to a safe bounded wait rather than throwing.

## Tests

`ServerSpec` asserts, for both `WAIT` and `WAITAOF`: `500.microseconds` → `1`, `Duration.Zero` → `0` (block-forever preserved), `-5.milliseconds` → `1`, and a normal `2.seconds` → `2000`.