### PR TITLE
Support numbered databases in Valkey clusters

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ val config = SageConfig(
 )
 ```
 
-The `database` is selected once at connection setup and fixed for the client's lifetime, re-applied on every reconnect. It is never changed by a runtime command, because that would move the keyspace under every fiber sharing the connection. A cluster has only database 0.
+The `database` is selected once at connection setup and fixed for the client's lifetime, re-applied on every reconnect. It is never changed by a runtime command, because that would move the keyspace under every fiber sharing the connection. Valkey 9+ also supports numbered databases in cluster mode; Redis Cluster and older Valkey versions reject a non-zero database during connection setup.
 
 ## Cluster
 
@@ -31,11 +31,13 @@ Give the cluster seeds. Sage discovers the full topology from them, routes each 
 val config = SageConfig(
   topology = Topology.Cluster(
     Vector(Endpoint("localhost", 7000), Endpoint("localhost", 7001))
-  )
+  ),
+  database = 0
 )
 ```
 
 Seeds bootstrap discovery only. Once the topology is known, sage routes to the nodes the cluster reports; any one seed answering is enough.
+Set `database` to a non-zero value for a Valkey 9+ cluster configured with a sufficiently large `cluster-databases` setting. Sage issues `SELECT` while establishing every node connection, including after reconnects and redirects. Servers without numbered cluster database support reject the connection.
 
 ### Hash tags
 

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
@@ -244,9 +244,12 @@ abstract class ClusterSuite(image: String, serverBinary: String, supportsNumbere
         val endpoint  = Endpoint(server.host, server.mappedPort(6379))
         val clustered = SageConfig(topology = Topology.Cluster(Vector(endpoint)), database = 2)
 
-        Client.connect(clustered).unsafeRun.failed.map { error =>
-          assert(error.isInstanceOf[ServerError], s"expected the server's SELECT error, got $error")
-        }
+        val attempted: CIO[Unit] = connectAndUse(clustered)(_ => CIO.value(()))
+        val program: CIO[Unit]   = attempted.fold(
+          _ => CIO.fail(new AssertionError("expected the cluster connection to reject database 2")),
+          error => CIO.value(assert(error.isInstanceOf[ServerError], s"expected the server's SELECT error, got $error"))
+        )
+        program.unsafeRun
       }
     }
 }

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
@@ -8,7 +8,7 @@ import com.dimafeng.testcontainers.munit.TestContainerForAll
 import kyo.compat.*
 
 import sage.{Bytes, Message}
-import sage.SageException.DecodeError
+import sage.SageException.{DecodeError, ServerError}
 import sage.client.{Endpoint, SageConfig, Topology}
 import sage.client.internal.{Client, ScanTarget}
 import sage.commands.{Command, Commands, FlushMode, ScanCursor}
@@ -20,10 +20,15 @@ import sage.protocol.Frame
   * testcontainers-mapped host port so the address the node reports in `CLUSTER SLOTS` is reachable from the test. This exercises topology
   * discovery, the `CLUSTER SLOTS` decoder against real wire output, and single-key routing; redirects and failover need multiple nodes.
   */
-abstract class ClusterSuite(image: String, serverBinary: String) extends munit.FunSuite with TestContainerForAll with ContainerClient {
+abstract class ClusterSuite(image: String, serverBinary: String, supportsNumberedDatabases: Boolean = false)
+  extends munit.FunSuite
+  with TestContainerForAll
+  with ContainerClient {
 
-  override val containerDef: GenericContainer.Def[GenericContainer] =
-    GenericContainer.Def(image, exposedPorts = Seq(6379), command = Seq(serverBinary, "--cluster-enabled", "yes"))
+  override val containerDef: GenericContainer.Def[GenericContainer] = {
+    val numberedDatabases = if (supportsNumberedDatabases) Seq("--cluster-databases", "16") else Seq.empty
+    GenericContainer.Def(image, exposedPorts = Seq(6379), command = Seq(serverBinary, "--cluster-enabled", "yes") ++ numberedDatabases)
+  }
 
   given ExecutionContext = munitExecutionContext
 
@@ -209,8 +214,43 @@ abstract class ClusterSuite(image: String, serverBinary: String) extends munit.F
       program.unsafeRun
     }
   }
