### PR TITLE
Drop encoded payloads once written instead of retaining them until the reply

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
@@ -129,7 +129,6 @@ final private[client] class DedicatedConnection private (
     private val remaining = new AtomicInteger(n)
     private val done      = new AtomicBoolean(false)
 
-    // the pending Slots pin this batch until every reply lands
     var payload: Bytes = Bytes.concatBy(commands)(_.encode)
 
     override def clearPayload(): Unit = payload = Bytes.empty

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
@@ -102,7 +102,9 @@ final private[client] class DedicatedConnection private (
 
   final private class Entry[A](command: Command[A], callback: Try[A] => Unit) extends Transport.Item with DedicatedConnection.Waiter {
 
-    val payload: Bytes = command.encode
+    var payload: Bytes = command.encode
+
+    override def clearPayload(): Unit = payload = Bytes.empty
 
     def writeAttempted(): Unit = { val _ = pending.add(this) }
 
@@ -127,7 +129,10 @@ final private[client] class DedicatedConnection private (
     private val remaining = new AtomicInteger(n)
     private val done      = new AtomicBoolean(false)
 
-    val payload: Bytes = Bytes.concatBy(commands)(_.encode)
+    // the pending Slots pin this batch until every reply lands
+    var payload: Bytes = Bytes.concatBy(commands)(_.encode)
+
+    override def clearPayload(): Unit = payload = Bytes.empty
 
     def writeAttempted(): Unit = {
       var i = 0

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -400,7 +400,9 @@ final private[client] class MultiplexedConnection private (
 
       @volatile var sentAtMillis: Long = 0L
 
-      val payload: Bytes = command.encode
+      var payload: Bytes = command.encode
+
+      override def clearPayload(): Unit = payload = Bytes.empty
 
       def writeAttempted(): Unit = {
         sentAtMillis = scheduler.nowMillis
@@ -420,6 +422,8 @@ final private[client] class MultiplexedConnection private (
     final private class Batch(entries: Vector[Entry[Any]]) extends Transport.Item {
 
       val payload: Bytes = Bytes.concatBy(entries)(_.payload)
+
+      override def clearPayload(): Unit = entries.foreach(_.clearPayload())
 
       def writeAttempted(): Unit = entries.foreach(_.writeAttempted())
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
@@ -128,9 +128,11 @@ final private[client] class SocketTransport private (
           }
         }
         if (batch.size == 1) {
+          val payload = first.payload
           first.writeAttempted()
+          first.clearPayload()
           attempted = 1
-          out.write(first.payload.unsafeArray)
+          out.write(payload.unsafeArray)
         } else {
           if (scratch == null || scratch.length < size) {
             var capacity = if (scratch == null) 1024L else scratch.length.toLong
@@ -145,6 +147,7 @@ final private[client] class SocketTransport private (
           }
           batch.forEach { item =>
             item.writeAttempted()
+            item.clearPayload()
             attempted += 1
           }
           out.write(scratch, 0, offset)

--- a/sage-client/shared/src/main/scala/sage/client/internal/Transport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Transport.scala
@@ -15,7 +15,7 @@ private[client] trait Transport {
   def start(): Unit
 
   /**
-    * Enqueues an item for writing; never blocks. Exactly one of the item's hooks is eventually invoked.
+    * Enqueues an item for writing; never blocks. Exactly one of `writeAttempted`/`dropped` eventually fires; `clearPayload` follows a write.
     */
   def send(item: Transport.Item): Unit
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/Transport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Transport.scala
@@ -15,7 +15,8 @@ private[client] trait Transport {
   def start(): Unit
 
   /**
-    * Enqueues an item for writing; never blocks. Exactly one of `writeAttempted`/`dropped` eventually fires; `clearPayload` follows a write.
+    * Enqueues an item for writing; never blocks. Exactly one of `writeAttempted`/`dropped` eventually fires; `clearPayload` follows
+    * `writeAttempted`, after the transport captures the payload.
     */
   def send(item: Transport.Item): Unit
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/Transport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Transport.scala
@@ -32,6 +32,11 @@ private[client] object Transport {
     def payload: Bytes
 
     /**
+      * Invoked after the payload has been captured for the write attempt; it is never read again, so the item may drop it.
+      */
+    def clearPayload(): Unit = ()
+
+    /**
       * Invoked on the writer thread immediately before the first write attempt: from here on the command may execute server-side.
       */
     def writeAttempted(): Unit

--- a/sage-client/shared/src/main/scala/sage/client/internal/Transport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Transport.scala
@@ -15,8 +15,7 @@ private[client] trait Transport {
   def start(): Unit
 
   /**
-    * Enqueues an item for writing; never blocks. Exactly one of `writeAttempted`/`dropped` eventually fires; `clearPayload` follows
-    * `writeAttempted`, after the transport captures the payload.
+    * Enqueues an item for writing; never blocks. Exactly one of `writeAttempted`/`dropped` fires; `clearPayload` follows the capture.
     */
   def send(item: Transport.Item): Unit
 

--- a/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
@@ -13,14 +13,14 @@ import sage.protocol.Frame
 
 class SocketTransportSpec extends munit.FunSuite {
 
-  final private class RecordingItem(text: String) extends Transport.Item {
-    val payload: Bytes                = Bytes.utf8(text)
+  final private class RecordingItem(val text: String) extends Transport.Item {
+    var payload: Bytes                = Bytes.utf8(text)
     @volatile var writeAttempts: Int  = 0
     @volatile var drops: Int          = 0
     @volatile var clears: Int         = 0
     def writeAttempted(): Unit        = writeAttempts += 1
     def dropped(): Unit               = drops += 1
-    override def clearPayload(): Unit = clears += 1
+    override def clearPayload(): Unit = { clears += 1; payload = Bytes.empty }
   }
 
   private def withTransport(
@@ -54,7 +54,7 @@ class SocketTransportSpec extends munit.FunSuite {
   }
 
   private def assertAllArrive(peer: Socket, items: Seq[RecordingItem]): Unit = {
-    val expected = items.map(item => item.payload.asUtf8String).mkString
+    val expected = items.map(_.text).mkString
     assertEquals(readExactly(peer.getInputStream, expected.length), expected)
   }
 

--- a/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
@@ -14,11 +14,13 @@ import sage.protocol.Frame
 class SocketTransportSpec extends munit.FunSuite {
 
   final private class RecordingItem(text: String) extends Transport.Item {
-    val payload: Bytes               = Bytes.utf8(text)
-    @volatile var writeAttempts: Int = 0
-    @volatile var drops: Int         = 0
-    def writeAttempted(): Unit       = writeAttempts += 1
-    def dropped(): Unit              = drops += 1
+    val payload: Bytes                = Bytes.utf8(text)
+    @volatile var writeAttempts: Int  = 0
+    @volatile var drops: Int          = 0
+    @volatile var clears: Int         = 0
+    def writeAttempted(): Unit        = writeAttempts += 1
+    def dropped(): Unit               = drops += 1
+    override def clearPayload(): Unit = clears += 1
   }
 
   private def withTransport(
@@ -64,6 +66,7 @@ class SocketTransportSpec extends munit.FunSuite {
       transport.send(item)
       assertEquals(readExactly(peer.getInputStream, 6), "PING\r\n")
       assertEquals(item.writeAttempts, 1)
+      assertEquals(item.clears, 1)
       peer.getOutputStream.write("+PONG\r\n".getBytes(StandardCharsets.UTF_8))
       peer.getOutputStream.flush()
       awaitUntil(frames == Vector(Frame.SimpleString("PONG")), "the PONG frame")
@@ -81,7 +84,10 @@ class SocketTransportSpec extends munit.FunSuite {
     withTransport(onClosed = () => (), beforeStart = transport => items.foreach(transport.send)) { (transport, peer) =>
       assertAllArrive(peer, items)
       awaitWriteCount(transport, 1L)
-      items.foreach(item => assertEquals(item.writeAttempts, 1))
+      items.foreach { item =>
+        assertEquals(item.writeAttempts, 1)
+        assertEquals(item.clears, 1)
+      }
       transport.close()
     }
   }
@@ -170,6 +176,7 @@ class SocketTransportSpec extends munit.FunSuite {
       transport.send(item)
       assertEquals(item.drops, 1)
       assertEquals(item.writeAttempts, 0)
+      assertEquals(item.clears, 0)
       transport.close()
     }
   }


### PR DESCRIPTION
Fixes #186.

A `Transport.Item` kept its encoded payload alive for the whole round trip: `MultiplexedConnection.Entry` and `DedicatedConnection.Entry` sit in `pending` until their reply arrives, and a `RawBatch` is pinned by its pending `Slot`s. Since the encoded bytes duplicate the value bytes already held by `Command.args`, a deep pipeline of large writes retained roughly 2x the payload data.

`Transport.Item` gains a `clearPayload()` hook (default no-op), invoked by the writer once the payload has been captured for the write attempt. In the single-item path the payload is captured into a local before `writeAttempted()`/`clearPayload()`, since `writeAttempted` runs before the write there; in the coalesced path the scratch copy already happens first. Retained items clear to `Bytes.empty`; `Batch` forwards to its entries, whose payloads outlive it in `pending`. `SubscriptionConnection.RawItem` is not retained past the write and keeps the no-op.

Write-failure semantics are untouched: `dropped()` still fires only for items never write-attempted (`mayHaveExecuted = false`), and the spec asserts the payload is cleared exactly once after a write attempt and never for dropped items, alongside the existing byte-correctness tests for single, batched, and capped writes.