### PR TITLE
Abort still-establishing connections on close

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
@@ -60,10 +60,22 @@ final private[client] class DedicatedConnection private (
     if (transport != null) transport.close()
   }
 
+  /**
+    * Opens the socket and runs the bootstrap synchronously; throws (no retry) if the connect or handshake fails. Split from the constructor
+    * ([[DedicatedConnection.create]]) so the pool can retain the reference and abort a still-establishing connection from `close`.
+    */
+  def establish(bootstrap: Vector[Command[?]]): Unit = {
+    start()
+    runBootstrap(bootstrap)
+  }
+
   private def start(): Unit = {
     val transport = factory(onFrame, onClosed)
+    // transportRef is published before the blocking connect, so a concurrent close() can abort it; `dead` (set by close before it reads
+    // transportRef) covers the narrow gap where close lands before the transport is published
     transportRef.set(transport)
-    transport.start()
+    if (dead) transport.close()
+    else transport.start()
   }
 
   private def runBootstrap(bootstrap: Vector[Command[?]]): Unit =
@@ -153,16 +165,9 @@ private[client] object DedicatedConnection {
   }
 
   /**
-    * Connects and runs the bootstrap synchronously; throws (no retry) if the connect or handshake fails.
+    * Builds an unconnected connection. The pool registers it, then drives the blocking [[DedicatedConnection.establish]] outside its lock, so
+    * a `close` racing the establish can abort the socket rather than stranding it until the connect timeout.
     */
