### PR TITLE
Release the parser buffer once an oversized reply is drained

### DIFF
--- a/sage-core/src/main/scala/sage/protocol/RespParser.scala
+++ b/sage-core/src/main/scala/sage/protocol/RespParser.scala
@@ -33,7 +33,7 @@ final private[sage] class RespParser {
   private var stack      = new Array[Agg](8)
   private var stackDepth = 0
 
-  // shrink hysteresis: the cycle's buffered high-water mark, and how many drains in a row stayed under MaxRetainedBuffer
+  // shrink hysteresis: the cycle's peak buffering demand, and how many drains in a row stayed under MaxRetainedBuffer
   private var highWater: Int   = 0
   private var quietDrains: Int = 0
 
@@ -97,6 +97,7 @@ final private[sage] class RespParser {
     val needed   = unparsed.toLong + length
     if (needed > MaxBuffer) false
     else {
+      if (needed > highWater) highWater = needed.toInt
       if (buf.length - writePos < length) {
         if (buf.length >= needed) {
           System.arraycopy(buf, readPos, buf, 0, unparsed)
@@ -112,7 +113,6 @@ final private[sage] class RespParser {
       }
       System.arraycopy(incoming, offset, buf, writePos, length)
       writePos += length
-      if (writePos > highWater) highWater = writePos
       true
     }
   }

--- a/sage-core/src/main/scala/sage/protocol/RespParser.scala
+++ b/sage-core/src/main/scala/sage/protocol/RespParser.scala
@@ -37,6 +37,8 @@ final private[sage] class RespParser {
   private var highWater: Int   = 0
   private var quietDrains: Int = 0
 
+  private[protocol] def unsafeBuffer: Array[Byte] = buf
+
   /**
     * Returns every frame completed by `bytes`, in order.
     */

--- a/sage-core/src/main/scala/sage/protocol/RespParser.scala
+++ b/sage-core/src/main/scala/sage/protocol/RespParser.scala
@@ -60,6 +60,8 @@ final private[sage] class RespParser {
         if (readPos == writePos) {
           readPos = 0
           writePos = 0
+          // a buffer grown by one huge element must not stay pinned for the connection's lifetime
+          if (buf.length > MaxRetainedBuffer) buf = Array.emptyByteArray
         }
         None
       }
@@ -406,6 +408,9 @@ final private[sage] class RespParser {
 
   // largest unconsumed input the parser will buffer (the JVM's max array size)
   private inline def MaxBuffer: Long = Int.MaxValue - 8
+
+  // largest buffer kept across feeds once fully drained (see the reset in feed)
+  private inline def MaxRetainedBuffer: Int = 1 << 20
 
   // bound on aggregate nesting so a hostile reply poisons cleanly instead of overflowing the JVM stack; real replies are shallow
   private inline def MaxDepth: Int = 512

--- a/sage-core/src/main/scala/sage/protocol/RespParser.scala
+++ b/sage-core/src/main/scala/sage/protocol/RespParser.scala
@@ -33,6 +33,10 @@ final private[sage] class RespParser {
   private var stack      = new Array[Agg](8)
   private var stackDepth = 0
 
+  // shrink hysteresis: the cycle's buffered high-water mark, and how many drains in a row stayed under MaxRetainedBuffer
+  private var highWater: Int   = 0
+  private var quietDrains: Int = 0
+
   /**
     * Returns every frame completed by `bytes`, in order.
     */
@@ -60,8 +64,15 @@ final private[sage] class RespParser {
         if (readPos == writePos) {
           readPos = 0
           writePos = 0
-          // a buffer grown by one huge element must not stay pinned for the connection's lifetime
-          if (buf.length > MaxRetainedBuffer) buf = Array.emptyByteArray
+          // a buffer grown by a huge element must not stay pinned forever, but consecutive large replies must keep reusing it
+          if (buf.length > MaxRetainedBuffer) {
+            if (highWater > MaxRetainedBuffer) quietDrains = 0
+            else {
+              quietDrains += 1
+              if (quietDrains >= ShrinkAfterDrains) buf = Array.emptyByteArray
+            }
+          }
+          highWater = 0
         }
         None
       }
@@ -99,6 +110,7 @@ final private[sage] class RespParser {
       }
       System.arraycopy(incoming, offset, buf, writePos, length)
       writePos += length
+      if (writePos > highWater) highWater = writePos
       true
     }
   }
@@ -411,6 +423,9 @@ final private[sage] class RespParser {
 
   // largest buffer kept across feeds once fully drained (see the reset in feed)
   private inline def MaxRetainedBuffer: Int = 1 << 20
+
+  // consecutive drains under MaxRetainedBuffer before an oversized buffer is released
+  private inline def ShrinkAfterDrains: Int = 8
 
   // bound on aggregate nesting so a hostile reply poisons cleanly instead of overflowing the JVM stack; real replies are shallow
   private inline def MaxDepth: Int = 512

--- a/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
+++ b/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
@@ -132,31 +132,50 @@ class RespParserSpec extends munit.FunSuite {
     assertEquals(parser.feed(Bytes.utf8("d\r\n")), Right(Vector(Frame.BulkString(Bytes.utf8("hello world")))))
   }
 
-  test("releases an oversized buffer once fully drained, then keeps parsing normally") {
-    val parser  = new RespParser
-    val length  = (1 << 20) + 1 // one byte past the retention threshold, so the drained buffer must be released
-    val payload = Array.fill[Byte](length)('x')
-    val wire    = s"$$$length\r\n".getBytes ++ payload ++ "\r\n".getBytes
-    val frames  = wire.grouped(8192).foldLeft(Vector.empty[Frame]) { (acc, chunk) =>
-      acc ++ parser.feed(Bytes.fromArray(chunk)).fold(error => fail(s"unexpected protocol error: $error"), identity)
-    }
-    assertEquals(frames, Vector(Frame.BulkString(Bytes.fromArray(payload))))
-    assert(bufferCapacity(parser) <= (1 << 20), "the grown buffer must not stay pinned after the reply is consumed")
+  test("releases an oversized buffer after enough drains no longer need it, then keeps parsing normally") {
+    val parser           = new RespParser
+    val (wire, expected) = largeBulk((1 << 20) + 1)
+    assertEquals(feedInChunks(parser, wire), Vector(expected))
+    assert(buffer(parser).length > (1 << 20), "the buffer stays grown right after the large reply")
+    for (_ <- 1 to 8)
+      assertEquals(parser.feed(Bytes.utf8("+OK\r\n")), Right(Vector(Frame.SimpleString("OK"))))
+    assert(buffer(parser).length <= (1 << 20), "the grown buffer must be released once no longer needed")
     assertEquals(parser.feed(Bytes.utf8("+OK\r\n")), Right(Vector(Frame.SimpleString("OK"))))
+  }
+
+  test("consecutive large replies reuse the grown buffer instead of shrinking and regrowing") {
+    val parser           = new RespParser
+    val (wire, expected) = largeBulk((1 << 20) + 1)
+    assertEquals(feedInChunks(parser, wire), Vector(expected))
+    val grown            = buffer(parser)
+    for (_ <- 1 to 3) {
+      assertEquals(feedInChunks(parser, wire), Vector(expected))
+      assert(buffer(parser) eq grown, "a large reply arriving between drains must reuse the buffer")
+    }
   }
 
   test("keeps a small buffer across feeds without reallocating") {
     val parser = new RespParser
     assertEquals(parser.feed(Bytes.utf8("$5\r\nhello\r\n")), Right(Vector(Frame.BulkString(Bytes.utf8("hello")))))
-    val buffer = bufferCapacity(parser)
+    val first  = buffer(parser)
     assertEquals(parser.feed(Bytes.utf8("$5\r\nworld\r\n")), Right(Vector(Frame.BulkString(Bytes.utf8("world")))))
-    assertEquals(bufferCapacity(parser), buffer)
+    assert(buffer(parser) eq first)
   }
 
-  private def bufferCapacity(parser: RespParser): Int = {
+  private def largeBulk(length: Int): (Array[Byte], Frame) = {
+    val payload = Array.fill[Byte](length)('x')
+    (s"$$$length\r\n".getBytes ++ payload ++ "\r\n".getBytes, Frame.BulkString(Bytes.fromArray(payload)))
+  }
+
+  private def feedInChunks(parser: RespParser, wire: Array[Byte]): Vector[Frame] =
+    wire.grouped(8192).foldLeft(Vector.empty[Frame]) { (acc, chunk) =>
+      acc ++ parser.feed(Bytes.fromArray(chunk)).fold(error => fail(s"unexpected protocol error: $error"), identity)
+    }
+
+  private def buffer(parser: RespParser): Array[Byte] = {
     val field = classOf[RespParser].getDeclaredField("buf")
     field.setAccessible(true)
-    field.get(parser).asInstanceOf[Array[Byte]].length
+    field.get(parser).asInstanceOf[Array[Byte]]
   }
 
   test("handles frames split at every two-way boundary") {

--- a/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
+++ b/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
@@ -167,8 +167,13 @@ class RespParserSpec extends munit.FunSuite {
     assertEquals(feedInChunks(parser, wire), Vector(expected))
     // 4-byte elements never align with the 8192-byte chunks, so the cursor passes the threshold with no mid-aggregate drain
     val count            = 325000
-    val aggregate        = s"*$count\r\n".getBytes ++ Array.fill(count)(":4\r\n".getBytes).flatten
-    assertEquals(feedInChunks(parser, aggregate), Vector(Frame.Array(Vector.fill(count)(Frame.Integer(4)))))
+    val aggregate        = (s"*$count\r\n" + ":4\r\n" * count).getBytes
+    feedInChunks(parser, aggregate) match {
+      case Vector(Frame.Array(elements)) =>
+        assertEquals(elements.length, count)
+        assert(elements.forall(_ == Frame.Integer(4)))
+      case other                         => fail(s"expected one array, got $other")
+    }
     for (_ <- 1 to 7)
       assertEquals(parser.feed(Bytes.utf8("+OK\r\n")), Right(Vector(Frame.SimpleString("OK"))))
     assert(buffer(parser).length <= (1 << 20), "cursor position must not be mistaken for buffering demand")

--- a/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
+++ b/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
@@ -171,7 +171,8 @@ class RespParserSpec extends munit.FunSuite {
     feedInChunks(parser, aggregate) match {
       case Vector(Frame.Array(elements)) =>
         assertEquals(elements.length, count)
-        assert(elements.forall(_ == Frame.Integer(4)))
+        val expected = Frame.Integer(4)
+        assert(elements.forall(_ == expected))
       case other                         => fail(s"expected one array, got $other")
     }
     for (_ <- 1 to 7)

--- a/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
+++ b/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
@@ -132,6 +132,33 @@ class RespParserSpec extends munit.FunSuite {
     assertEquals(parser.feed(Bytes.utf8("d\r\n")), Right(Vector(Frame.BulkString(Bytes.utf8("hello world")))))
   }
 
+  test("releases an oversized buffer once fully drained, then keeps parsing normally") {
+    val parser  = new RespParser
+    val length  = (1 << 20) + 1 // one byte past the retention threshold, so the drained buffer must be released
+    val payload = Array.fill[Byte](length)('x')
+    val wire    = s"$$$length\r\n".getBytes ++ payload ++ "\r\n".getBytes
+    val frames  = wire.grouped(8192).foldLeft(Vector.empty[Frame]) { (acc, chunk) =>
+      acc ++ parser.feed(Bytes.fromArray(chunk)).fold(error => fail(s"unexpected protocol error: $error"), identity)
+    }
+    assertEquals(frames, Vector(Frame.BulkString(Bytes.fromArray(payload))))
+    assert(bufferCapacity(parser) <= (1 << 20), "the grown buffer must not stay pinned after the reply is consumed")
+    assertEquals(parser.feed(Bytes.utf8("+OK\r\n")), Right(Vector(Frame.SimpleString("OK"))))
+  }
+
+  test("keeps a small buffer across feeds without reallocating") {
+    val parser = new RespParser
+    assertEquals(parser.feed(Bytes.utf8("$5\r\nhello\r\n")), Right(Vector(Frame.BulkString(Bytes.utf8("hello")))))
+    val buffer = bufferCapacity(parser)
+    assertEquals(parser.feed(Bytes.utf8("$5\r\nworld\r\n")), Right(Vector(Frame.BulkString(Bytes.utf8("world")))))
+    assertEquals(bufferCapacity(parser), buffer)
+  }
+
+  private def bufferCapacity(parser: RespParser): Int = {
+    val field = classOf[RespParser].getDeclaredField("buf")
+    field.setAccessible(true)
+    field.get(parser).asInstanceOf[Array[Byte]].length
+  }
+
   test("handles frames split at every two-way boundary") {
     val (wires, expected) = goldens.unzip
     val stream            = wires.mkString.getBytes

--- a/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
+++ b/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
@@ -136,11 +136,42 @@ class RespParserSpec extends munit.FunSuite {
     val parser           = new RespParser
     val (wire, expected) = largeBulk((1 << 20) + 1)
     assertEquals(feedInChunks(parser, wire), Vector(expected))
-    assert(buffer(parser).length > (1 << 20), "the buffer stays grown right after the large reply")
-    for (_ <- 1 to 8)
+    val grown            = buffer(parser)
+    assert(grown.length > (1 << 20), "the buffer stays grown right after the large reply")
+    for (_ <- 1 to 7) {
       assertEquals(parser.feed(Bytes.utf8("+OK\r\n")), Right(Vector(Frame.SimpleString("OK"))))
+      assert(buffer(parser) eq grown, "the buffer must survive until the quiet-drain streak completes")
+    }
+    assertEquals(parser.feed(Bytes.utf8("+OK\r\n")), Right(Vector(Frame.SimpleString("OK"))))
     assert(buffer(parser).length <= (1 << 20), "the grown buffer must be released once no longer needed")
     assertEquals(parser.feed(Bytes.utf8("+OK\r\n")), Right(Vector(Frame.SimpleString("OK"))))
+  }
+
+  test("a large reply mid-streak resets the shrink countdown") {
+    val parser           = new RespParser
+    val (wire, expected) = largeBulk((1 << 20) + 1)
+    assertEquals(feedInChunks(parser, wire), Vector(expected))
+    val grown            = buffer(parser)
+    for (_ <- 1 to 4)
+      assertEquals(parser.feed(Bytes.utf8("+OK\r\n")), Right(Vector(Frame.SimpleString("OK"))))
+    assertEquals(feedInChunks(parser, wire), Vector(expected))
+    for (_ <- 1 to 7) {
+      assertEquals(parser.feed(Bytes.utf8("+OK\r\n")), Right(Vector(Frame.SimpleString("OK"))))
+      assert(buffer(parser) eq grown, "a large reply must restart the quiet-drain streak")
+    }
+  }
+
+  test("a long stream of small elements through an enlarged buffer still counts as quiet") {
+    val parser           = new RespParser
+    val (wire, expected) = largeBulk((1 << 20) + 1)
+    assertEquals(feedInChunks(parser, wire), Vector(expected))
+    // 4-byte elements never align with the 8192-byte chunks, so the cursor passes the threshold with no mid-aggregate drain
+    val count            = 325000
+    val aggregate        = s"*$count\r\n".getBytes ++ Array.fill(count)(":4\r\n".getBytes).flatten
+    assertEquals(feedInChunks(parser, aggregate), Vector(Frame.Array(Vector.fill(count)(Frame.Integer(4)))))
+    for (_ <- 1 to 7)
+      assertEquals(parser.feed(Bytes.utf8("+OK\r\n")), Right(Vector(Frame.SimpleString("OK"))))
+    assert(buffer(parser).length <= (1 << 20), "cursor position must not be mistaken for buffering demand")
   }
 
   test("consecutive large replies reuse the grown buffer instead of shrinking and regrowing") {

--- a/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
+++ b/sage-core/src/test/scala/sage/protocol/RespParserSpec.scala
@@ -172,11 +172,7 @@ class RespParserSpec extends munit.FunSuite {
       acc ++ parser.feed(Bytes.fromArray(chunk)).fold(error => fail(s"unexpected protocol error: $error"), identity)
     }
 
-  private def buffer(parser: RespParser): Array[Byte] = {
-    val field = classOf[RespParser].getDeclaredField("buf")
-    field.setAccessible(true)
-    field.get(parser).asInstanceOf[Array[Byte]]
-  }
+  private def buffer(parser: RespParser): Array[Byte] = parser.unsafeBuffer
 
   test("handles frames split at every two-way boundary") {
     val (wires, expected) = goldens.unzip


### PR DESCRIPTION
Fixes #185.

`RespParser` grew its buffer geometrically but never downsized it, so a single multi-MB bulk string left a grown array (up to just under 2x the required size) pinned to the connection for its lifetime (multiplied by node connections in cluster mode).

On the empty-buffer reset in `feed`, an oversized buffer (over `MaxRetainedBuffer`, 1 MiB) is now released — but only after `ShrinkAfterDrains` (8) consecutive drain cycles whose peak buffering demand (unparsed tail + incoming bytes, the quantity that actually drives growth) stayed under the threshold. A cycle that needs more resets the streak, so consecutive large replies keep reusing the grown buffer instead of shrinking and regrowing it. Demand, not the write cursor, is tracked deliberately: a long aggregate of small elements can advance the cursor far past the threshold inside an enlarged buffer while only ever holding a tiny tail, and must still count as quiet.

Tests: a >1 MiB bulk parses across 8 KB chunks and the buffer survives (by reference identity) each of the first 7 quiet drains before being released on the 8th, with parsing continuing normally; a large reply arriving mid-streak restarts the countdown; consecutive large replies reuse the same array; a 1.3 MB aggregate of chunk-misaligned small elements still counts as quiet (fails under cursor-based tracking); and small replies keep their buffer with no reallocation.