### PR TITLE
Broadcast SCRIPT EXISTS to every cluster master and AND the results

### DIFF
--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -10,7 +10,7 @@ import sage.Bytes
 import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, NotConnected, ServerError}
 import sage.client.internal.{ClusterLive, FakeTransport, MultiplexedConnection, Scheduler}
 import sage.cluster.{Node, Slot}
-import sage.commands.{BroadcastReduce, Command, Connection, Keys, Server, Strings}
+import sage.commands.{BroadcastReduce, Command, Connection, Keys, Scripting, Server, Strings}
 import sage.protocol.Frame
 
 class ClusterClientSpec extends munit.FunSuite {
@@ -292,6 +292,36 @@ class ClusterClientSpec extends munit.FunSuite {
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.run(Server.dbSize).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[ServerError], s"expected ServerError, got $error")
+    }
+  }
+
+  test("SCRIPT EXISTS broadcasts to every master and reports a sha present only when every master has it") {
+    val mid                = Slot.Count / 2
+    def flags(bits: Long*) = Frame.Array(bits.map(Frame.Integer(_)).toVector)
+    val behaviour          = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else if (text.contains("SCRIPT")) Seq(if (node == nodeA) flags(1L, 1L) else flags(1L, 0L))
+      else Seq(Frame.Null)
+    val fixture            = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Scripting.scriptExists("a", "b")).unsafeRun.map { result =>
+      assertEquals(result, Vector(true, false))
+      assert(fixture.written(nodeA).exists(_.contains("SCRIPT")), "nodeA did not receive SCRIPT EXISTS")
+      assert(fixture.written(nodeB).exists(_.contains("SCRIPT")), "nodeB did not receive SCRIPT EXISTS")
+    }
+  }
+
+  test("SCRIPT EXISTS fails when any master fails, rather than reporting a partial answer") {
+    val mid       = Slot.Count / 2
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else if (text.contains("SCRIPT"))
+        Seq(if (node == nodeA) Frame.Array(Vector(Frame.Integer(1L))) else Frame.SimpleError("ERR unavailable"))
+      else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Scripting.scriptExists("a")).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[ServerError], s"expected ServerError, got $error")
     }
   }

--- a/sage-core/src/main/scala/sage/commands/Scripting.scala
+++ b/sage-core/src/main/scala/sage/commands/Scripting.scala
@@ -1,6 +1,7 @@
 package sage.commands
 
 import sage.Bytes
+import sage.SageException.DecodeError
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.protocol.Frame
 