-  def establish(
-    factory: MultiplexedConnection.TransportFactory,
-    bootstrap: Vector[Command[?]],
-    connectTimeoutMillis: Long
-  ): DedicatedConnection = {
-    val connection = new DedicatedConnection(factory, connectTimeoutMillis)
-    connection.start()
-    connection.runBootstrap(bootstrap)
-    connection
-  }
+  def create(factory: MultiplexedConnection.TransportFactory, connectTimeoutMillis: Long): DedicatedConnection =
+    new DedicatedConnection(factory, connectTimeoutMillis)
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
@@ -61,8 +61,7 @@ final private[client] class DedicatedConnection private (
   }
 
   /**
-    * Opens the socket and runs the bootstrap synchronously; throws (no retry) if the connect or handshake fails. Split from the constructor
-    * ([[DedicatedConnection.create]]) so the pool can retain the reference and abort a still-establishing connection from `close`.
+    * Opens the socket and runs the bootstrap synchronously; throws (no retry) if the connect or handshake fails.
     */
   def establish(bootstrap: Vector[Command[?]]): Unit = {
     start()
@@ -165,8 +164,8 @@ private[client] object DedicatedConnection {
   }
 
   /**
-    * Builds an unconnected connection. The pool registers it, then drives the blocking [[DedicatedConnection.establish]] outside its lock, so
-    * a `close` racing the establish can abort the socket rather than stranding it until the connect timeout.
+    * Builds an unconnected connection; the pool drives the blocking [[DedicatedConnection.establish]] separately so it can hold the reference
+    * and abort one still establishing.
     */
   def create(factory: MultiplexedConnection.TransportFactory, connectTimeoutMillis: Long): DedicatedConnection =
     new DedicatedConnection(factory, connectTimeoutMillis)

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
@@ -70,8 +70,6 @@ final private[client] class DedicatedConnection private (
 
   private def start(): Unit = {
     val transport = factory(onFrame, onClosed)
-    // transportRef is published before the blocking connect, so a concurrent close() can abort it; `dead` (set by close before it reads
-    // transportRef) covers the narrow gap where close lands before the transport is published
     transportRef.set(transport)
     if (dead) transport.close()
     else transport.start()
@@ -164,8 +162,7 @@ private[client] object DedicatedConnection {
   }
 
   /**
-    * Builds an unconnected connection; the pool drives the blocking [[DedicatedConnection.establish]] separately so it can hold the reference
-    * and abort one still establishing.
+    * Builds an unconnected connection; the pool runs the blocking [[DedicatedConnection.establish]] separately.
     */
   def create(factory: MultiplexedConnection.TransportFactory, connectTimeoutMillis: Long): DedicatedConnection =
     new DedicatedConnection(factory, connectTimeoutMillis)

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -39,6 +39,9 @@ final private[client] class DedicatedPool(
 
   private val idle                              = mutable.ArrayDeque.empty[DedicatedPool.Idle]
   private val live                              = mutable.Set.empty[DedicatedConnection]
+  // connections whose socket is being opened outside the lock; retained so close() can abort one still stuck in connect rather than
+  // stranding it until the connect timeout. The establisher removes its own entry on return.
+  private val establishing                      = mutable.Set.empty[DedicatedConnection]
   private var reserved                          = 0
   private var closing                           = false
   private val sweepHandle: Scheduler.Cancelable =
@@ -115,7 +118,8 @@ final private[client] class DedicatedPool(
       closing = true
       if (sweepHandle != null) sweepHandle.cancel()
       available.signalAll()
-      val snapshot = live.toVector
+      // establishing connections abort their in-flight connect; they still remove their own entry when the establish unwinds
+      val snapshot = (live ++ establishing).toVector
       live.clear()
       idle.clear()
       snapshot
@@ -144,18 +148,21 @@ final private[client] class DedicatedPool(
     }
   }
 
-  // entered holding the lock with `reserved` already incremented; drops the lock for the blocking establish, then re-accounts under it.
+  // entered holding the lock with `reserved` already incremented; registers the connection, drops the lock for the blocking establish, then
+  // re-accounts under it. Registering before the unlock lets a concurrent close() abort the socket instead of stranding it in connect.
   private def establishOutsideLock(): DedicatedConnection = {
+    val connection = DedicatedConnection.create(factory, connectTimeoutMillis)
+    establishing += connection
     lock.unlock()
-    val connection =
-      try DedicatedConnection.establish(factory, bootstrap, connectTimeoutMillis)
-      catch {
-        case e: Throwable =>
-          locked { reserved -= 1; available.signal() }
-          lock.lock() // re-take so acquire()'s `locked` block unlocks exactly once on exit
-          throw e
-      }
+    try connection.establish(bootstrap)
+    catch {
+      case e: Throwable =>
+        locked { establishing -= connection; reserved -= 1; available.signal() }
+        lock.lock() // re-take so acquire()'s `locked` block unlocks exactly once on exit
+        throw e
+    }
     lock.lock()
+    establishing -= connection
     reserved -= 1
     // stamp with the epoch live the moment it joins the pool, so a connection built across a reconnect is born current, never stale
     if (closing) {

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -118,7 +118,6 @@ final private[client] class DedicatedPool(
       closing = true
       if (sweepHandle != null) sweepHandle.cancel()
       available.signalAll()
-      // establishing connections abort their in-flight connect; they still remove their own entry when the establish unwinds
       val snapshot = (live ++ establishing).toVector
       live.clear()
       idle.clear()

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -39,8 +39,7 @@ final private[client] class DedicatedPool(
 
   private val idle                              = mutable.ArrayDeque.empty[DedicatedPool.Idle]
   private val live                              = mutable.Set.empty[DedicatedConnection]
-  // connections whose socket is being opened outside the lock; retained so close() can abort one still stuck in connect rather than
-  // stranding it until the connect timeout. The establisher removes its own entry on return.
+  // connections whose socket is being opened outside the lock, so close() can abort one still connecting
   private val establishing                      = mutable.Set.empty[DedicatedConnection]
   private var reserved                          = 0
   private var closing                           = false
@@ -148,7 +147,7 @@ final private[client] class DedicatedPool(
   }
 
   // entered holding the lock with `reserved` already incremented; registers the connection, drops the lock for the blocking establish, then
-  // re-accounts under it. Registering before the unlock lets a concurrent close() abort the socket instead of stranding it in connect.
+  // re-accounts under it.
   private def establishOutsideLock(): DedicatedConnection = {
     val connection = DedicatedConnection.create(factory, connectTimeoutMillis)
     establishing += connection

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -153,24 +153,29 @@ final private[client] class MultiplexedConnection private (
   private[internal] def isCurrent(g: Generation): Boolean = liveEpoch.get() == g
 
   private def connectInitial(): Unit = {
-    val conn = establish() // the first connect propagates a handshake failure; only reconnects retry
+    val conn     = establish() // the first connect propagates a handshake failure; only reconnects retry
     // emit under the lock so the enqueue is ordered with the state transition: a socket dropping immediately after cannot deliver
     // Disconnected before this Connected (the same lock serializes both)
-    locked {
-      if (conn.isTerminated) scheduleReconnect(0)
+    val teardown = locked {
+      // a close() that arrived while establish() ran (e.g. the owning pool shutting down) wins: don't publish this connection Live
+      if (state == State.Closed) conn
+      else if (conn.isTerminated) { scheduleReconnect(0); null }
       else {
         current = conn
         generation = generation.next
         transition(State.Live)
         startWatchdog()
         events.emit(SageEvent.Connection.Connected(node))
+        null
       }
     }
+    if (teardown != null) teardown.close()
   }
 
   private def establish(): Conn = {
     val conn = new Conn
-    locked { establishing = conn }
+    // register before the blocking connect so a concurrent close() can abort it; if the close already fired, abort right away
+    locked { establishing = conn; if (state == State.Closed) conn.close() }
     try {
       conn.start()
       // reserve(1) per command: submit does not self-increment, so this balances the retire() the reply will trigger. A half-open peer can
@@ -454,10 +459,14 @@ private[client] object MultiplexedConnection {
     closeTimeout: FiniteDuration,
     cacheMaxBytes: Long = 0L,
     node: Option[Node] = None,
-    events: Events = Events.disabled
+    events: Events = Events.disabled,
+    onConstructed: MultiplexedConnection => Unit = _ => ()
   ): MultiplexedConnection = {
     val connection =
       new MultiplexedConnection(factory, scheduler, bootstrap, backoff, watchdog, connectTimeout, closeTimeout, cacheMaxBytes, node, events)
+    // hand the instance to the caller before the blocking initial connect, so an owner (e.g. a NodePool) can abort it from close() rather
+    // than stranding the socket until the connect timeout
+    onConstructed(connection)
     connection.connectInitial()
     connection
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -157,7 +157,7 @@ final private[client] class MultiplexedConnection private (
     // emit under the lock so the enqueue is ordered with the state transition: a socket dropping immediately after cannot deliver
     // Disconnected before this Connected (the same lock serializes both)
     val teardown = locked {
-      // a close() that arrived while establish() ran (e.g. the owning pool shutting down) wins: don't publish this connection Live
+      // a close() during establish() wins: tear down rather than publish Live
       if (state == State.Closed) conn
       else if (conn.isTerminated) { scheduleReconnect(0); null }
       else {
@@ -174,7 +174,6 @@ final private[client] class MultiplexedConnection private (
 
   private def establish(): Conn = {
     val conn = new Conn
-    // register before the blocking connect so a concurrent close() can abort it; if the close already fired, abort right away
     locked { establishing = conn; if (state == State.Closed) conn.close() }
     try {
       conn.start()
@@ -464,8 +463,7 @@ private[client] object MultiplexedConnection {
   ): MultiplexedConnection = {
     val connection =
       new MultiplexedConnection(factory, scheduler, bootstrap, backoff, watchdog, connectTimeout, closeTimeout, cacheMaxBytes, node, events)
-    // hand the instance to the caller before the blocking initial connect, so an owner (e.g. a NodePool) can abort it from close() rather
-    // than stranding the socket until the connect timeout
+    // expose the instance before the blocking connect so an owner can abort it from close()
     onConstructed(connection)
     connection.connectInitial()
     connection

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
@@ -60,10 +60,12 @@ private[client] object NodeClient {
     cacheMaxBytes: Long = 0L,
     node: Option[Node] = None,
     events: Events = Events.disabled,
-    dedicatedBootstrap: Option[Vector[Command[?]]] = None
+    dedicatedBootstrap: Option[Vector[Command[?]]] = None,
+    onConstructed: MultiplexedConnection => Unit = _ => ()
   ): NodeClient = {
     val connection =
-      MultiplexedConnection.connect(factory, scheduler, bootstrap, reconnect, watchdog, connectTimeout, closeTimeout, cacheMaxBytes, node, events)
+      MultiplexedConnection
+        .connect(factory, scheduler, bootstrap, reconnect, watchdog, connectTimeout, closeTimeout, cacheMaxBytes, node, events, onConstructed)
     val pool       =
       DedicatedPool.forConnection(factory, dedicatedBootstrap.getOrElse(bootstrap), scheduler, connection, dedicatedPool, connectTimeout.toMillis)
     new NodeClient(connection, pool)

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -142,7 +142,7 @@ final private[client] class NodePool(
     // release callers blocked on an in-flight connect now, rather than stranding them for the connect timeout; the establisher still
     // observes `closed` on return and closes the node it opened
     waiters.foreach(_.fail(NotConnected()))
-    // abort connections still opening their socket, so a shutdown doesn't wait out the connect timeout; each establisher then removes its entry
+    // abort connections still opening their socket, rather than stranding them for the connect timeout
     opening.foreach(_.close())
     all.foreach(_.close())
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -36,8 +36,7 @@ final private[client] class NodePool(
   private val lock             = new ReentrantLock()
   private val established      = mutable.HashMap.empty[Node, NodeClient]
   private val pendingEstablish = mutable.HashMap.empty[Node, NodePool.Establish]
-  // connections whose socket is still being opened, retained so close() can abort one stuck in connect rather than waiting out the connect
-  // timeout; each establisher removes its own entry once the connect settles
+  // connections whose socket is still being opened, so close() can abort one still connecting
   private val establishing     = mutable.Set.empty[MultiplexedConnection]
   @volatile private var closed = false
 
@@ -91,7 +90,6 @@ final private[client] class NodePool(
             Some(node),
             events,
             dedicatedBootstrap,
-            // register the connection before its blocking connect; if close() already fired, abort it now so it doesn't strand the socket
             onConstructed = conn => { connRef.set(conn); if (locked { establishing += conn; closed }) conn.close() }
           )
         catch {
@@ -142,7 +140,6 @@ final private[client] class NodePool(
     // release callers blocked on an in-flight connect now, rather than stranding them for the connect timeout; the establisher still
     // observes `closed` on return and closes the node it opened
     waiters.foreach(_.fail(NotConnected()))
-    // abort connections still opening their socket, rather than stranding them for the connect timeout
     opening.foreach(_.close())
     all.foreach(_.close())
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -36,6 +36,9 @@ final private[client] class NodePool(
   private val lock             = new ReentrantLock()
   private val established      = mutable.HashMap.empty[Node, NodeClient]
   private val pendingEstablish = mutable.HashMap.empty[Node, NodePool.Establish]
+  // connections whose socket is still being opened, retained so close() can abort one stuck in connect rather than waiting out the connect
+  // timeout; each establisher removes its own entry once the connect settles
+  private val establishing     = mutable.Set.empty[MultiplexedConnection]
   @volatile private var closed = false
 
   private inline def locked[A](inline body: A): A = {
@@ -72,6 +75,7 @@ final private[client] class NodePool(
     if (existing != null) existing
     else if (waitOn != null) waitOn.get()
     else {
+      val connRef = new java.util.concurrent.atomic.AtomicReference[MultiplexedConnection]()
       val nc      =
         try
           NodeClient.connect(
@@ -86,16 +90,24 @@ final private[client] class NodePool(
             cacheMaxBytes,
             Some(node),
             events,
-            dedicatedBootstrap
+            dedicatedBootstrap,
+            // register the connection before its blocking connect; if close() already fired, abort it now so it doesn't strand the socket
+            onConstructed = conn => { connRef.set(conn); if (locked { establishing += conn; closed }) conn.close() }
           )
         catch {
           case error: Throwable =>
-            locked(if (pendingEstablish.get(node).exists(_ eq mine)) { val _ = pendingEstablish.remove(node) })
+            locked {
+              val conn = connRef.get()
+              if (conn != null) { val _ = establishing -= conn }
+              if (pendingEstablish.get(node).exists(_ eq mine)) { val _ = pendingEstablish.remove(node) }
+            }
             mine.fail(error)
             throw error
         }
       // publish only if our token is still current: a retain, close, or newer attempt supersedes us, and the new client is discarded not leaked
       val publish = locked {
+        val conn    = connRef.get()
+        if (conn != null) { val _ = establishing -= conn }
         val current = pendingEstablish.get(node).exists(_ eq mine)
         if (current) { val _ = pendingEstablish.remove(node) }
         if (current && !closed) { established.put(node, nc); true }
@@ -118,17 +130,20 @@ final private[client] class NodePool(
   }
 
   def close(): Unit = {
-    val (all, waiters) = locked {
+    val (all, waiters, opening) = locked {
       closed = true
-      val snap    = established.values.toVector
-      val pending = pendingEstablish.values.toVector
+      val snap     = established.values.toVector
+      val pending  = pendingEstablish.values.toVector
+      val inFlight = establishing.toVector
       established.clear()
       pendingEstablish.clear()
-      (snap, pending)
+      (snap, pending, inFlight)
     }
     // release callers blocked on an in-flight connect now, rather than stranding them for the connect timeout; the establisher still
     // observes `closed` on return and closes the node it opened
     waiters.foreach(_.fail(NotConnected()))
+    // abort connections still opening their socket, so a shutdown doesn't wait out the connect timeout; each establisher then removes its entry
+    opening.foreach(_.close())
     all.foreach(_.close())
   }
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -44,16 +44,17 @@ final private[client] class SubscriptionConnection(
 ) extends Placement.ShardConn {
   import SubscriptionConnection.*
 
-  private val lock               = new ReentrantLock()
-  private val established        = lock.newCondition()
-  private val confirmed          = lock.newCondition()
-  private var state: State       = State.Idle
-  private var current: Conn      = null
-  // the connection whose socket is being opened, so a shutdown can abort one still connecting
-  private var establishing: Conn = null
-  private val channelSinks       = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
-  private val patternSinks       = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
-  private val shardSinks         = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
+  private val lock          = new ReentrantLock()
+  private val established   = lock.newCondition()
+  private val confirmed     = lock.newCondition()
+  private var state: State  = State.Idle
+  private var current: Conn = null
+  // connections whose socket is being opened, so a shutdown can abort every one still connecting; a set because an admitted reconnect can
+  // overlap a fresh attach once closeOwned flips Reconnecting -> Idle (see db9d6387)
+  private val establishing  = mutable.Set.empty[Conn]
+  private val channelSinks  = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
+  private val patternSinks  = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
+  private val shardSinks    = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
 
   // SUBSCRIBE-ack accounting (guarded by `lock`): the server confirms each subscribed name with one push frame in send order, so a subscribe
   // waits until `subscribeConfirmed` catches `subscribeSent` before returning — otherwise `subscribe` then `publish` races across the sockets.
@@ -258,7 +259,7 @@ final private[client] class SubscriptionConnection(
 
   private def establish(): Conn = {
     val conn = new Conn
-    locked { establishing = conn; if (state == State.Closed) conn.close() }
+    locked { establishing += conn; if (state == State.Closed) conn.close() }
     try {
       try conn.start()
       catch {
@@ -270,7 +271,7 @@ final private[client] class SubscriptionConnection(
       }
       runBootstrap(conn)
       conn
-    } finally locked { if (establishing eq conn) establishing = null }
+    } finally locked { val _ = establishing -= conn }
   }
 
   // per-conn waiter (two establishes can bootstrap concurrently and must not cross-complete); the finally clears it so a later PONG isn't misrouted
@@ -386,73 +387,55 @@ final private[client] class SubscriptionConnection(
     if (failure != null) throw failure
   }
 
+  // transition to Closed and hand back every connection to tear down: the live one plus all still establishing. Must hold `lock`.
+  private def markClosed(): Vector[Conn] = {
+    val conns = (Option(current) ++ establishing).toVector
+    establishing.clear()
+    state = State.Closed
+    stopWatchdog()
+    current = null
+    established.signalAll()
+    confirmed.signalAll()
+    conns
+  }
+
   // atomic empty-check + Closed transition, so a racing attach can't bind a sink to a connection about to close
   def closeIfEmpty(): Boolean = {
-    var conn: Conn             = null
-    var establishingConn: Conn = null
-    val closing                = locked {
+    var toClose: Vector[Conn] = Vector.empty
+    val closing               = locked {
       if (!isEmptyUnlocked) false
-      else {
-        conn = current
-        establishingConn = establishing
-        establishing = null
-        state = State.Closed
-        stopWatchdog()
-        current = null
-        established.signalAll()
-        confirmed.signalAll()
-        true
-      }
+      else { toClose = markClosed(); true }
     }
-    if (establishingConn != null) establishingConn.close()
-    if (conn != null) conn.close()
+    toClose.foreach(_.close())
     closing
   }
 
   // close socket/watchdog but keep the sinks (unlike close), so a re-home re-attaches them
   def shutdown(): Unit = {
-    var conn: Conn             = null
-    var establishingConn: Conn = null
-    locked {
-      conn = current
-      establishingConn = establishing
-      establishing = null
-      state = State.Closed
-      stopWatchdog()
-      current = null
+    val toClose = locked {
+      val conns = markClosed()
       channelSinks.clear()
       patternSinks.clear()
       shardSinks.clear()
-      established.signalAll()
-      confirmed.signalAll()
+      conns
     }
-    if (establishingConn != null) establishingConn.close()
-    if (conn != null) conn.close()
+    toClose.foreach(_.close())
   }
 
   def close(): Unit = {
-    var conn: Conn             = null
-    var establishingConn: Conn = null
-    var sinks: Set[Sink]       = Set.empty
-    locked {
+    var sinks: Set[Sink] = Set.empty
+    val toClose          = locked {
       sinks = (channelSinks.values.flatten ++ patternSinks.values.flatten ++ shardSinks.values.flatten).toSet
-      conn = current
-      establishingConn = establishing
-      establishing = null
-      state = State.Closed
-      stopWatchdog()
-      current = null
+      val conns = markClosed()
       channelSinks.clear()
       patternSinks.clear()
       shardSinks.clear()
-      established.signalAll()
-      confirmed.signalAll()
+      conns
     }
     // terminate before close: conn.close() joins the reader, which only exits Sink.offer once its sink is closed — closing first deadlocks.
     // In cluster mode the manager owns the sinks and terminates them before calling close(), so this set is already empty.
     sinks.foreach(_.terminate())
-    if (establishingConn != null) establishingConn.close()
-    if (conn != null) conn.close()
+    toClose.foreach(_.close())
   }
 
   private def register(sink: Sink, names: Vector[String], kind: Kind): Vector[String] = {

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -49,8 +49,7 @@ final private[client] class SubscriptionConnection(
   private val confirmed     = lock.newCondition()
   private var state: State  = State.Idle
   private var current: Conn = null
-  // connections whose socket is being opened, so a shutdown can abort every one still connecting; a set because an admitted reconnect can
-  // overlap a fresh attach once closeOwned flips Reconnecting -> Idle (see db9d6387)
+  // connections still being opened; a set, since a reconnect and a fresh attach can be establishing at once
   private val establishing  = mutable.Set.empty[Conn]
   private val channelSinks  = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
   private val patternSinks  = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
@@ -387,7 +386,7 @@ final private[client] class SubscriptionConnection(
     if (failure != null) throw failure
   }
 
-  // transition to Closed and hand back every connection to tear down: the live one plus all still establishing. Must hold `lock`.
+  // must hold `lock`: transition to Closed and return the connections to tear down (current + establishing)
   private def markClosed(): Vector[Conn] = {
     val conns = (Option(current) ++ establishing).toVector
     establishing.clear()

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -44,14 +44,17 @@ final private[client] class SubscriptionConnection(
 ) extends Placement.ShardConn {
   import SubscriptionConnection.*
 
-  private val lock          = new ReentrantLock()
-  private val established   = lock.newCondition()
-  private val confirmed     = lock.newCondition()
-  private var state: State  = State.Idle
-  private var current: Conn = null
-  private val channelSinks  = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
-  private val patternSinks  = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
-  private val shardSinks    = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
+  private val lock               = new ReentrantLock()
+  private val established        = lock.newCondition()
+  private val confirmed          = lock.newCondition()
+  private var state: State       = State.Idle
+  private var current: Conn      = null
+  // the connection whose socket is being opened (an attach or a reconnect), retained so a shutdown can abort one still stuck in connect
+  // rather than stranding it until the connect timeout; the establisher clears it when the connect unwinds
+  private var establishing: Conn = null
+  private val channelSinks       = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
+  private val patternSinks       = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
+  private val shardSinks         = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
 
   // SUBSCRIBE-ack accounting (guarded by `lock`): the server confirms each subscribed name with one push frame in send order, so a subscribe
   // waits until `subscribeConfirmed` catches `subscribeSent` before returning — otherwise `subscribe` then `publish` races across the sockets.
@@ -256,16 +259,20 @@ final private[client] class SubscriptionConnection(
 
   private def establish(): Conn = {
     val conn = new Conn
-    try conn.start()
-    catch {
-      case e: SageException => throw e
-      case NonFatal(e)      =>
-        val failed = ConnectionFailed(s"could not open the subscription connection: $e")
-        failed.initCause(e)
-        throw failed
-    }
-    runBootstrap(conn)
-    conn
+    // register before the blocking connect so a concurrent shutdown can abort it; if the shutdown already fired, abort right away
+    locked { establishing = conn; if (state == State.Closed) conn.close() }
+    try {
+      try conn.start()
+      catch {
+        case e: SageException => throw e
+        case NonFatal(e)      =>
+          val failed = ConnectionFailed(s"could not open the subscription connection: $e")
+          failed.initCause(e)
+          throw failed
+      }
+      runBootstrap(conn)
+      conn
+    } finally locked { if (establishing eq conn) establishing = null }
   }
 
   // per-conn waiter (two establishes can bootstrap concurrently and must not cross-complete); the finally clears it so a later PONG isn't misrouted
@@ -383,11 +390,14 @@ final private[client] class SubscriptionConnection(
 
   // atomic empty-check + Closed transition, so a racing attach can't bind a sink to a connection about to close
   def closeIfEmpty(): Boolean = {
-    var conn: Conn = null
-    val closing    = locked {
+    var conn: Conn             = null
+    var establishingConn: Conn = null
+    val closing                = locked {
       if (!isEmptyUnlocked) false
       else {
         conn = current
+        establishingConn = establishing
+        establishing = null
         state = State.Closed
         stopWatchdog()
         current = null
@@ -396,15 +406,19 @@ final private[client] class SubscriptionConnection(
         true
       }
     }
+    if (establishingConn != null) establishingConn.close()
     if (conn != null) conn.close()
     closing
   }
 
   // close socket/watchdog but keep the sinks (unlike close), so a re-home re-attaches them
   def shutdown(): Unit = {
-    var conn: Conn = null
+    var conn: Conn             = null
+    var establishingConn: Conn = null
     locked {
       conn = current
+      establishingConn = establishing
+      establishing = null
       state = State.Closed
       stopWatchdog()
       current = null
@@ -414,15 +428,19 @@ final private[client] class SubscriptionConnection(
       established.signalAll()
       confirmed.signalAll()
     }
+    if (establishingConn != null) establishingConn.close()
     if (conn != null) conn.close()
   }
 
   def close(): Unit = {
-    var conn: Conn       = null
-    var sinks: Set[Sink] = Set.empty
+    var conn: Conn             = null
+    var establishingConn: Conn = null
+    var sinks: Set[Sink]       = Set.empty
     locked {
       sinks = (channelSinks.values.flatten ++ patternSinks.values.flatten ++ shardSinks.values.flatten).toSet
       conn = current
+      establishingConn = establishing
+      establishing = null
       state = State.Closed
       stopWatchdog()
       current = null
@@ -435,6 +453,7 @@ final private[client] class SubscriptionConnection(
     // terminate before close: conn.close() joins the reader, which only exits Sink.offer once its sink is closed — closing first deadlocks.
     // In cluster mode the manager owns the sinks and terminates them before calling close(), so this set is already empty.
     sinks.foreach(_.terminate())
+    if (establishingConn != null) establishingConn.close()
     if (conn != null) conn.close()
   }
 
@@ -491,14 +510,18 @@ final private[client] class SubscriptionConnection(
 
     private val transportRef                     = new AtomicReference[Transport]()
     @volatile private var terminated             = false
+    @volatile private var aborted                = false
     @volatile var bootstrapWaiter: Frame => Unit = null
 
     def isTerminated: Boolean = terminated
 
     def start(): Unit = {
       val transport = factory(frame => onFrame(this, frame), () => { terminated = true; onConnClosed(this) })
+      // transportRef is published before the blocking connect so a concurrent close() can abort it; `aborted` (set by close before it reads
+      // transportRef) covers the narrow gap where close lands before the transport is published
       transportRef.set(transport)
-      transport.start()
+      if (aborted) transport.close()
+      else transport.start()
     }
 
     def send(payload: Bytes): Unit = {
@@ -507,6 +530,7 @@ final private[client] class SubscriptionConnection(
     }
 
     def close(): Unit = {
+      aborted = true
       val transport = transportRef.get()
       if (transport != null) transport.close()
     }

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -6,10 +6,11 @@ import java.util.concurrent.locks.ReentrantLock
 
 import scala.collection.mutable
 import scala.concurrent.duration.*
+import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
 import sage.{Bytes, SageEvent, SageException}
-import sage.SageException.{ConnectionFailed, NotConnected}
+import sage.SageException.{ConnectionFailed, ConnectionLost, NotConnected}
 import sage.client.{BackoffConfig, WatchdogConfig}
 import sage.cluster.Node
 import sage.commands.{Command, Connection, Pubsub, Reply}
@@ -280,12 +281,13 @@ final private[client] class SubscriptionConnection(
         bootstrap,
         connectTimeoutMillis,
         (command, cb) => {
-          conn.bootstrapWaiter = frame => cb(Reply.decode(command, frame))
-          conn.send(command.encode)
+          conn.armBootstrap(result => cb(result.flatMap(frame => Reply.decode(command, frame))))
+          if (conn.isTerminated) { val _ = conn.completeBootstrap(Failure(ConnectionLost(mayHaveExecuted = false))) }
+          else conn.send(command.encode)
         },
         () => conn.close()
       )
-    finally conn.bootstrapWaiter = null
+    finally conn.clearBootstrap()
 
   private def scheduleReconnect(attempt: Int): Unit =
     scheduler.after(Backoff.jitteredMillis(backoff, attempt, scheduler).millis)(attemptReconnect(attempt))
@@ -343,9 +345,7 @@ final private[client] class SubscriptionConnection(
         }
       case reply                => // non-push reply: bootstrap HELLO, watchdog PONG, or an unexpected error
         lastReplyAtMillis = scheduler.nowMillis
-        val waiter = conn.bootstrapWaiter
-        if (waiter != null) waiter(reply)
-        else
+        if (!conn.completeBootstrap(Success(reply)))
           reply match {
             // an error (e.g. MOVED on SSUBSCRIBE) isn't a PONG: drop the connection so re-home/reconnect re-plans
             case _: Frame.SimpleError | _: Frame.BulkError => scheduler.after(Duration.Zero)(conn.close()) // off the reader thread: close() joins it
@@ -488,18 +488,33 @@ final private[client] class SubscriptionConnection(
 
   final private class Conn {
 
-    private val transportRef                     = new AtomicReference[Transport]()
-    @volatile private var terminated             = false
-    @volatile private var aborted                = false
-    @volatile var bootstrapWaiter: Frame => Unit = null
+    private val transportRef         = new AtomicReference[Transport]()
+    @volatile private var terminated = false
+    @volatile private var aborted    = false
+    private val bootstrapWaiter      = new AtomicReference[Try[Frame] => Unit]()
 
     def isTerminated: Boolean = terminated
 
     def start(): Unit = {
-      val transport = factory(frame => onFrame(this, frame), () => { terminated = true; onConnClosed(this) })
+      val transport = factory(frame => onFrame(this, frame), () => onTerminated())
       transportRef.set(transport)
       if (aborted) transport.close()
       else transport.start()
+    }
+
+    private def onTerminated(): Unit = {
+      terminated = true
+      val _ = completeBootstrap(Failure(ConnectionLost(mayHaveExecuted = false)))
+      onConnClosed(this)
+    }
+
+    def armBootstrap(waiter: Try[Frame] => Unit): Unit = bootstrapWaiter.set(waiter)
+    def clearBootstrap(): Unit                         = bootstrapWaiter.set(null)
+
+    def completeBootstrap(result: Try[Frame]): Boolean = {
+      val waiter = bootstrapWaiter.getAndSet(null)
+      if (waiter != null) { waiter(result); true }
+      else false
     }
 
     def send(payload: Bytes): Unit = {

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -49,8 +49,7 @@ final private[client] class SubscriptionConnection(
   private val confirmed          = lock.newCondition()
   private var state: State       = State.Idle
   private var current: Conn      = null
-  // the connection whose socket is being opened (an attach or a reconnect), retained so a shutdown can abort one still stuck in connect
-  // rather than stranding it until the connect timeout; the establisher clears it when the connect unwinds
+  // the connection whose socket is being opened, so a shutdown can abort one still connecting
   private var establishing: Conn = null
   private val channelSinks       = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
   private val patternSinks       = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
@@ -259,7 +258,6 @@ final private[client] class SubscriptionConnection(
 
   private def establish(): Conn = {
     val conn = new Conn
-    // register before the blocking connect so a concurrent shutdown can abort it; if the shutdown already fired, abort right away
     locked { establishing = conn; if (state == State.Closed) conn.close() }
     try {
       try conn.start()
@@ -517,8 +515,6 @@ final private[client] class SubscriptionConnection(
 
     def start(): Unit = {
       val transport = factory(frame => onFrame(this, frame), () => { terminated = true; onConnClosed(this) })
-      // transportRef is published before the blocking connect so a concurrent close() can abort it; `aborted` (set by close before it reads
-      // transportRef) covers the narrow gap where close lands before the transport is published
       transportRef.set(transport)
       if (aborted) transport.close()
       else transport.start()

--- a/sage-client/shared/src/test/scala/sage/client/internal/ConnectingTransport.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ConnectingTransport.scala
@@ -2,7 +2,9 @@ package sage.client.internal
 
 import java.util.concurrent.CountDownLatch
 
-// A transport whose start() blocks like a socket connect until close() aborts it; `reached` fires when start() is entered
+/**
+  * A transport whose `start()` blocks like a socket connect until `close()` aborts it; `reached` fires when `start()` is entered.
+  */
 final class ConnectingTransport(onClosed: () => Unit) extends Transport {
   val reached                          = new CountDownLatch(1)
   private val gate                     = new CountDownLatch(1)

--- a/sage-client/shared/src/test/scala/sage/client/internal/ConnectingTransport.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ConnectingTransport.scala
@@ -13,12 +13,11 @@ final class ConnectingTransport(onClosed: () => Unit) extends Transport {
   private val queued                   = new ConcurrentLinkedQueue[Transport.Item]()
   def wasClosed: Boolean               = closed.get()
   def start(): Unit                    = { reached.countDown(); gate.await(); throw new java.io.IOException("connect aborted") }
-  def send(item: Transport.Item): Unit = { val _ = queued.add(item) }
-  def close(): Unit                    =
-    if (closed.compareAndSet(false, true)) {
-      gate.countDown()
-      var item = queued.poll()
-      while (item != null) { item.dropped(); item = queued.poll() }
-      onClosed()
-    }
+  def send(item: Transport.Item): Unit = { val _ = queued.add(item); if (closed.get()) drainQueue() }
+  def close(): Unit                    = if (closed.compareAndSet(false, true)) { gate.countDown(); drainQueue(); onClosed() }
+
+  private def drainQueue(): Unit = {
+    var item = queued.poll()
+    while (item != null) { item.dropped(); item = queued.poll() }
+  }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/ConnectingTransport.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ConnectingTransport.scala
@@ -8,8 +8,9 @@ import java.util.concurrent.CountDownLatch
 final class ConnectingTransport(onClosed: () => Unit) extends Transport {
   val reached                          = new CountDownLatch(1)
   private val gate                     = new CountDownLatch(1)
-  @volatile var wasClosed: Boolean     = false
+  private val closed                   = new java.util.concurrent.atomic.AtomicBoolean(false)
+  def wasClosed: Boolean               = closed.get()
   def start(): Unit                    = { reached.countDown(); gate.await(); throw new java.io.IOException("connect aborted") }
   def send(item: Transport.Item): Unit = item.dropped()
-  def close(): Unit                    = { wasClosed = true; gate.countDown(); onClosed() }
+  def close(): Unit                    = if (closed.compareAndSet(false, true)) { gate.countDown(); onClosed() }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/ConnectingTransport.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ConnectingTransport.scala
@@ -1,6 +1,7 @@
 package sage.client.internal
 
-import java.util.concurrent.CountDownLatch
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch}
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
   * A transport whose `start()` blocks like a socket connect until `close()` aborts it; `reached` fires when `start()` is entered.
@@ -8,9 +9,16 @@ import java.util.concurrent.CountDownLatch
 final class ConnectingTransport(onClosed: () => Unit) extends Transport {
   val reached                          = new CountDownLatch(1)
   private val gate                     = new CountDownLatch(1)
-  private val closed                   = new java.util.concurrent.atomic.AtomicBoolean(false)
+  private val closed                   = new AtomicBoolean(false)
+  private val queued                   = new ConcurrentLinkedQueue[Transport.Item]()
   def wasClosed: Boolean               = closed.get()
   def start(): Unit                    = { reached.countDown(); gate.await(); throw new java.io.IOException("connect aborted") }
-  def send(item: Transport.Item): Unit = item.dropped()
-  def close(): Unit                    = if (closed.compareAndSet(false, true)) { gate.countDown(); onClosed() }
+  def send(item: Transport.Item): Unit = { val _ = queued.add(item) }
+  def close(): Unit                    =
+    if (closed.compareAndSet(false, true)) {
+      gate.countDown()
+      var item = queued.poll()
+      while (item != null) { item.dropped(); item = queued.poll() }
+      onClosed()
+    }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/ConnectingTransport.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ConnectingTransport.scala
@@ -1,0 +1,16 @@
+package sage.client.internal
+
+import java.util.concurrent.CountDownLatch
+
+/**
+  * A transport whose `start()` blocks like a socket connect until `close()` aborts it, for exercising shutdown while a connection is still
+  * establishing. `reached` fires once `start()` is entered (the connection is registered by then), so a test can wait for that before closing.
+  */
+final class ConnectingTransport(onClosed: () => Unit) extends Transport {
+  val reached                          = new CountDownLatch(1)
+  private val gate                     = new CountDownLatch(1)
+  @volatile var wasClosed: Boolean     = false
+  def start(): Unit                    = { reached.countDown(); gate.await(); throw new java.io.IOException("connect aborted") }
+  def send(item: Transport.Item): Unit = item.dropped()
+  def close(): Unit                    = { wasClosed = true; gate.countDown(); onClosed() }
+}

--- a/sage-client/shared/src/test/scala/sage/client/internal/ConnectingTransport.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ConnectingTransport.scala
@@ -2,10 +2,7 @@ package sage.client.internal
 
 import java.util.concurrent.CountDownLatch
 
-/**
-  * A transport whose `start()` blocks like a socket connect until `close()` aborts it, for exercising shutdown while a connection is still
-  * establishing. `reached` fires once `start()` is entered (the connection is registered by then), so a test can wait for that before closing.
-  */
+// A transport whose start() blocks like a socket connect until close() aborts it; `reached` fires when start() is entered
 final class ConnectingTransport(onClosed: () => Unit) extends Transport {
   val reached                          = new CountDownLatch(1)
   private val gate                     = new CountDownLatch(1)

--- a/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
@@ -327,15 +327,6 @@ class DedicatedPoolSpec extends munit.FunSuite {
   }
 
   test("close aborts a dedicated connection still blocked in the connect (start) phase") {
-    // a transport whose start() blocks like socket.connect until close() aborts it
-    final class ConnectingTransport(onClosed: () => Unit) extends Transport {
-      private val gate                     = new java.util.concurrent.CountDownLatch(1)
-      @volatile var wasClosed: Boolean     = false
-      def start(): Unit                    = { gate.await(); throw new java.io.IOException("connect aborted") }
-      def send(item: Transport.Item): Unit = item.dropped()
-      def close(): Unit                    = { wasClosed = true; gate.countDown(); onClosed() }
-    }
-
     val connecting                                      = new java.util.concurrent.atomic.AtomicReference[ConnectingTransport]()
     val scheduler                                       = new ManualScheduler
     val factory: MultiplexedConnection.TransportFactory = (_, onClosed) => {

--- a/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
@@ -344,7 +344,8 @@ class DedicatedPoolSpec extends munit.FunSuite {
 
     val deadline = System.currentTimeMillis() + 2000
     while (connecting.get() == null && System.currentTimeMillis() < deadline) Thread.sleep(1)
-    assert(connecting.get() != null, "the establish never reached the connect phase")
+    assert(connecting.get() != null, "the establish never started")
+    assert(connecting.get().reached.await(2, java.util.concurrent.TimeUnit.SECONDS), "the establish never reached the connect phase")
 
     pool.close()
     establishing.join(2000)

--- a/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
@@ -133,7 +133,8 @@ class DedicatedPoolSpec extends munit.FunSuite {
     val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
       val t = new FakeTransport(onFrame, onClosed, replyWith(Nil)); transports += t; t
     }
-    val conn                                            = DedicatedConnection.establish(factory, Vector(Connection.hello()), 1000L)
+    val conn                                            = DedicatedConnection.create(factory, 1000L)
+    conn.establish(Vector(Connection.hello()))
     transports.head.autoWrite = false // hold the write so the command stays queued: the path the transport drops on teardown
 
     var healthyWhenFailed: Option[Boolean] = None
@@ -323,5 +324,41 @@ class DedicatedPoolSpec extends munit.FunSuite {
     assert(!waiter.isAlive, "the parked waiter must be woken, not sleep out the 10s acquireTimeout")
     assert(result.exists(_.failed.toOption.exists(_.isInstanceOf[NotConnected])), s"expected NotConnected, got $result")
     pool.releaseTransaction(held, reusable = false)
+  }
+
+  test("close aborts a dedicated connection still blocked in the connect (start) phase") {
+    // a transport whose start() blocks like socket.connect until close() aborts it
+    final class ConnectingTransport(onClosed: () => Unit) extends Transport {
+      private val gate                     = new java.util.concurrent.CountDownLatch(1)
+      @volatile var wasClosed: Boolean     = false
+      def start(): Unit                    = { gate.await(); throw new java.io.IOException("connect aborted") }
+      def send(item: Transport.Item): Unit = item.dropped()
+      def close(): Unit                    = { wasClosed = true; gate.countDown(); onClosed() }
+    }
+
+    val connecting                                      = new java.util.concurrent.atomic.AtomicReference[ConnectingTransport]()
+    val scheduler                                       = new ManualScheduler
+    val factory: MultiplexedConnection.TransportFactory = (_, onClosed) => {
+      val transport = new ConnectingTransport(onClosed)
+      connecting.set(transport)
+      transport
+    }
+    val gen                                             = MultiplexedConnection.Generation.initial
+    val pool                                            =
+      new DedicatedPool(factory, Vector(Connection.hello()), scheduler, () => true, () => Some(gen), _ == gen, DedicatedPoolConfig(), 1000L)
+
+    pool.use(blPop, _ => ())
+    val establishing = new Thread(() => scheduler.advance(Duration.Zero)) // blocks inside ConnectingTransport.start()
+    establishing.start()
+
+    val deadline = System.currentTimeMillis() + 2000
+    while (connecting.get() == null && System.currentTimeMillis() < deadline) Thread.sleep(1)
+    assert(connecting.get() != null, "the establish never reached the connect phase")
+
+    pool.close()
+    establishing.join(2000)
+
+    assert(!establishing.isAlive, "close must abort the establishing connection, not wait out the connect")
+    assert(connecting.get().wasClosed, "close must abort the establishing transport")
   }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
@@ -450,15 +450,6 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
   }
 
   test("close aborts a reconnect still blocked in the connect (start) phase") {
-    // a transport whose start() blocks like socket.connect until close() aborts it — the reconnect generation uses it
-    final class ConnectingTransport(onClosed: () => Unit) extends Transport {
-      private val gate                     = new java.util.concurrent.CountDownLatch(1)
-      @volatile var wasClosed: Boolean     = false
-      def start(): Unit                    = { gate.await(); throw new java.io.IOException("connect aborted") }
-      def send(item: Transport.Item): Unit = item.dropped()
-      def close(): Unit                    = { wasClosed = true; gate.countDown(); onClosed() }
-    }
-
     val connecting                                      = new java.util.concurrent.atomic.AtomicReference[ConnectingTransport]()
     var head: FakeTransport                             = null
     val scheduler                                       = new ManualScheduler

--- a/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
@@ -161,4 +161,37 @@ class NodePoolSpec extends munit.FunSuite {
     assertEquals(gated.transport(1).closeCount, 0, "attempt 2's published client must not be closed")
     pool.close()
   }
+
+  test("close aborts an in-flight node establishment still blocked in the connect (start) phase") {
+    // a transport whose start() blocks like socket.connect until close() aborts it
+    final class ConnectingTransport(onClosed: () => Unit) extends Transport {
+      private val gate                     = new CountDownLatch(1)
+      @volatile var wasClosed: Boolean     = false
+      def start(): Unit                    = { gate.await(); throw new java.io.IOException("connect aborted") }
+      def send(item: Transport.Item): Unit = item.dropped()
+      def close(): Unit                    = { wasClosed = true; gate.countDown(); onClosed() }
+    }
+
+    val connecting                                              = new AtomicReference[ConnectingTransport]()
+    val factory: Node => MultiplexedConnection.TransportFactory = _ =>
+      (_, onClosed) => {
+        val transport = new ConnectingTransport(onClosed)
+        connecting.set(transport)
+        transport
+      }
+    val pool                                                    = newPool(factory)
+    val node                                                    = Node("slow", 6379)
+
+    val result       = new AtomicReference[Try[NodeClient]]()
+    val establishing = new Thread(() => result.set(Try(pool.getOrEstablish(node))), "establisher")
+    establishing.start()
+    awaitTrue(connecting.get() != null, "the establish never reached the connect phase")
+
+    pool.close()
+    establishing.join(2000)
+
+    assert(!establishing.isAlive, "close must abort the in-flight establishment, not wait out the connect")
+    assert(connecting.get().wasClosed, "close must abort the establishing transport")
+    assert(result.get() != null && result.get().isFailure, s"the aborted establisher should fail: ${result.get()}")
+  }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
@@ -163,15 +163,6 @@ class NodePoolSpec extends munit.FunSuite {
   }
 
   test("close aborts an in-flight node establishment still blocked in the connect (start) phase") {
-    // a transport whose start() blocks like socket.connect until close() aborts it
-    final class ConnectingTransport(onClosed: () => Unit) extends Transport {
-      private val gate                     = new CountDownLatch(1)
-      @volatile var wasClosed: Boolean     = false
-      def start(): Unit                    = { gate.await(); throw new java.io.IOException("connect aborted") }
-      def send(item: Transport.Item): Unit = item.dropped()
-      def close(): Unit                    = { wasClosed = true; gate.countDown(); onClosed() }
-    }
-
     val connecting                                              = new AtomicReference[ConnectingTransport]()
     val factory: Node => MultiplexedConnection.TransportFactory = _ =>
       (_, onClosed) => {

--- a/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
@@ -176,7 +176,8 @@ class NodePoolSpec extends munit.FunSuite {
     val result       = new AtomicReference[Try[NodeClient]]()
     val establishing = new Thread(() => result.set(Try(pool.getOrEstablish(node))), "establisher")
     establishing.start()
-    awaitTrue(connecting.get() != null, "the establish never reached the connect phase")
+    awaitTrue(connecting.get() != null, "the establish never started")
+    assert(connecting.get().reached.await(2, TimeUnit.SECONDS), "the establish never reached the connect phase")
 
     pool.close()
     establishing.join(2000)

--- a/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
@@ -521,12 +521,9 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
   }
 
   test("close unblocks a subscriber parked waiting for the bootstrap reply") {
-    val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
-    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
-      val t = new FakeTransport(onFrame, onClosed, _ => Nil)
-      transports += t
-      t
-    }
+    val pinged                                          = new CountDownLatch(1)
+    val factory: MultiplexedConnection.TransportFactory =
+      (onFrame, onClosed) => new FakeTransport(onFrame, onClosed, payload => { if (payload.asUtf8String.contains("PING")) pinged.countDown(); Nil })
     val connection                                      =
       new SubscriptionConnection(factory, Vector(Connection.ping()), new ManualScheduler, fixedBackoff, noWatchdog, 60000L, 16, () => true)
 
@@ -535,11 +532,7 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
       catch { case _: Throwable => () }
     )
     subscribing.start()
-
-    val deadline = System.currentTimeMillis() + 2000
-    def pinged   = transports.headOption.exists(_.written.exists(_.asUtf8String.contains("PING")))
-    while (!pinged && System.currentTimeMillis() < deadline) Thread.sleep(1)
-    assert(pinged, "the bootstrap PING was never sent")
+    assert(pinged.await(2, TimeUnit.SECONDS), "the bootstrap PING was never sent")
 
     connection.close()
     subscribing.join(2000)

--- a/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
@@ -506,9 +506,11 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
       try { val _ = connection.subscribeChannels(Vector("news")) }
       catch { case _: Throwable => () }
     )
-    subscribing.start() // blocks inside ConnectingTransport.start()
+    subscribing.start() // blocks in the connect
 
-    assert(connecting.get() != null || { Thread.sleep(50); connecting.get() != null }, "the establish never started")
+    val deadline = System.currentTimeMillis() + 2000
+    while (connecting.get() == null && System.currentTimeMillis() < deadline) Thread.sleep(1)
+    assert(connecting.get() != null, "the establish never started")
     assert(connecting.get().reached.await(2, TimeUnit.SECONDS), "the establish never reached the connect phase")
 
     connection.close()
@@ -516,6 +518,34 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
 
     assert(!subscribing.isAlive, "close must abort the establishing connection, not wait out the connect")
     assert(connecting.get().wasClosed, "close must abort the establishing transport")
+  }
+
+  test("close unblocks a subscriber parked waiting for the bootstrap reply") {
+    val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
+      val t = new FakeTransport(onFrame, onClosed, _ => Nil) // never answers the bootstrap
+      transports += t
+      t
+    }
+    // long timeout: a broken close() would leave the caller parked well past the join
+    val connection                                      =
+      new SubscriptionConnection(factory, Vector(Connection.ping()), new ManualScheduler, fixedBackoff, noWatchdog, 60000L, 16, () => true)
+
+    val subscribing = new Thread(() =>
+      try { val _ = connection.subscribeChannels(Vector("news")) }
+      catch { case _: Throwable => () }
+    )
+    subscribing.start()
+
+    val deadline = System.currentTimeMillis() + 2000
+    def pinged   = transports.headOption.exists(_.written.exists(_.asUtf8String.contains("PING")))
+    while (!pinged && System.currentTimeMillis() < deadline) Thread.sleep(1)
+    assert(pinged, "the bootstrap PING was never sent")
+
+    connection.close()
+    subscribing.join(2000)
+
+    assert(!subscribing.isAlive, "close must fail the bootstrap wait, not leave the caller parked for the connect timeout")
   }
 
   test("close aborts every overlapping establishment, not just the most recent") {

--- a/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
@@ -523,11 +523,11 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
   test("close unblocks a subscriber parked waiting for the bootstrap reply") {
     val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
     val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
-      val t = new FakeTransport(onFrame, onClosed, _ => Nil) // never answers the bootstrap
+      val t = new FakeTransport(onFrame, onClosed, _ => Nil)
       transports += t
       t
     }
-    val connection =
+    val connection                                      =
       new SubscriptionConnection(factory, Vector(Connection.ping()), new ManualScheduler, fixedBackoff, noWatchdog, 60000L, 16, () => true)
 
     val subscribing = new Thread(() =>

--- a/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
@@ -519,7 +519,7 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
   }
 
   test("close aborts every overlapping establishment, not just the most recent") {
-    // a reconnect attempt and a fresh attach can both be establishing at once once closeOwned flips Reconnecting -> Idle; close must abort both
+    // a reconnect and a fresh attach can be establishing at once; close must abort both
     val scheduler                                       = new ManualScheduler
     val attempt                                         = new java.util.concurrent.atomic.AtomicInteger(0)
     val connecting                                      = new java.util.concurrent.CopyOnWriteArrayList[ConnectingTransport]()
@@ -542,17 +542,17 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
     val sub = connection.subscribeChannels(Vector("a"))
     fake.close() // the socket drops -> Reconnecting, reconnect scheduled
 
-    val reconnect = new Thread(() => scheduler.advance(1.milli)) // blocks inside the reconnect's ConnectingTransport.start()
+    val reconnect = new Thread(() => scheduler.advance(1.milli)) // blocks in the reconnect's connect
     reconnect.start()
     val conn1     = awaitReached(0)
 
-    sub.close() // closeOwned: Reconnecting -> Idle, leaving conn1 still establishing
+    sub.close() // Reconnecting -> Idle, leaving conn1 still establishing
 
     val attaching = new Thread(() =>
       try { val _ = connection.subscribeChannels(Vector("b")) }
       catch { case _: Throwable => () }
     )
-    attaching.start() // blocks inside the attach's ConnectingTransport.start()
+    attaching.start() // blocks in the attach's connect
     val conn2     = awaitReached(1)
 
     connection.close()

--- a/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
@@ -491,4 +491,40 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
     connection.attach(sink, Vector("news"), SubscriptionConnection.Kind.Channel)
     assert(connection.detach(sink, Vector("news"), SubscriptionConnection.Kind.Channel)) // must return, not throw the interrupt
   }
+
+  test("close aborts a subscription connection still blocked in the connect (start) phase") {
+    // a transport whose start() blocks like socket.connect until close() aborts it
+    final class ConnectingTransport(onClosed: () => Unit) extends Transport {
+      private val gate                     = new CountDownLatch(1)
+      @volatile var wasClosed: Boolean     = false
+      def start(): Unit                    = { gate.await(); throw new java.io.IOException("connect aborted") }
+      def send(item: Transport.Item): Unit = item.dropped()
+      def close(): Unit                    = { wasClosed = true; gate.countDown(); onClosed() }
+    }
+
+    val connecting                                      = new AtomicReference[ConnectingTransport]()
+    val factory: MultiplexedConnection.TransportFactory = (_, onClosed) => {
+      val transport = new ConnectingTransport(onClosed)
+      connecting.set(transport)
+      transport
+    }
+    val connection                                      =
+      new SubscriptionConnection(factory, Vector(Connection.ping()), new ManualScheduler, fixedBackoff, noWatchdog, 1000L, 16, () => true)
+
+    val subscribing = new Thread(() =>
+      try { val _ = connection.subscribeChannels(Vector("news")) }
+      catch { case _: Throwable => () }
+    )
+    subscribing.start() // blocks inside ConnectingTransport.start()
+
+    val deadline = System.currentTimeMillis() + 2000
+    while (connecting.get() == null && System.currentTimeMillis() < deadline) Thread.sleep(1)
+    assert(connecting.get() != null, "the establish never reached the connect phase")
+
+    connection.close()
+    subscribing.join(2000)
+
+    assert(!subscribing.isAlive, "close must abort the establishing connection, not wait out the connect")
+    assert(connecting.get().wasClosed, "close must abort the establishing transport")
+  }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
@@ -1,6 +1,6 @@
 package sage.client.internal
 
-import java.util.concurrent.CountDownLatch
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.collection.mutable
@@ -493,15 +493,6 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
   }
 
   test("close aborts a subscription connection still blocked in the connect (start) phase") {
-    // a transport whose start() blocks like socket.connect until close() aborts it
-    final class ConnectingTransport(onClosed: () => Unit) extends Transport {
-      private val gate                     = new CountDownLatch(1)
-      @volatile var wasClosed: Boolean     = false
-      def start(): Unit                    = { gate.await(); throw new java.io.IOException("connect aborted") }
-      def send(item: Transport.Item): Unit = item.dropped()
-      def close(): Unit                    = { wasClosed = true; gate.countDown(); onClosed() }
-    }
-
     val connecting                                      = new AtomicReference[ConnectingTransport]()
     val factory: MultiplexedConnection.TransportFactory = (_, onClosed) => {
       val transport = new ConnectingTransport(onClosed)
@@ -517,14 +508,59 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
     )
     subscribing.start() // blocks inside ConnectingTransport.start()
 
-    val deadline = System.currentTimeMillis() + 2000
-    while (connecting.get() == null && System.currentTimeMillis() < deadline) Thread.sleep(1)
-    assert(connecting.get() != null, "the establish never reached the connect phase")
+    assert(connecting.get() != null || { Thread.sleep(50); connecting.get() != null }, "the establish never started")
+    assert(connecting.get().reached.await(2, TimeUnit.SECONDS), "the establish never reached the connect phase")
 
     connection.close()
     subscribing.join(2000)
 
     assert(!subscribing.isAlive, "close must abort the establishing connection, not wait out the connect")
     assert(connecting.get().wasClosed, "close must abort the establishing transport")
+  }
+
+  test("close aborts every overlapping establishment, not just the most recent") {
+    // a reconnect attempt and a fresh attach can both be establishing at once once closeOwned flips Reconnecting -> Idle; close must abort both
+    val scheduler                                       = new ManualScheduler
+    val attempt                                         = new java.util.concurrent.atomic.AtomicInteger(0)
+    val connecting                                      = new java.util.concurrent.CopyOnWriteArrayList[ConnectingTransport]()
+    var fake: FakeTransport                             = null
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) =>
+      if (attempt.getAndIncrement() == 0) { fake = new FakeTransport(onFrame, onClosed, serverResponder); fake }
+      else { val t = new ConnectingTransport(onClosed); connecting.add(t); t }
+    val connection                                      =
+      new SubscriptionConnection(factory, Vector(Connection.ping()), scheduler, fixedBackoff, noWatchdog, 5000L, 16, () => true)
+
+    def awaitReached(i: Int): ConnectingTransport = {
+      val deadline = System.currentTimeMillis() + 2000
+      while (connecting.size <= i && System.currentTimeMillis() < deadline) Thread.sleep(1)
+      assert(connecting.size > i, s"establishment $i never started")
+      val t        = connecting.get(i)
+      assert(t.reached.await(2, TimeUnit.SECONDS), s"establishment $i never reached connect")
+      t
+    }
+
+    val sub = connection.subscribeChannels(Vector("a"))
+    fake.close() // the socket drops -> Reconnecting, reconnect scheduled
+
+    val reconnect = new Thread(() => scheduler.advance(1.milli)) // blocks inside the reconnect's ConnectingTransport.start()
+    reconnect.start()
+    val conn1     = awaitReached(0)
+
+    sub.close() // closeOwned: Reconnecting -> Idle, leaving conn1 still establishing
+
+    val attaching = new Thread(() =>
+      try { val _ = connection.subscribeChannels(Vector("b")) }
+      catch { case _: Throwable => () }
+    )
+    attaching.start() // blocks inside the attach's ConnectingTransport.start()
+    val conn2     = awaitReached(1)
+
+    connection.close()
+    reconnect.join(2000)
+    attaching.join(2000)
+
+    assert(!reconnect.isAlive && !attaching.isAlive, "close must unblock both establishments")
+    assert(conn1.wasClosed, "close must abort the reconnect establishment")
+    assert(conn2.wasClosed, "close must abort the concurrent attach establishment")
   }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
@@ -527,8 +527,7 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
       transports += t
       t
     }
-    // long timeout: a broken close() would leave the caller parked well past the join
-    val connection                                      =
+    val connection =
       new SubscriptionConnection(factory, Vector(Connection.ping()), new ManualScheduler, fixedBackoff, noWatchdog, 60000L, 16, () => true)
 
     val subscribing = new Thread(() =>


### PR DESCRIPTION
## Problem

`close()` on the dedicated pool, node pool, and subscription connection closed only *live* connections. A connection caught in TCP/TLS/bootstrap establishment lives outside the owning lock, so `close()` couldn't see it and it stayed alive until the connect timeout — and potentially longer during uninterruptible DNS resolution. This is a deterministic shutdown / resource-hygiene issue (no data-corruption risk: late publication is already rejected everywhere).

The desired pattern already existed in `MultiplexedConnection`: retain the establishing reference and abort it from `close()`.

## Fix

Applied that pattern to all three paths, plus a publish-then-recheck guard in each `start()` for the narrow window where `close()` lands before the transport is published:

- **`DedicatedConnection`** — split `establish` into `create` (no I/O) + an instance `establish`, so the pool holds the reference before the blocking connect; recheck `dead` after publishing the transport.
- **`DedicatedPool`** — track establishing connections in a set, abort them from `close()`.
- **`SubscriptionConnection`** — track establishing `Conn`s in a set (an admitted reconnect can overlap a fresh attach), abort them from `close`/`shutdown`/`closeIfEmpty`; recheck `aborted` after publishing the transport; fail an in-flight bootstrap reply-wait on termination so a close during the handshake unblocks the caller immediately.
- **`NodePool`** — the `NodeClient` doesn't exist until the blocking connect returns, so thread an `onConstructed` callback through `NodeClient.connect` / `MultiplexedConnection.connect` that hands the connection to the pool *before* the blocking initial connect. Harden `connectInitial`/`establish` so a `close()` racing the initial connect can't publish it Live.

Every path still rejects a late publication (schedule-close + `NotConnected` when closing / `!closed` publish gate / `goLive` teardown).

## Tests

One targeted concurrency test per path: a transport that blocks in `start()` like a real socket connect, aborted by `close()` — each confirmed to fail without its fix and pass with it. Plus tests for the two subscription-specific cases: aborting every overlapping establishment (not just the last), and unblocking a caller parked in the bootstrap reply-wait. Full client unit suite passes.
