### PR TITLE
Support transparent cross-slot commands

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,19 @@ Set `database` to a non-zero value for a Valkey 9+ cluster configured with a suf
 Redis Cluster hashes the bytes inside the first non-empty `{...}` pair instead of the whole key. Use the same tag in every key that must live
 in one slot, for example `user:{42}:profile` and `user:{42}:settings`. Transactions require all keys to share one slot.
 
+### Supported cross-slot commands
+
+Ordinary `mGet`, `mSet`, `exists`, `del`, `unlink`, and `touch` calls may span cluster slots. Sage transparently groups their keys by exact slot and
+sends one subcommand per slot through the normal routing and redirect machinery. This also works when the command is an entry in a pipeline.
+For `mGet`, Sage restores values to request order, retaining missing and repeated positions. For `exists`, `del`, `unlink`, and `touch`, it
+sums the slot-specific counts; `mSet` succeeds only when every slot subgroup returns `OK`.
+
+Each slot-specific command is atomic, but the combined operation is not cluster-wide atomic. A cross-slot `mGet` is not a point-in-time
+snapshot, and a failing cross-slot `mSet`, `del`, or `unlink` may already have applied writes in successful slot groups. If any subgroup
+fails, the logical call fails as a whole. Use a common hash tag when the operation must be atomic. `mSetNx` is not split because doing so would
+break its all-or-nothing condition. All cross-slot commands remain rejected inside a transaction because `MULTI`/`EXEC` must stay pinned to
+one slot.
+
 ## Master-replica
 
 Select `Topology.MasterReplica` with seed endpoints. Sage asks each its role, discovers the master and its replicas, sends writes to the master, and routes reads per the read policy:

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -14,7 +14,7 @@ Every sage failure is a `SageException`, a single sealed hierarchy you can match
 | `NotConnected()` | The client was never started, or has been closed. |
 | `UnsupportedServer(message)` | The server rejected `HELLO 3` (it predates RESP3, or is a RESP2-only proxy). |
 | `TlsError(message)` | TLS could not be established (rejected certificate or unusable trust material). |
-| `CrossSlot(message)` | A multi-key command or transaction touched keys in more than one cluster slot. |
+| `CrossSlot(message)` | An unsupported multi-key command or a transaction touched keys in more than one cluster slot. `MGET`, `MSET`, `EXISTS`, `DEL`, `UNLINK`, and `TOUCH` are transparently split outside transactions. |
 | `TimedOut(message)` | A blocking command or transaction waited past `dedicatedPool.acquireTimeout` for a free pooled connection. Not a per-command timeout; bound a command's own duration with your backend's timeout combinator. |
 | `TransactionDiscarded(message)` | A transaction was discarded server-side (`EXECABORT`); nothing ran. |
 | `NotCacheable(message)` | `cached` was given a command that cannot be safely cached. |

--- a/docs/pipelines-transactions.md
+++ b/docs/pipelines-transactions.md
@@ -6,6 +6,10 @@ Both group several commands together, but they answer different needs. A **pipel
 
 A pipeline is an applicative composition of `Command` values, sent in one round-trip and decoded into a typed tuple. There is no atomicity: other clients' commands may interleave, and in a cluster the pipeline is split and routed per key, then reassembled in order.
 
