### PR TITLE
Keep the listener worker alive when a listener leaves the interrupt flag set

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
@@ -71,8 +71,10 @@ private[client] object Events {
     def close(): Unit = if (worker != null) { running = false; worker.interrupt() }
 
     private def drain(): Unit = {
-      try while (running) dispatch(queue.take())
-      catch { case _: InterruptedException => () }
+      // keep serving while running: a listener may leave the interrupt flag set, and shutdown clears running first, so only it ends the loop
+      while (running)
+        try dispatch(queue.take())
+        catch { case _: InterruptedException => () }
       // best-effort: deliver what is already queued before exiting
       var event = queue.poll()
       while (event != null) { dispatch(event); event = queue.poll() }

--- a/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
@@ -131,9 +131,10 @@ class EventsSpec extends munit.FunSuite {
   test("a listener that leaves the interrupt flag set does not permanently kill the worker") {
     val gotFirst         = new CountDownLatch(1)
     val gotSecond        = new CountDownLatch(1)
+    val worker           = new java.util.concurrent.atomic.AtomicReference[Thread]()
     val first            = new java.util.concurrent.atomic.AtomicBoolean(true)
     val selfInterrupting = new SageListener {
-      def onEvent(event: SageEvent): Unit = if (first.getAndSet(false)) Thread.currentThread().interrupt()
+      def onEvent(event: SageEvent): Unit = if (first.getAndSet(false)) { worker.set(Thread.currentThread()); Thread.currentThread().interrupt() }
     }
     val healthy          = new SageListener {
       def onEvent(event: SageEvent): Unit = event match {
@@ -146,7 +147,12 @@ class EventsSpec extends munit.FunSuite {
     try {
       bus.emit(SageEvent.Cache.Hit("first"))
       assert(gotFirst.await(2, TimeUnit.SECONDS), "the peer never received the first event")
-      Thread.sleep(100) // let a worker that mishandled the interrupt finish exiting before the later event is queued
+      // deterministic: a surviving worker parks WAITING on take(); a worker that mishandled the interrupt is TERMINATED. Decide before emitting.
+      val t        = worker.get()
+      val deadline = System.nanoTime() + 2.seconds.toNanos
+      def settled  = t.getState == Thread.State.WAITING || t.getState == Thread.State.TERMINATED
+      while (!settled && System.nanoTime() < deadline) Thread.sleep(5)
+      assert(settled, "the worker never settled after the self-interrupt")
       bus.emit(SageEvent.Cache.Hit("second"))
       assert(gotSecond.await(2, TimeUnit.SECONDS), "the worker died after a self-interrupt; the later event was lost")
     } finally bus.close()

--- a/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
@@ -147,7 +147,6 @@ class EventsSpec extends munit.FunSuite {
     try {
       bus.emit(SageEvent.Cache.Hit("first"))
       assert(gotFirst.await(2, TimeUnit.SECONDS), "the peer never received the first event")
-      // deterministic: a surviving worker parks WAITING on take(); a worker that mishandled the interrupt is TERMINATED. Decide before emitting.
       val t        = worker.get()
       val deadline = System.nanoTime() + 2.seconds.toNanos
       def settled  = t.getState == Thread.State.WAITING || t.getState == Thread.State.TERMINATED

--- a/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
@@ -128,6 +128,30 @@ class EventsSpec extends munit.FunSuite {
     } finally bus.close()
   }
 
+  test("a listener that leaves the interrupt flag set does not permanently kill the worker") {
+    val gotFirst         = new CountDownLatch(1)
+    val gotSecond        = new CountDownLatch(1)
+    val first            = new java.util.concurrent.atomic.AtomicBoolean(true)
+    val selfInterrupting = new SageListener {
+      def onEvent(event: SageEvent): Unit = if (first.getAndSet(false)) Thread.currentThread().interrupt()
+    }
+    val healthy          = new SageListener {
+      def onEvent(event: SageEvent): Unit = event match {
+        case SageEvent.Cache.Hit("first")  => gotFirst.countDown()
+        case SageEvent.Cache.Hit("second") => gotSecond.countDown()
+        case _                             => ()
+      }
+    }
+    val bus              = Events(Vector(selfInterrupting, healthy))
+    try {
+      bus.emit(SageEvent.Cache.Hit("first"))
+      assert(gotFirst.await(2, TimeUnit.SECONDS), "the peer never received the first event")
+      Thread.sleep(100) // let a worker that mishandled the interrupt finish exiting before the later event is queued
+      bus.emit(SageEvent.Cache.Hit("second"))
+      assert(gotSecond.await(2, TimeUnit.SECONDS), "the worker died after a self-interrupt; the later event was lost")
+    } finally bus.close()
+  }
+
   // --- command completion ----------------------------------------------------------------------------------------------------------------
 
   test("trackCommand emits a completion with name and outcome, and is transparent when disabled") {


### PR DESCRIPTION
## Problem

Listeners run on the event worker thread. If a listener calls `Thread.currentThread.interrupt()`, or catches an `InterruptedException` and restores the interrupt flag, the flag stays set on the worker. The next `queue.take()` then throws while `running` is still `true` — not a shutdown. The outer `catch` drained the current backlog and permanently exited the worker, so later `emit` calls kept enqueueing but no consumer remained and all future observability events were silently lost.

This is distinct from #179 (a listener *throwing* `InterruptedException`, caught per-listener in `dispatch`); here the listener leaves the flag set and returns normally, and the interrupt surfaces at `take()`.

## Fix

Move the `InterruptedException` catch inside the `while (running)` loop so a stray interrupt is swallowed and serving continues. Shutdown still clears `running` before interrupting, so only a shutdown interrupt ends the loop; the best-effort post-shutdown drain is unchanged.

## Tests

New `EventsSpec` regression: a listener self-interrupts on the first event; a healthy peer must still receive a later event. Teeth-checked: reverting to the outer `try/while` kills the worker and the later event is lost (test fails). Full `EventsSpec` (21) green.