### PR TITLE
Retry cross-slot commands that fail with -TRYAGAIN during resharding

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,6 +57,11 @@ fails, the logical call fails as a whole. Use a common hash tag when the operati
 break its all-or-nothing condition. All cross-slot commands remain rejected inside a transaction because `MULTI`/`EXEC` must stay pinned to
 one slot.
 
+While a slot is being migrated, the server answers a multi-key command whose keys briefly straddle the moving slot with `-TRYAGAIN`. The command
+did not run, so sage retries it. The retry shares the same `maxRedirects` budget as `MOVED`/`ASK` follows, but where those are resent
+immediately, a `-TRYAGAIN` retry is paced by a short jittered delay. If the migration outlasts that budget, the original `-TRYAGAIN` surfaces as
+a `ServerError`.
+
 ## Master-replica
 
 Select `Topology.MasterReplica` with seed endpoints. Sage asks each its role, discovers the master and its replicas, sends writes to the master, and routes reads per the read policy:

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -412,6 +412,7 @@ final private[client] class ClusterLive(
         }
       case Fault.Lost(false)                =>
         if (rest.nonEmpty) tryReadCandidates(command, rest, master, redirectsLeft, complete) else onUnreachable(command, redirectsLeft, complete)
+      case Fault.TryAgain                   => onTryAgain(command, error, redirectsLeft, complete)
       case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error))
       case Fault.Fatal                      => Events.attributeNode(complete, node); complete(Failure(error))
     }
@@ -562,6 +563,7 @@ final private[client] class ClusterLive(
     Fault.categorize(error) match {
       case Fault.Redirected(redirect)       => onRedirect(node, redirect, command, redirectsLeft, complete, lease)
       case Fault.Lost(false)                => onUnreachable(command, redirectsLeft, complete, lease)
+      case Fault.TryAgain                   => onTryAgain(command, error, redirectsLeft, complete, lease)
       case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error))
       case Fault.Fatal                      => Events.attributeNode(complete, node); complete(Failure(error))
     }
@@ -590,6 +592,20 @@ final private[client] class ClusterLive(
     if (redirectsLeft <= 0) complete(Failure(NotConnected()))
     else {
       refresh(force = true)
+      val attempt = (cluster.maxRedirects - redirectsLeft).max(0)
+      scheduler.after(Backoff.jitteredMillis(reconnect, attempt, scheduler).millis)(dispatch(command, redirectsLeft - 1, complete, lease = lease))
+    }
+
+  // -TRYAGAIN is a transient mid-migration refusal: the slot mapping is still valid, so retry (bounded, jittered) without refreshing the topology.
+  private def onTryAgain[A](
+    command: Command[A],
+    error: Throwable,
+    redirectsLeft: Int,
+    complete: Try[A] => Unit,
+    lease: DedicatedPool.Lease = null
+  ): Unit =
+    if (redirectsLeft <= 0) complete(Failure(error))
+    else {
       val attempt = (cluster.maxRedirects - redirectsLeft).max(0)
       scheduler.after(Backoff.jitteredMillis(reconnect, attempt, scheduler).millis)(dispatch(command, redirectsLeft - 1, complete, lease = lease))
     }
@@ -786,6 +802,7 @@ final private[client] class ClusterLive(
                 case RedirectKind.Moved                                             => reroute(index)
               }
             case Fault.Lost(false)                => reroute(index)
+            case Fault.TryAgain                   => onTryAgain(p.commands(index), error, cluster.maxRedirects, emits(index))
             case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); settle(index, result)
             case Fault.Fatal                      => settle(index, result)
           }