+A supported cross-slot command (`MGET`, `MSET`, `EXISTS`, `DEL`, `UNLINK`, or `TOUCH`) inside a cluster pipeline is itself split once more by exact
+slot and merged back into its one logical pipeline position. Each slot-specific operation is atomic individually, not across the cluster;
+write subgroups may already have applied when another subgroup fails.
+
 ::: code-group
 
 ```scala [Ox]
@@ -119,7 +123,7 @@ A few rules follow from how Redis transactions work:
 - **Reads inside the scope must be ordinary commands.** A blocking command is rejected rather than parking the lease.
 - **A queueing-phase rejection discards the whole transaction**, so nothing runs.
 - **An execution-phase error leaves the other commands committed.** Redis does not roll back, so those errors surface per position, like a pipeline.
-- **In a cluster, every key in the transaction must hash to one slot** (use a [hash tag](/configuration#hash-tags) to force that). A pipeline has no such restriction.
+- **In a cluster, every key in the transaction must hash to one slot** (use a [hash tag](/configuration#hash-tags) to force that). A pipeline has no such restriction for commands with documented cross-slot support.
 
 ## Which to use
 

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
@@ -96,6 +96,48 @@ abstract class ClusterSuite(image: String, serverBinary: String, supportsNumbere
     }
   }
 
+  test("supported cross-slot commands are transparently split and merged against a real cluster") {
+    withContainers { server =>
+      val host       = server.host
+      val port       = server.mappedPort(6379)
+      val standalone = SageConfig(topology = Topology.Standalone(Endpoint(host, port)))
+      val clustered  = SageConfig(topology = Topology.Cluster(Vector(Endpoint(host, port))))
+      val keyA       = "{mget-a}value"
+      val keyB       = "{mget-b}value"
+      val missingA   = "{mget-a}missing"
+      val missingB   = "{mget-b}missing"
+      val msetA      = "{mset-a}value"
+      val msetB      = "{mset-b}value"
+
+      val program =
+        connectAndUse(standalone)(formSingleNodeCluster(_, host, port)).flatMap { _ =>
+          connectAndUse(clustered) { client =>
+            for {
+              _         <- client.set(keyA, "a")
+              _         <- client.set(keyB, "b")
+              values    <- client.mGet[String](keyA, keyB, missingA, keyB)
+              piped     <- client.pipeline((Commands.mGet[String, String](keyA, keyB), Commands.get[String, String](keyA)))
+              exists    <- client.exists(keyA, keyB, missingA, keyB)
+              touched   <- client.touch(keyA, keyB, missingA)
+              _         <- client.mSet(msetA -> "set-a", msetB -> "set-b")
+              setValues <- client.mGet[String](msetA, msetB)
+              deleted   <- client.del(keyA, missingB)
+              unlinked  <- client.unlink(keyB, missingA)
+            } yield {
+              assertEquals(values, Vector(Some("a"), Some("b"), None, Some("b")))
+              assertEquals(piped, (Vector(Some("a"), Some("b")), Some("a")))
+              assertEquals(exists, 3L)
+              assertEquals(touched, 2L)
+              assertEquals(setValues, Vector(Some("set-a"), Some("set-b")))
+              assertEquals(deleted, 1L)
+              assertEquals(unlinked, 1L)
+            }
+          }
+        }
+      program.unsafeRun
+    }
+  }
+
   // sharded and classic pub/sub against a real (single-node) cluster: SSUBSCRIBE/SPUBLISH route by slot and coexist with classic SUBSCRIBE.
   // Resubscription on slot migration needs multiple nodes and is covered deterministically by ClusterClientSpec.
   test("sharded and classic pub/sub coexist on a cluster client") {

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -100,12 +100,15 @@ trait CommandRunner[F[_], K](using KeyCodec[K]) {
   final def incrByFloat(key: K, increment: Double): F[Double] = run(Strings.incrByFloat(key, increment))
 
   /**
-    * Gets the values at several keys in request order, each `None` if that key is absent.
+    * Gets the values at several keys in request order, each `None` if that key is absent. In cluster mode, keys spanning slots are
+    * transparently split into one MGET per exact slot and merged; each subgroup is atomic, but the combined result is not a cluster-wide
+    * point-in-time snapshot. Cross-slot MGET remains invalid inside a transaction.
     */
   final def mGet[V: ValueCodec](first: K, rest: K*): F[Vector[Option[V]]] = run(Strings.mGet(first, rest*))
 
   /**
-    * Sets several key/value pairs atomically.
+    * Sets several key/value pairs atomically on one server. In cluster mode, pairs spanning slots are set independently per exact slot; a
+    * failed call may therefore have already set pairs in successful slot groups. Cross-slot MSET remains invalid inside a transaction.
     */
   final def mSet[V: ValueCodec](first: (K, V), rest: (K, V)*): F[Unit] = run(Strings.mSet(first, rest*))
 
@@ -210,7 +213,8 @@ trait CommandRunner[F[_], K](using KeyCodec[K]) {
     run(Keys.copy(source, destination, replace))
 
   /**
-    * Deletes the given keys, returning how many existed.
+    * Deletes the given keys, returning how many existed. In cluster mode, keys spanning slots are deleted independently per exact slot and
+    * the counts are summed; a failed call may therefore have already deleted keys in successful slot groups.
     */
   final def del(first: K, rest: K*): F[Long] = run(Keys.del(first, rest*))
 
@@ -220,7 +224,8 @@ trait CommandRunner[F[_], K](using KeyCodec[K]) {
   final def delIfEq[V: ValueCodec](key: K, value: V): F[Boolean] = run(Keys.delIfEq(key, value))
 
   /**
-    * Returns how many of the given keys exist (counting duplicates).
+    * Returns how many of the given keys exist (counting duplicates). In cluster mode, keys spanning slots are checked independently per exact
+    * slot and the counts are summed.
     */
   final def exists(first: K, rest: K*): F[Long] = run(Keys.exists(first, rest*))
 
@@ -287,7 +292,8 @@ trait CommandRunner[F[_], K](using KeyCodec[K]) {
   ): F[ScanPage[K]] = run(Keys.scan(cursor, pattern, count, ofType))
 
   /**
-    * Updates the last-access time of the given keys without reading them, returning how many existed.
+    * Updates the last-access time of the given keys without reading them, returning how many existed. In cluster mode, keys spanning slots
+    * are touched independently per exact slot and the counts are summed.
     */
   final def touch(first: K, rest: K*): F[Long] = run(Keys.touch(first, rest*))
 
@@ -302,7 +308,8 @@ trait CommandRunner[F[_], K](using KeyCodec[K]) {
   final def typeOf(key: K): F[Option[RedisType]] = run(Keys.typeOf(key))
 
   /**
-    * Deletes the given keys, reclaiming memory asynchronously, returning how many existed.
+    * Deletes the given keys, reclaiming memory asynchronously, returning how many existed. In cluster mode, keys spanning slots are unlinked
+    * independently per exact slot and the counts are summed; a failed call may therefore have already unlinked keys in successful slot groups.
     */
   final def unlink(first: K, rest: K*): F[Long] = run(Keys.unlink(first, rest*))
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -1,17 +1,19 @@
 package sage.client.internal
 
+import java.util.Locale
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.util.concurrent.locks.ReentrantLock
 
+import scala.collection.mutable
 import scala.concurrent.duration.*
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
 import kyo.compat.*
 
-import sage.{CommandSpan, Message, PatternMessage, SageEvent, SageException}
-import sage.SageException.{ConnectionLost, CrossSlot, NotConnected, ServerError}
+import sage.{Bytes, CommandSpan, Message, PatternMessage, SageEvent, SageException}
+import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, NotConnected, ServerError}
 import sage.client.{BackoffConfig, ClusterConfig, DedicatedPoolConfig, ReadFrom, SageConfig, WatchdogConfig}
 import sage.cluster.{ClusterTopology, Node, NodeGroup, Redirect, RedirectKind, Rejected, Route, Shard, Slot, SplitPlan}
 import sage.codec.{KeyCodec, ValueCodec}
@@ -218,11 +220,115 @@ final private[client] class ClusterLive(
               sendKeylessRead(topology, command, redirectsLeft, complete)
             else sendToAny(topology, command, redirectsLeft, complete, lease)
           case Route.Unowned(_)         => offload(onUnowned(command, redirectsLeft, complete, lease))
-          case Route.CrossSlot(slots)   => complete(Failure(crossSlot(command.name, slots)))
+          case Route.CrossSlot(slots)   =>
+            multiSlotPolicy(command) match {
+              case Some(policy) => scatterMultiSlot(command, policy, redirectsLeft, complete, allowReplica)
+              case None         => complete(Failure(crossSlot(command.name, slots)))
+            }
           case Route.Malformed          =>
             complete(Failure(malformedKeys(command.name)))
         }
     }
+
+  private enum MultiSlotMerge {
+    case Positional, Sum, AllSucceeded
+  }
+
+  final private case class MultiSlotPolicy(merge: MultiSlotMerge, argsPerKey: Int)
+
+  final private case class MultiSlotEntry(resultIndex: Int, argIndex: Int)
+
+  // A supported logical cross-slot command becomes one ordinary command per exact slot, not per owner node. Every subgroup re-enters
+  // dispatch so replica policy, topology refresh, and MOVED/ASK handling stay identical to a normal one-slot call. The merge waits for every
+  // subgroup and decodes once through the original command: MGET scatters positional frames, integer commands sum per-slot counts, and MSET
+  // requires every per-slot reply to succeed with OK.
+  private def scatterMultiSlot[A](
+    command: Command[A],
+    policy: MultiSlotPolicy,
+    redirectsLeft: Int,
+    complete: Try[A] => Unit,
+    allowReplica: Boolean
+  ): Unit = {
+    val bySlot = mutable.LinkedHashMap.empty[Slot, mutable.ArrayBuffer[MultiSlotEntry]]
+    command.keyIndices.iterator.zipWithIndex.foreach { case (argIndex, resultIndex) =>
+      val key   = command.args(argIndex)
+      val entry = MultiSlotEntry(resultIndex, argIndex)
+      val group = bySlot.getOrElseUpdate(Slot.of(key), mutable.ArrayBuffer.empty)
+      group += entry
+    }
+    val groups = bySlot.valuesIterator.map(_.toVector).toVector
+
+    lazy val values = new java.util.concurrent.atomic.AtomicReferenceArray[Frame](command.keyIndices.size)
+    lazy val total  = new java.util.concurrent.atomic.AtomicLong(0L)
+    val remaining   = new java.util.concurrent.atomic.AtomicInteger(groups.size)
+    val firstError  = new java.util.concurrent.atomic.AtomicReference[Throwable](null)
+
+    def settle(group: Vector[MultiSlotEntry], result: Try[Frame]): Unit = {
+      (policy.merge, result) match {
+        case (MultiSlotMerge.Positional, Success(Frame.Array(elements))) if elements.size == group.size =>
+          group.iterator.zip(elements).foreach { case (entry, frame) => values.set(entry.resultIndex, frame) }
+        case (MultiSlotMerge.Positional, Success(Frame.Array(elements)))                                =>
+          firstError.compareAndSet(
+            null,
+            DecodeError(s"an array of ${group.size} MGET values", s"an array of ${elements.size} values")
+          )
+        case (MultiSlotMerge.Positional, Success(other))                                                =>
+          firstError.compareAndSet(null, DecodeError(s"an array of ${group.size} MGET values", Frame.describe(other)))
+        case (MultiSlotMerge.Sum, Success(Frame.Integer(value)))                                        => total.addAndGet(value)
+        case (MultiSlotMerge.Sum, Success(other))                                                       =>
+          firstError.compareAndSet(null, DecodeError("an integer count", Frame.describe(other)))
+        case (MultiSlotMerge.AllSucceeded, Success(Frame.SimpleString("OK")))                           => ()
+        case (MultiSlotMerge.AllSucceeded, Success(other))                                              =>
+          firstError.compareAndSet(null, DecodeError("simple string 'OK'", Frame.describe(other)))
+        case (_, Failure(error))                                                                        =>
+          firstError.compareAndSet(null, error)
+      }
+
+      if (remaining.decrementAndGet() == 0)
+        Option(firstError.get()) match {
+          case Some(error) => complete(Failure(error))
+          case None        =>
+            val merged = policy.merge match {
+              case MultiSlotMerge.Positional   => Frame.Array(collectFrames(values, command.keyIndices.size))
+              case MultiSlotMerge.Sum          => Frame.Integer(total.get())
+              case MultiSlotMerge.AllSucceeded => Frame.SimpleString("OK")
+            }
+            complete(Reply.decode(command, merged))
+        }
+    }
+
+    val raw = command.rawFrame
+    groups.foreach { group =>
+      val args = Vector.newBuilder[Bytes]
+      args.sizeHint(group.size * policy.argsPerKey)
+      group.foreach { entry =>
+        var offset = 0
+        while (offset < policy.argsPerKey) {
+          args += command.args(entry.argIndex + offset)
+          offset += 1
+        }
+      }
+      val sub  = raw.copy(
+        keyIndices = Vector.tabulate(group.size)(_ * policy.argsPerKey),
+        args = args.result()
+      )
+      dispatch(sub, redirectsLeft, result => settle(group, result), allowReplica = allowReplica)
+    }
+  }
+
+  // Validate each recognized command's complete argument shape before splitting so a custom command that merely shares its name can never
+  // lose or misassociate non-key arguments during subgroup construction.
+  private def multiSlotPolicy(command: Command[?]): Option[MultiSlotPolicy] =
+    command.name.toUpperCase(Locale.ROOT) match {
+      case "MGET" if hasKeyStride(command, 1)                                => Some(MultiSlotPolicy(MultiSlotMerge.Positional, 1))
+      case "DEL" | "EXISTS" | "TOUCH" | "UNLINK" if hasKeyStride(command, 1) => Some(MultiSlotPolicy(MultiSlotMerge.Sum, 1))
+      case "MSET" if hasKeyStride(command, 2)                                => Some(MultiSlotPolicy(MultiSlotMerge.AllSucceeded, 2))
+      case _                                                                 => None
+    }
+
+  private def hasKeyStride(command: Command[?], argsPerKey: Int): Boolean =
+    command.args.nonEmpty && command.args.size % argsPerKey == 0 &&
+      command.keyIndices == Vector.tabulate(command.args.size / argsPerKey)(_ * argsPerKey)
 
   // walk the policy's ordered candidates, falling through on connection loss; strict Replica with no live replica exhausts to NotConnected
   private def sendRead[A](command: Command[A], master: Node, slot: Slot, redirectsLeft: Int, complete: Try[A] => Unit): Unit = {
@@ -574,7 +680,9 @@ final private[client] class ClusterLive(
     def reroute(index: Int): Unit = dispatch(p.commands(index), cluster.maxRedirects, emits(index), allowReplica = useReplica)
 
     plan.rejected.foreach {
-      case (index, Rejected.CrossSlot(slots)) => emits(index)(Failure(crossSlot(p.commands(index).name, slots)))
+      case (index, Rejected.CrossSlot(slots)) =>
+        if (multiSlotPolicy(p.commands(index)).nonEmpty) reroute(index)
+        else emits(index)(Failure(crossSlot(p.commands(index).name, slots)))
       case (index, Rejected.Unowned(_))       => reroute(index) // dispatch refreshes then re-routes
       case (_, Rejected.Malformed)            => ()             // unreachable: the guard above returned
     }

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -451,14 +451,264 @@ class ClusterClientSpec extends munit.FunSuite {
     }
   }
 
-  test("a single command whose keys span slots fails CrossSlot") {
-    val behaviour                = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.Integer(1))
-    val fixture                  = new Fixture(behaviour, Vector(nodeA))
-    val crossSlot: Command[Long] =
-      Command("MSET", Vector(0, 2), Vector("{a}", "v", "{b}", "v").map(Bytes.utf8), _ => Right(1L))
+  test("an unsupported multi-key command whose keys span slots fails CrossSlot") {
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.Integer(1))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
 
-    fixture.live.run(crossSlot).unsafeRun.failed.map { error =>
+    fixture.live.run(Strings.mSetNx("{a}" -> "a", "{b}" -> "b")).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[CrossSlot], s"unexpected error: $error")
+    }
+  }
+
+  test("an MSET-named custom command without alternating key/value arguments is not rewritten") {
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+    val malformed = Command[Unit](
+      "MSET",
+      Vector(0, 3),
+      Vector("{a}", "a-value", "option", "{b}", "b-value").map(Bytes.utf8),
+      _ => Right(())
+    )
+
+    fixture.live.run(malformed).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[CrossSlot], s"unexpected error: $error")
+      assert(!fixture.written(nodeA).exists(_.contains("MSET")), "an unvalidated custom shape reached the wire")
+    }
+  }
+
+  test("an MGET-named custom command with non-key arguments is not rewritten") {
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.Array(Vector.empty))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+    val malformed = Command[Vector[String]](
+      "MGET",
+      Vector(0, 2),
+      Vector("{a}", "not-a-key", "{b}").map(Bytes.utf8),
+      _ => Right(Vector.empty)
+    )
+
+    fixture.live.run(malformed).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[CrossSlot], s"unexpected error: $error")
+      assert(!fixture.written(nodeA).exists(_.contains("MGET")), "an unvalidated custom shape reached the wire")
+    }
+  }
+
+  test("a cross-slot MGET splits by exact slot on one node and restores positional results") {
+    val keyA      = "{mget-a}value"
+    val keyB      = "{mget-b}value"
+    val missingA  = "{mget-a}missing"
+    assert(Slot.of(Bytes.utf8(keyA)) != Slot.of(Bytes.utf8(keyB)), "test keys must hash to different slots")
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (text.contains(keyA))
+        Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("a-value")), Frame.Null)))
+      else if (text.contains(keyB))
+        Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("b-value")), Frame.BulkString(Bytes.utf8("b-value")))))
+      else Seq(Frame.SimpleError("ERR unexpected command"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.mGet[String, String](keyA, keyB, missingA, keyB)).unsafeRun.map { result =>
+      assertEquals(result, Vector(Some("a-value"), Some("b-value"), None, Some("b-value")))
+      val subMgets = fixture.written(nodeA).filter(_.contains("MGET"))
+      assertEquals(subMgets.size, 2, "different slots must remain separate even when one node owns both")
+      assert(subMgets.forall(text => !(text.contains(keyA) && text.contains(keyB))), s"a subgroup crossed slots: $subMgets")
+    }
+  }
+
+  test("a lowercase supported command name is transparently split") {
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else Seq(Frame.Integer(1L))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+    val lowercase = Keys.exists(keyA, keyB).copy(name = "exists")
+
+    fixture.live.run(lowercase).unsafeRun.map { result =>
+      assertEquals(result, 2L)
+      assertEquals(fixture.written(nodeA).count(_.contains("\r\nexists\r\n")), 2)
+    }
+  }
+
+  test("a single-slot MGET keeps the one-command fast path") {
+    val first     = "{same}one"
+    val second    = "{same}two"
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("one")), Frame.BulkString(Bytes.utf8("two")))))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.mGet[String, String](first, second)).unsafeRun.map { result =>
+      assertEquals(result, Vector(Some("one"), Some("two")))
+      val mgets = fixture.written(nodeA).filter(_.contains("MGET"))
+      assertEquals(mgets.size, 1)
+      assert(mgets.head.contains(first) && mgets.head.contains(second), s"same-slot keys were split: $mgets")
+    }
+  }
+
+  test("a cross-slot MSET keeps values paired while splitting by exact slot") {
+    val firstA    = "{mset-a}one"
+    val keyB      = "{mset-b}one"
+    val secondA   = "{mset-a}two"
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.mSet(firstA -> "first", keyB -> "other", secondA -> "second")).unsafeRun.map { _ =>
+      val subMsets = fixture.written(nodeA).filter(_.contains("\r\nMSET\r\n"))
+      assertEquals(subMsets.size, 2, "different slots must remain separate even when one node owns both")
+      val groupA   = subMsets.find(_.contains(firstA)).getOrElse(fail(s"missing first slot subgroup: $subMsets"))
+      val groupB   = subMsets.find(_.contains(keyB)).getOrElse(fail(s"missing second slot subgroup: $subMsets"))
+      assert(groupA.contains("first") && groupA.contains(secondA) && groupA.contains("second"), s"values lost pairing: $groupA")
+      assert(groupB.contains("other"), s"value lost pairing: $groupB")
+      assert(!groupA.contains(keyB) && !groupB.contains(firstA), s"an MSET subgroup crossed slots: $subMsets")
+    }
+  }
+
+  test("a single-slot MSET keeps the one-command fast path") {
+    val first     = "{same}one"
+    val second    = "{same}two"
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.mSet(first -> "one", second -> "two")).unsafeRun.map { _ =>
+      val msets = fixture.written(nodeA).filter(_.contains("\r\nMSET\r\n"))
+      assertEquals(msets.size, 1)
+      assert(msets.head.contains(first) && msets.head.contains(second), s"same-slot pairs were split: $msets")
+    }
+  }
+
+  test("a cross-slot MGET routes slot groups independently to their owners") {
+    val keyA      = "{a}"
+    val keyB      = "{b}"
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(splitOn(Slot.of(Bytes.utf8(keyB)).value))
+      else Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8(node.host)))))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.mGet[String, String](keyA, keyB)).unsafeRun.map { result =>
+      assertEquals(result, Vector(Some(nodeA.host), Some(nodeB.host)))
+      assert(fixture.written(nodeA).exists(text => text.contains("MGET") && text.contains(keyA)), "nodeA missed its slot group")
+      assert(fixture.written(nodeB).exists(text => text.contains("MGET") && text.contains(keyB)), "nodeB missed its slot group")
+    }
+  }
+
+  test("a cross-slot MGET fails as a whole when one slot group fails") {
+    val keyA      = "{a}"
+    val keyB      = "{b}"
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(splitOn(Slot.of(Bytes.utf8(keyB)).value))
+      else if (node == nodeB) Seq(Frame.SimpleError("ERR subgroup unavailable"))
+      else Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("ok")))))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.mGet[String, String](keyA, keyB)).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[ServerError], s"expected ServerError, got $error")
+      assert(fixture.written(nodeA).exists(_.contains("MGET")), "the successful group was not issued")
+      assert(fixture.written(nodeB).exists(_.contains("MGET")), "the failing group was not issued")
+    }
+  }
+
+  test("a cross-slot MGET rejects a subgroup reply with the wrong positional length") {
+    val keyA      = "{a}"
+    val keyB      = "{b}"
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (text.contains(keyA)) Seq(Frame.Array(Vector.empty))
+      else Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("b")))))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.mGet[String, String](keyA, keyB)).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[DecodeError], s"expected DecodeError, got $error")
+    }
+  }
+
+  test("a cross-slot MGET follows a redirect for only the affected slot group") {
+    val keyA      = "{a}"
+    val keyB      = "{b}"
+    val slotB     = Slot.of(Bytes.utf8(keyB)).value
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (node == nodeA && text.contains(keyB)) Seq(Frame.SimpleError(s"MOVED $slotB b:6379"))
+      else if (text.contains(keyA)) Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("a")))))
+      else Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("b")))))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.mGet[String, String](keyA, keyB)).unsafeRun.map { result =>
+      assertEquals(result, Vector(Some("a"), Some("b")))
+      assert(fixture.written(nodeB).exists(text => text.contains("MGET") && text.contains(keyB)), "redirected subgroup missed nodeB")
+      assert(!fixture.written(nodeB).exists(_.contains(keyA)), "unaffected subgroup followed the other slot's redirect")
+    }
+  }
+
+  Vector("DEL", "EXISTS", "TOUCH", "UNLINK").foreach { name =>
+    test(s"a cross-slot $name splits by exact slot and sums subgroup counts") {
+      val firstA    = "{sum-a}one"
+      val keyB      = "{sum-b}one"
+      val secondA   = "{sum-a}two"
+      val behaviour = (_: Node, text: String) =>
+        if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+        else Seq(Frame.Integer(if (text.contains(secondA)) 2L else 1L))
+      val fixture   = new Fixture(behaviour, Vector(nodeA))
+      val command   = name match {
+        case "DEL"    => Keys.del(firstA, keyB, secondA)
+        case "EXISTS" => Keys.exists(firstA, keyB, secondA)
+        case "TOUCH"  => Keys.touch(firstA, keyB, secondA)
+        case "UNLINK" => Keys.unlink(firstA, keyB, secondA)
+        case other    => fail(s"unexpected command: $other")
+      }
+
+      fixture.live.run(command).unsafeRun.map { result =>
+        assertEquals(result, 3L)
+        val subcommands = fixture.written(nodeA).filter(_.contains(s"\r\n$name\r\n"))
+        assertEquals(subcommands.size, 2, "different slots must remain separate even when one node owns both")
+        assert(subcommands.forall(text => !(text.contains(firstA) && text.contains(keyB))), s"a subgroup crossed slots: $subcommands")
+      }
+    }
+  }
+
+  test("a summed cross-slot command fails as a whole when one subgroup fails") {
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(splitOn(slotB))
+      else if (node == nodeB) Seq(Frame.SimpleError("ERR subgroup unavailable"))
+      else Seq(Frame.Integer(1L))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Keys.del(keyA, keyB)).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[ServerError], s"expected ServerError, got $error")
+      assert(fixture.written(nodeA).exists(_.contains("DEL")), "the successful subgroup was not issued")
+      assert(fixture.written(nodeB).exists(_.contains("DEL")), "the failing subgroup was not issued")
+    }
+  }
+
+  test("a summed cross-slot command rejects a non-integer subgroup reply") {
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.Array(Vector.empty))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Keys.exists(keyA, keyB)).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[DecodeError], s"expected DecodeError, got $error")
+    }
+  }
+
+  test("a cross-slot MSET fails as a whole after issuing every subgroup") {
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(splitOn(slotB))
+      else if (node == nodeB) Seq(Frame.SimpleError("ERR subgroup unavailable"))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.mSet(keyA -> "a", keyB -> "b")).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[ServerError], s"expected ServerError, got $error")
+      assert(fixture.written(nodeA).exists(_.contains("MSET")), "the successful subgroup was not issued")
+      assert(fixture.written(nodeB).exists(_.contains("MSET")), "the failing subgroup was not issued")
+    }
+  }
+
+  test("a cross-slot MSET rejects a subgroup reply other than OK") {
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (text.contains(keyA)) Seq(Frame.SimpleString("OK"))
+      else Seq(Frame.Integer(1L))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.mSet(keyA -> "a", keyB -> "b")).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[DecodeError], s"expected DecodeError, got $error")
     }
   }
 
@@ -514,6 +764,43 @@ class ClusterClientSpec extends munit.FunSuite {
       assertEquals(result, (Right(Some(nodeA.host)), Right(Some(nodeB.host))))
       assert(fixture.written(nodeA).exists(_.contains("GET")), "nodeA did not receive its GET")
       assert(fixture.written(nodeB).exists(_.contains("GET")), "nodeB did not receive its GET")
+    }
+  }
+
+  test("a pipeline transparently executes a cross-slot MGET at its logical position") {
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (text.contains("MGET") && text.contains(keyA)) Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("a")))))
+      else if (text.contains("MGET") && text.contains(keyB)) Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("b")))))
+      else Seq(Frame.BulkString(Bytes.utf8("tail")))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.pipeline((Strings.mGet[String, String](keyA, keyB), Strings.get[String, String]("{a}tail"))).unsafeRun.map { result =>
+      assertEquals(result, (Vector(Some("a"), Some("b")), Some("tail")))
+    }
+  }
+
+  test("a pipeline transparently executes a summed cross-slot command at its logical position") {
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (text.contains("EXISTS")) Seq(Frame.Integer(1L))
+      else Seq(Frame.BulkString(Bytes.utf8("tail")))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.pipeline((Keys.exists(keyA, keyB), Strings.get[String, String]("{a}tail"))).unsafeRun.map { result =>
+      assertEquals(result, (2L, Some("tail")))
+    }
+  }
+
+  test("a pipeline transparently executes a cross-slot MSET at its logical position") {
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (text.contains("MSET")) Seq(Frame.SimpleString("OK"))
+      else Seq(Frame.BulkString(Bytes.utf8("tail")))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.pipeline((Strings.mSet(keyA -> "a", keyB -> "b"), Strings.get[String, String]("{a}tail"))).unsafeRun.map { result =>
+      assertEquals(result, ((), Some("tail")))
     }
   }
 
@@ -614,6 +901,42 @@ class ClusterClientSpec extends munit.FunSuite {
       Thread.sleep(150)
       val clusterCalls = fixture.written(nodeA).count(_.contains("CLUSTER"))
       assert(clusterCalls >= 3, s"each tx fault must force a refresh despite the throttle; CLUSTER calls: $clusterCalls")
+    }
+  }
+
+  test("a cross-slot MGET remains forbidden inside a transaction") {
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(splitOn(slotB)) else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.transaction(_.run(Strings.mGet[String, String](keyA, keyB))).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[CrossSlot], s"unexpected error: $error")
+      assert(!fixture.written(nodeA).exists(_.contains("MULTI")), "no MULTI should be sent for a rejected MGET")
+      assert(!fixture.written(nodeA).exists(_.contains("MGET")), "no MGET subgroup should escape the transaction")
+      assert(!fixture.written(nodeB).exists(_.contains("MGET")), "no MGET subgroup should escape the transaction")
+    }
+  }
+
+  test("a summed cross-slot command remains forbidden inside a transaction") {
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(splitOn(slotB)) else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.transaction(_.run(Keys.exists(keyA, keyB))).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[CrossSlot], s"unexpected error: $error")
+      assert(!fixture.written(nodeA).exists(_.contains("MULTI")), "no MULTI should be sent for a rejected EXISTS")
+      assert(!fixture.written(nodeA).exists(_.contains("EXISTS")), "no EXISTS subgroup should escape the transaction")
+      assert(!fixture.written(nodeB).exists(_.contains("EXISTS")), "no EXISTS subgroup should escape the transaction")
+    }
+  }
+
+  test("a cross-slot MSET remains forbidden inside a transaction") {
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(splitOn(slotB)) else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.transaction(_.run(Strings.mSet(keyA -> "a", keyB -> "b"))).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[CrossSlot], s"unexpected error: $error")
+      assert(!fixture.written(nodeA).exists(_.contains("MULTI")), "no MULTI should be sent for a rejected MSET")
+      assert(!fixture.written(nodeA).exists(_.contains("MSET")), "no MSET subgroup should escape the transaction")
+      assert(!fixture.written(nodeB).exists(_.contains("MSET")), "no MSET subgroup should escape the transaction")
     }
   }
 

--- a/sage-core/src/main/scala/sage/SageException.scala
+++ b/sage-core/src/main/scala/sage/SageException.scala
@@ -77,7 +77,9 @@ object SageException {
   final case class TlsError(message: String) extends SageException(message)
 
   /**
-    * A multi-key command or transaction touched keys in more than one cluster slot, which the server cannot serve atomically.
+    * An unsupported multi-key command or a transaction touched keys in more than one cluster slot, which the server cannot serve atomically.
+    * Supported multi-slot commands are handled transparently outside transactions and therefore do not produce this error solely for spanning
+    * slots.
     */
   final case class CrossSlot(message: String) extends SageException(message)
 


### PR DESCRIPTION
## Summary

Redis/Valkey Cluster rejects multi-key commands when their keys span hash slots. This change transparently scatters the commands Sage can safely merge:

- `MGET`: group keys by exact slot, issue one subcommand per slot, and restore values to request order (including duplicates and missing keys)
- `MSET`: keep each value paired with its key, issue one atomic MSET per exact slot, and succeed when every subgroup returns `OK`
- `EXISTS`, `DEL`, `UNLINK`, and `TOUCH`: group keys by exact slot and sum the per-slot integer counts
- preserve the existing one-slot fast path
- support the same behavior when these commands appear in pipelines
- keep transactions strict: cross-slot commands are still rejected before `MULTI`

Each subgroup re-enters the normal cluster dispatch path, so replica policy, topology refresh, and `MOVED`/`ASK` handling remain unchanged. If any subgroup fails, the logical command fails as a whole.

`MSETNX` remains unsupported across slots because splitting it would break its all-or-nothing condition.

## Consistency semantics

The combined operation is not cluster-wide atomic. A cross-slot `MGET` is not a point-in-time snapshot. For `MSET`, `DEL`, and `UNLINK`, successful slot groups may already have applied writes when another subgroup fails. The client API and cluster documentation call this out and recommend hash tags when cluster-wide atomicity is required.

## Validation

- Review completed with no remaining correctness or scope findings
- 711 core tests
- 280 client tests
- Scala 3.8.4 client compilation
- 12 live Redis and Valkey cluster integration tests