### PR TITLE
Remove the per-command scheduler and virtual-thread hop in cluster and master-replica modes

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -11,6 +11,7 @@ Workloads (the command path only — no blocking or pub/sub):
 | Workload | Class / method | Notes |
 | --- | --- | --- |
 | Throughput | `ThroughputBench.get` / `.set` | swept over a **concurrency** param (`1, 8, 64, 256`) and **valueSize** (`16, 1024`); reported as a curve. Auto-pipelining only pays off as concurrency rises, so a single point would mislead. |
+| Topology | `TopologyBench.get` / `.set` | sage-only, in the `benchmarksZio` cell: the throughput workload swept over a **topology** param (`standalone, cluster, master-replica`). The cluster is a single self-provisioned node owning every slot and master-replica discovers a replica-less master, so all three serve identical commands and the delta is per-topology dispatch overhead. |
 | Big collection | `CollectionBench.mget` / `.hgetall` | a single MGET / HGETALL of 1000 keys/fields — the large-reply parse path (concurrency does not apply). |
 
 Allocation profile: add `-prof gc` to any run (see below).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -11,7 +11,7 @@ Workloads (the command path only — no blocking or pub/sub):
 | Workload | Class / method | Notes |
 | --- | --- | --- |
 | Throughput | `ThroughputBench.get` / `.set` | swept over a **concurrency** param (`1, 8, 64, 256`) and **valueSize** (`16, 1024`); reported as a curve. Auto-pipelining only pays off as concurrency rises, so a single point would mislead. |
-| Topology | `TopologyBench.get` / `.set` | sage-only, in the `benchmarksZio` cell: the throughput workload swept over a **topology** param (`standalone, cluster, master-replica`). The cluster is a single self-provisioned node owning every slot and master-replica discovers a replica-less master, so all three serve identical commands and the delta is per-topology dispatch overhead. |
+| Topology | `TopologyBench.get` / `.set` | sage-only, in the `benchmarksZio` cell: the throughput workload swept over a **topology** param (`standalone, cluster, master-replica`). The cluster is a single self-provisioned node owning every slot and master-replica discovers a replica-less master, so all three serve identical commands. The comparison is **end-to-end topology overhead**: the cluster trial runs a `--cluster-enabled` server in its own container, so server-mode differences and instance variance are included, not client dispatch alone. |
 | Big collection | `CollectionBench.mget` / `.hgetall` | a single MGET / HGETALL of 1000 keys/fields — the large-reply parse path (concurrency does not apply). |
 
 Allocation profile: add `-prof gc` to any run (see below).

--- a/benchmarks/shared/src/main/scala/sage/benchmarks/ClusterFormation.scala
+++ b/benchmarks/shared/src/main/scala/sage/benchmarks/ClusterFormation.scala
@@ -1,0 +1,60 @@
+package sage.benchmarks
+
+import java.io.{BufferedReader, InputStreamReader, OutputStreamWriter}
+import java.net.Socket
+import java.nio.charset.StandardCharsets.UTF_8
+
+/**
+  * Forms a single-node cluster on a freshly-started `--cluster-enabled` server: the node claims every slot and announces the
+  * testcontainers-mapped host/port so the address it reports in `CLUSTER SLOTS` is reachable from the benchmark (the same trick as the
+  * integration `ClusterSuite`).
+  */
+object ClusterFormation {
+
+  def formSingleNodeCluster(host: String, port: Int): Unit = {
+    val socket = new Socket(host, port)
+    try {
+      val out                            = new OutputStreamWriter(socket.getOutputStream, UTF_8)
+      val in                             = new BufferedReader(new InputStreamReader(socket.getInputStream, UTF_8))
+      def command(args: String*): String = {
+        out.write(args.mkString("", " ", "\r\n"))
+        out.flush()
+        reply(in)
+      }
+      def clusterOk: Boolean             = command("CLUSTER", "INFO").contains("cluster_state:ok")
+
+      val _        = command("CONFIG", "SET", "cluster-announce-ip", host)
+      val _        = command("CONFIG", "SET", "cluster-announce-port", port.toString)
+      if (!clusterOk) { val _ = command("CLUSTER", "ADDSLOTSRANGE", "0", "16383") }
+      var attempts = 100
+      var ok       = clusterOk
+      while (!ok && attempts > 0) {
+        Thread.sleep(100)
+        attempts -= 1
+        ok = clusterOk
+      }
+      if (!ok) throw new IllegalStateException("single-node cluster did not converge")
+    } finally socket.close()
+  }
+
+  private def reply(in: BufferedReader): String = {
+    val line = in.readLine()
+    if (line == null) throw new IllegalStateException("connection closed while forming the cluster")
+    else if (line.startsWith("-")) throw new IllegalStateException(s"server error: $line")
+    else if (line.startsWith("$")) {
+      val length = line.drop(1).toInt
+      if (length < 0) ""
+      else {
+        val payload = new Array[Char](length)
+        var read    = 0
+        while (read < length) {
+          val n = in.read(payload, read, length - read)
+          if (n < 0) throw new IllegalStateException("connection closed while forming the cluster")
+          read += n
+        }
+        in.readLine()
+        new String(payload)
+      }
+    } else line
+  }
+}