@@ -856,10 +873,7 @@ final private[client] class ClusterLive(
     // a transaction never follows a redirect (that would break MULTI/EXEC atomicity), but on any ownership/connection fault it refreshes in the
     // background so the caller's retry re-pins to the new owner instead of looping on the stale node; a data error refreshes nothing
     private def refreshOnFault(error: Throwable): Unit =
-      Fault.categorize(error) match {
-        case Fault.Fatal => ()
-        case _           => forceRefresh()
-      }
+      if (Fault.categorize(error).refreshesTopology) forceRefresh()
 
     private def faulting[A](complete: Try[A] => Unit): Try[A] => Unit = {
       case failure @ Failure(error) => refreshOnFault(error); complete(failure)
@@ -870,7 +884,7 @@ final private[client] class ClusterLive(
     // level and the EXEC array and refresh on any non-terminal one so the caller's retry re-pins
     private def refreshOnExecFault(frames: Vector[Frame]): Unit = {
       val nested = frames.lastOption match { case Some(Frame.Array(elems)) => elems.iterator; case _ => Iterator.empty[Frame] }
-      val fault  = (frames.iterator ++ nested).flatMap(TxSupport.errorOf).exists(m => Fault.categorize(ServerError.of(m)) != Fault.Fatal)
+      val fault  = (frames.iterator ++ nested).flatMap(TxSupport.errorOf).exists(m => Fault.categorize(ServerError.of(m)).refreshesTopology)
       if (fault) forceRefresh()
     }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/Fault.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Fault.scala
@@ -10,7 +10,14 @@ private[client] enum Fault {
   case Redirected(redirect: Redirect)
   case Demoted
   case Lost(mayHaveExecuted: Boolean)
+  case TryAgain
   case Fatal
+
+  // an ownership or connection change the topology must adopt; a data error or a transient mid-migration TryAgain leaves the mapping valid
+  def refreshesTopology: Boolean = this match {
+    case Fatal | TryAgain => false
+    case _                => true
+  }
 }
 
 private[client] object Fault {
@@ -21,6 +28,7 @@ private[client] object Fault {
         Redirect.parse(e.getMessage) match {
           case Some(redirect)               => Fault.Redirected(redirect)
           case None if e.code == "READONLY" => Fault.Demoted
+          case None if e.code == "TRYAGAIN" => Fault.TryAgain
           case None                         => Fault.Fatal
         }
       case NotConnected()           => Fault.Lost(mayHaveExecuted = false)

--- a/sage-client/shared/src/test/scala/sage/client/internal/FaultSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/FaultSpec.scala
@@ -23,6 +23,10 @@ class FaultSpec extends munit.FunSuite {
     assertEquals(Fault.categorize(ServerError("READONLY", "You can't write against a read only replica.")), Fault.Demoted)
   }
 
+  test("a TRYAGAIN reply categorizes as TryAgain") {
+    assertEquals(Fault.categorize(ServerError("TRYAGAIN", "Multiple keys request during rehashing of slot")), Fault.TryAgain)
+  }
+
   test("any other ServerError categorizes as Fatal") {
     assertEquals(Fault.categorize(ServerError("WRONGTYPE", "Operation against a key holding the wrong kind of value")), Fault.Fatal)
     assertEquals(Fault.categorize(ServerError("ERR", "foo bar")), Fault.Fatal)

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -451,6 +451,33 @@ class ClusterClientSpec extends munit.FunSuite {
     }
   }
 
+  test("a TRYAGAIN reply is retried and eventually succeeds") {
+    val attempts  = new java.util.concurrent.atomic.AtomicInteger(0)
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (text.contains("GET"))
+        if (attempts.getAndIncrement() == 0) Seq(Frame.SimpleError("TRYAGAIN Multiple keys request during rehashing of slot"))
+        else Seq(Frame.BulkString(Bytes.utf8("value")))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
+      assertEquals(result, Some("value"))
+      assert(attempts.get() >= 2, s"TRYAGAIN was not retried: ${attempts.get()} attempts")
+    }
+  }
+
+  test("a persistent TRYAGAIN surfaces the original error after exhausting retries") {
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else Seq(Frame.SimpleError("TRYAGAIN Multiple keys request during rehashing of slot"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[ServerError] && error.asInstanceOf[ServerError].code == "TRYAGAIN", s"unexpected error: $error")
+    }
+  }
+
   test("an unsupported multi-key command whose keys span slots fails CrossSlot") {
     val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.Integer(1))
     val fixture   = new Fixture(behaviour, Vector(nodeA))


### PR DESCRIPTION
## What

While a cluster slot is migrating, the server answers a multi-key command whose keys briefly straddle the moving slot with `-TRYAGAIN`. The command did not run, but sage had no case for it: it fell through to `Fault.Fatal` and surfaced as a bare `ServerError`, turning a transient migration hiccup into a hard failure.

Sage now categorizes `-TRYAGAIN` as a transient fault and retries the command after a short jittered delay. The retry shares the same `maxRedirects` budget as `MOVED`/`ASK` follows, but where those are resent immediately, a `-TRYAGAIN` retry is paced by a jittered backoff. This is consistent with the no-auto-retry rule (ADR-0006): like a redirect, `-TRYAGAIN` means the command did not execute, so retrying it is a pre-execution re-send, not a re-run of a possibly-applied write.

## Details

- New `Fault.TryAgain` case; `ServerError` with code `TRYAGAIN` maps to it.
- New `onTryAgain` helper mirrors `onUnreachable` but does **not** force a topology refresh: the slot mapping is still valid mid-migration, so only an ownership change (`MOVED`/unowned/`READONLY`/unreachable) warrants a refresh. On exhaustion it surfaces the original `-TRYAGAIN`, not a synthetic error.
- Wired into every dispatch failure site: the write path (`onFailure`), the replica read path (`onReadFailure`), and per-position in a pipeline (`submitBatch`). Because transparent cross-slot subgroups re-enter `dispatch`, they inherit the retry for free.
- The transaction refresh paths (`refreshOnFault`, `refreshOnExecFault`) reuse a new `Fault.refreshesTopology` predicate, which centralizes the refresh policy and excludes `TryAgain` and `Fatal`, so a transient `-TRYAGAIN` does not trigger a background refresh.
- Docs: a note in the cross-slot section of `configuration.md`.

## Tests

- `FaultSpec`: `TRYAGAIN` categorizes as `TryAgain`.
- `ClusterClientSpec`: retries then succeeds; a persistent `-TRYAGAIN` surfaces the original error after exhausting the budget.

All client unit tests pass; `scalafmtCheckAll` is clean.