### PR TITLE
Catch a listener InterruptedException during shutdown drain

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
@@ -81,8 +81,12 @@ private[client] object Events {
     private def dispatch(event: SageEvent): Unit = {
       var i = 0
       while (i < listeners.length) {
+        // InterruptedException too: a shutdown interrupt landing in one listener must not skip its peers or abort the best-effort drain
         try listeners(i).onEvent(event)
-        catch { case NonFatal(_) => () }
+        catch {
+          case _: InterruptedException => ()
+          case NonFatal(_)             => ()
+        }
         i += 1
       }
     }

--- a/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
@@ -104,26 +104,28 @@ class EventsSpec extends munit.FunSuite {
   }
 
   test("a listener interrupted during shutdown drain still delivers to peers and completes the drain") {
-    val started   = new CountDownLatch(1)
-    val block     = new CountDownLatch(1) // never released; the first callback parks here until the shutdown interrupt
-    val calls     = new java.util.concurrent.atomic.AtomicInteger(0)
-    val bad       = new SageListener {
+    val started      = new CountDownLatch(1)
+    val block        = new CountDownLatch(1) // never released; the first callback parks here until the shutdown interrupt
+    val calls        = new java.util.concurrent.atomic.AtomicInteger(0)
+    val interrupting = new SageListener {
       def onEvent(event: SageEvent): Unit =
         if (calls.getAndIncrement() == 0) { started.countDown(); block.await() } // await throws InterruptedException on interrupt
         else throw new InterruptedException("interrupted again during the drain")
     }
-    val peer      = new ConcurrentLinkedQueue[SageEvent]()
-    val delivered = new CountDownLatch(2)
-    val healthy   = new SageListener {
+    val peer         = new ConcurrentLinkedQueue[SageEvent]()
+    val delivered    = new CountDownLatch(2)
+    val healthy      = new SageListener {
       def onEvent(event: SageEvent): Unit = { peer.add(event); delivered.countDown() }
     }
-    val bus       = Events(Vector(bad, healthy))
-    bus.emit(SageEvent.Cache.Hit("first"))
-    assert(started.await(2, TimeUnit.SECONDS), "the first callback never started")
-    bus.emit(SageEvent.Cache.Hit("second"))
-    bus.close() // running = false, then interrupt: the parked first callback throws, and the drained event throws again
-    assert(delivered.await(2, TimeUnit.SECONDS), "the healthy peer did not receive both events")
-    assertEquals(peer.asScala.toVector, Vector(SageEvent.Cache.Hit("first"), SageEvent.Cache.Hit("second")))
+    val bus          = Events(Vector(interrupting, healthy))
+    try {
+      bus.emit(SageEvent.Cache.Hit("first"))
+      assert(started.await(2, TimeUnit.SECONDS), "the first callback never started")
+      bus.emit(SageEvent.Cache.Hit("second"))
+      bus.close() // running = false, then interrupt: the parked first callback throws, and the drained event throws again
+      assert(delivered.await(2, TimeUnit.SECONDS), "the healthy peer did not receive both events")
+      assertEquals(peer.asScala.toVector, Vector(SageEvent.Cache.Hit("first"), SageEvent.Cache.Hit("second")))
+    } finally bus.close() // safety net: an early assertion failure must still interrupt the parked worker
   }
 
   // --- command completion ----------------------------------------------------------------------------------------------------------------

--- a/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
@@ -105,11 +105,11 @@ class EventsSpec extends munit.FunSuite {
 
   test("a listener interrupted during shutdown drain still delivers to peers and completes the drain") {
     val started      = new CountDownLatch(1)
-    val block        = new CountDownLatch(1) // never released; the first callback parks here until the shutdown interrupt
+    val block        = new CountDownLatch(1)
     val calls        = new java.util.concurrent.atomic.AtomicInteger(0)
     val interrupting = new SageListener {
       def onEvent(event: SageEvent): Unit =
-        if (calls.getAndIncrement() == 0) { started.countDown(); block.await() } // await throws InterruptedException on interrupt
+        if (calls.getAndIncrement() == 0) { started.countDown(); block.await() }
         else throw new InterruptedException("interrupted again during the drain")
     }
     val peer         = new ConcurrentLinkedQueue[SageEvent]()
@@ -122,10 +122,10 @@ class EventsSpec extends munit.FunSuite {
       bus.emit(SageEvent.Cache.Hit("first"))
       assert(started.await(2, TimeUnit.SECONDS), "the first callback never started")
       bus.emit(SageEvent.Cache.Hit("second"))
-      bus.close() // running = false, then interrupt: the parked first callback throws, and the drained event throws again
+      bus.close()
       assert(delivered.await(2, TimeUnit.SECONDS), "the healthy peer did not receive both events")
       assertEquals(peer.asScala.toVector, Vector(SageEvent.Cache.Hit("first"), SageEvent.Cache.Hit("second")))
-    } finally bus.close() // safety net: an early assertion failure must still interrupt the parked worker
+    } finally bus.close()
   }
 
   // --- command completion ----------------------------------------------------------------------------------------------------------------

--- a/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
@@ -103,6 +103,29 @@ class EventsSpec extends munit.FunSuite {
     assert(seen.get() <= 1100, s"expected drops, retained ${seen.get()}")
   }
 
+  test("a listener interrupted during shutdown drain still delivers to peers and completes the drain") {
+    val started   = new CountDownLatch(1)
+    val block     = new CountDownLatch(1) // never released; the first callback parks here until the shutdown interrupt
+    val calls     = new java.util.concurrent.atomic.AtomicInteger(0)
+    val bad       = new SageListener {
+      def onEvent(event: SageEvent): Unit =
+        if (calls.getAndIncrement() == 0) { started.countDown(); block.await() } // await throws InterruptedException on interrupt
+        else throw new InterruptedException("interrupted again during the drain")
+    }
+    val peer      = new ConcurrentLinkedQueue[SageEvent]()
+    val delivered = new CountDownLatch(2)
+    val healthy   = new SageListener {
+      def onEvent(event: SageEvent): Unit = { peer.add(event); delivered.countDown() }
+    }
+    val bus       = Events(Vector(bad, healthy))
+    bus.emit(SageEvent.Cache.Hit("first"))
+    assert(started.await(2, TimeUnit.SECONDS), "the first callback never started")
+    bus.emit(SageEvent.Cache.Hit("second"))
+    bus.close() // running = false, then interrupt: the parked first callback throws, and the drained event throws again
+    assert(delivered.await(2, TimeUnit.SECONDS), "the healthy peer did not receive both events")
+    assertEquals(peer.asScala.toVector, Vector(SageEvent.Cache.Hit("first"), SageEvent.Cache.Hit("second")))
+  }
+
   // --- command completion ----------------------------------------------------------------------------------------------------------------
 
   test("trackCommand emits a completion with name and outcome, and is transparent when disabled") {


### PR DESCRIPTION
## Problem

The listener dispatch loop guarded each callback with `catch { case NonFatal(_) => () }`, and `NonFatal` deliberately excludes `InterruptedException`. During shutdown:

1. `close()` sets `running = false` and interrupts the listener worker.
2. An interruptible listener callback throws `InterruptedException`.
3. The outer `drain` loop catches the first interruption and enters best-effort queue draining.
4. A **second** listener interruption during that drain is outside the outer catch — it terminates the worker, so peer listeners and later queued events never receive delivery.

## Fix

Catch `InterruptedException` explicitly at the individual listener boundary, alongside `NonFatal`. Delivery continues to later listeners and the best-effort drain finishes. `running = false` stays the shutdown signal, and fatal JVM errors still propagate (no broad `Throwable` catch).

## Tests

New `EventsSpec` regression:
- first listener parks on its first callback;
- a second event is queued;
- `close()` interrupts the parked callback (which throws `InterruptedException`);
- that listener throws `InterruptedException` again on the drained event;
- a healthy peer must receive **both** events and the drain must complete.

Teeth-checked: reverting to `NonFatal`-only kills the worker and the peer receives neither event. Full `EventsSpec` (20) green.