### PR TITLE
Invalidate rejected in-flight establishments on NodePool.retain

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -71,41 +71,53 @@ final private[client] class NodePool(
     }
     if (existing != null) existing
     else if (waitOn != null) waitOn.get()
-    else
-      try {
-        val nc    = NodeClient.connect(
-          nodeFactory(node),
-          scheduler,
-          bootstrap,
-          reconnect,
-          watchdog,
-          connectTimeout,
-          closeTimeout,
-          dedicatedPool,
-          cacheMaxBytes,
-          Some(node),
-          events,
-          dedicatedBootstrap
-        )
-        val stale = locked { pendingEstablish.remove(node); if (closed) true else { established.put(node, nc); false } }
-        if (stale) { nc.close(); throw NotConnected() }
-        mine.succeed(nc)
-        nc
-      } catch {
-        case error: Throwable =>
-          locked(pendingEstablish.remove(node))
-          mine.fail(error)
-          throw error
+    else {
+      val nc      =
+        try
+          NodeClient.connect(
+            nodeFactory(node),
+            scheduler,
+            bootstrap,
+            reconnect,
+            watchdog,
+            connectTimeout,
+            closeTimeout,
+            dedicatedPool,
+            cacheMaxBytes,
+            Some(node),
+            events,
+            dedicatedBootstrap
+          )
+        catch {
+          case error: Throwable =>
+            // remove only our own token: a `retain` or `close` may have dropped it and a newer attempt may already own the slot
+            locked(if (pendingEstablish.get(node).exists(_ eq mine)) { val _ = pendingEstablish.remove(node) })
+            mine.fail(error)
+            throw error
+        }
+      // publish only if our token is still the current pending entry: a `retain` that rejected this node, a `close`, or a newer attempt for
+      // the same node all supersede us, and then the freshly opened client is discarded rather than leaked back into the registry
+      val publish = locked {
+        val current = pendingEstablish.get(node).exists(_ eq mine)
+        if (current) { val _ = pendingEstablish.remove(node) }
+        if (current && !closed) { established.put(node, nc); true }
+        else false
       }
+      if (publish) { mine.succeed(nc); nc }
+      else { nc.close(); mine.fail(NotConnected()); throw NotConnected() }
+    }
   }
 
