### PR TITLE
Make the cluster test transports thread-safe to fix a flaky CME

### DIFF
--- a/sage-client/shared/src/test/scala/sage/client/internal/FakeTransport.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/FakeTransport.scala
@@ -16,8 +16,10 @@ final class FakeTransport(
   var autoWrite: Boolean = true
 ) extends Transport {
 
-  val written: mutable.ArrayBuffer[Bytes]                 = mutable.ArrayBuffer.empty
+  private val writes: mutable.ArrayBuffer[Bytes]          = mutable.ArrayBuffer.empty
   private val queued: mutable.ArrayBuffer[Transport.Item] = mutable.ArrayBuffer.empty
+
+  def written: Vector[Bytes] = synchronized(writes.toVector)
 
   var closeCount: Int = 0
 
@@ -47,7 +49,7 @@ final class FakeTransport(
 
   private def write(item: Transport.Item): Unit = {
     item.writeAttempted()
-    val _ = written += item.payload
+    synchronized { val _ = writes += item.payload }
     respond(item.payload).foreach(onFrame)
   }
 }

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -61,9 +61,14 @@ class ClusterClientSpec extends munit.FunSuite {
     // nodes whose *next* HELLO fails and then clears: simulates an establish that fails once mid-recovery, so a re-home must retry to converge
     val flakyHello = mutable.Set.empty[Node]
 
+    private def transportsOf(node: Node): Vector[FakeTransport] =
+      transports.synchronized(transports.get(node).map(_.toVector).getOrElse(Vector.empty))
+
+    private def allTransports: Vector[FakeTransport] = transports.synchronized(transports.values.flatten.toVector)
+
     private val factory: Node => MultiplexedConnection.TransportFactory = node =>
       (onFrame, onClosed) => {
-        connectGate(node, transports.get(node).map(_.size).getOrElse(0))
+        connectGate(node, transportsOf(node).size)
         val respond: Bytes => Seq[Frame] = payload => {
           val text = payload.asUtf8String
           if (text.contains("HELLO"))
@@ -71,7 +76,7 @@ class ClusterClientSpec extends munit.FunSuite {
           else behaviour(node, text)
         }
         val transport                    = new FakeTransport(onFrame, onClosed, respond)
-        transports.getOrElseUpdate(node, mutable.ArrayBuffer.empty) += transport
+        transports.synchronized { val _ = transports.getOrElseUpdate(node, mutable.ArrayBuffer.empty) += transport }
         transport
       }
 
@@ -93,27 +98,20 @@ class ClusterClientSpec extends munit.FunSuite {
 
     live.bootstrapTopology()
 
-    def written(node: Node): Vector[String] =
-      transports.getOrElse(node, mutable.ArrayBuffer.empty).toVector.flatMap(_.written.map(_.asUtf8String))
+    def written(node: Node): Vector[String] = transportsOf(node).flatMap(_.written.map(_.asUtf8String))
 
     // simulate the server dropping a node's Sharded Subscription Connection (the post-migration disconnect): close the transport that
     // carried the SSUBSCRIBE so its onClosed fires and the manager re-homes
     def dropShardConn(node: Node): Unit =
-      transports
-        .getOrElse(node, mutable.ArrayBuffer.empty)
-        .find(_.written.exists(_.asUtf8String.contains("SSUBSCRIBE")))
-        .foreach(_.close())
+      transportsOf(node).find(_.written.exists(_.asUtf8String.contains("SSUBSCRIBE"))).foreach(_.close())
 
     // close the master's classic Subscription Connection so its onClosed fires and the manager re-homes
     def dropClassicConn(): Unit =
-      transports.values.flatten
-        .find(_.written.exists(_.asUtf8String.contains("\r\nSUBSCRIBE\r\n")))
-        .foreach(_.close())
+      allTransports.find(_.written.exists(_.asUtf8String.contains("\r\nSUBSCRIBE\r\n"))).foreach(_.close())
 
-    def drop(node: Node): Unit = transports.getOrElse(node, mutable.ArrayBuffer.empty).foreach(_.close())
+    def drop(node: Node): Unit = transportsOf(node).foreach(_.close())
 
-    def deliver(node: Node, frame: Frame): Unit =
-      transports.getOrElse(node, mutable.ArrayBuffer.empty).lastOption.foreach(_.emit(frame))
+    def deliver(node: Node, frame: Frame): Unit = transportsOf(node).lastOption.foreach(_.emit(frame))
   }
 
   private def awaitWritten(fixture: Fixture, node: Node, token: String): Unit = {


### PR DESCRIPTION
## Problem

`ClusterClientSpec` intermittently fails with `java.util.ConcurrentModificationException: mutation occurred during iteration` (e.g. [this run](https://github.com/ghostdogpr/sage/actions/runs/29477495778/job/87553557211)). The test helpers hold plain `mutable.ArrayBuffer`/`mutable.Map` state that the runtime appends to from its own reply and connection-establish threads, while the test thread polls it (via `awaitWritten`, `written`, etc.). Scala's mutation tracking then throws mid-iteration.

Two shared mutable structures were racing:
- `FakeTransport.written` — appended to on the runtime's write path, iterated on the test thread.
- `ClusterClientSpec`'s per-node `transports` map — populated on establish threads, read on the test thread.

## Fix

Test-infra only, no production change:
- `FakeTransport` keeps a private write buffer, appends under its monitor, and exposes `written` as an immutable snapshot taken under the same lock.
- The fixture guards every access to the `transports` map and hands readers a `Vector` snapshot.

## Verification

- `clientZio/test` (241) and `clientCe/test` (170) pass.
- Ran `ClusterClientSpec` in a loop with no CME recurrence.

This is a pre-existing flake surfaced by an unrelated PR's CI; splitting it out so it can be reviewed and merged on its own.