--- a/benchmarks/shared/src/main/scala/sage/benchmarks/RedisFixture.scala
+++ b/benchmarks/shared/src/main/scala/sage/benchmarks/RedisFixture.scala
@@ -13,8 +13,9 @@ final class RedisFixture {
   var host: String = ""
   var port: Int    = 0
 
-  def start(): Unit = {
-    val c = GenericContainer(RedisFixture.Image, exposedPorts = Seq(6379))
+  def start(clusterEnabled: Boolean = false): Unit = {
+    val command = if (clusterEnabled) Seq("redis-server", "--cluster-enabled", "yes") else Seq.empty
+    val c       = GenericContainer(RedisFixture.Image, exposedPorts = Seq(6379), command = command)
     c.start()
     container = Some(c)
     host = c.host

--- a/benchmarks/shared/src/main/scala/sage/benchmarks/TopologyBenchState.scala
+++ b/benchmarks/shared/src/main/scala/sage/benchmarks/TopologyBenchState.scala
@@ -4,7 +4,8 @@ import org.openjdk.jmh.annotations.{Level, Setup, TearDown}
 
 /**
   * Shared JMH state for the topology benchmarks: the same workload against the standalone, cluster, and master-replica runtimes, each on a
-  * single self-provisioned server, so the numbers isolate per-topology dispatch overhead.
+  * single self-provisioned server. The comparison is end-to-end per-topology overhead — the cluster trial runs a `--cluster-enabled` server
+  * in its own container, so server-mode and instance variance are included, not client dispatch alone.
   */
 abstract class TopologyBenchState {
 

--- a/benchmarks/shared/src/main/scala/sage/benchmarks/TopologyBenchState.scala
+++ b/benchmarks/shared/src/main/scala/sage/benchmarks/TopologyBenchState.scala
@@ -1,0 +1,36 @@
+package sage.benchmarks
+
+import org.openjdk.jmh.annotations.{Level, Setup, TearDown}
+
+/**
+  * Shared JMH state for the topology benchmarks: the same workload against the standalone, cluster, and master-replica runtimes, each on a
+  * single self-provisioned server, so the numbers isolate per-topology dispatch overhead.
+  */
+abstract class TopologyBenchState {
+
+  val fixture: RedisFixture = new RedisFixture
+  var subject: BenchClient  = null
+  var keys: Array[String]   = Array.empty
+
+  protected def topologyName: String
+
+  protected def seedValueBytes: Int
+
+  protected def buildClient(host: String, port: Int, topology: String): BenchClient
+
+  @Setup(Level.Trial)
+  def setupTrial(): Unit = {
+    val cluster = topologyName == "cluster"
+    fixture.start(clusterEnabled = cluster)
+    if (cluster) ClusterFormation.formSingleNodeCluster(fixture.host, fixture.port)
+    subject = buildClient(fixture.host, fixture.port, topologyName)
+    keys = Payloads.keys("bench")
+    subject.seed("bench", Payloads.KeyCount, Payloads.value(seedValueBytes), Payloads.HashKey, Payloads.HashFields)
+  }
+
+  @TearDown(Level.Trial)
+  def tearDownTrial(): Unit = {
+    if (subject != null) subject.close()
+    fixture.stop()
+  }
+}

--- a/benchmarks/zio/src/main/scala/sage/benchmarks/Clients.scala
+++ b/benchmarks/zio/src/main/scala/sage/benchmarks/Clients.scala
@@ -17,9 +17,19 @@ import sage.client.{Endpoint, SageConfig, Topology}
   */
 object Clients {
   def build(host: String, port: Int, name: String): BenchClient = name match {
-    case "sage-zio"  => new SageZioBench(host, port)
+    case "sage-zio"  => new SageZioBench(Topology.Standalone(Endpoint(host, port)))
     case "zio-redis" => new ZioRedisBench(host, port)
     case other       => throw new IllegalArgumentException(s"unknown client: $other")
+  }
+
+  def buildTopology(host: String, port: Int, topology: String): BenchClient = {
+    val endpoint = Endpoint(host, port)
+    topology match {
+      case "standalone"     => new SageZioBench(Topology.Standalone(endpoint))
+      case "cluster"        => new SageZioBench(Topology.Cluster(Vector(endpoint)))
+      case "master-replica" => new SageZioBench(Topology.MasterReplica(Vector(endpoint)))
+      case other            => throw new IllegalArgumentException(s"unknown topology: $other")
+    }
   }
 }
 
@@ -29,10 +39,10 @@ private object Run {
     Unsafe.unsafe(implicit u => runtime.unsafe.run(z).getOrThrowFiberFailure())
 }
 
-final class SageZioBench(host: String, port: Int) extends BenchClient {
+final class SageZioBench(topology: Topology) extends BenchClient {
 
   private val client: SageClient =
-    Run(SageClient.connect(SageConfig(topology = Topology.Standalone(Endpoint(host, port)))))
+    Run(SageClient.connect(SageConfig(topology = topology)))
 
   def name: String = "sage-zio"
 

--- a/benchmarks/zio/src/main/scala/sage/benchmarks/ZioBenchmarks.scala
+++ b/benchmarks/zio/src/main/scala/sage/benchmarks/ZioBenchmarks.scala
@@ -25,7 +25,7 @@ class ThroughputBench extends RedisBenchState {
   @Benchmark def set(): Long = subject.setAll(keys, Payloads.value(valueSize), concurrency)
 }
 
-// the throughput workload swept over the client topology (sage only): every topology serves identical commands, so the delta is dispatch overhead
+// the throughput workload swept over the client topology (sage only): end-to-end overhead, server mode included — see TopologyBenchState
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)

--- a/benchmarks/zio/src/main/scala/sage/benchmarks/ZioBenchmarks.scala
+++ b/benchmarks/zio/src/main/scala/sage/benchmarks/ZioBenchmarks.scala
@@ -25,6 +25,29 @@ class ThroughputBench extends RedisBenchState {
   @Benchmark def set(): Long = subject.setAll(keys, Payloads.value(valueSize), concurrency)
 }
 
+// the throughput workload swept over the client topology (sage only): every topology serves identical commands, so the delta is dispatch overhead
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@OperationsPerInvocation(1000) // = Payloads.KeyCount
+@Fork(1)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 5, time = 3)
+class TopologyBench extends TopologyBenchState {
+
+  @Param(Array("sage-zio")) var client: String                                  = "sage-zio"
+  @Param(Array("standalone", "cluster", "master-replica")) var topology: String = "standalone"
+  @Param(Array("1", "8", "64", "256")) var concurrency: Int                     = 1
+  @Param(Array("16")) var valueSize: Int                                        = 16
+
+  protected def topologyName: String                                            = topology
+  override protected def seedValueBytes: Int                                    = valueSize
+  protected def buildClient(host: String, port: Int, name: String): BenchClient = Clients.buildTopology(host, port, name)
+
+  @Benchmark def get(): Long = subject.getAll(keys, concurrency)
+  @Benchmark def set(): Long = subject.setAll(keys, Payloads.value(valueSize), concurrency)
+}
+
 // a single big-reply command per invocation (no concurrency — that's the throughput workload); valueSize sizes the seeded values
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -26,9 +26,9 @@ import sage.protocol.Frame
   * submission order; positions a stale topology can't resolve fall back to per-command [[dispatch]]. A Transaction leases one Dedicated
   * Connection, pinned lazily to the slot of its first key, and rejects any key on another slot with [[CrossSlot]].
   *
-  * Dispatch to an already-established node runs inline on the caller: the registry lookup and the submit never block. Only the paths that
-  * may establish a connection or refresh the topology hop to an offloaded virtual thread, and a submit's reply callback re-offloads before
-  * any blocking continuation (never on the reply thread).
+  * Dispatch to an already-established node runs inline on the caller: the registry lookup and the submit never block, even mid-reconnect,
+  * where the submit fails fast. Only the paths that may establish a connection or refresh the topology hop to an offloaded virtual thread,
+  * and a submit's reply callback re-offloads before any blocking continuation (never on the reply thread).
   */
 final private[client] class ClusterLive(
   nodeFactory: Node => MultiplexedConnection.TransportFactory,
@@ -404,7 +404,6 @@ final private[client] class ClusterLive(
     complete: Try[A] => Unit,
     lease: DedicatedPool.Lease
   ): Unit = {
-    // an established node — even one mid-reconnect, whose submit fails fast — takes the inline path
     val existing = masterPool.existing(node)
     if (existing != null) submitTo(existing, node, command, asking, redirectsLeft, complete, lease)
     else

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -194,13 +194,19 @@ final private[client] class ClusterLive(
     else {
       val topology = topologyRef.get()
       if (command.allMasters)
-        offload {
-          command.broadcast match {
-            case BroadcastReduce.First      => sendToAllMasters(topology, command, complete)
-            case BroadcastReduce.Concat     => broadcastCombine(topology, command, concatFrames, complete)
-            case BroadcastReduce.Fold(fold) => broadcastCombine(topology, command, _.reduce(fold), complete)
+        if (slotOwningMasters(topology).forall(node => masterPool.existing(node) != null))
+          broadcast(topology, command, complete, masterPool.existing)
+        else
+          offload {
+            broadcast(
+              topology,
+              command,
+              complete,
+              node =>
+                try getOrEstablish(node)
+                catch { case NonFatal(_) => null }
+            )
           }
-        }
       else
         topology.route(command) match {
           case Route.ToNode(node, slot) =>
@@ -304,9 +310,16 @@ final private[client] class ClusterLive(
       case Fault.Fatal                      => Events.attributeNode(complete, node); complete(Failure(error))
     }
 
+  private def broadcast[A](topology: ClusterTopology, command: Command[A], complete: Try[A] => Unit, resolve: Node => NodeClient): Unit =
+    command.broadcast match {
+      case BroadcastReduce.First      => sendToAllMasters(topology, command, complete, resolve)
+      case BroadcastReduce.Concat     => broadcastCombine(topology, command, concatFrames, complete, resolve)
+      case BroadcastReduce.Fold(fold) => broadcastCombine(topology, command, _.reduce(fold), complete, resolve)
+    }
+
   // a broadcast command (SCRIPT LOAD, FUNCTION LOAD, …) runs on every slot-owning master, since a cluster replicates no script/function
   // cache; any node failing fails the command
-  private def sendToAllMasters[A](topology: ClusterTopology, command: Command[A], complete: Try[A] => Unit): Unit = {
+  private def sendToAllMasters[A](topology: ClusterTopology, command: Command[A], complete: Try[A] => Unit, resolve: Node => NodeClient): Unit = {
     val masters = slotOwningMasters(topology)
     if (masters.isEmpty) sendToAny(topology, command, cluster.maxRedirects, complete)
     else {
@@ -322,9 +335,7 @@ final private[client] class ClusterLive(
           complete(Option(firstError.get()).map(Failure(_)).getOrElse(firstValue.get()))
       }
       masters.foreach { node =>
-        val nc =
-          try getOrEstablish(node)
-          catch { case NonFatal(_) => null }
+        val nc = resolve(node)
         if (nc == null) settle(Failure(NotConnected()))
         else nc.submit[A](command, asking = false, settle)
       }
@@ -338,7 +349,8 @@ final private[client] class ClusterLive(
     topology: ClusterTopology,
     command: Command[A],
     combine: Vector[Frame] => Frame,
-    complete: Try[A] => Unit
+    complete: Try[A] => Unit,
+    resolve: Node => NodeClient
   ): Unit = {
     val masters = slotOwningMasters(topology)
     if (masters.isEmpty) sendToAny(topology, command, cluster.maxRedirects, complete)
@@ -359,9 +371,7 @@ final private[client] class ClusterLive(
           }
       }
       masters.iterator.zipWithIndex.foreach { case (node, index) =>
-        val nc =
-          try getOrEstablish(node)
-          catch { case NonFatal(_) => null }
+        val nc = resolve(node)
         if (nc == null) settle(index, Failure(NotConnected()))
         else nc.submit[Frame](raw, asking = false, result => settle(index, result))
       }
@@ -576,15 +586,35 @@ final private[client] class ClusterLive(
     }
   }
 
-  // first live read candidate for a shard under the policy, with the node it landed on; (master, null) when none
-  private def readConn(master: Node): (Node, NodeClient) = {
+  // the read candidates for `master`'s shard under the policy, advancing its round-robin cursor once
+  private def readCandidates(master: Node): Vector[Node] = {
     val replicas = topologyRef.get().shards.collectFirst { case s if s.master == master => s.replicas }.getOrElse(Vector.empty)
     val cursor   = replicaCursors.computeIfAbsent(master, _ => new java.util.concurrent.atomic.AtomicInteger())
-    val it       = ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement()).iterator
+    ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement())
+  }
+
+  // lock-free walk: the first live established candidate, Some((master, null)) when all are established but none live, and None when an
+  // unestablished candidate is met first — only then must the caller offload to establish
+  private def liveEstablished(candidates: Vector[Node], master: Node): Option[(Node, NodeClient)] = {
+    val it = candidates.iterator
     while (it.hasNext) {
       val node = it.next()
+      val pool = if (node == master) masterPool else replicaPool
+      val nc   = pool.existing(node)
+      if (nc == null) return None
+      if (nc.isLive) return Some((node, nc))
+    }
+    Some((master, null))
+  }
+
+  // first live read candidate, establishing as needed, with the node it landed on; (master, null) when none
+  private def establishRead(candidates: Vector[Node], master: Node): (Node, NodeClient) = {
+    val it = candidates.iterator
+    while (it.hasNext) {
+      val node = it.next()
+      val pool = if (node == master) masterPool else replicaPool
       val nc   =
-        try if (node == master) getOrEstablish(node) else replicaPool.getOrEstablish(node)
+        try pool.getOrEstablish(node)
         catch { case NonFatal(_) => null }
       if (nc != null && nc.isLive) return (node, nc)
     }
@@ -598,23 +628,29 @@ final private[client] class ClusterLive(
     emits: Vector[Try[Any] => Unit],
     reroute: Int => Unit,
     useReplica: Boolean
-  ): Unit = {
-    val existing = if (useReplica) null else masterPool.existing(node)
-    if (existing != null) submitBatch(node, existing, indices, p, emits, reroute, useReplica)
-    else
-      offload {
-        // the node the batch lands on (a replica when useReplica), so completions attribute the serving node
-        val (target, nc) =
-          if (useReplica) readConn(node)
-          else
-            (
-              node,
-              try getOrEstablish(node)
-              catch { case NonFatal(_) => null }
-            )
-        submitBatch(target, nc, indices, p, emits, reroute, useReplica)
+  ): Unit =
+    // the batch attributes to the node it lands on (a replica when useReplica)
+    if (useReplica) {
+      val candidates = readCandidates(node)
+      liveEstablished(candidates, node) match {
+        case Some((target, nc)) => submitBatch(target, nc, indices, p, emits, reroute, useReplica)
+        case None               =>
+          offload {
+            val (target, nc) = establishRead(candidates, node)
+            submitBatch(target, nc, indices, p, emits, reroute, useReplica)
+          }
       }
-  }
+    } else {
+      val existing = masterPool.existing(node)
+      if (existing != null) submitBatch(node, existing, indices, p, emits, reroute, useReplica)
+      else
+        offload {
+          val nc =
+            try getOrEstablish(node)
+            catch { case NonFatal(_) => null }
+          submitBatch(node, nc, indices, p, emits, reroute, useReplica)
+        }
+    }
 
   private def submitBatch[Out, R](
     target: Node,

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -26,8 +26,9 @@ import sage.protocol.Frame
   * submission order; positions a stale topology can't resolve fall back to per-command [[dispatch]]. A Transaction leases one Dedicated
   * Connection, pinned lazily to the slot of its first key, and rejects any key on another slot with [[CrossSlot]].
   *
-  * Routing and redirect-following run on offloaded virtual threads (never the reply thread), since establishing a node and refreshing the
-  * topology both block. A submit's reply callback re-offloads before any blocking continuation.
+  * Dispatch to an already-established node runs inline on the caller: the registry lookup and the submit never block. Only the paths that
+  * may establish a connection or refresh the topology hop to an offloaded virtual thread, and a submit's reply callback re-offloads before
+  * any blocking continuation (never on the reply thread).
   */
 final private[client] class ClusterLive(
   nodeFactory: Node => MultiplexedConnection.TransportFactory,
@@ -114,11 +115,9 @@ final private[client] class ClusterLive(
   def run[A](command: Command[A]): CIO[A] = {
     def body(lease: DedicatedPool.Lease): CIO[A] =
       CIO.async[A] { complete =>
-        val span = Events.startSpan(events, command)
-        offload {
-          val tracked = Events.trackCommand(events, command, complete, span)
-          Client.completing(tracked)(dispatch(command, cluster.maxRedirects, tracked, lease = lease))
-        }
+        val span    = Events.startSpan(events, command)
+        val tracked = Events.trackCommand(events, command, complete, span)
+        Client.completing(tracked)(dispatch(command, cluster.maxRedirects, tracked, lease = lease))
       }
     if (!command.isBlocking) body(null)
     // acquire a fresh lease per execution: a lease is single-shot (cancel is terminal), so a captured one would make a re-run of this value hang
@@ -131,11 +130,9 @@ final private[client] class ClusterLive(
     if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command))
     else
       CIO.async[A] { complete =>
-        val span = Events.startSpan(events, command)
-        offload {
-          val tracked = Events.trackCommand(events, command, complete, span)
-          Client.completing(tracked)(dispatch(command, cluster.maxRedirects, tracked, allowReplica = false))
-        }
+        val span    = Events.startSpan(events, command)
+        val tracked = Events.trackCommand(events, command, complete, span)
+        Client.completing(tracked)(dispatch(command, cluster.maxRedirects, tracked, allowReplica = false))
       }
 
   // SCAN cursors are node-local, so a full SCAN must sweep every slot-owning master; a reshard mid-scan can still miss or duplicate keys
@@ -155,11 +152,9 @@ final private[client] class ClusterLive(
       case Some(node) =>
         def body(lease: DedicatedPool.Lease): CIO[A] =
           CIO.async[A] { complete =>
-            val span = Events.startSpan(events, command)
-            offload {
-              val tracked = Events.trackCommand(events, command, complete, span)
-              Client.completing(tracked)(sendTo(node, command, asking = false, redirectsLeft = 0, tracked, lease))
-            }
+            val span    = Events.startSpan(events, command)
+            val tracked = Events.trackCommand(events, command, complete, span)
+            Client.completing(tracked)(sendTo(node, command, asking = false, redirectsLeft = 0, tracked, lease))
           }
         // mirror run: a blocking command needs a cancelable lease so an interrupt releases the slot instead of leaking it
         if (!command.isBlocking) body(null)
@@ -199,10 +194,12 @@ final private[client] class ClusterLive(
     else {
       val topology = topologyRef.get()
       if (command.allMasters)
-        command.broadcast match {
-          case BroadcastReduce.First      => sendToAllMasters(topology, command, complete)
-          case BroadcastReduce.Concat     => broadcastCombine(topology, command, concatFrames, complete)
-          case BroadcastReduce.Fold(fold) => broadcastCombine(topology, command, _.reduce(fold), complete)
+        offload {
+          command.broadcast match {
+            case BroadcastReduce.First      => sendToAllMasters(topology, command, complete)
+            case BroadcastReduce.Concat     => broadcastCombine(topology, command, concatFrames, complete)
+            case BroadcastReduce.Fold(fold) => broadcastCombine(topology, command, _.reduce(fold), complete)
+          }
         }
       else
         topology.route(command) match {
@@ -214,7 +211,7 @@ final private[client] class ClusterLive(
             if (allowReplica && readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command))
               sendKeylessRead(topology, command, redirectsLeft, complete)
             else sendToAny(topology, command, redirectsLeft, complete, lease)
-          case Route.Unowned(_)         => onUnowned(command, redirectsLeft, complete, lease)
+          case Route.Unowned(_)         => offload(onUnowned(command, redirectsLeft, complete, lease))
           case Route.CrossSlot(slots)   => complete(Failure(crossSlot(command.name, slots)))
           case Route.Malformed          =>
             complete(Failure(malformedKeys(command.name)))
@@ -246,22 +243,40 @@ final private[client] class ClusterLive(
   private def tryReadCandidates[A](command: Command[A], candidates: Vector[Node], master: Node, redirectsLeft: Int, complete: Try[A] => Unit): Unit =
     candidates match {
       case node +: rest =>
-        val nc =
-          try if (node == master) getOrEstablish(node) else replicaPool.getOrEstablish(node)
-          catch { case NonFatal(_) => null }
-        if (nc == null || !nc.isLive) tryReadCandidates(command, rest, master, redirectsLeft, complete)
+        val pool     = if (node == master) masterPool else replicaPool
+        val existing = pool.existing(node)
+        if (existing != null)
+          if (existing.isLive) submitRead(existing, node, command, rest, master, redirectsLeft, complete)
+          else tryReadCandidates(command, rest, master, redirectsLeft, complete)
         else
-          nc.submit[A](
-            command,
-            asking = false,
-            {
-              case Success(value) => Events.attributeNode(complete, node); complete(Success(value))
-              case Failure(error) => offload(onReadFailure(node, command, error, rest, master, redirectsLeft, complete))
-            }
-          )
+          offload {
+            val nc =
+              try pool.getOrEstablish(node)
+              catch { case NonFatal(_) => null }
+            if (nc == null || !nc.isLive) tryReadCandidates(command, rest, master, redirectsLeft, complete)
+            else submitRead(nc, node, command, rest, master, redirectsLeft, complete)
+          }
       // strict Replica, all candidates unreachable: refresh so the next read sees the new roster
       case _            => triggerRefresh(); complete(Failure(NotConnected()))
     }
+
+  private def submitRead[A](
+    nc: NodeClient,
+    node: Node,
+    command: Command[A],
+    rest: Vector[Node],
+    master: Node,
+    redirectsLeft: Int,
+    complete: Try[A] => Unit
+  ): Unit =
+    nc.submit[A](
+      command,
+      asking = false,
+      {
+        case Success(value) => Events.attributeNode(complete, node); complete(Success(value))
+        case Failure(error) => offload(onReadFailure(node, command, error, rest, master, redirectsLeft, complete))
+      }
+    )
 
   private def onReadFailure[A](
     node: Node,
@@ -389,21 +404,37 @@ final private[client] class ClusterLive(
     complete: Try[A] => Unit,
     lease: DedicatedPool.Lease
   ): Unit = {
-    val nc =
-      try getOrEstablish(node)
-      catch { case NonFatal(_) => null }
-    if (nc == null) onUnreachable(command, redirectsLeft, complete, lease)
+    // an established node — even one mid-reconnect, whose submit fails fast — takes the inline path
+    val existing = masterPool.existing(node)
+    if (existing != null) submitTo(existing, node, command, asking, redirectsLeft, complete, lease)
     else
-      nc.submit[A](
-        command,
-        asking,
-        {
-          case Success(value) => Events.attributeNode(complete, node); complete(Success(value))
-          case Failure(error) => offload(onFailure(node, command, error, redirectsLeft, complete, lease))
-        },
-        lease
-      )
+      offload {
+        val nc =
+          try getOrEstablish(node)
+          catch { case NonFatal(_) => null }
+        if (nc == null) onUnreachable(command, redirectsLeft, complete, lease)
+        else submitTo(nc, node, command, asking, redirectsLeft, complete, lease)
+      }
   }
+
+  private def submitTo[A](
+    nc: NodeClient,
+    node: Node,
+    command: Command[A],
+    asking: Boolean,
+    redirectsLeft: Int,
+    complete: Try[A] => Unit,
+    lease: DedicatedPool.Lease
+  ): Unit =
+    nc.submit[A](
+      command,
+      asking,
+      {
+        case Success(value) => Events.attributeNode(complete, node); complete(Success(value))
+        case Failure(error) => offload(onFailure(node, command, error, redirectsLeft, complete, lease))
+      },
+      lease
+    )
 
   private def onFailure[A](
     node: Node,
@@ -500,7 +531,7 @@ final private[client] class ClusterLive(
       )
     else
       CIO.async { complete =>
-        offload(runPipeline(p, complete, Events.deferSpans(events, p.commands)))
+        runPipeline(p, complete, Events.deferSpans(events, p.commands))
       }
 
   // a position a stale topology can't resolve falls back to per-command dispatch; the collector completes once every position lands terminally
@@ -531,7 +562,7 @@ final private[client] class ClusterLive(
     }
     // all-or-nothing: reroutes honor the same choice so a slot is never split across master and replica
     val useReplica                = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
-    def reroute(index: Int): Unit = offload(dispatch(p.commands(index), cluster.maxRedirects, emits(index), allowReplica = useReplica))
+    def reroute(index: Int): Unit = dispatch(p.commands(index), cluster.maxRedirects, emits(index), allowReplica = useReplica)
 
     plan.rejected.foreach {
       case (index, Rejected.CrossSlot(slots)) => emits(index)(Failure(crossSlot(p.commands(index).name, slots)))
@@ -569,15 +600,32 @@ final private[client] class ClusterLive(
     reroute: Int => Unit,
     useReplica: Boolean
   ): Unit = {
-    // the node the batch lands on (a replica when useReplica), so completions attribute the serving node
-    val (target, nc)                               =
-      if (useReplica) readConn(node)
-      else
-        (
-          node,
-          try getOrEstablish(node)
-          catch { case NonFatal(_) => null }
-        )
+    val existing = if (useReplica) null else masterPool.existing(node)
+    if (existing != null) submitBatch(node, existing, indices, p, emits, reroute, useReplica)
+    else
+      offload {
+        // the node the batch lands on (a replica when useReplica), so completions attribute the serving node
+        val (target, nc) =
+          if (useReplica) readConn(node)
+          else
+            (
+              node,
+              try getOrEstablish(node)
+              catch { case NonFatal(_) => null }
+            )
+        submitBatch(target, nc, indices, p, emits, reroute, useReplica)
+      }
+  }
+
+  private def submitBatch[Out, R](
+    target: Node,
+    nc: NodeClient,
+    indices: Vector[Int],
+    p: Pipeline[Out, R],
+    emits: Vector[Try[Any] => Unit],
+    reroute: Int => Unit,
+    useReplica: Boolean
+  ): Unit = {
     def settle(index: Int, result: Try[Any]): Unit = { Events.attributeNode(emits(index), target); emits(index)(result) }
     val callbacks: Vector[Try[Any] => Unit]        = indices.map { index => (result: Try[Any]) =>
       result match {

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -155,13 +155,11 @@ final private[client] class MasterReplicaLive(
   def run[A](command: Command[A]): CIO[A] = {
     def body(lease: DedicatedPool.Lease): CIO[A] =
       CIO.async[A] { complete =>
-        val span = Events.startSpan(events, command)
-        offload {
-          val tracked = Events.trackCommand(events, command, complete, span)
-          Client.completing(tracked) {
-            if (readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command)) sendRead(command, tracked)
-            else sendMaster(command, tracked, lease)
-          }
+        val span    = Events.startSpan(events, command)
+        val tracked = Events.trackCommand(events, command, complete, span)
+        Client.completing(tracked) {
+          if (readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command)) sendRead(command, tracked)
+          else sendMaster(command, tracked, lease)
         }
       }
     if (!command.isBlocking) body(null)
@@ -173,46 +171,51 @@ final private[client] class MasterReplicaLive(
     if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command))
     else if (!cachingEnabled)
       CIO.async[A] { complete =>
-        val span = Events.startSpan(events, command)
-        offload {
-          val tracked = Events.trackCommand(events, command, complete, span)
-          Client.completing(tracked)(sendMaster(command, tracked))
-        }
+        val span    = Events.startSpan(events, command)
+        val tracked = Events.trackCommand(events, command, complete, span)
+        Client.completing(tracked)(sendMaster(command, tracked))
       }
     else
       CIO.async[A] { complete =>
         val deferred = Events.deferSpan(events, command)
-        offload(Client.completing(complete)(sendMasterCached(command, ttl.toMillis, complete, deferred)))
+        Client.completing(complete)(sendMasterCached(command, ttl.toMillis, complete, deferred))
       }
 
   private def sendMaster[A](command: Command[A], complete: Try[A] => Unit, lease: DedicatedPool.Lease = null): Unit =
     onMaster(complete)((nc, _, cb) => nc.submit[A](command, asking = false, cb, lease))
 
-  private def sendMasterCached[A](command: Command[A], ttlMillis: Long, complete: Try[A] => Unit, deferred: () => CommandSpan): Unit = {
-    var reached = false
-    onMaster(complete) { (nc, _, cb) => reached = true; nc.cachedSubmit[A](command, ttlMillis, cb, deferred) }
-    // onMaster short-circuited (master down) without reaching cachedSubmit, so settle a Failed span the deferred factory would otherwise never start
-    if (!reached) Events.settleSpan(Events.startDeferred(deferred), Outcome.Failed(NotConnected()))
+  private def sendMasterCached[A](command: Command[A], ttlMillis: Long, complete: Try[A] => Unit, deferred: () => CommandSpan): Unit =
+    // a short-circuit (master down) never reaches cachedSubmit, so settle a Failed span the deferred factory would otherwise never start
+    onMaster(complete, onDown = () => Events.settleSpan(Events.startDeferred(deferred), Outcome.Failed(NotConnected()))) { (nc, _, cb) =>
+      nc.cachedSubmit[A](command, ttlMillis, cb, deferred)
+    }
+
+  // run `submit` on the master, completing with node attribution; an ownership fault (a demoted master) kicks a re-discovery.
+  // `onDown` fires on any short-circuit that never reaches `submit`.
+  private def onMaster[A](complete: Try[A] => Unit, onDown: () => Unit = () => ())(submit: (NodeClient, Node, Try[A] => Unit) => Unit): Unit = {
+    if (closed) { onDown(); complete(Failure(NotConnected())); return }
+    val node     = masterNodeRef.get()
+    val existing = masterPool.existing(node)
+    if (existing != null) submitMaster(existing, node, complete, submit)
+    else
+      offload {
+        val nc =
+          try masterPool.getOrEstablish(node)
+          catch { case NonFatal(_) => null }
+        if (nc == null) { triggerRefresh(); onDown(); complete(Failure(NotConnected())) }
+        else submitMaster(nc, node, complete, submit)
+      }
   }
 
-  // run `submit` on the master, completing with node attribution; an ownership fault (a demoted master) kicks a re-discovery
-  private def onMaster[A](complete: Try[A] => Unit)(submit: (NodeClient, Node, Try[A] => Unit) => Unit): Unit = {
-    if (closed) { complete(Failure(NotConnected())); return }
-    val node = masterNodeRef.get()
-    val nc   =
-      try masterPool.getOrEstablish(node)
-      catch { case NonFatal(_) => null }
-    if (nc == null) { triggerRefresh(); complete(Failure(NotConnected())) }
-    else
-      submit(
-        nc,
-        node,
-        {
-          case s @ Success(_) => Events.attributeNode(complete, node); complete(s)
-          case f @ Failure(e) => if (isOwnershipFault(e)) triggerRefresh(); Events.attributeNode(complete, node); complete(f)
-        }
-      )
-  }
+  private def submitMaster[A](nc: NodeClient, node: Node, complete: Try[A] => Unit, submit: (NodeClient, Node, Try[A] => Unit) => Unit): Unit =
+    submit(
+      nc,
+      node,
+      {
+        case s @ Success(_) => Events.attributeNode(complete, node); complete(s)
+        case f @ Failure(e) => if (isOwnershipFault(e)) triggerRefresh(); Events.attributeNode(complete, node); complete(f)
+      }
+    )
 
   private def sendRead[A](command: Command[A], complete: Try[A] => Unit): Unit = {
     if (closed) { complete(Failure(NotConnected())); return }
@@ -225,22 +228,40 @@ final private[client] class MasterReplicaLive(
     candidates match {
       case node +: rest =>
         val isMaster = node == master
-        val nc       =
-          try if (isMaster) masterPool.getOrEstablish(node) else replicaPool.getOrEstablish(node)
-          catch { case NonFatal(_) => null }
-        if (nc == null || !nc.isLive) tryRead(command, rest, master, complete)
+        val pool     = if (isMaster) masterPool else replicaPool
+        val existing = pool.existing(node)
+        if (existing != null)
+          if (existing.isLive) submitRead(existing, node, isMaster, command, rest, master, complete)
+          else tryRead(command, rest, master, complete)
         else
-          nc.submit[A](
-            command,
-            asking = false,
-            {
-              case s @ Success(_) => Events.attributeNode(complete, node); complete(s)
-              case Failure(error) => offload(onReadFault(node, isMaster, error, command, rest, master, complete))
-            }
-          )
+          offload {
+            val nc =
+              try pool.getOrEstablish(node)
+              catch { case NonFatal(_) => null }
+            if (nc == null || !nc.isLive) tryRead(command, rest, master, complete)
+            else submitRead(nc, node, isMaster, command, rest, master, complete)
+          }
       // nothing reached the wire, so no fault event fires: re-discover here or a strict-Replica read stays stuck on a stale replica set
       case _            => triggerRefresh(); complete(Failure(NotConnected()))
     }
+
+  private def submitRead[A](
+    nc: NodeClient,
+    node: Node,
+    isMaster: Boolean,
+    command: Command[A],
+    rest: Vector[Node],
+    master: Node,
+    complete: Try[A] => Unit
+  ): Unit =
+    nc.submit[A](
+      command,
+      asking = false,
+      {
+        case s @ Success(_) => Events.attributeNode(complete, node); complete(s)
+        case Failure(error) => offload(onReadFault(node, isMaster, error, command, rest, master, complete))
+      }
+    )
 
   private def onReadFault[A](
     node: Node,
@@ -279,11 +300,10 @@ final private[client] class MasterReplicaLive(
       CIO.fail(new IllegalArgumentException("a Pipeline cannot carry blocking commands; run them individually on the client"))
     else
       CIO.async { complete =>
-        val spans = Events.startSpans(events, p.commands)
-        offload {
-          // all-or-nothing: a fully replica-eligible pipeline batches on a replica, else the master, never split
-          val useReplica = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
-          val (node, nc) = if (useReplica) readConn() else masterConn()
+        val spans                                      = Events.startSpans(events, p.commands)
+        // all-or-nothing: a fully replica-eligible pipeline batches on a replica, else the master, never split
+        val useReplica                                 = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
+        def submitOn(node: Node, nc: NodeClient): Unit = {
           // no reachable node fires no wire fault, so re-discover here or a stale replica set / down master strands the pipeline forever
           if (nc == null) triggerRefresh()
           val submit     = if (nc == null) (_: Vector[Command[?]], _: Vector[Try[Any] => Unit]) => false else nc.submitAll
@@ -291,6 +311,10 @@ final private[client] class MasterReplicaLive(
           val attributed = if (nc == null) None else Some(node)
           Client.submitBatchOnOne(events, p.commands, spans, submit, complete, attributed)
         }
+        val master                                     = masterNodeRef.get()
+        val existing                                   = if (useReplica) null else masterPool.existing(master)
+        if (existing != null) submitOn(master, existing)
+        else offload { val (node, nc) = if (useReplica) readConn() else masterConn(); submitOn(node, nc) }
       }
 
   private def masterConn(): (Node, NodeClient) = {

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -312,34 +312,51 @@ final private[client] class MasterReplicaLive(
           Client.submitBatchOnOne(events, p.commands, spans, submit, complete, attributed)
         }
         val master                                     = masterNodeRef.get()
-        val existing                                   = if (useReplica) null else masterPool.existing(master)
-        if (existing != null) submitOn(master, existing)
-        else offload { val (node, nc) = if (useReplica) readConn() else masterConn(); submitOn(node, nc) }
+        if (useReplica) {
+          val candidates = ReadRouting.candidates(readFrom, master, replicasRef.get(), cursor.getAndIncrement())
+          liveEstablished(candidates, master) match {
+            case Some((node, nc)) => submitOn(node, nc)
+            case None             => offload { val (node, nc) = establishRead(candidates, master); submitOn(node, nc) }
+          }
+        } else {
+          val existing = masterPool.existing(master)
+          if (existing != null) submitOn(master, existing)
+          else
+            offload {
+              val nc =
+                try masterPool.getOrEstablish(master)
+                catch { case NonFatal(_) => null }
+              submitOn(master, nc)
+            }
+        }
       }
 
-  private def masterConn(): (Node, NodeClient) = {
-    val node = masterNodeRef.get()
-    (
-      node,
-      try masterPool.getOrEstablish(node)
-      catch { case NonFatal(_) => null }
-    )
+  // lock-free walk: the first live established candidate, Some((null, null)) when all are established but none live, and None when an
+  // unestablished candidate is met first — only then must the caller offload to establish
+  private def liveEstablished(candidates: Vector[Node], master: Node): Option[(Node, NodeClient)] = {
+    val it = candidates.iterator
+    while (it.hasNext) {
+      val node = it.next()
+      val pool = if (node == master) masterPool else replicaPool
+      val nc   = pool.existing(node)
+      if (nc == null) return None
+      if (nc.isLive) return Some((node, nc))
+    }
+    Some((null, null))
   }
 
-  // the first live read candidate under the policy with the node it landed on; (null, null) when none
-  private def readConn(): (Node, NodeClient) = {
-    val master            = masterNodeRef.get()
-    val it                = ReadRouting.candidates(readFrom, master, replicasRef.get(), cursor.getAndIncrement()).iterator
-    var foundNode: Node   = null
-    var found: NodeClient = null
-    while (found == null && it.hasNext) {
+  // the first live read candidate, establishing as needed, with the node it landed on; (null, null) when none
+  private def establishRead(candidates: Vector[Node], master: Node): (Node, NodeClient) = {
+    val it = candidates.iterator
+    while (it.hasNext) {
       val node = it.next()
+      val pool = if (node == master) masterPool else replicaPool
       val nc   =
-        try if (node == master) masterPool.getOrEstablish(node) else replicaPool.getOrEstablish(node)
+        try pool.getOrEstablish(node)
         catch { case NonFatal(_) => null }
-      if (nc != null && nc.isLive) { foundNode = node; found = nc }
+      if (nc != null && nc.isLive) return (node, nc)
     }
-    (foundNode, found)
+    (null, null)
   }
 
   // --- transactions (always on the master) ---------------------------------------------------------------------------------------------

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.locks.ReentrantLock
 
 import scala.collection.mutable
 import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
 
 import sage.SageException.NotConnected
 import sage.client.{BackoffConfig, DedicatedPoolConfig, WatchdogConfig}
@@ -34,7 +35,8 @@ final private[client] class NodePool(
 ) {
 
   private val lock             = new ReentrantLock()
-  private val established      = mutable.HashMap.empty[Node, NodeClient]
+  // lock-free reads; every mutation stays under `lock`
+  private val established      = new java.util.concurrent.ConcurrentHashMap[Node, NodeClient]()
   private val pendingEstablish = mutable.HashMap.empty[Node, NodePool.Establish]
   // connections whose socket is still being opened, so close() can abort one still connecting
   private val establishing     = mutable.Set.empty[MultiplexedConnection]
@@ -46,30 +48,35 @@ final private[client] class NodePool(
     finally lock.unlock()
   }
 
-  def existingLive(node: Node): Option[NodeClient] = locked(established.get(node)).filter(_.isLive)
+  /**
+    * The node's established client, or `null` — never blocks.
+    */
+  def existing(node: Node): NodeClient = established.get(node)
 
-  def firstLiveNode: Option[Node] = locked(established.collectFirst { case (node, nc) if nc.isLive => node })
+  def existingLive(node: Node): Option[NodeClient] = Option(established.get(node)).filter(_.isLive)
+
+  def firstLiveNode: Option[Node] = established.asScala.collectFirst { case (node, nc) if nc.isLive => node }
 
   // live nodes first, so a refresh prefers a known-good node
   def candidatesByLiveness: Vector[Node] = {
-    val (live, others) = locked(established.toVector).partition(_._2.isLive)
+    val (live, others) = established.asScala.toVector.partition(_._2.isLive)
     live.map(_._1) ++ others.map(_._1)
   }
 
   def getOrEstablish(node: Node): NodeClient = {
+    val fast                       = established.get(node)
+    if (fast != null) return fast
     var existing: NodeClient       = null
     var waitOn: NodePool.Establish = null
     var mine: NodePool.Establish   = null
     locked {
       if (closed) throw NotConnected()
-      established.get(node) match {
-        case Some(nc) => existing = nc
-        case None     =>
-          pendingEstablish.get(node) match {
-            case Some(p) => waitOn = p
-            case None    => mine = new NodePool.Establish; pendingEstablish.put(node, mine)
-          }
-      }
+      existing = established.get(node)
+      if (existing == null)
+        pendingEstablish.get(node) match {
+          case Some(p) => waitOn = p
+          case None    => mine = new NodePool.Establish; val _ = pendingEstablish.put(node, mine)
+        }
     }
     if (existing != null) existing
     else if (waitOn != null) waitOn.get()
@@ -119,7 +126,7 @@ final private[client] class NodePool(
   // drops/closes bundles `keep` rejects and invalidates in-flight establishments for rejected nodes, so neither leaks; closes are offloaded
   def retain(keep: Node => Boolean): Unit = {
     val (gone, rejected) = locked {
-      val absent          = established.keysIterator.filterNot(keep).toVector.flatMap(node => established.remove(node))
+      val absent          = established.keySet.asScala.toVector.filterNot(keep).flatMap(node => Option(established.remove(node)))
       val rejectedPending = pendingEstablish.keysIterator.filterNot(keep).toVector.flatMap(node => pendingEstablish.remove(node))
       (absent, rejectedPending)
     }
@@ -130,7 +137,7 @@ final private[client] class NodePool(
   def close(): Unit = {
     val (all, waiters, opening) = locked {
       closed = true
-      val snap     = established.values.toVector
+      val snap     = established.values.asScala.toVector
       val pending  = pendingEstablish.values.toVector
       val inFlight = establishing.toVector
       established.clear()

--- a/sage-client/shared/src/main/scala/sage/client/internal/Scheduler.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Scheduler.scala
@@ -47,7 +47,7 @@ private[client] object Scheduler {
       if (boundExclusive <= 0) 0L else ThreadLocalRandom.current().nextLong(boundExclusive)
 
     def after(delay: FiniteDuration)(task: => Unit): Unit =
-      // zero delay: spawn directly, off the timer thread shared with watchdog/reconnect timing
+      // zero-delay offloads must not queue behind watchdog/reconnect timing on the timer thread
       if (delay <= Duration.Zero) { val _ = Thread.ofVirtual().name("sage-offload").start(() => task) }
       else {
         val _ = timer.schedule(

--- a/sage-client/shared/src/main/scala/sage/client/internal/Scheduler.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Scheduler.scala
@@ -2,7 +2,7 @@ package sage.client.internal
 
 import java.util.concurrent.{Executors, ScheduledExecutorService, ScheduledFuture, ThreadLocalRandom, TimeUnit}
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.control.NonFatal
 
 /**
@@ -46,13 +46,16 @@ private[client] object Scheduler {
     def jitterMillis(boundExclusive: Long): Long =
       if (boundExclusive <= 0) 0L else ThreadLocalRandom.current().nextLong(boundExclusive)
 
-    def after(delay: FiniteDuration)(task: => Unit): Unit = {
-      val _ = timer.schedule(
-        (() => { val _ = Thread.ofVirtual().name("sage-reconnect").start(() => task) }): Runnable,
-        delay.toMillis,
-        TimeUnit.MILLISECONDS
-      )
-    }
+    def after(delay: FiniteDuration)(task: => Unit): Unit =
+      // zero delay: spawn directly, off the timer thread shared with watchdog/reconnect timing
+      if (delay <= Duration.Zero) { val _ = Thread.ofVirtual().name("sage-offload").start(() => task) }
+      else {
+        val _ = timer.schedule(
+          (() => { val _ = Thread.ofVirtual().name("sage-reconnect").start(() => task) }): Runnable,
+          delay.toMillis,
+          TimeUnit.MILLISECONDS
+        )
+      }
 
     def every(interval: FiniteDuration)(task: => Unit): Cancelable = {
       // a throwing task cancels a scheduleAtFixedRate future forever, so swallow it to keep the periodic alive

--- a/sage-client/shared/src/test/scala/sage/client/internal/CountingScheduler.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/CountingScheduler.scala
@@ -1,0 +1,24 @@
+package sage.client.internal
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
+/**
+  * Delegates to [[Scheduler.real]] while counting zero-delay offloads, so a test can assert a dispatch stayed inline.
+  */
+final class CountingScheduler extends Scheduler {
+
+  val zeroDelays = new AtomicInteger(0)
+
+  def nowMillis: Long = Scheduler.real.nowMillis
+
+  def jitterMillis(boundExclusive: Long): Long = Scheduler.real.jitterMillis(boundExclusive)
+
+  def after(delay: FiniteDuration)(task: => Unit): Unit = {
+    if (delay <= Duration.Zero) { val _ = zeroDelays.incrementAndGet() }
+    Scheduler.real.after(delay)(task)
+  }
+
+  def every(interval: FiniteDuration)(task: => Unit): Scheduler.Cancelable = Scheduler.real.every(interval)(task)
+}

--- a/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
@@ -71,6 +71,28 @@ class NodePoolSpec extends munit.FunSuite {
   private def awaitAllWaiting(threads: Seq[Thread]): Unit =
     awaitTrue(threads.forall(_.getState == Thread.State.WAITING), "a waiter never blocked on the in-flight establishment")
 
+  test("existing answers immediately while an establishment is in flight, and tracks publish and retain") {
+    val node  = Node("gated", 6379)
+    val gated = new GatedFactory(1)
+    val pool  = newPool(gated.factory)
+    assertEquals(pool.existing(node), null)
+
+    val establishing = new Thread(() => { val _ = Try(pool.getOrEstablish(node)) }, "establisher")
+    establishing.start()
+    gated.awaitReached(0)
+    assertEquals(pool.existing(node), null)
+
+    gated.release(0)
+    establishing.join(2000)
+    val nc = pool.existing(node)
+    assert(nc != null, "the published client should be visible")
+    assert(pool.existingLive(node).exists(_ eq nc))
+
+    pool.retain(_ => false)
+    assertEquals(pool.existing(node), null)
+    pool.close()
+  }
+
   test("retain invalidates an in-flight establishment for a rejected node: the client is closed, absent, and every waiter fails") {
     val node  = Node("gated", 6379)
     val gated = new GatedFactory(1)

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -148,7 +148,6 @@ class ClusterClientSpec extends munit.FunSuite {
       (node: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.BulkString(Bytes.utf8(node.host)))
     val fixture   = new Fixture(behaviour, Vector(nodeA), scheduler = counting)
 
-    // bootstrap already established the seed
     val before = counting.zeroDelays.get()
     fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
       assertEquals(result, Some(nodeA.host))

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -169,6 +169,45 @@ class ClusterClientSpec extends munit.FunSuite {
     }
   }
 
+  test("a broadcast to established masters dispatches inline, with no zero-delay scheduler hop") {
+    val counting  = new CountingScheduler
+    val mid       = Slot.Count / 2
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else if (text.contains("DBSIZE")) Seq(Frame.Integer(if (node == nodeA) 2L else 3L))
+      else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA), scheduler = counting)
+
+    fixture.live.run(Server.dbSize).unsafeRun.flatMap { _ =>
+      val before = counting.zeroDelays.get()
+      fixture.live.run(Server.dbSize).unsafeRun.map { total =>
+        assertEquals(total, 5L)
+        assertEquals(counting.zeroDelays.get(), before, "a broadcast to established masters must not offload")
+      }
+    }
+  }
+
+  test("a warmed read-only pipeline under ReadFrom.Replica dispatches inline, with no zero-delay scheduler hop") {
+    val counting  = new CountingScheduler
+    val nodeR     = Node("r", 6379)
+    def slots     =
+      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slots)
+      else if (text.contains("READONLY")) Seq(Frame.SimpleString("OK"))
+      else Seq(Frame.BulkString(Bytes.utf8("v1")), Frame.BulkString(Bytes.utf8("v2")))
+    val fixture   = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.Replica, scheduler = counting)
+
+    val pipe = fixture.live.pipeline((Strings.get[String, String]("{x}1"), Strings.get[String, String]("{x}2")))
+    pipe.unsafeRun.flatMap { _ =>
+      val before = counting.zeroDelays.get()
+      pipe.unsafeRun.map { result =>
+        assertEquals(result, (Some("v1"), Some("v2")))
+        assertEquals(counting.zeroDelays.get(), before, "a warmed replica pipeline must not offload")
+      }
+    }
+  }
+
   test("KEYS broadcasts to every slot-owning master and concatenates the per-node slices") {
     // nodeA owns the lower half, nodeB the upper half; KEYS is node-local, so each returns only its own keys
     val mid             = Slot.Count / 2

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -8,7 +8,7 @@ import kyo.compat.*
 
 import sage.Bytes
 import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, NotConnected, ServerError}
-import sage.client.internal.{ClusterLive, FakeTransport, MultiplexedConnection, Scheduler}
+import sage.client.internal.{ClusterLive, CountingScheduler, FakeTransport, MultiplexedConnection, Scheduler}
 import sage.cluster.{Node, Slot}
 import sage.commands.{BroadcastReduce, Command, Connection, Keys, Scripting, Server, Strings}
 import sage.protocol.Frame
@@ -51,7 +51,8 @@ class ClusterClientSpec extends munit.FunSuite {
     seeds: Vector[Node],
     unreachable: Set[Node] = Set.empty,
     readFrom: ReadFrom = ReadFrom.Master,
-    connectGate: (Node, Int) => Unit = (_, _) => () // blocks a node's nth transport creation, to park an establish mid-flight
+    connectGate: (Node, Int) => Unit = (_, _) => (), // blocks a node's nth transport creation, to park an establish mid-flight
+    scheduler: Scheduler = Scheduler.real
   ) {
 
     // accumulate every transport per node (a node has both a Multiplexed and, once a transaction pins, a Dedicated connection) so a refresh
@@ -83,7 +84,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val live: ClusterLive =
       new ClusterLive(
         factory,
-        Scheduler.real,
+        scheduler,
         Vector(Connection.hello(None)),
         BackoffConfig(),
         WatchdogConfig(enabled = false),
@@ -138,6 +139,34 @@ class ClusterClientSpec extends munit.FunSuite {
       assertEquals(result, Some(owner.host))
       assert(fixture.written(owner).exists(_.contains("GET")), "owner did not receive GET")
       assert(!fixture.written(other).exists(_.contains("GET")), "non-owner received GET")
+    }
+  }
+
+  test("a command to an established node dispatches inline, with no zero-delay scheduler hop") {
+    val counting  = new CountingScheduler
+    val behaviour =
+      (node: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.BulkString(Bytes.utf8(node.host)))
+    val fixture   = new Fixture(behaviour, Vector(nodeA), scheduler = counting)
+
+    // bootstrap already established the seed
+    val before = counting.zeroDelays.get()
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
+      assertEquals(result, Some(nodeA.host))
+      assertEquals(counting.zeroDelays.get(), before, "an established-node dispatch must not offload")
+    }
+  }
+
+  test("a pipeline to an established node dispatches inline, with no zero-delay scheduler hop") {
+    val counting  = new CountingScheduler
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else Seq(Frame.BulkString(Bytes.utf8("v1")), Frame.BulkString(Bytes.utf8("v2")))
+    val fixture   = new Fixture(behaviour, Vector(nodeA), scheduler = counting)
+
+    val before = counting.zeroDelays.get()
+    fixture.live.pipeline((Strings.get[String, String]("{x}1"), Strings.get[String, String]("{x}2"))).unsafeRun.map { result =>
+      assertEquals(result, (Some("v1"), Some("v2")))
+      assertEquals(counting.zeroDelays.get(), before, "an established-node batch must not offload")
     }
   }
 

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
@@ -9,7 +9,7 @@ import scala.jdk.CollectionConverters.*
 import kyo.compat.*
 
 import sage.{Bytes, CommandSpan, CommandTracer, Outcome, SageEvent, SageListener}
-import sage.client.internal.{Events, FakeTransport, MasterReplicaLive, MultiplexedConnection, Scheduler}
+import sage.client.internal.{CountingScheduler, Events, FakeTransport, MasterReplicaLive, MultiplexedConnection, Scheduler}
 import sage.cluster.Node
 import sage.commands.{Command, Connection}
 import sage.protocol.Frame
@@ -87,7 +87,7 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
     latch: CountDownLatch
   )
 
-  private def build(readFrom: ReadFrom): Fixture = {
+  private def build(readFrom: ReadFrom, scheduler: Scheduler = Scheduler.real): Fixture = {
     val completions                                             = new ConcurrentLinkedQueue[SageEvent.CommandCompleted]()
     val latch                                                   = new CountDownLatch(2)
     val listener                                                = new SageListener {
@@ -102,7 +102,7 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
     val live                                                    =
       new MasterReplicaLive(
         factory,
-        Scheduler.real,
+        scheduler,
         Vector(Connection.hello(None)),
         SageConfig(readFrom = readFrom),
         Vector(master),
@@ -111,6 +111,21 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
       )
     live.bootstrapRoles()
     Fixture(live, completions, tracer, latch)
+  }
+
+  test("a command to the established master dispatches inline, with no zero-delay scheduler hop") {
+    val counting = new CountingScheduler
+    val f        = build(ReadFrom.Master, counting)
+    // the first command establishes the master connection (offloaded)
+    f.live.run(writeCmd).unsafeRun.flatMap { _ =>
+      val before = counting.zeroDelays.get()
+      f.live.run(writeCmd).unsafeRun.flatMap { _ =>
+        f.live.pipeline(Seq(writeCmd, readCmd)).unsafeRun.map { _ =>
+          assertEquals(counting.zeroDelays.get(), before, "an established-master dispatch must not offload")
+          val _ = f.live.close.unsafeRun
+        }
+      }
+    }
   }
 
   test("a fully read-only pipeline under ReadFrom.Replica attributes every command to the replica") {

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
@@ -116,7 +116,6 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
   test("a command to the established master dispatches inline, with no zero-delay scheduler hop") {
     val counting = new CountingScheduler
     val f        = build(ReadFrom.Master, counting)
-    // the first command establishes the master connection (offloaded)
     f.live.run(writeCmd).unsafeRun.flatMap { _ =>
       val before = counting.zeroDelays.get()
       f.live.run(writeCmd).unsafeRun.flatMap { _ =>

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
@@ -127,6 +127,18 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
     }
   }
 
+  test("a warmed read-only pipeline under ReadFrom.Replica dispatches inline, with no zero-delay scheduler hop") {
+    val counting = new CountingScheduler
+    val f        = build(ReadFrom.Replica, counting)
+    f.live.pipeline(Seq(readCmd, readCmd)).unsafeRun.flatMap { _ =>
+      val before = counting.zeroDelays.get()
+      f.live.pipeline(Seq(readCmd, readCmd)).unsafeRun.map { _ =>
+        assertEquals(counting.zeroDelays.get(), before, "a warmed replica pipeline must not offload")
+        val _ = f.live.close.unsafeRun
+      }
+    }
+  }
+
   test("a fully read-only pipeline under ReadFrom.Replica attributes every command to the replica") {
     val f = build(ReadFrom.Replica)
     f.live


### PR DESCRIPTION
Closes #184.

In cluster and master-replica modes every command was dispatched through `scheduler.after(Duration.Zero)`: a contended enqueue into the single-threaded `sage-scheduler` timer, a hop through that one thread, and a fresh virtual thread per command — even when the target node's connection was already established and the whole dispatch is non-blocking. Standalone mode pays none of this.

### Changes

- **Inline fast path** (`ClusterLive`, `MasterReplicaLive`): dispatch to an already-established node — including one mid-reconnect, whose submit fails fast — runs on the caller with no `scheduler.after` and no virtual thread. This covers `run`, `cached`, `runOn`, replica reads, pipelines (master and warmed replica batches, via a lock-free candidate walk), and all-masters broadcasts (preflighted: inline when every slot-owning master is established). Only a genuinely blocking step — establishing a node or refreshing the topology — hops to an offloaded thread.
- **Lock-free established-node read** (`NodePool`): `established` is now a `ConcurrentHashMap` with a lock-free `existing` lookup; every mutation (single-flight establish, `retain`, `close`) stays under the lock, so the lifecycle invariants and the existing race tests are unchanged.
- **Zero-delay offloads bypass the timer** (`Scheduler.real.after`): a zero delay spawns the virtual thread directly (`sage-offload`), so the remaining offload sites no longer serialize on the timer thread or share its queue with watchdog/reconnect timing.
- The `reached` flag in `sendMasterCached` became racy once the slow path offloads, so the short-circuit span settlement moved into an explicit `onDown` hook on `onMaster`.

### Benchmarks

The harness only covered standalone, so this adds a sage-only `TopologyBench` (zio cell) sweeping `standalone` / `cluster` / `master-replica` over the concurrency curve: the cluster trial provisions a `--cluster-enabled` node owning all 16384 slots with `cluster-announce` pointed at the mapped port (the integration `ClusterSuite` trick), and master-replica discovers a replica-less master, so all three serve identical commands. The comparison is **end-to-end topology overhead** — the cluster trial runs a cluster-enabled server in its own container, so server-mode differences and instance variance are included, not client dispatch alone.

Quick run of `TopologyBench.get` (`-f 1 -wi 2 -i 3`, valueSize 16) before (main + the benchmark commit) and after; error intervals are wide at 3 iterations, so the signal is each topology's gap to standalone *within the same run*:

| concurrency | topology | before (ops/s) | after (ops/s) | gap to standalone: before → after |
| --- | --- | --- | --- | --- |
| 64 | standalone | 153 826 | 158 844 | — |
| 64 | cluster | 132 159 | 150 110 | **−14.1% → −5.5%** |
| 64 | master-replica | 139 842 | 159 229 | **−9.1% → +0.2%** |
| 1 | standalone | 3 405 | 3 725 | — |
| 1 | cluster | 3 153 | 3 362 | −7.4% → −9.7% |
| 1 | master-replica | 3 198 | 3 551 | −6.1% → −4.7% |

At concurrency 64 the cluster gap shrinks by ~2.5× and master-replica reaches parity with standalone (both ~+13% absolute). At concurrency 1 the round-trip dominates and the numbers are within noise. (Numbers predate the broadcast/replica-pipeline fast-path extension, which does not touch the measured single-key GET path.)

### Tests

- `ClusterClientSpec`/`MasterReplicaPipelineSpec`: a command, a pipeline, an all-masters broadcast, and a warmed `ReadFrom.Replica` pipeline to established nodes each complete with zero `after(0)` calls, via a counting scheduler; all six tests fail if the fast path is removed (verified by neutering `existing`).
- `NodePoolSpec`: `existing` answers immediately while an establishment is parked in flight, sees the publish, and empties on `retain`.
- All existing suites pass unchanged (255 unit tests), and the full zio integration suite — including the cluster and master-replica suites against real Redis/Valkey — passes (324 tests).