### PR TITLE
Attribute the serving node on master-replica pipeline completions

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2147,6 +2147,10 @@ object Client {
     try submit
     catch { case NonFatal(error) => complete(Failure(error)) }
 
+  // attributes the node at the completion site, so a batch that never reaches the wire (a false submit) leaves its callbacks unattributed
+  private def attributeOnComplete(cb: Try[Any] => Unit, node: Node): Try[Any] => Unit =
+    result => { Events.attributeNode(cb, node); cb(result) }
+
   // a pipeline batched onto a single connection: scatter each reply into its submission-order slot, and on a disconnect report a failed
   // completion per position before failing the effect once. Shared by standalone/master-replica; the cluster runtime splits per node instead.
   private[internal] def submitBatchOnOne(
@@ -2158,17 +2162,19 @@ object Client {
     node: Option[Node] = None
   ): Unit = {
     val collector = new TxSupport.IndexedCollector[Either[SageException, Any]](commands.length, complete)
-    val callbacks = Vector.tabulate(commands.length) { i =>
+    val tracked   = Vector.tabulate(commands.length) { i =>
       val span = if (spans.isEmpty) CommandSpan.noop else spans(i)
       Events.trackCommand[Any](events, commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)), span)
     }
-    // before submitAll, since a synchronous transport can complete a callback inline
-    node.foreach(n => callbacks.foreach(Events.attributeNode(_, n)))
+    val callbacks = node match {
+      case Some(n) => tracked.map(attributeOnComplete(_, n))
+      case None    => tracked
+    }
     if (!submitAll(commands, callbacks)) {
       val error = NotConnected()
-      callbacks.foreach(Events.abandonSpan(_, error))
+      tracked.foreach(Events.abandonSpan(_, error))
       if (events.emitsEvents)
-        commands.foreach(c => events.emit(SageEvent.CommandCompleted(c.name, node, Duration.Zero, Outcome.Failed(error))))
+        commands.foreach(c => events.emit(SageEvent.CommandCompleted(c.name, None, Duration.Zero, Outcome.Failed(error))))
       complete(Failure(error))
     }
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2162,7 +2162,7 @@ object Client {
       val span = if (spans.isEmpty) CommandSpan.noop else spans(i)
       Events.trackCommand[Any](events, commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)), span)
     }
-    // attribute the serving node before submitAll: a synchronous (fake/fast) transport can complete a callback inline, ahead of any later attribution
+    // before submitAll, since a synchronous transport can complete a callback inline
     node.foreach(n => callbacks.foreach(Events.attributeNode(_, n)))
     if (!submitAll(commands, callbacks)) {
       val error = NotConnected()

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2154,18 +2154,21 @@ object Client {
     commands: Vector[Command[?]],
     spans: Vector[CommandSpan],
     submitAll: (Vector[Command[?]], Vector[Try[Any] => Unit]) => Boolean,
-    complete: Try[Vector[Either[SageException, Any]]] => Unit
+    complete: Try[Vector[Either[SageException, Any]]] => Unit,
+    node: Option[Node] = None
   ): Unit = {
     val collector = new TxSupport.IndexedCollector[Either[SageException, Any]](commands.length, complete)
     val callbacks = Vector.tabulate(commands.length) { i =>
       val span = if (spans.isEmpty) CommandSpan.noop else spans(i)
       Events.trackCommand[Any](events, commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)), span)
     }
+    // attribute the serving node before submitAll: a synchronous (fake/fast) transport can complete a callback inline, ahead of any later attribution
+    node.foreach(n => callbacks.foreach(Events.attributeNode(_, n)))
     if (!submitAll(commands, callbacks)) {
       val error = NotConnected()
       callbacks.foreach(Events.abandonSpan(_, error))
       if (events.emitsEvents)
-        commands.foreach(c => events.emit(SageEvent.CommandCompleted(c.name, None, Duration.Zero, Outcome.Failed(error))))
+        commands.foreach(c => events.emit(SageEvent.CommandCompleted(c.name, node, Duration.Zero, Outcome.Failed(error))))
       complete(Failure(error))
     }
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -283,31 +283,39 @@ final private[client] class MasterReplicaLive(
         offload {
           // all-or-nothing: a fully replica-eligible pipeline batches on a replica, else the master, never split
           val useReplica = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
-          val nc         = if (useReplica) readConn() else masterConn()
+          val (node, nc) = if (useReplica) readConn() else masterConn()
           // no reachable node fires no wire fault, so re-discover here or a stale replica set / down master strands the pipeline forever
           if (nc == null) triggerRefresh()
           val submit     = if (nc == null) (_: Vector[Command[?]], _: Vector[Try[Any] => Unit]) => false else nc.submitAll
-          Client.submitBatchOnOne(events, p.commands, spans, submit, complete)
+          // None when nothing reached the wire, so the batch is not attributed to a node it never landed on
+          val attributed = if (nc == null) None else Some(node)
+          Client.submitBatchOnOne(events, p.commands, spans, submit, complete, attributed)
         }
       }
 