-  // drops and closes every bundle whose node `keep` rejects, so a vanished node's reconnect loop cannot leak; closes are offloaded
+  // drops and closes every bundle whose node `keep` rejects, so a vanished node's reconnect loop cannot leak; closes are offloaded. Also
+  // invalidates any in-flight establishment for a rejected node, so a connect completing after this refresh cannot re-publish a dropped node
   def retain(keep: Node => Boolean): Unit = {
-    val gone = locked {
-      val absent = established.keysIterator.filterNot(keep).toVector
-      absent.flatMap(node => established.remove(node))
+    val (gone, rejected) = locked {
+      val absent          = established.keysIterator.filterNot(keep).toVector.flatMap(node => established.remove(node))
+      val rejectedPending = pendingEstablish.keysIterator.filterNot(keep).toVector.flatMap(node => pendingEstablish.remove(node))
+      (absent, rejectedPending)
     }
     gone.foreach(nc => scheduler.after(Duration.Zero)(nc.close()))
+    rejected.foreach(_.fail(NotConnected()))
   }
 
   def close(): Unit = {

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -90,13 +90,11 @@ final private[client] class NodePool(
           )
         catch {
           case error: Throwable =>
-            // remove only our own token: a `retain` or `close` may have dropped it and a newer attempt may already own the slot
             locked(if (pendingEstablish.get(node).exists(_ eq mine)) { val _ = pendingEstablish.remove(node) })
             mine.fail(error)
             throw error
         }
-      // publish only if our token is still the current pending entry: a `retain` that rejected this node, a `close`, or a newer attempt for
-      // the same node all supersede us, and then the freshly opened client is discarded rather than leaked back into the registry
+      // publish only if our token is still current: a retain, close, or newer attempt supersedes us, and the new client is discarded not leaked
       val publish = locked {
         val current = pendingEstablish.get(node).exists(_ eq mine)
         if (current) { val _ = pendingEstablish.remove(node) }
@@ -108,8 +106,7 @@ final private[client] class NodePool(
     }
   }
 
-  // drops and closes every bundle whose node `keep` rejects, so a vanished node's reconnect loop cannot leak; closes are offloaded. Also
-  // invalidates any in-flight establishment for a rejected node, so a connect completing after this refresh cannot re-publish a dropped node
+  // drops/closes bundles `keep` rejects and invalidates in-flight establishments for rejected nodes, so neither leaks; closes are offloaded
   def retain(keep: Node => Boolean): Unit = {
     val (gone, rejected) = locked {
       val absent          = established.keysIterator.filterNot(keep).toVector.flatMap(node => established.remove(node))

--- a/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
@@ -1,0 +1,126 @@
+package sage.client.internal
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.concurrent.duration.*
+import scala.util.Try
+
+import sage.Bytes
+import sage.SageException.NotConnected
+import sage.client.{BackoffConfig, DedicatedPoolConfig, WatchdogConfig}
+import sage.cluster.Node
+import sage.commands.Connection
+import sage.protocol.Frame
+
+class NodePoolSpec extends munit.FunSuite {
+
+  private val helloReply: Frame =
+    Frame.Map(
+      Vector(
+        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
+        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
+        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
+        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
+      )
+    )
+
+  private def respond(payload: Bytes): Seq[Frame] =
+    if (payload.asUtf8String.contains("HELLO")) Seq(helloReply) else Nil
+
+  private def newPool(factory: Node => MultiplexedConnection.TransportFactory): NodePool =
+    new NodePool(
+      factory,
+      Scheduler.real,
+      Vector(Connection.hello(None)),
+      BackoffConfig(),
+      WatchdogConfig(enabled = false),
+      1.second,
+      Duration.Zero,
+      DedicatedPoolConfig()
+    )
+
+  // a factory that blocks the first (multiplexed) connect on `gate`, signalling `reached` first, and captures the opened transport
+  private def gatedFactory(
+    reached: CountDownLatch,
+    gate: CountDownLatch,
+    transport: AtomicReference[FakeTransport]
+  ): Node => MultiplexedConnection.TransportFactory =
+    _ =>
+      (onFrame, onClosed) => {
+        if (transport.get() == null) { reached.countDown(); gate.await() }
+        val t = new FakeTransport(onFrame, onClosed, respond)
+        transport.compareAndSet(null, t)
+        t
+      }
+
+  private def awaitTrue(cond: => Boolean, clue: String): Unit = {
+    val deadline = System.nanoTime() + 2.seconds.toNanos
+    while (!cond && System.nanoTime() < deadline) Thread.sleep(10)
+    assert(cond, clue)
+  }
+
+  test("retain invalidates an in-flight establishment for a rejected node: the client is closed, absent, and every waiter fails") {
+    val node      = Node("gated", 6379)
+    val reached   = new CountDownLatch(1)
+    val gate      = new CountDownLatch(1)
+    val transport = new AtomicReference[FakeTransport]()
+    val pool      = newPool(gatedFactory(reached, gate, transport))
+
+    val establisher  = new AtomicReference[Try[NodeClient]]()
+    val establishing = new Thread(() => establisher.set(Try(pool.getOrEstablish(node))), "establisher")
+    establishing.start()
+    assert(reached.await(2, TimeUnit.SECONDS), "the establisher never reached connect")
+
+    val waiters = (1 to 3).map { i =>
+      val result = new AtomicReference[Try[NodeClient]]()
+      val thread = new Thread(() => result.set(Try(pool.getOrEstablish(node))), s"waiter-$i")
+      thread.start()
+      (thread, result)
+    }
+    Thread.sleep(100) // let the waiters block on the shared establishment before retain runs
+
+    pool.retain(_ => false) // topology dropped the node while its connect is still in flight
+
+    waiters.foreach { case (thread, _) => thread.join(2000) }
+    waiters.foreach { case (_, result) =>
+      assert(result.get() != null && result.get().isFailure, "a waiter did not fail")
+      assert(result.get().failed.get.isInstanceOf[NotConnected], s"unexpected waiter error: ${result.get()}")
+    }
+
+    gate.countDown() // the connect completes only after retain rejected it
+    establishing.join(2000)
+    assert(
+      establisher.get() != null && establisher.get().isFailure && establisher.get().failed.get.isInstanceOf[NotConnected],
+      s"establisher: ${establisher.get()}"
+    )
+
+    val opened = transport.get()
+    assert(opened != null, "no transport was ever created")
+    awaitTrue(opened.closeCount > 0, "the discarded NodeClient was not closed")
+    assert(pool.existingLive(node).isEmpty, "the rejected node leaked into the pool")
+    assert(!pool.candidatesByLiveness.contains(node), "the rejected node leaked into refresh candidates")
+    pool.close()
+  }
+
+  test("retain leaves an accepted in-flight establishment to complete and publish") {
+    val node      = Node("kept", 6379)
+    val reached   = new CountDownLatch(1)
+    val gate      = new CountDownLatch(1)
+    val transport = new AtomicReference[FakeTransport]()
+    val pool      = newPool(gatedFactory(reached, gate, transport))
+
+    val result       = new AtomicReference[Try[NodeClient]]()
+    val establishing = new Thread(() => result.set(Try(pool.getOrEstablish(node))), "establisher")
+    establishing.start()
+    assert(reached.await(2, TimeUnit.SECONDS), "the establisher never reached connect")
+
+    pool.retain(_ => true) // the node survives the refresh
+
+    gate.countDown()
+    establishing.join(2000)
+    assert(result.get() != null && result.get().isSuccess, s"expected success, got ${result.get()}")
+    assert(pool.existingLive(node).isDefined, "the accepted node should be live in the pool")
+    pool.close()
+  }
+}

--- a/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
@@ -1,7 +1,7 @@
 package sage.client.internal
 
 import java.util.concurrent.{CountDownLatch, TimeUnit}
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference, AtomicReferenceArray}
 
 import scala.concurrent.duration.*
 import scala.util.Try
@@ -40,19 +40,25 @@ class NodePoolSpec extends munit.FunSuite {
       DedicatedPoolConfig()
     )
 
-  // a factory that blocks the first (multiplexed) connect on `gate`, signalling `reached` first, and captures the opened transport
-  private def gatedFactory(
-    reached: CountDownLatch,
-    gate: CountDownLatch,
-    transport: AtomicReference[FakeTransport]
-  ): Node => MultiplexedConnection.TransportFactory =
-    _ =>
+  // gates the nth connect attempt: it signals `reached(n)`, blocks until `release(n)`, then opens a transport captured at `transport(n)`
+  final private class GatedFactory(count: Int) {
+    val reached                                                 = Vector.fill(count)(new CountDownLatch(1))
+    private val gate                                            = Vector.fill(count)(new CountDownLatch(1))
+    private val opened                                          = new AtomicReferenceArray[FakeTransport](count)
+    private val attempt                                         = new AtomicInteger(0)
+    val factory: Node => MultiplexedConnection.TransportFactory = _ =>
       (onFrame, onClosed) => {
-        if (transport.get() == null) { reached.countDown(); gate.await() }
+        val i = attempt.getAndIncrement()
+        reached(i).countDown()
+        gate(i).await()
         val t = new FakeTransport(onFrame, onClosed, respond)
-        transport.compareAndSet(null, t)
+        opened.set(i, t)
         t
       }
+    def awaitReached(i: Int): Unit                              = assert(reached(i).await(2, TimeUnit.SECONDS), s"attempt $i never reached connect")
+    def release(i: Int): Unit                                   = gate(i).countDown()
+    def transport(i: Int): FakeTransport                        = opened.get(i)
+  }
 
   private def awaitTrue(cond: => Boolean, clue: String): Unit = {
     val deadline = System.nanoTime() + 2.seconds.toNanos
@@ -60,17 +66,20 @@ class NodePoolSpec extends munit.FunSuite {
     assert(cond, clue)
   }
 
+  // every waiter parks on the single-flight latch (or, briefly, the pool lock); once all are WAITING at once none holds the lock, so each
+  // must be blocked on the establishment, not still racing toward it
+  private def awaitAllWaiting(threads: Seq[Thread]): Unit =
+    awaitTrue(threads.forall(_.getState == Thread.State.WAITING), "a waiter never blocked on the in-flight establishment")
+
   test("retain invalidates an in-flight establishment for a rejected node: the client is closed, absent, and every waiter fails") {
-    val node      = Node("gated", 6379)
-    val reached   = new CountDownLatch(1)
-    val gate      = new CountDownLatch(1)
-    val transport = new AtomicReference[FakeTransport]()
-    val pool      = newPool(gatedFactory(reached, gate, transport))
+    val node  = Node("gated", 6379)
+    val gated = new GatedFactory(1)
+    val pool  = newPool(gated.factory)
 
     val establisher  = new AtomicReference[Try[NodeClient]]()
     val establishing = new Thread(() => establisher.set(Try(pool.getOrEstablish(node))), "establisher")
     establishing.start()
-    assert(reached.await(2, TimeUnit.SECONDS), "the establisher never reached connect")
+    gated.awaitReached(0)
 
     val waiters = (1 to 3).map { i =>
       val result = new AtomicReference[Try[NodeClient]]()
@@ -78,7 +87,7 @@ class NodePoolSpec extends munit.FunSuite {
       thread.start()
       (thread, result)
     }
-    Thread.sleep(100) // let the waiters block on the shared establishment before retain runs
+    awaitAllWaiting(waiters.map(_._1)) // every waiter is parked on the original token before retain runs
 
     pool.retain(_ => false)
 
@@ -88,39 +97,68 @@ class NodePoolSpec extends munit.FunSuite {
       assert(result.get().failed.get.isInstanceOf[NotConnected], s"unexpected waiter error: ${result.get()}")
     }
 
-    gate.countDown()
+    gated.release(0)
     establishing.join(2000)
     assert(
       establisher.get() != null && establisher.get().isFailure && establisher.get().failed.get.isInstanceOf[NotConnected],
       s"establisher: ${establisher.get()}"
     )
 
-    val opened = transport.get()
-    assert(opened != null, "no transport was ever created")
-    awaitTrue(opened.closeCount > 0, "the discarded NodeClient was not closed")
+    awaitTrue(gated.transport(0).closeCount > 0, "the discarded NodeClient was not closed")
     assert(pool.existingLive(node).isEmpty, "the rejected node leaked into the pool")
     assert(!pool.candidatesByLiveness.contains(node), "the rejected node leaked into refresh candidates")
     pool.close()
   }
 
   test("retain leaves an accepted in-flight establishment to complete and publish") {
-    val node      = Node("kept", 6379)
-    val reached   = new CountDownLatch(1)
-    val gate      = new CountDownLatch(1)
-    val transport = new AtomicReference[FakeTransport]()
-    val pool      = newPool(gatedFactory(reached, gate, transport))
+    val node  = Node("kept", 6379)
+    val gated = new GatedFactory(1)
+    val pool  = newPool(gated.factory)
 
     val result       = new AtomicReference[Try[NodeClient]]()
     val establishing = new Thread(() => result.set(Try(pool.getOrEstablish(node))), "establisher")
     establishing.start()
-    assert(reached.await(2, TimeUnit.SECONDS), "the establisher never reached connect")
+    gated.awaitReached(0)
 
     pool.retain(_ => true)
 
-    gate.countDown()
+    gated.release(0)
     establishing.join(2000)
     assert(result.get() != null && result.get().isSuccess, s"expected success, got ${result.get()}")
     assert(pool.existingLive(node).isDefined, "the accepted node should be live in the pool")
+    pool.close()
+  }
+
+  test("an attempt invalidated by retain neither removes nor prevents a newer attempt for the same node") {
+    val node  = Node("racing", 6379)
+    val gated = new GatedFactory(2)
+    val pool  = newPool(gated.factory)
+
+    val first       = new AtomicReference[Try[NodeClient]]()
+    val firstThread = new Thread(() => first.set(Try(pool.getOrEstablish(node))), "attempt-1")
+    firstThread.start()
+    gated.awaitReached(0)
+
+    pool.retain(_ => false) // clears attempt 1 from pending while its connect is still in flight
+
+    val second       = new AtomicReference[Try[NodeClient]]()
+    val secondThread = new Thread(() => second.set(Try(pool.getOrEstablish(node))), "attempt-2")
+    secondThread.start()
+    gated.awaitReached(1) // a fresh attempt, since attempt 1 is no longer pending
+
+    gated.release(0) // attempt 1 completes last: it must discard without touching attempt 2
+    firstThread.join(2000)
+    assert(
+      first.get() != null && first.get().isFailure && first.get().failed.get.isInstanceOf[NotConnected],
+      s"attempt 1: ${first.get()}"
+    )
+    awaitTrue(gated.transport(0).closeCount > 0, "attempt 1's discarded client was not closed")
+
+    gated.release(1)
+    secondThread.join(2000)
+    assert(second.get() != null && second.get().isSuccess, s"attempt 2: ${second.get()}")
+    assert(pool.existingLive(node).isDefined, "attempt 2 did not publish")
+    assertEquals(gated.transport(1).closeCount, 0, "attempt 2's published client must not be closed")
     pool.close()
   }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
@@ -146,7 +146,7 @@ class NodePoolSpec extends munit.FunSuite {
     secondThread.start()
     gated.awaitReached(1) // a fresh attempt, since attempt 1 is no longer pending
 
-    gated.release(0) // attempt 1 completes last: it must discard without touching attempt 2
+    gated.release(0) // attempt 1 completes while attempt 2 is pending: it must discard without touching attempt 2
     firstThread.join(2000)
     assert(
       first.get() != null && first.get().isFailure && first.get().failed.get.isInstanceOf[NotConnected],

--- a/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
@@ -80,7 +80,7 @@ class NodePoolSpec extends munit.FunSuite {
     }
     Thread.sleep(100) // let the waiters block on the shared establishment before retain runs
 
-    pool.retain(_ => false) // topology dropped the node while its connect is still in flight
+    pool.retain(_ => false)
 
     waiters.foreach { case (thread, _) => thread.join(2000) }
     waiters.foreach { case (_, result) =>
@@ -88,7 +88,7 @@ class NodePoolSpec extends munit.FunSuite {
       assert(result.get().failed.get.isInstanceOf[NotConnected], s"unexpected waiter error: ${result.get()}")
     }
 
-    gate.countDown() // the connect completes only after retain rejected it
+    gate.countDown()
     establishing.join(2000)
     assert(
       establisher.get() != null && establisher.get().isFailure && establisher.get().failed.get.isInstanceOf[NotConnected],
@@ -115,7 +115,7 @@ class NodePoolSpec extends munit.FunSuite {
     establishing.start()
     assert(reached.await(2, TimeUnit.SECONDS), "the establisher never reached connect")
 
-    pool.retain(_ => true) // the node survives the refresh
+    pool.retain(_ => true)
 
     gate.countDown()
     establishing.join(2000)


### PR DESCRIPTION
## Summary

Removed cluster nodes could leak back into a `NodePool` through an in-flight establishment race.

### The race
1. `getOrEstablish` records a pending establishment (in `pendingEstablish`) and connects **outside the lock**.
2. A topology refresh calls `retain`, which removed only entries already in `established` — it ignored the pending connection.
3. The connect completes and the old completion path published the node checking only `closed`.
4. The just-rejected node was published anyway: it then served keyless routing, stayed a refresh candidate, and kept reconnecting.

### Fix
- `retain` now also removes **and fails** any in-flight establishment whose node it rejects, so blocked callers fail promptly and the connect can no longer re-publish a dropped node.
- A completing connect publishes only if its own `Establish` token is still the current pending entry; otherwise it **closes** the freshly opened `NodeClient` and fails rather than publishing it.
- Token-identity removal on both the publish path and the connect-error path means an older attempt's cleanup can never remove a newer attempt for the same node.

Standalone/`close` behavior is unchanged.

## Tests (`NodePoolSpec`, shared)
Both use a gated establishment (the connect blocks inside the transport factory until released):
- **Rejected while connecting:** three concurrent waiters join the in-flight establishment, `retain(_ => false)` runs, the connect is released — then every waiter fails with `NotConnected`, the establisher fails, the opened transport is closed, and the node is absent from both `existingLive` and the refresh candidates.
- **Accepted while connecting:** `retain(_ => true)` leaves the pending establishment alone, and the released connect completes, publishes, and is live in the pool.

Verified with teeth: reverting the `retain` invalidation makes the rejection test fail (a waiter receives the leaked node).