+
+  if (supportsNumberedDatabases)
+    test("a numbered database is selected on a Valkey cluster connection") {
+      withContainers { server =>
+        val host       = server.host
+        val port       = server.mappedPort(6379)
+        val standalone = SageConfig(topology = Topology.Standalone(Endpoint(host, port)))
+        val clustered  = SageConfig(topology = Topology.Cluster(Vector(Endpoint(host, port))), database = 2)
+        val key        = "cluster-numbered-database"
+
+        val program =
+          connectAndUse(standalone)(formSingleNodeCluster(_, host, port)).flatMap { _ =>
+            connectAndUse(standalone)(_.set(key, "database-0")).flatMap { _ =>
+              connectAndUse(clustered) { client =>
+                client.set(key, "database-2").flatMap(_ => client.get[String](key)).map(value => assertEquals(value, Some("database-2")))
+              }.flatMap { _ =>
+                connectAndUse(standalone)(_.get[String](key)).map(value => assertEquals(value, Some("database-0")))
+              }
+            }
+          }
+        program.unsafeRun
+      }
+    }
+
+  if (!supportsNumberedDatabases)
+    test("an unsupported cluster server rejects a numbered database during bootstrap") {
+      withContainers { server =>
+        val endpoint  = Endpoint(server.host, server.mappedPort(6379))
+        val clustered = SageConfig(topology = Topology.Cluster(Vector(endpoint)), database = 2)
+
+        Client.connect(clustered).unsafeRun.failed.map { error =>
+          assert(error.isInstanceOf[ServerError], s"expected the server's SELECT error, got $error")
+        }
+      }
+    }
 }
 
 class RedisClusterSuite extends ClusterSuite(Images.redis, "redis-server")
 
-class ValkeyClusterSuite extends ClusterSuite(Images.valkey, "valkey-server")
+class ValkeyClusterSuite extends ClusterSuite(Images.valkey, "valkey-server", supportsNumberedDatabases = true)

--- a/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
+++ b/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
@@ -154,7 +154,8 @@ enum Topology {
   * @param readFrom       which node read-only commands may run on — see [[ReadFrom]]
   * @param database       the logical keyspace `SELECT`ed once at setup and fixed for the client's lifetime (re-issued on every reconnect and
   *                       every connection); never changed by a runtime command, since that would move the keyspace under every fiber sharing
-  *                       a connection. Must be 0 for a cluster topology, which has only database 0
+  *                       a connection. Valkey 9+ supports numbered databases in cluster mode; Redis and older Valkey versions reject a
+  *                       non-zero database during connection setup
   * @param clientName     sets `CLIENT SETNAME`, visible in `CLIENT LIST`/`CLIENT INFO`; the library name and version are announced automatically
   * @param listeners      observers of runtime [[sage.SageEvent]]s — see [[sage.SageListener]]
   * @param tracer         an optional distributed tracer, driven synchronously on the command path so its spans nest under the caller's active