-  private def masterConn(): NodeClient =
-    try masterPool.getOrEstablish(masterNodeRef.get())
-    catch { case NonFatal(_) => null }
+  private def masterConn(): (Node, NodeClient) = {
+    val node = masterNodeRef.get()
+    (
+      node,
+      try masterPool.getOrEstablish(node)
+      catch { case NonFatal(_) => null }
+    )
+  }
 
-  // the first live read candidate under the policy, master or replica; null when none
-  private def readConn(): NodeClient = {
+  // the first live read candidate under the policy with the node it landed on; (null, null) when none
+  private def readConn(): (Node, NodeClient) = {
     val master            = masterNodeRef.get()
     val it                = ReadRouting.candidates(readFrom, master, replicasRef.get(), cursor.getAndIncrement()).iterator
+    var foundNode: Node   = null
     var found: NodeClient = null
     while (found == null && it.hasNext) {
       val node = it.next()
       val nc   =
         try if (node == master) masterPool.getOrEstablish(node) else replicaPool.getOrEstablish(node)
         catch { case NonFatal(_) => null }
-      if (nc != null && nc.isLive) found = nc
+      if (nc != null && nc.isLive) { foundNode = node; found = nc }
     }
-    found
+    (foundNode, found)
   }
 
   // --- transactions (always on the master) ---------------------------------------------------------------------------------------------

--- a/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
@@ -131,6 +131,34 @@ class EventsSpec extends munit.FunSuite {
     }
   }
 
+  test("submitBatchOnOne attributes each completion to the selected node, and routes its span there") {
+    val tracer   = new RecordingTracer
+    val rec      = new Recording(Some(tracer))
+    val node     = Node("replica", 7001)
+    val commands = Vector(Connection.ping(None))
+    Client.submitBatchOnOne(
+      rec,
+      commands,
+      Events.startSpans(rec, commands),
+      (_, cbs) => { cbs.foreach(_(Success("PONG"))); true },
+      _ => (),
+      Some(node)
+    )
+    assertEquals(rec.events.collect { case c: SageEvent.CommandCompleted => c.node }, Vector(Some(node)))
+    assert(tracer.log.contains(s"routed:${node.host}:${node.port}"), s"expected routedTo the selected node, got ${tracer.log.toVector}")
+  }
+
+  test("submitBatchOnOne attributes no node when the batch is not submitted, even if a target was selected") {
+    val tracer                                                             = new RecordingTracer
+    val rec                                                                = new Recording(Some(tracer))
+    val commands                                                           = Vector(Connection.ping(None), Connection.ping(None))
+    var completed: scala.util.Try[Vector[Either[sage.SageException, Any]]] = null
+    Client.submitBatchOnOne(rec, commands, Events.startSpans(rec, commands), (_, _) => false, r => completed = r, Some(Node("replica", 7001)))
+    assert(completed != null && completed.isFailure, s"an unsubmitted batch must fail the effect, got $completed")
+    assertEquals(rec.events.collect { case c: SageEvent.CommandCompleted => c.node }, Vector(None, None))
+    assert(!tracer.log.exists(_.startsWith("routed:")), s"an unsent batch must route no span, got ${tracer.log.toVector}")
+  }
+
   // --- tracing ---------------------------------------------------------------------------------------------------------------------------
 
   test("a tracer-only bus is enabled but emits no events, and drives the span lifecycle through trackCommand") {

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
@@ -50,9 +50,7 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
       )
     )
 