@@ -59,16 +60,24 @@ private[sage] object Scripting {
   def scriptLoad(script: String): Command[String] =
     Command("SCRIPT", Command.NoKeys, Vector(Load, Bytes.utf8(script)), Decode.utf8String, allMasters = true)
 
+  private def isFlag(n: Long): Boolean = n == 0L || n == 1L
+
+  private def flagFrame(f: Frame): Boolean = f match {
+    case Frame.Integer(n) => isFlag(n)
+    case _                => false
+  }
+
+  private def andFlag(a: Frame, b: Frame): Frame =
+    (a, b) match {
+      case (Frame.Integer(x), Frame.Integer(y)) if isFlag(x) && isFlag(y) => Frame.Integer(if (x == 1L && y == 1L) 1L else 0L)
+      case (bad, _) if !flagFrame(bad)                                    => bad
+      case (_, bad)                                                       => bad
+    }
+
   private val existsAnd: (Frame, Frame) => Frame = (a, b) =>
     (a, b) match {
-      case (Frame.Array(xs), Frame.Array(ys)) if xs.length == ys.length =>
-        Frame.Array(xs.lazyZip(ys).map {
-          case (Frame.Integer(x), Frame.Integer(y)) => Frame.Integer(if (x == 1L && y == 1L) 1L else 0L)
-          case (Frame.Integer(_), bad)              => bad
-          case (bad, _)                             => bad
-        })
-      case (Frame.Array(_), bad)                                        => bad
-      case (bad, _)                                                     => bad
+      case (Frame.Array(xs), Frame.Array(ys)) if xs.length == ys.length => Frame.Array(xs.lazyZip(ys).map(andFlag))
+      case _                                                            => throw DecodeError("SCRIPT EXISTS per-master flag arrays of equal length", s"${Frame.describe(a)} vs ${Frame.describe(b)}")
     }
 
   def scriptExists(first: String, rest: String*): Command[Vector[Boolean]] =

--- a/sage-core/src/main/scala/sage/commands/Scripting.scala
+++ b/sage-core/src/main/scala/sage/commands/Scripting.scala
@@ -6,8 +6,9 @@ import sage.protocol.Frame
 
 /**
   * Server-side Lua scripting. `EVAL`/`EVALSHA` and their `_RO` reads return the raw RESP3 [[Frame]], since a script's reply shape is
-  * defined by user code. `SCRIPT LOAD` and `SCRIPT FLUSH` run on every master, because a cluster keeps no shared script cache and a
-  * later key-routed `EVALSHA` must find the script wherever its keys live.
+  * defined by user code. `SCRIPT LOAD`, `SCRIPT FLUSH` and `SCRIPT EXISTS` run on every master, because a cluster keeps no shared script
+  * cache and a later key-routed `EVALSHA` must find the script wherever its keys live. `EXISTS` therefore reports a sha present only when
+  * every master has it (a per-sha AND), so a `true` reply guarantees the key-routed `EVALSHA` cannot hit a master that lacks the script.
   */
 private[sage] object Scripting {
 
@@ -58,8 +59,27 @@ private[sage] object Scripting {
   def scriptLoad(script: String): Command[String] =
     Command("SCRIPT", Command.NoKeys, Vector(Load, Bytes.utf8(script)), Decode.utf8String, allMasters = true)
 
+  private val existsAnd: (Frame, Frame) => Frame = (a, b) =>
+    (a, b) match {
+      case (Frame.Array(xs), Frame.Array(ys)) if xs.length == ys.length =>
+        Frame.Array(xs.lazyZip(ys).map {
+          case (Frame.Integer(x), Frame.Integer(y)) => Frame.Integer(if (x == 1L && y == 1L) 1L else 0L)
+          case (Frame.Integer(_), bad)              => bad
+          case (bad, _)                             => bad
+        })
+      case (Frame.Array(_), bad)                                        => bad
+      case (bad, _)                                                     => bad
+    }
+
   def scriptExists(first: String, rest: String*): Command[Vector[Boolean]] =
-    Command("SCRIPT", Command.NoKeys, Exists +: (first +: rest).iterator.map(Bytes.utf8).toVector, Decode.vector(Decode.flag))
+    Command(
+      "SCRIPT",
+      Command.NoKeys,
+      Exists +: (first +: rest).iterator.map(Bytes.utf8).toVector,
+      Decode.vector(Decode.flag),
+      allMasters = true,
+      broadcast = BroadcastReduce.Fold(existsAnd)
+    )
 
   def scriptFlush(mode: Option[FlushMode] = None): Command[Unit] =
     Command("SCRIPT", Command.NoKeys, Flush +: FlushMode.args(mode), Decode.ok, allMasters = true)

--- a/sage-core/src/test/scala/sage/commands/ScriptingSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ScriptingSpec.scala
@@ -8,6 +8,13 @@ class ScriptingSpec extends munit.FunSuite {
 
   private def bulk(value: String): Frame = Frame.BulkString(Bytes.utf8(value))
 
+  private def flags(bits: Long*): Frame = Frame.Array(bits.iterator.map(Frame.Integer(_)).toVector)
+
+  private val existsFold: (Frame, Frame) => Frame = {
+    val BroadcastReduce.Fold(combine) = Scripting.scriptExists("x").broadcast: @unchecked
+    combine
+  }
+
   test("EVAL returns the raw RESP3 frame untouched") {
     assertEquals(Reply.run(Scripting.eval("return 1"), Frame.Integer(1L)), Right(Frame.Integer(1L)))
     val nested = Frame.Array(Vector(bulk("a"), Frame.Integer(2L)))
@@ -49,22 +56,14 @@ class ScriptingSpec extends munit.FunSuite {
   }
 
   test("SCRIPT EXISTS folds per-sha presence across masters with AND") {
-    val BroadcastReduce.Fold(combine) = Scripting.scriptExists("a", "b").broadcast: @unchecked
-    val a                             = Frame.Array(Vector(Frame.Integer(1L), Frame.Integer(1L)))
-    val b                             = Frame.Array(Vector(Frame.Integer(1L), Frame.Integer(0L)))
-    assertEquals(combine(a, b), Frame.Array(Vector(Frame.Integer(1L), Frame.Integer(0L))))
+    assertEquals(existsFold(flags(1L, 1L), flags(1L, 0L)), flags(1L, 0L))
   }
 
   test("SCRIPT EXISTS surfaces a non-binary flag so the strict decode rejects it rather than coercing to false") {
-    val BroadcastReduce.Fold(combine) = Scripting.scriptExists("a").broadcast: @unchecked
-    val merged                        = combine(Frame.Array(Vector(Frame.Integer(2L))), Frame.Array(Vector(Frame.Integer(1L))))
-    assert(Reply.run(Scripting.scriptExists("a"), merged).isLeft)
+    assert(Reply.run(Scripting.scriptExists("a"), existsFold(flags(2L), flags(1L))).isLeft)
   }
 
   test("SCRIPT EXISTS fails a length mismatch across masters rather than hiding the malformed reply") {
-    val BroadcastReduce.Fold(combine) = Scripting.scriptExists("a", "b").broadcast: @unchecked
-    val whole                         = Frame.Array(Vector(Frame.Integer(1L), Frame.Integer(1L)))
-    val short                         = Frame.Array(Vector(Frame.Integer(1L)))
-    intercept[DecodeError](combine(whole, short))
+    intercept[DecodeError](existsFold(flags(1L, 1L), flags(1L)))
   }
 }

--- a/sage-core/src/test/scala/sage/commands/ScriptingSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ScriptingSpec.scala
@@ -1,6 +1,7 @@
 package sage.commands
 
 import sage.Bytes
+import sage.SageException.DecodeError
 import sage.protocol.Frame
 
 class ScriptingSpec extends munit.FunSuite {
@@ -52,5 +53,18 @@ class ScriptingSpec extends munit.FunSuite {
     val a                             = Frame.Array(Vector(Frame.Integer(1L), Frame.Integer(1L)))
     val b                             = Frame.Array(Vector(Frame.Integer(1L), Frame.Integer(0L)))
     assertEquals(combine(a, b), Frame.Array(Vector(Frame.Integer(1L), Frame.Integer(0L))))
+  }
+
+  test("SCRIPT EXISTS surfaces a non-binary flag so the strict decode rejects it rather than coercing to false") {
+    val BroadcastReduce.Fold(combine) = Scripting.scriptExists("a").broadcast: @unchecked
+    val merged                        = combine(Frame.Array(Vector(Frame.Integer(2L))), Frame.Array(Vector(Frame.Integer(1L))))
+    assert(Reply.run(Scripting.scriptExists("a"), merged).isLeft)
+  }
+
+  test("SCRIPT EXISTS fails a length mismatch across masters rather than hiding the malformed reply") {
+    val BroadcastReduce.Fold(combine) = Scripting.scriptExists("a", "b").broadcast: @unchecked
+    val whole                         = Frame.Array(Vector(Frame.Integer(1L), Frame.Integer(1L)))
+    val short                         = Frame.Array(Vector(Frame.Integer(1L)))
+    intercept[DecodeError](combine(whole, short))
   }
 }

--- a/sage-core/src/test/scala/sage/commands/ScriptingSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ScriptingSpec.scala
@@ -39,11 +39,18 @@ class ScriptingSpec extends munit.FunSuite {
     assertEquals(Reply.run(Scripting.scriptLoad("return 1"), bulk("abc123")), Right("abc123"))
   }
 
-  test("the cluster mutations are All-Masters Commands; reads and KILL are not") {
+  test("SCRIPT LOAD, FLUSH and EXISTS are All-Masters Commands; KILL and EVALSHA are not") {
     assert(Scripting.scriptLoad("s").allMasters)
     assert(Scripting.scriptFlush().allMasters)
+    assert(Scripting.scriptExists("a").allMasters)
     assert(!Scripting.scriptKill.allMasters)
-    assert(!Scripting.scriptExists("a").allMasters)
     assert(!Scripting.evalSha("sha").allMasters)
+  }
+
+  test("SCRIPT EXISTS folds per-sha presence across masters with AND") {
+    val BroadcastReduce.Fold(combine) = Scripting.scriptExists("a", "b").broadcast: @unchecked
+    val a                             = Frame.Array(Vector(Frame.Integer(1L), Frame.Integer(1L)))
+    val b                             = Frame.Array(Vector(Frame.Integer(1L), Frame.Integer(0L)))
+    assertEquals(combine(a, b), Frame.Array(Vector(Frame.Integer(1L), Frame.Integer(0L))))
   }
 }


### PR DESCRIPTION
## Problem

`SCRIPT LOAD` and `SCRIPT FLUSH` broadcast to every cluster master, but `SCRIPT EXISTS` did not. Being keyless, it was routed to one arbitrary master. Script caches are server-local and volatile across restart/failover/flush ([Redis scripting docs](https://redis.io/docs/latest/develop/programmability/eval-intro/)), so if master A held a script but master B had lost its cache, `scriptExists` could return `true` while a later key-routed `EVALSHA` on B failed with `NOSCRIPT`.

## Fix

- Mark `scriptExists` as `allMasters = true` so it fans out to every slot-owning master.
- Fold each node's per-sha flag vector element-wise with AND: a sha is reported present only when **every** master has it, so a `true` reply guarantees a key-routed `EVALSHA` cannot land on a master that lacks the script.
- Any master failing still fails the whole command (existing broadcast semantics), rather than reporting a partial answer.

This matches how Lettuce handles cluster `SCRIPT EXISTS`.

## Tests

- `ScriptingSpec`: the fold reduces `[1,1]` with `[1,0]` to `[1,0]`; `SCRIPT EXISTS` is now an all-masters command.
- `ClusterClientSpec`: a cluster with differing per-master replies returns `Vector(true, false)`, reaching both masters; a failing master fails the command.
- Updated the prior assertion that expected `scriptExists(...).allMasters` to be false.

All teeth-checked: each new test fails against the pre-fix behavior.