@@ -184,9 +185,9 @@ object SageConfig {
     * Parses a `redis://`/`rediss://` connection URI into a config. `rediss` selects TLS with system trust. Userinfo becomes auth
     * (`redis://user:pass@…`, or `redis://:pass@…` for the default user), percent-decoded so a managed-service password like `p%40ss`
     * authenticates as `p@ss`. A single host yields a standalone topology; comma-separated hosts
-    * (`redis://h1:6379,h2:6380`) yield cluster seeds. A `/<db>` path sets `database`, rejected for a cluster URI (cluster has only db 0).
-    * Other tuning stays programmatic: `fromUri(…).map(_.copy(watchdog = …))`. Returns the problem as a `Left` rather than throwing; there
-    * is intentionally no way to select insecure TLS from a URI.
+    * (`redis://h1:6379,h2:6380`) yield cluster seeds. A `/<db>` path sets `database`; when the endpoints form a cluster, the server must support
+    * numbered cluster databases (Valkey 9+). Other tuning stays programmatic: `fromUri(…).map(_.copy(watchdog = …))`. Returns the problem as a
+    * `Left` rather than throwing; there is intentionally no way to select insecure TLS from a URI.
     */
   def fromUri(uri: String): Either[String, SageConfig] = {
     val shown                                   = redactCredentials(uri)
@@ -213,10 +214,6 @@ object SageConfig {
           topology   = endpoints match {
                          case Vector(one) => Topology.Standalone(one)
                          case seeds       => Topology.Cluster(seeds)
-                       }
-          _         <- topology match {
-                         case _: Topology.Cluster if db != 0 => fail[Unit]("cluster URIs cannot select a database (cluster has only db 0)")
-                         case _                              => Right(())
                        }
         } yield SageConfig(topology = topology, auth = auth, tls = tls, database = db)
       case _                   => fail("expected redis:// or rediss://")

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2222,7 +2222,6 @@ object Client {
       case Topology.Cluster(seeds, cluster)             =>
         Vector(
           cond(seeds.nonEmpty, "cluster topology requires at least one seed"),
-          cond(config.database == 0, "cluster topology has no SELECT; database must be 0"),
           cond(cluster.maxRedirects >= 0, "cluster.maxRedirects must be >= 0"),
           atLeastOneMilli(cluster.minRefreshInterval, "cluster.minRefreshInterval")
         ) ++ seeds.map(s => port(s.port, s"seed ${s.host}:${s.port} port"))

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -1015,7 +1015,6 @@ private[client] object ClusterLive {
     translate: Throwable => Throwable
   ): CIO[Client[CIO, String]] =
     CIO.blocking[Client[CIO, String]] {
-      // cluster validation forces database 0, so this adds no SELECT
       val bootstrap                                               = Bootstrap.commands(config.auth, config.database, config.clientName)
       val factory: Node => MultiplexedConnection.TransportFactory = node => {
         val upgrade = Tls.buildUpgrade(config.tls, node.host, node.port)

--- a/sage-client/shared/src/test/scala/sage/client/SageConfigSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/SageConfigSpec.scala
@@ -75,9 +75,9 @@ class SageConfigSpec extends munit.FunSuite {
     assert(SageConfig.fromUri("redis://[]:6379").isLeft) // empty host
   }
 
-  test("a cluster URI cannot select a non-zero database") {
-    assert(SageConfig.fromUri("redis://a,b/2").isLeft)
-    assert(SageConfig.fromUri("redis://a,b/0").isRight)
+  test("a cluster URI can select a database when the server supports it") {
+    assertEquals(parsed("redis://a,b/2").database, 2)
+    assertEquals(parsed("redis://a,b/0").database, 0)
   }
 
   test("malformed URIs fail with a Left, never throw") {


### PR DESCRIPTION
## Summary

- allow non-zero databases with cluster topologies and cluster connection URIs
- let Redis or Valkey validate `SELECT` during connection bootstrap
- document Valkey 9+ cluster database configuration
- cover successful Valkey database isolation and Redis server-side rejection

## Why

Sage rejected every non-zero cluster database before opening a connection. Valkey 9+ supports numbered databases in cluster mode, and Sage already applies `SELECT` to each physical connection and reconnect. Removing the client-side guards allows supported Valkey deployments while keeping `SELECT` rejection fatal on Redis and older or incompatible servers.

## Impact

Valkey 9+ clusters configured with a sufficiently large `cluster-databases` value can use `SageConfig.database` or a database path in a cluster URI. Unsupported cluster servers now return their bootstrap `SELECT` error instead of Sage failing early with an `IllegalArgumentException`.

## Validation

- `clientZio/test` — 255 passed
- `integrationTestsZio/testOnly sage.integration.cluster.ValkeyClusterSuite` — 5 passed
- `integrationTestsZio/testOnly sage.integration.cluster.RedisClusterSuite` — 5 passed
- relevant Scalafmt checks and `git diff --check`

Closes #194