-  // one reply frame per command occurrence in a batch payload, so a pipeline of N commands gets N replies dispatched in order; only the
-  // master answers ROLE, so discovery resolves the topology from the seed. Non-pipeline bootstrap commands (CLIENT TRACKING on the caching
-  // master pool, etc.) each get a single OK
+  // one reply per command occurrence in a batch; only the master answers ROLE; other bootstrap commands each get a single OK
   private def respondFor(node: Node): Bytes => Seq[Frame] = payload => {
     val s = payload.asUtf8String
     if (s.contains("HELLO")) Seq(helloReply)
@@ -70,7 +68,6 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
     count
   }
 
-  // records the node each command's span was routed to, so tracer attribution can be asserted per command name
   final private class RoutingTracer extends CommandTracer {
     val routed                                      = new ConcurrentLinkedQueue[(String, Node)]()
     def onCommand(command: Command[?]): CommandSpan =

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
@@ -80,7 +80,14 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
   private val readCmd: Command[Unit]  = Command("PREAD", Command.NoKeys, Vector.empty, (_: Frame) => Right(()), isReadOnly = true)
   private val writeCmd: Command[Unit] = Command("PWRITE", Command.NoKeys, Vector.empty, (_: Frame) => Right(()), isReadOnly = false)
 
-  private def build(readFrom: ReadFrom): (MasterReplicaLive, ConcurrentLinkedQueue[SageEvent.CommandCompleted], RoutingTracer, CountDownLatch) = {
+  final private case class Fixture(
+    live: MasterReplicaLive,
+    completions: ConcurrentLinkedQueue[SageEvent.CommandCompleted],
+    tracer: RoutingTracer,
+    latch: CountDownLatch
+  )
+
+  private def build(readFrom: ReadFrom): Fixture = {
     val completions                                             = new ConcurrentLinkedQueue[SageEvent.CommandCompleted]()
     val latch                                                   = new CountDownLatch(2)
     val listener                                                = new SageListener {
@@ -103,36 +110,36 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
         Events(Vector(listener), Some(tracer))
       )
     live.bootstrapRoles()
-    (live, completions, tracer, latch)
+    Fixture(live, completions, tracer, latch)
   }
 
   test("a fully read-only pipeline under ReadFrom.Replica attributes every command to the replica") {
-    val (live, completions, tracer, latch) = build(ReadFrom.Replica)
-    live
+    val f = build(ReadFrom.Replica)
+    f.live
       .pipeline(Seq(readCmd, readCmd))
       .unsafeRun
       .map { _ =>
-        assert(latch.await(2, TimeUnit.SECONDS), "expected a completion per pipeline position")
-        val nodes  = completions.asScala.toVector.map(_.node)
+        assert(f.latch.await(2, TimeUnit.SECONDS), "expected a completion per pipeline position")
+        val nodes  = f.completions.asScala.toVector.map(_.node)
         assertEquals(nodes, Vector(Some(replica), Some(replica)), s"pipeline commands should attribute to the replica, got $nodes")
-        val routed = tracer.routed.asScala.toVector.filter(_._1 == "PREAD").map(_._2)
-        assertEquals(routed, Vector(replica, replica), s"tracer routedTo should carry the replica, got $routed")
-        val _      = live.close.unsafeRun
+        val routed = f.tracer.routed.asScala.toVector.filter(_._1 == "PREAD")
+        assertEquals(routed, Vector("PREAD" -> replica, "PREAD" -> replica), s"tracer should route both reads to the replica, got $routed")
+        val _      = f.live.close.unsafeRun
       }
   }
 
   test("a pipeline containing a write attributes the whole batch to the master") {
-    val (live, completions, tracer, latch) = build(ReadFrom.Replica)
-    live
+    val f = build(ReadFrom.Replica)
+    f.live
       .pipeline(Seq(writeCmd, readCmd))
       .unsafeRun
       .map { _ =>
-        assert(latch.await(2, TimeUnit.SECONDS), "expected a completion per pipeline position")
-        val nodes  = completions.asScala.toVector.map(_.node)
-        assertEquals(nodes.toSet, Set(Some(master)), s"a write forces the whole batch to the master, got $nodes")
-        val routed = tracer.routed.asScala.toVector.filter(p => p._1 == "PWRITE" || p._1 == "PREAD").map(_._2)
-        assertEquals(routed.toSet, Set(master), s"tracer routedTo should carry the master, got $routed")
-        val _      = live.close.unsafeRun
+        assert(f.latch.await(2, TimeUnit.SECONDS), "expected a completion per pipeline position")
+        val nodes  = f.completions.asScala.toVector.map(_.node)
+        assertEquals(nodes, Vector(Some(master), Some(master)), s"a write forces the whole batch to the master, got $nodes")
+        val routed = f.tracer.routed.asScala.toVector.filter(p => p._1 == "PWRITE" || p._1 == "PREAD")
+        assertEquals(routed, Vector("PWRITE" -> master, "PREAD" -> master), s"tracer should route both commands to the master, got $routed")
+        val _      = f.live.close.unsafeRun
       }
   }
 }

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
@@ -1,0 +1,141 @@
+package sage.client
+
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+
+import kyo.compat.*
+
+import sage.{Bytes, CommandSpan, CommandTracer, Outcome, SageEvent, SageListener}
+import sage.client.internal.{Events, FakeTransport, MasterReplicaLive, MultiplexedConnection, Scheduler}
+import sage.cluster.Node
+import sage.commands.{Command, Connection}
+import sage.protocol.Frame
+
+class MasterReplicaPipelineSpec extends munit.FunSuite {
+
+  private given ExecutionContext = munitExecutionContext
+
+  private val master  = Node("master-host", 7000)
+  private val replica = Node("replica-host", 7001)
+
+  private val helloReply: Frame =
+    Frame.Map(
+      Vector(
+        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
+        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
+        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
+        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
+      )
+    )
+
+  private val roleReply: Frame =
+    Frame.Array(
+      Vector(
+        Frame.BulkString(Bytes.utf8("master")),
+        Frame.Integer(0L),
+        Frame.Array(
+          Vector(
+            Frame.Array(
+              Vector(
+                Frame.BulkString(Bytes.utf8(replica.host)),
+                Frame.BulkString(Bytes.utf8(replica.port.toString)),
+                Frame.BulkString(Bytes.utf8("0"))
+              )
+            )
+          )
+        )
+      )
+    )
+
+  // one reply frame per command occurrence in a batch payload, so a pipeline of N commands gets N replies dispatched in order; only the
+  // master answers ROLE, so discovery resolves the topology from the seed. Non-pipeline bootstrap commands (CLIENT TRACKING on the caching
+  // master pool, etc.) each get a single OK
+  private def respondFor(node: Node): Bytes => Seq[Frame] = payload => {
+    val s = payload.asUtf8String
+    if (s.contains("HELLO")) Seq(helloReply)
+    else if (s.contains("ROLE")) if (node == master) Seq(roleReply) else Nil
+    else {
+      val batch = occurrences(s, "PREAD") + occurrences(s, "PWRITE")
+      if (batch > 0) Seq.fill(batch)(Frame.SimpleString("OK")) else Seq(Frame.SimpleString("OK"))
+    }
+  }
+
+  private def occurrences(haystack: String, needle: String): Int = {
+    var count = 0
+    var from  = haystack.indexOf(needle)
+    while (from >= 0) { count += 1; from = haystack.indexOf(needle, from + needle.length) }
+    count
+  }
+
+  // records the node each command's span was routed to, so tracer attribution can be asserted per command name
+  final private class RoutingTracer extends CommandTracer {
+    val routed                                      = new ConcurrentLinkedQueue[(String, Node)]()
+    def onCommand(command: Command[?]): CommandSpan =
+      new CommandSpan {
+        def routedTo(node: Node): Unit      = { val _ = routed.add(command.name -> node) }
+        def settled(outcome: Outcome): Unit = ()
+      }
+  }
+
+  private val readCmd: Command[Unit]  = Command("PREAD", Command.NoKeys, Vector.empty, (_: Frame) => Right(()), isReadOnly = true)
+  private val writeCmd: Command[Unit] = Command("PWRITE", Command.NoKeys, Vector.empty, (_: Frame) => Right(()), isReadOnly = false)
+
+  private def build(readFrom: ReadFrom): (MasterReplicaLive, ConcurrentLinkedQueue[SageEvent.CommandCompleted], RoutingTracer, CountDownLatch) = {
+    val completions                                             = new ConcurrentLinkedQueue[SageEvent.CommandCompleted]()
+    val latch                                                   = new CountDownLatch(2)
+    val listener                                                = new SageListener {
+      def onEvent(event: SageEvent): Unit = event match {
+        case c: SageEvent.CommandCompleted if c.name == "PREAD" || c.name == "PWRITE" => completions.add(c); latch.countDown()
+        case _                                                                        => ()
+      }
+    }
+    val tracer                                                  = new RoutingTracer
+    val factory: Node => MultiplexedConnection.TransportFactory =
+      node => (onFrame, onClosed) => new FakeTransport(onFrame, onClosed, respondFor(node))
+    val live                                                    =
+      new MasterReplicaLive(
+        factory,
+        Scheduler.real,
+        Vector(Connection.hello(None)),
+        SageConfig(readFrom = readFrom),
+        Vector(master),
+        1.second,
+        Events(Vector(listener), Some(tracer))
+      )
+    live.bootstrapRoles()
+    (live, completions, tracer, latch)
+  }
+
+  test("a fully read-only pipeline under ReadFrom.Replica attributes every command to the replica") {
+    val (live, completions, tracer, latch) = build(ReadFrom.Replica)
+    live
+      .pipeline(Seq(readCmd, readCmd))
+      .unsafeRun
+      .map { _ =>
+        assert(latch.await(2, TimeUnit.SECONDS), "expected a completion per pipeline position")
+        val nodes  = completions.asScala.toVector.map(_.node)
+        assertEquals(nodes, Vector(Some(replica), Some(replica)), s"pipeline commands should attribute to the replica, got $nodes")
+        val routed = tracer.routed.asScala.toVector.filter(_._1 == "PREAD").map(_._2)
+        assertEquals(routed, Vector(replica, replica), s"tracer routedTo should carry the replica, got $routed")
+        val _      = live.close.unsafeRun
+      }
+  }
+
+  test("a pipeline containing a write attributes the whole batch to the master") {
+    val (live, completions, tracer, latch) = build(ReadFrom.Replica)
+    live
+      .pipeline(Seq(writeCmd, readCmd))
+      .unsafeRun
+      .map { _ =>
+        assert(latch.await(2, TimeUnit.SECONDS), "expected a completion per pipeline position")
+        val nodes  = completions.asScala.toVector.map(_.node)
+        assertEquals(nodes.toSet, Set(Some(master)), s"a write forces the whole batch to the master, got $nodes")
+        val routed = tracer.routed.asScala.toVector.filter(p => p._1 == "PWRITE" || p._1 == "PREAD").map(_._2)
+        assertEquals(routed.toSet, Set(master), s"tracer routedTo should carry the master, got $routed")
+        val _      = live.close.unsafeRun
+      }
+  }
+}


### PR DESCRIPTION
## Problem

In `MasterReplicaLive.submitPipeline`, pipeline routing selected a `NodeClient` but `masterConn`/`readConn` discarded the corresponding `Node`. As a result the generic batch callbacks never received `Events.attributeNode`:

- pipeline `CommandCompleted.node` was always `None`
- pipeline tracing spans never received `routedTo`
- ordinary (non-pipeline) master-replica commands attributed correctly, so observability silently differed only for pipelines

The cluster runtime already does this correctly (`sendBatch` returns `(target, nc)` and attributes each completion); only the master-replica pipeline path was missing it.

## Fix

- `masterConn`/`readConn` now return the `(Node, NodeClient)` the batch lands on.
- `Client.submitBatchOnOne` takes an optional `node: Option[Node]` and, when set, attributes every per-command callback **before** `submitAll` (a fake/fast transport can complete a callback inline), and tags the batch submission-failure path with the same node instead of a hardcoded `None`.
- `None` is preserved when no node could be reached, so a batch is never attributed to a node it never landed on.
- The new parameter defaults to `None`, leaving standalone and cluster callers unchanged.

## Tests

New `MasterReplicaPipelineSpec` drives a real `MasterReplicaLive` over node-keyed fake transports:

- a fully read-only pipeline under `ReadFrom.Replica` attributes every command to the replica
- a pipeline containing a write attributes the whole batch to the master

Both assert listener `CommandCompleted.node` **and** tracer `routedTo`. Teeth-checked: reverting the attribution makes both tests report `node = None`. Full `clientZio` suite (236 tests) green.