### PR TITLE
Support client-side caching in cluster mode

### DIFF
--- a/docs/client-side-caching.md
+++ b/docs/client-side-caching.md
@@ -39,4 +39,11 @@ Tune cache sizing and behavior through `clientCache` on [`SageConfig`](/configur
 
 ## Topology
 
-Caching works on a standalone client and on a master-replica client (cached reads run on the master, which holds the tracking-backed cache; a failover starts the new master's cache cold). On a cluster client, `cached` currently runs the read without caching so the call stays portable; per-node tracking through redirects and failover is a planned follow-up. In every case the result is correct, you only forgo the local hit where caching is not active.
+Caching works on every topology. On a standalone or master-replica client, cached reads run on the master, which holds the tracking-backed cache. On a cluster client, each slot-owning master owns its own cache, and a cached read is routed to the master owning the key's slot (never a replica, whatever the read policy). The same call is therefore portable across all three topologies; the result is always correct, you only forgo the local hit where caching is not active.
+
+## Limitations
+
+- The cache budget is per master, not global: `clientCache.maxBytes` sizes each master's cache, so a cluster's effective ceiling is `maxBytes` times the number of masters.
+- A cache goes cold whenever its connection is replaced or its master stops owning the slot: a reconnect, a cluster failover, or a resharding that moves the slot off its master all start it fresh. Steady-state hit rates are unaffected; only these (rare) events reset it.
+- During a live slot migration a cached read of a migrating key runs uncached (following the `ASK` redirect once) until the migration completes.
+- A server that speaks RESP3 but rejects `CLIENT TRACKING` (an ACL or proxy restriction) still connects; cached reads there run uncached, exactly as when caching is disabled.

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterFailoverSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterFailoverSuite.scala
@@ -125,33 +125,34 @@ abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends
   private def writeAll(client: Client[CIO, String], keys: Vector[String]): CIO[Unit] =
     keys.foldLeft(CIO.value(()))((acc, key) => acc.flatMap(_ => writeKey(client, key, 150)))
 
-  // retry a read across the failover window until the client refreshes onto the promoted master; each key stores its own name
+  // retries a transport error, but fails at once on a `reject` value: retrying a stale success would let it slip through behind a later refresh
+  private def awaitReadEquals(read: () => CIO[Option[String]], expected: String, reject: Option[String], attempts: Int): CIO[Boolean] =
+    read().fold(
+      {
+        case Some(v) if v == expected      => CIO.value(true)
+        case Some(v) if reject.contains(v) => CIO.value(false)
+        case _ if attempts <= 0            => CIO.value(false)
+        case _                             => CIO.sleep(200.millis).flatMap(_ => awaitReadEquals(read, expected, reject, attempts - 1))
+      },
+      _ => if (attempts <= 0) CIO.value(false) else CIO.sleep(200.millis).flatMap(_ => awaitReadEquals(read, expected, reject, attempts - 1))
+    )
+
   private def recoverKey(client: Client[CIO, String], key: String, attempts: Int): CIO[Boolean] =
-    client
-      .get[String](key)
-      .fold(
-        {
-          case Some(v) if v == key => CIO.value(true)
-          case _ if attempts <= 0  => CIO.value(false)
-          case _                   => CIO.sleep(200.millis).flatMap(_ => recoverKey(client, key, attempts - 1))
-        },
-        _ => if (attempts <= 0) CIO.value(false) else CIO.sleep(200.millis).flatMap(_ => recoverKey(client, key, attempts - 1))
-      )
+    awaitReadEquals(() => client.get[String](key), key, None, attempts)
+
+  private def recoverCached(client: Client[CIO, String], key: String, expected: String, stale: String, attempts: Int): CIO[Boolean] =
+    awaitReadEquals(() => client.cached(Commands.get[String, String](key), 1.minute), expected, Some(stale), attempts)
 
   private def recoverAll(client: Client[CIO, String], keys: Vector[String]): CIO[Boolean] =
     keys.foldLeft(CIO.value(true))((acc, key) => acc.flatMap(ok => if (!ok) CIO.value(false) else recoverKey(client, key, 150)))
 
-  private def recoverCached(client: Client[CIO, String], key: String, attempts: Int): CIO[Boolean] =
-    client
-      .cached(Commands.get[String, String](key), 1.minute)
-      .fold(
-        {
-          case Some(v) if v == key => CIO.value(true)
-          case _ if attempts <= 0  => CIO.value(false)
-          case _                   => CIO.sleep(200.millis).flatMap(_ => recoverCached(client, key, attempts - 1))
-        },
-        _ => if (attempts <= 0) CIO.value(false) else CIO.sleep(200.millis).flatMap(_ => recoverCached(client, key, attempts - 1))
-      )
+  // retries until the node accepts the write (e.g. a replica once it is promoted to master)
+  private def writeDirect(container: FixedHostPortGenericContainer, port: Int, key: String, value: String, attempts: Int): CIO[Unit] =
+    CIO.blocking(cli(container, port, "set", key, value)).flatMap { out =>
+      if (out.contains("OK")) CIO.value(())
+      else if (attempts <= 0) CIO.fail(new RuntimeException(s"could not write $key on $port: $out"))
+      else CIO.sleep(200.millis).flatMap(_ => writeDirect(container, port, key, value, attempts - 1))
+    }
 
   private def masterId(container: FixedHostPortGenericContainer, port: Int): String = cli(container, port, "cluster", "myid").trim
 
@@ -159,12 +160,11 @@ abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends
   private def clusterNodeLines(container: FixedHostPortGenericContainer): Vector[Array[String]] =
     parseKeys(cli(container, victim, "cluster", "nodes")).map(_.split("\\s+"))
 
-  private def otherMasterPort(container: FixedHostPortGenericContainer): Int =
-    clusterNodeLines(container).iterator
+  private def masterPortsExcludingVictim(container: FixedHostPortGenericContainer): Vector[Int] =
+    clusterNodeLines(container)
       .filter(f => f.length > 2 && f(2).contains("master"))
       .map(f => f(1).split("@")(0).split(":")(1).toInt)
-      .find(_ != victim)
-      .getOrElse(throw new RuntimeException("no other master found to receive resharded slots"))
+      .filter(_ != victim)
 
   // slot tokens are `start-end` or a single slot; `[...]` migration markers are not owned slots
   private def slotCount(fields: Array[String]): Int =
@@ -177,8 +177,11 @@ abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends
       }
       .sum
 
-  private def victimSlotCount(container: FixedHostPortGenericContainer): Int =
-    clusterNodeLines(container).collectFirst { case f if f.length > 2 && f(2).contains("myself") => slotCount(f) }.getOrElse(0)
+  private def ownSlotCount(container: FixedHostPortGenericContainer, port: Int): Int =
+    parseKeys(cli(container, port, "cluster", "nodes"))
+      .map(_.split("\\s+"))
+      .collectFirst { case f if f.length > 2 && f(2).contains("myself") => slotCount(f) }
+      .getOrElse(0)
 
   private def reshard(container: FixedHostPortGenericContainer, fromId: String, toId: String, slots: Int): String =
     exec(
@@ -238,17 +241,18 @@ abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends
               onVictim  <- CIO.blocking(parseKeys(cli(container, victim, "keys", "*")))
               probe      = onVictim.head
               first     <- client.cached(Commands.get[String, String](probe), 1.minute)
+              dest      <- CIO.blocking(masterPortsExcludingVictim(container).head)
               fromId    <- CIO.blocking(masterId(container, victim))
-              toPort    <- CIO.blocking(otherMasterPort(container))
-              toId      <- CIO.blocking(masterId(container, toPort))
-              moved     <- CIO.blocking(victimSlotCount(container))
+              toId      <- CIO.blocking(masterId(container, dest))
+              moved     <- CIO.blocking(ownSlotCount(container, victim))
               _         <- CIO.blocking(reshard(container, fromId, toId, moved))
               _         <- awaitClusterOk(container, 60)
-              recovered <- recoverCached(client, probe, 150)
+              _         <- writeDirect(container, dest, probe, "reshard-fresh", 50)
+              recovered <- recoverCached(client, probe, "reshard-fresh", probe, 150)
             } yield {
               assert(onVictim.nonEmpty, "no keys landed on the victim master; cannot prove reshard recovery")
               assertEquals(first, Some(probe))
-              assert(recovered, "cached read did not follow MOVED to the resharded slot's new owner")
+              assert(recovered, "cached read did not observe the resharded slot's new owner's current value")
             }
           }
         }
@@ -273,10 +277,11 @@ abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends
               replicaPort <- CIO.blocking(victimReplicaPort(container))
               _           <- awaitReplicated(container, replicaPort, onVictim.toSet, 100)
               _           <- CIO.blocking(Try(cli(container, victim, "shutdown", "nosave")))
-              recovered   <- recoverCached(client, probe, 150)
+              _           <- writeDirect(container, replicaPort, probe, "failover-fresh", 150)
+              recovered   <- recoverCached(client, probe, "failover-fresh", probe, 150)
             } yield {
               assert(onVictim.nonEmpty, "no keys landed on the victim master; cannot prove cached failover recovery")
-              assert(recovered, "cached read did not recover from the promoted master after the victim crashed")
+              assert(recovered, "cached read did not observe the promoted master's current value after the victim crashed")
             }
           }
         }

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterFailoverSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterFailoverSuite.scala
@@ -5,11 +5,12 @@ import scala.concurrent.duration.*
 import scala.util.Try
 
 import com.dimafeng.testcontainers.FixedHostPortGenericContainer
-import com.dimafeng.testcontainers.munit.TestContainerForAll
+import com.dimafeng.testcontainers.munit.TestContainerForEach
 import kyo.compat.*
 
 import sage.client.{ClusterConfig, Endpoint, SageConfig, Topology}
 import sage.client.internal.Client
+import sage.commands.Commands
 import sage.integration.{ContainerClient, Images}
 
 /**
@@ -24,7 +25,7 @@ import sage.integration.{ContainerClient, Images}
   * The cost is fixed host ports (7100-7105), which must be free on the host — the only single-host scheme a multi-node cluster admits short of
   * Linux-only host networking.
   */
-abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends munit.FunSuite with TestContainerForAll with ContainerClient {
+abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends munit.FunSuite with TestContainerForEach with ContainerClient {
 
   private val ports  = 7100 to 7105
   private val victim = 7100 // redis-cli --cluster-create makes the first nodes masters, so 7100 is a master with a replica to promote
@@ -140,6 +141,61 @@ abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends
   private def recoverAll(client: Client[CIO, String], keys: Vector[String]): CIO[Boolean] =
     keys.foldLeft(CIO.value(true))((acc, key) => acc.flatMap(ok => if (!ok) CIO.value(false) else recoverKey(client, key, 150)))
 
+  private def recoverCached(client: Client[CIO, String], key: String, attempts: Int): CIO[Boolean] =
+    client
+      .cached(Commands.get[String, String](key), 1.minute)
+      .fold(
+        {
+          case Some(v) if v == key => CIO.value(true)
+          case _ if attempts <= 0  => CIO.value(false)
+          case _                   => CIO.sleep(200.millis).flatMap(_ => recoverCached(client, key, attempts - 1))
+        },
+        _ => if (attempts <= 0) CIO.value(false) else CIO.sleep(200.millis).flatMap(_ => recoverCached(client, key, attempts - 1))
+      )
+
+  private def masterId(container: FixedHostPortGenericContainer, port: Int): String = cli(container, port, "cluster", "myid").trim
+
+  // queried via the victim, so its own line carries the `myself` flag
+  private def clusterNodeLines(container: FixedHostPortGenericContainer): Vector[Array[String]] =
+    parseKeys(cli(container, victim, "cluster", "nodes")).map(_.split("\\s+"))
+
+  private def otherMasterPort(container: FixedHostPortGenericContainer): Int =
+    clusterNodeLines(container).iterator
+      .filter(f => f.length > 2 && f(2).contains("master"))
+      .map(f => f(1).split("@")(0).split(":")(1).toInt)
+      .find(_ != victim)
+      .getOrElse(throw new RuntimeException("no other master found to receive resharded slots"))
+
+  // slot tokens are `start-end` or a single slot; `[...]` migration markers are not owned slots
+  private def slotCount(fields: Array[String]): Int =
+    fields
+      .drop(8)
+      .filterNot(_.startsWith("["))
+      .map { token =>
+        val parts = token.split("-")
+        if (parts.length == 2) parts(1).toInt - parts(0).toInt + 1 else 1
+      }
+      .sum
+
+  private def victimSlotCount(container: FixedHostPortGenericContainer): Int =
+    clusterNodeLines(container).collectFirst { case f if f.length > 2 && f(2).contains("myself") => slotCount(f) }.getOrElse(0)
+
+  private def reshard(container: FixedHostPortGenericContainer, fromId: String, toId: String, slots: Int): String =
+    exec(
+      container,
+      "redis-cli",
+      "--cluster",
+      "reshard",
+      s"127.0.0.1:$victim",
+      "--cluster-from",
+      fromId,
+      "--cluster-to",
+      toId,
+      "--cluster-slots",
+      slots.toString,
+      "--cluster-yes"
+    )
+
   test("the client recovers reads after a master crashes and its replica is promoted") {
     withContainers { container =>
       val seeds  = ports.map(p => Endpoint("127.0.0.1", p)).toVector
@@ -161,6 +217,66 @@ abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends
             } yield {
               assert(onVictim.nonEmpty, "no keys landed on the victim master; cannot prove failover recovery")
               assert(recovered, "client did not recover the victim master's keys after its replica was promoted")
+            }
+          }
+        }
+      program.unsafeRun
+    }
+  }
+
+  test("a cached read follows MOVED to the new owner after its slot is resharded off its master") {
+    withContainers { container =>
+      val seeds  = ports.map(p => Endpoint("127.0.0.1", p)).toVector
+      val config = SageConfig(topology = Topology.Cluster(seeds, ClusterConfig(minRefreshInterval = 500.millis)))
+      val keys   = (1 to 30).map(i => s"reshard:$i").toVector
+
+      val program =
+        formCluster(container).flatMap { _ =>
+          connectAndUse(config) { client =>
+            for {
+              _         <- writeAll(client, keys)
+              onVictim  <- CIO.blocking(parseKeys(cli(container, victim, "keys", "*")))
+              probe      = onVictim.head
+              first     <- client.cached(Commands.get[String, String](probe), 1.minute)
+              fromId    <- CIO.blocking(masterId(container, victim))
+              toPort    <- CIO.blocking(otherMasterPort(container))
+              toId      <- CIO.blocking(masterId(container, toPort))
+              moved     <- CIO.blocking(victimSlotCount(container))
+              _         <- CIO.blocking(reshard(container, fromId, toId, moved))
+              _         <- awaitClusterOk(container, 60)
+              recovered <- recoverCached(client, probe, 150)
+            } yield {
+              assert(onVictim.nonEmpty, "no keys landed on the victim master; cannot prove reshard recovery")
+              assertEquals(first, Some(probe))
+              assert(recovered, "cached read did not follow MOVED to the resharded slot's new owner")
+            }
+          }
+        }
+      program.unsafeRun
+    }
+  }
+
+  test("a cached read recovers from the promoted master after a failover, never serving the dead master's entry") {
+    withContainers { container =>
+      val seeds  = ports.map(p => Endpoint("127.0.0.1", p)).toVector
+      val config = SageConfig(topology = Topology.Cluster(seeds, ClusterConfig(minRefreshInterval = 500.millis)))
+      val keys   = (1 to 30).map(i => s"cachedfailover:$i").toVector
+
+      val program =
+        formCluster(container).flatMap { _ =>
+          connectAndUse(config) { client =>
+            for {
+              _           <- writeAll(client, keys)
+              onVictim    <- CIO.blocking(parseKeys(cli(container, victim, "keys", "*")))
+              probe        = onVictim.head
+              _           <- client.cached(Commands.get[String, String](probe), 1.minute)
+              replicaPort <- CIO.blocking(victimReplicaPort(container))
+              _           <- awaitReplicated(container, replicaPort, onVictim.toSet, 100)
+              _           <- CIO.blocking(Try(cli(container, victim, "shutdown", "nosave")))
+              recovered   <- recoverCached(client, probe, 150)
+            } yield {
+              assert(onVictim.nonEmpty, "no keys landed on the victim master; cannot prove cached failover recovery")
+              assert(recovered, "cached read did not recover from the promoted master after the victim crashed")
             }
           }
         }

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
@@ -65,6 +65,12 @@ abstract class ClusterSuite(image: String, serverBinary: String, supportsNumbere
       else CIO.sleep(100.millis).flatMap(_ => awaitClusterOk(admin0, attempts - 1))
     }
 
+  private def awaitCached(client: Client[CIO, String], key: String, expected: String, attempts: Int): CIO[Option[String]] =
+    client.cached(Commands.get[String, String](key), 1.minute).flatMap { value =>
+      if (value.contains(expected) || attempts <= 1) CIO.value(value)
+      else CIO.sleep(100.millis).flatMap(_ => awaitCached(client, key, expected, attempts - 1))
+    }
+
   // one shared container per suite, so the cluster is formed once and all routing exercised in a single test
   test("single-key commands, pipelines, and transactions route against a real cluster") {
     withContainers { server =>
@@ -249,6 +255,35 @@ abstract class ClusterSuite(image: String, serverBinary: String, supportsNumbere
               fcall match {
                 case Frame.BulkString(b) => assertEquals(b.asUtf8String, "v")
                 case other               => fail(s"expected bulk string, got $other")
+              }
+            }
+          }
+        }
+      program.unsafeRun
+    }
+  }
+
+  test("a cluster cached read is served locally and a server-side write evicts it via invalidation") {
+    withContainers { server =>
+      val host       = server.host
+      val port       = server.mappedPort(6379)
+      val standalone = SageConfig(topology = Topology.Standalone(Endpoint(host, port)))
+      val clustered  = SageConfig(topology = Topology.Cluster(Vector(Endpoint(host, port))))
+
+      val program =
+        connectAndUse(standalone)(formSingleNodeCluster(_, host, port)).flatMap { _ =>
+          connectAndUse(clustered) { reader =>
+            connectAndUse(clustered) { writer =>
+              for {
+                _       <- writer.set("csc:cluster", "v1")
+                first   <- reader.cached(Commands.get[String, String]("csc:cluster"), 1.minute)
+                hit     <- reader.cached(Commands.get[String, String]("csc:cluster"), 1.minute)
+                _       <- writer.set("csc:cluster", "v2")
+                evicted <- awaitCached(reader, "csc:cluster", "v2", attempts = 50)
+              } yield {
+                assertEquals(first, Some("v1"))
+                assertEquals(hit, Some("v1"))
+                assertEquals(evicted, Some("v2"))
               }
             }
           }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Bootstrap.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Bootstrap.scala
@@ -62,5 +62,6 @@ private[client] object Bootstrap {
     * rather than fail the connection (ADR-0045). Every other bootstrap command is load-bearing, so its failure stays fatal.
     */
   private def bestEffort(command: Command[?]): Boolean =
-    command.name == "CLIENT" && command.args.headOption.map(_.asUtf8String).exists(sub => sub == "SETINFO" || sub == "TRACKING")
+    Connection.isClientTracking(command) ||
+      (command.name == "CLIENT" && command.args.headOption.exists(_.asUtf8String == "SETINFO"))
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Bootstrap.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Bootstrap.scala
@@ -29,14 +29,16 @@ private[client] object Bootstrap {
     * Runs the connection-setup handshake on a freshly opened connection: submits each command in turn and blocks for its reply up to
     * `connectTimeoutMillis`, then closes the half-built connection and throws on a timeout or a failed reply so the caller discards it.
     * `submit` enqueues one command and delivers its decoded reply; replies are FIFO, so each command is awaited before the next is sent.
-    * A [[bestEffort]] command whose reply is a `ServerError` is tolerated rather than fatal; a `ConnectionLost`/`DecodeError` stays fatal
-    * even for it. Used by the Multiplexed, Dedicated, and Subscription connections, which differ only in how a reply is obtained.
+    * A [[bestEffort]] command whose reply is a `ServerError` is tolerated rather than fatal (and reported to `onTolerated`); a
+    * `ConnectionLost`/`DecodeError` stays fatal even for it. Used by the Multiplexed, Dedicated, and Subscription connections, which differ
+    * only in how a reply is obtained.
     */
   def run(
     commands: Vector[Command[?]],
     connectTimeoutMillis: Long,
     submit: (Command[?], Try[Any] => Unit) => Unit,
-    close: () => Unit
+    close: () => Unit,
+    onTolerated: Command[?] => Unit = _ => ()
   ): Unit =
     commands.foreach { command =>
       val latch   = new CountDownLatch(1)
@@ -47,17 +49,18 @@ private[client] object Bootstrap {
         throw ConnectionLost(mayHaveExecuted = false)
       }
       outcome.get() match {
-        case Failure(_: ServerError) if bestEffort(command) => ()
+        case Failure(_: ServerError) if bestEffort(command) => onTolerated(command)
         case Failure(error)                                 => close(); throw error
         case Success(_)                                     => ()
       }
     }
 
   /**
-    * Whether a server-error reply to this command may be tolerated during bootstrap. Only `CLIENT SETINFO` qualifies: it is library
-    * identification added in Redis 7.2, so an older server rejects it with an error every client ignores. Every other bootstrap command is
-    * load-bearing, so its failure stays fatal.
+    * Whether a server-error reply to this command may be tolerated during bootstrap. `CLIENT SETINFO` qualifies because it is library
+    * identification added in Redis 7.2, so an older server rejects it with an error every client ignores. `CLIENT TRACKING` qualifies because
+    * a server that permits `HELLO` but denies tracking (an ACL restriction, a proxy) should still connect and serve cached reads uncached
+    * rather than fail the connection (ADR-0045). Every other bootstrap command is load-bearing, so its failure stays fatal.
     */
   private def bestEffort(command: Command[?]): Boolean =
-    command.name == "CLIENT" && command.args.headOption.exists(_.asUtf8String == "SETINFO")
+    command.name == "CLIENT" && command.args.headOption.map(_.asUtf8String).exists(sub => sub == "SETINFO" || sub == "TRACKING")
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2048,8 +2048,9 @@ trait Client[F[_], K] extends CommandRunner[F, K] {
     * Runs a read with client-side caching: served from the local cache until a server invalidation push or `ttl` evicts it. Only a
     * cacheable command with at least one key qualifies — a read whose result is a pure function of its keys' state, so an invalidation
     * covers every change. A write, a keyless read, or a time-varying/non-deterministic read (`TTL`, `SRANDMEMBER`) fails with
-    * [[sage.SageException.NotCacheable]]. On a cluster client this currently runs the read without caching, so the same call stays
-    * topology-portable.
+    * [[sage.SageException.NotCacheable]]. The read is always served from the master (never a replica, whatever the `ReadFrom` policy); in a
+    * cluster each slot-owning master owns an independent cache. Caching is transparent to the call, so it stays topology-portable: with caching
+    * disabled, or against a server that rejects tracking, the same call simply runs uncached.
     */
   def cached[A](command: Command[A], ttl: FiniteDuration): F[A]
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
@@ -18,12 +18,13 @@ final private[client] class ClientCache(maxBytes: Long) {
   import ClientCache.*
   import ClientCache.Acquire.*
 
-  private val lock            = new ReentrantLock()
+  private val lock                             = new ReentrantLock()
   // accessOrder = true: a lookup promotes the entry to most-recently-used, so eviction sheds the genuinely cold entries
-  private val entries         = new java.util.LinkedHashMap[Key, Entry](16, 0.75f, true)
-  private val reverse         = mutable.HashMap.empty[Key, mutable.HashSet[Key]]
-  private val pending         = mutable.HashMap.empty[Key, InFlight]
-  private var bytesUsed: Long = 0L
+  private val entries                          = new java.util.LinkedHashMap[Key, Entry](16, 0.75f, true)
+  private val reverse                          = mutable.HashMap.empty[Key, mutable.HashSet[Key]]
+  private val pending                          = mutable.HashMap.empty[Key, InFlight]
+  private var bytesUsed: Long                  = 0L
+  @volatile private var generation: CacheEpoch = CacheEpoch.initial
 
   /**
     * Tries to serve `commandBytes` from cache. [[Hit]] returns the stored frame (decode it and complete the caller). [[Fetch]] means the
@@ -36,7 +37,7 @@ final private[client] class ClientCache(maxBytes: Long) {
       val key   = new Key(commandBytes)
       val entry = entries.get(key)
       if (entry != null) {
-        if (entry.expiresAt > now) return Hit(entry.frame)
+        if (entry.expiresAt > now) return Hit(entry.frame, generation)
         removeEntry(key, entry)
       }
       pending.get(key) match {
@@ -99,8 +100,11 @@ final private[client] class ClientCache(maxBytes: Long) {
       reverse.clear()
       bytesUsed = 0L
       pending.valuesIterator.foreach(_.dirty = true)
+      generation = generation.next
     } finally lock.unlock()
   }
+
+  def isCurrent(epoch: CacheEpoch): Boolean = generation == epoch
 
   private def insert(key: Key, entry: Entry): Unit = {
     val previous = entries.put(key, entry)
@@ -147,8 +151,14 @@ private[client] object ClientCache {
     }
   }
 
+  opaque type CacheEpoch = Long
+  object CacheEpoch {
+    val initial: CacheEpoch = 0L
+  }
+  extension (e: CacheEpoch) def next: CacheEpoch = e + 1L
+
   enum Acquire {
-    case Hit(frame: Frame)
+    case Hit(frame: Frame, epoch: CacheEpoch)
     case Fetch
     case Wait
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
@@ -18,13 +18,14 @@ final private[client] class ClientCache(maxBytes: Long) {
   import ClientCache.*
   import ClientCache.Acquire.*
 
-  private val lock                        = new ReentrantLock()
+  private val lock                                   = new ReentrantLock()
   // accessOrder = true: a lookup promotes the entry to most-recently-used, so eviction sheds the genuinely cold entries
-  private val entries                     = new java.util.LinkedHashMap[Key, Entry](16, 0.75f, true)
-  private val reverse                     = mutable.HashMap.empty[Key, mutable.HashSet[Key]]
-  private val pending                     = mutable.HashMap.empty[Key, InFlight]
-  private var bytesUsed: Long             = 0L
-  @volatile private var epoch: CacheEpoch = CacheEpoch.initial
+  private val entries                                = new java.util.LinkedHashMap[Key, Entry](16, 0.75f, true)
+  private val reverse                                = mutable.HashMap.empty[Key, mutable.HashSet[Key]]
+  private val pending                                = mutable.HashMap.empty[Key, InFlight]
+  private var bytesUsed: Long                        = 0L
+  @volatile private var epoch: CacheEpoch            = CacheEpoch.initial
+  @volatile private var rerouteWatermark: CacheEpoch = CacheEpoch.initial
 
   /**
     * Tries to serve `commandBytes` from cache. [[Hit]] returns the stored frame (decode it and complete the caller). [[Fetch]] means the
@@ -95,16 +96,27 @@ final private[client] class ClientCache(maxBytes: Long) {
 
   def flush(): Unit = {
     lock.lock()
-    try {
-      entries.clear()
-      reverse.clear()
-      bytesUsed = 0L
-      pending.valuesIterator.foreach(_.dirty = true)
-      epoch = epoch.next
-    } finally lock.unlock()
+    try clearAndBump()
+    finally lock.unlock()
+  }
+
+  def flushForReroute(): Unit = {
+    lock.lock()
+    try { clearAndBump(); rerouteWatermark = epoch }
+    finally lock.unlock()
+  }
+
+  private def clearAndBump(): Unit = {
+    entries.clear()
+    reverse.clear()
+    bytesUsed = 0L
+    pending.valuesIterator.foreach(_.dirty = true)
+    epoch = epoch.next
   }
 
   def isCurrent(stamped: CacheEpoch): Boolean = epoch == stamped
+
+  def rerouteRetired(stamped: CacheEpoch): Boolean = rerouteWatermark.isAfter(stamped)
 
   private def insert(key: Key, entry: Entry): Unit = {
     val previous = entries.put(key, entry)
@@ -155,7 +167,10 @@ private[client] object ClientCache {
   object CacheEpoch {
     val initial: CacheEpoch = 0L
   }
-  extension (e: CacheEpoch) def next: CacheEpoch = e + 1L
+  extension (e: CacheEpoch) {
+    def next: CacheEpoch                    = e + 1L
+    def isAfter(other: CacheEpoch): Boolean = e > other
+  }
 
   enum Acquire {
     case Hit(frame: Frame, epoch: CacheEpoch)

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
@@ -96,22 +96,26 @@ final private[client] class ClientCache(maxBytes: Long) {
 
   def flush(): Unit = {
     lock.lock()
-    try clearAndBump()
+    try { clearEntries(); epoch = epoch.next }
     finally lock.unlock()
   }
 
   def flushForReroute(): Unit = {
     lock.lock()
-    try { clearAndBump(); rerouteWatermark = epoch }
-    finally lock.unlock()
+    try {
+      clearEntries()
+      val retired = epoch.next
+      // publish the watermark before the epoch a reader tests first, so it can never see the new epoch with the stale watermark
+      rerouteWatermark = retired
+      epoch = retired
+    } finally lock.unlock()
   }
 
-  private def clearAndBump(): Unit = {
+  private def clearEntries(): Unit = {
     entries.clear()
     reverse.clear()
     bytesUsed = 0L
     pending.valuesIterator.foreach(_.dirty = true)
-    epoch = epoch.next
   }
 
   def isCurrent(stamped: CacheEpoch): Boolean = epoch == stamped

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
@@ -18,13 +18,13 @@ final private[client] class ClientCache(maxBytes: Long) {
   import ClientCache.*
   import ClientCache.Acquire.*
 
-  private val lock                             = new ReentrantLock()
+  private val lock                        = new ReentrantLock()
   // accessOrder = true: a lookup promotes the entry to most-recently-used, so eviction sheds the genuinely cold entries
-  private val entries                          = new java.util.LinkedHashMap[Key, Entry](16, 0.75f, true)
-  private val reverse                          = mutable.HashMap.empty[Key, mutable.HashSet[Key]]
-  private val pending                          = mutable.HashMap.empty[Key, InFlight]
-  private var bytesUsed: Long                  = 0L
-  @volatile private var generation: CacheEpoch = CacheEpoch.initial
+  private val entries                     = new java.util.LinkedHashMap[Key, Entry](16, 0.75f, true)
+  private val reverse                     = mutable.HashMap.empty[Key, mutable.HashSet[Key]]
+  private val pending                     = mutable.HashMap.empty[Key, InFlight]
+  private var bytesUsed: Long             = 0L
+  @volatile private var epoch: CacheEpoch = CacheEpoch.initial
 
   /**
     * Tries to serve `commandBytes` from cache. [[Hit]] returns the stored frame (decode it and complete the caller). [[Fetch]] means the
@@ -37,7 +37,7 @@ final private[client] class ClientCache(maxBytes: Long) {
       val key   = new Key(commandBytes)
       val entry = entries.get(key)
       if (entry != null) {
-        if (entry.expiresAt > now) return Hit(entry.frame, generation)
+        if (entry.expiresAt > now) return Hit(entry.frame, epoch)
         removeEntry(key, entry)
       }
       pending.get(key) match {
@@ -100,11 +100,11 @@ final private[client] class ClientCache(maxBytes: Long) {
       reverse.clear()
       bytesUsed = 0L
       pending.valuesIterator.foreach(_.dirty = true)
-      generation = generation.next
+      epoch = epoch.next
     } finally lock.unlock()
   }
 
-  def isCurrent(epoch: CacheEpoch): Boolean = generation == epoch
+  def isCurrent(stamped: CacheEpoch): Boolean = epoch == stamped
 
   private def insert(key: Key, entry: Entry): Unit = {
     val previous = entries.put(key, entry)

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -591,7 +591,9 @@ final private[client] class ClusterLive(
     complete: Try[A] => Unit,
     lease: DedicatedPool.Lease = null,
     cacheCtx: Cached = null
-  ): Unit =
+  ): Unit = {
+    // a MOVED proves `from` lost the slot; retire its cache even if the retry budget is now exhausted
+    if (redirect.kind == RedirectKind.Moved) flushNode(from)
     if (redirectsLeft <= 0)
       complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
     else {
@@ -601,6 +603,7 @@ final private[client] class ClusterLive(
         case RedirectKind.Ask   => sendTo(target, command, asking = true, redirectsLeft - 1, complete, lease, cacheCtx)
       }
     }
+  }
 
   // the command provably never executed: refresh to adopt the promoted master, then re-route. Jittered backoff paces retries so an in-progress
   // failover is not hammered; redirectsLeft bounds it.
@@ -1095,6 +1098,9 @@ final private[client] class ClusterLive(
 
   private def getOrEstablish(node: Node): NodeClient = masterPool.getOrEstablish(node)
 
+  private def flushNode(node: Node): Unit =
+    if (cachingEnabled) { val nc = masterPool.existing(node); if (nc != null) nc.flushCache() }
+
   // --- topology refresh (single-flight, throttled) -------------------------------------------------------------------------------------
 
   private def triggerRefresh(): Unit = offload(refresh(force = false))
@@ -1135,6 +1141,8 @@ final private[client] class ClusterLive(
     val oldTopology  = topologyRef.get()
     val previous     = if (events.emitsEvents) slotOwningMasters(oldTopology).toSet else Set.empty[Node]
     val newTopology  = ClusterTopology.from(resolved)
+    // retire losing masters' caches before the new topology is published
+    if (cachingEnabled) newTopology.mastersLosingSlots(oldTopology).foreach(flushNode)
     topologyRef.set(newTopology)
     // skip the empty -> populated bootstrap transition: discovering the topology at connect is not a change
     if (events.emitsEvents && previous.nonEmpty) {
@@ -1147,11 +1155,6 @@ final private[client] class ClusterLive(
     val replicaNodes = resolved.iterator.flatMap(_.replicas).toSet
     replicaPool.retain(replicaNodes.contains)
     replicaCursors.keySet.removeIf(node => !masters.contains(node))
-    if (cachingEnabled)
-      newTopology.mastersLosingSlots(oldTopology).foreach { node =>
-        val nc = masterPool.existing(node)
-        if (nc != null) nc.flushCache()
-      }
     // re-home shard subscriptions only when slot ownership changed; else a forced refresh mid-failover loops (refresh -> adopt -> reconcile ->
     // refresh) at RTT. A classic subscription follows the cluster bus, so it re-homes only when its pinned master's socket drops, never here.
     if (!newTopology.sameOwnership(oldTopology)) subscriptions.onTopologyChanged()

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -1112,8 +1112,8 @@ final private[client] class ClusterLive(
     refreshThrottle(force) {
       querySlots(refreshCandidates()) match {
         case Some((from, shards)) => adopt(from, shards)
-        // only a forced refresh treats unanswered CLUSTER SLOTS as lost topology worth flushing every cache for
-        case None                 => if (cachingEnabled && force) masterPool.foreachEstablished(_.flushCache())
+        // no candidate answered CLUSTER SLOTS: ownership is unknowable, so retire every cache
+        case None                 => if (cachingEnabled) masterPool.foreachEstablished(_.flushCache())
       }
     }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -196,6 +196,9 @@ final private[client] class ClusterLive(
 
   final private case class Cached(ttlMillis: Long, deferred: () => CommandSpan)
 
+  // a cached read is master-pinned, so it may use a replica only when there is no cache context
+  private def replicaAllowed(cacheCtx: Cached): Boolean = cacheCtx == null
+
   private def dispatch[A](
     command: Command[A],
     redirectsLeft: Int,
@@ -619,7 +622,7 @@ final private[client] class ClusterLive(
       refresh(force = true)
       val attempt = (cluster.maxRedirects - redirectsLeft).max(0)
       scheduler.after(Backoff.jitteredMillis(reconnect, attempt, scheduler).millis)(
-        dispatch(command, redirectsLeft - 1, complete, allowReplica = cacheCtx == null, lease = lease, cacheCtx = cacheCtx)
+        dispatch(command, redirectsLeft - 1, complete, allowReplica = replicaAllowed(cacheCtx), lease = lease, cacheCtx = cacheCtx)
       )
     }
 
@@ -636,14 +639,14 @@ final private[client] class ClusterLive(
     else {
       val attempt = (cluster.maxRedirects - redirectsLeft).max(0)
       scheduler.after(Backoff.jitteredMillis(reconnect, attempt, scheduler).millis)(
-        dispatch(command, redirectsLeft - 1, complete, allowReplica = cacheCtx == null, lease = lease, cacheCtx = cacheCtx)
+        dispatch(command, redirectsLeft - 1, complete, allowReplica = replicaAllowed(cacheCtx), lease = lease, cacheCtx = cacheCtx)
       )
     }
 
   private def onUnowned[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit, lease: DedicatedPool.Lease, cacheCtx: Cached): Unit = {
     refresh(force = false)
     val topology     = topologyRef.get()
-    val allowReplica = cacheCtx == null // cached reads are master-pinned
+    val allowReplica = replicaAllowed(cacheCtx)
     topology.route(command) match {
       // re-apply the read policy: an eligible read must still go to a replica once the slot resolves, not be pinned to its master
       case Route.ToNode(node, slot)                                                                  =>

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -45,7 +45,9 @@ final private[client] class ClusterLive(
   pubsubBufferSize: Int,
   seeds: Vector[Node],
   readFrom: ReadFrom = ReadFrom.Master,
-  events: Events = Events.disabled
+  events: Events = Events.disabled,
+  cachingEnabled: Boolean = false,
+  cacheMaxBytes: Long = 0L
 ) extends Client[CIO, String] {
 
   private val topologyRef = new AtomicReference[ClusterTopology](ClusterTopology.from(Vector.empty))
@@ -84,13 +86,15 @@ final private[client] class ClusterLive(
   private val masterPool       = new NodePool(
     nodeFactory,
     scheduler,
-    bootstrap,
+    if (cachingEnabled) bootstrap :+ Connection.clientTrackingOnOptin else bootstrap,
     reconnect,
     watchdog,
     connectTimeout,
     closeTimeout,
     dedicatedPool,
-    events = events
+    cacheMaxBytes = if (cachingEnabled) cacheMaxBytes else 0L,
+    events = events,
+    dedicatedBootstrap = Some(bootstrap)
   )
   // set once by close; routing refuses afterwards, so close is terminal like the standalone client's
   @volatile private var closed = false
@@ -126,15 +130,20 @@ final private[client] class ClusterLive(
     else CIO.acquireReleaseWith(CIO.defer(new DedicatedPool.Lease))(lease => CIO.blocking(lease.cancel()))(body)
   }
 
-  // caching is not applied in cluster mode (per-node tracking through redirects/failover is unsupported): the read runs uncached but on the
-  // master (allowReplica = false), so it never honors ReadFrom and the call stays portable; the cacheability guard still applies
   def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =
     if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command))
-    else
+    else if (!cachingEnabled)
       CIO.async[A] { complete =>
         val span    = Events.startSpan(events, command)
         val tracked = Events.trackCommand(events, command, complete, span)
         Client.completing(tracked)(dispatch(command, cluster.maxRedirects, tracked, allowReplica = false))
+      }
+    else
+      CIO.async[A] { complete =>
+        val deferred = Events.deferSpan(events, command)
+        Client.completing(complete)(
+          dispatch(command, cluster.maxRedirects, complete, allowReplica = false, cacheCtx = Cached(ttl.toMillis, deferred))
+        )
       }
 
   // SCAN cursors are node-local, so a full SCAN must sweep every slot-owning master; a reshard mid-scan can still miss or duplicate keys
@@ -185,12 +194,15 @@ final private[client] class ClusterLive(
 
   // --- routing -------------------------------------------------------------------------------------------------------------------------
 
+  final private case class Cached(ttlMillis: Long, deferred: () => CommandSpan)
+
   private def dispatch[A](
     command: Command[A],
     redirectsLeft: Int,
     complete: Try[A] => Unit,
     allowReplica: Boolean = true,
-    lease: DedicatedPool.Lease = null
+    lease: DedicatedPool.Lease = null,
+    cacheCtx: Cached = null
   ): Unit =
     if (closed) complete(Failure(NotConnected()))
     else {
@@ -214,15 +226,15 @@ final private[client] class ClusterLive(
           case Route.ToNode(node, slot) =>
             if (allowReplica && readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command))
               sendRead(command, node, slot, redirectsLeft, complete)
-            else sendTo(node, command, asking = false, redirectsLeft, complete, lease)
+            else sendTo(node, command, asking = false, redirectsLeft, complete, lease, cacheCtx)
           case Route.Keyless            =>
             if (allowReplica && readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command))
               sendKeylessRead(topology, command, redirectsLeft, complete)
-            else sendToAny(topology, command, redirectsLeft, complete, lease)
-          case Route.Unowned(_)         => offload(onUnowned(command, redirectsLeft, complete, lease))
+            else sendToAny(topology, command, redirectsLeft, complete, lease, cacheCtx)
+          case Route.Unowned(_)         => offload(onUnowned(command, redirectsLeft, complete, lease, cacheCtx))
           case Route.CrossSlot(slots)   =>
             multiSlotPolicy(command) match {
-              case Some(policy) => scatterMultiSlot(command, policy, redirectsLeft, complete, allowReplica)
+              case Some(policy) => scatterMultiSlot(command, policy, redirectsLeft, complete, allowReplica, cacheCtx)
               case None         => complete(Failure(crossSlot(command.name, slots)))
             }
           case Route.Malformed          =>
@@ -247,7 +259,8 @@ final private[client] class ClusterLive(
     policy: MultiSlotPolicy,
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    allowReplica: Boolean
+    allowReplica: Boolean,
+    cacheCtx: Cached
   ): Unit = {
     val bySlot = mutable.LinkedHashMap.empty[Slot, mutable.ArrayBuffer[MultiSlotEntry]]
     command.keyIndices.iterator.zipWithIndex.foreach { case (argIndex, resultIndex) =>
@@ -312,7 +325,7 @@ final private[client] class ClusterLive(
         keyIndices = Vector.tabulate(group.size)(_ * policy.argsPerKey),
         args = args.result()
       )
-      dispatch(sub, redirectsLeft, result => settle(group, result), allowReplica = allowReplica)
+      dispatch(sub, redirectsLeft, result => settle(group, result), allowReplica = allowReplica, cacheCtx = cacheCtx)
     }
   }
 
@@ -506,10 +519,11 @@ final private[client] class ClusterLive(
     command: Command[A],
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    lease: DedicatedPool.Lease = null
+    lease: DedicatedPool.Lease = null,
+    cacheCtx: Cached = null
   ): Unit =
     pickNode(topology) match {
-      case Some(node) => sendTo(node, command, asking = false, redirectsLeft, complete, lease)
+      case Some(node) => sendTo(node, command, asking = false, redirectsLeft, complete, lease, cacheCtx)
       case None       => complete(Failure(NotConnected()))
     }
 
@@ -519,17 +533,18 @@ final private[client] class ClusterLive(
     asking: Boolean,
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    lease: DedicatedPool.Lease
+    lease: DedicatedPool.Lease,
+    cacheCtx: Cached = null
   ): Unit = {
     val existing = masterPool.existing(node)
-    if (existing != null) submitTo(existing, node, command, asking, redirectsLeft, complete, lease)
+    if (existing != null) submitTo(existing, node, command, asking, redirectsLeft, complete, lease, cacheCtx)
     else
       offload {
         val nc =
           try getOrEstablish(node)
           catch { case NonFatal(_) => null }
-        if (nc == null) onUnreachable(command, redirectsLeft, complete, lease)
-        else submitTo(nc, node, command, asking, redirectsLeft, complete, lease)
+        if (nc == null) onUnreachable(command, redirectsLeft, complete, lease, cacheCtx)
+        else submitTo(nc, node, command, asking, redirectsLeft, complete, lease, cacheCtx)
       }
   }
 
@@ -540,17 +555,16 @@ final private[client] class ClusterLive(
     asking: Boolean,
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    lease: DedicatedPool.Lease
-  ): Unit =
-    nc.submit[A](
-      command,
-      asking,
-      {
-        case Success(value) => Events.attributeNode(complete, node); complete(Success(value))
-        case Failure(error) => offload(onFailure(node, command, error, redirectsLeft, complete, lease))
-      },
-      lease
-    )
+    lease: DedicatedPool.Lease,
+    cacheCtx: Cached
+  ): Unit = {
+    val onReply: Try[A] => Unit = {
+      case Success(value) => Events.attributeNode(complete, node); complete(Success(value))
+      case Failure(error) => offload(onFailure(node, command, error, redirectsLeft, complete, lease, cacheCtx))
+    }
+    if (cacheCtx != null && !asking) nc.cachedSubmit[A](command, cacheCtx.ttlMillis, onReply, cacheCtx.deferred)
+    else nc.submit[A](command, asking, onReply, lease)
+  }
 
   private def onFailure[A](
     node: Node,
@@ -558,12 +572,13 @@ final private[client] class ClusterLive(
     error: Throwable,
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    lease: DedicatedPool.Lease
+    lease: DedicatedPool.Lease,
+    cacheCtx: Cached
   ): Unit =
     Fault.categorize(error) match {
-      case Fault.Redirected(redirect)       => onRedirect(node, redirect, command, redirectsLeft, complete, lease)
-      case Fault.Lost(false)                => onUnreachable(command, redirectsLeft, complete, lease)
-      case Fault.TryAgain                   => onTryAgain(command, error, redirectsLeft, complete, lease)
+      case Fault.Redirected(redirect)       => onRedirect(node, redirect, command, redirectsLeft, complete, lease, cacheCtx)
+      case Fault.Lost(false)                => onUnreachable(command, redirectsLeft, complete, lease, cacheCtx)
+      case Fault.TryAgain                   => onTryAgain(command, error, redirectsLeft, complete, lease, cacheCtx)
       case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error))
       case Fault.Fatal                      => Events.attributeNode(complete, node); complete(Failure(error))
     }
@@ -574,26 +589,35 @@ final private[client] class ClusterLive(
     command: Command[A],
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    lease: DedicatedPool.Lease = null
+    lease: DedicatedPool.Lease = null,
+    cacheCtx: Cached = null
   ): Unit =
     if (redirectsLeft <= 0)
       complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
     else {
       val target = resolve(redirect.target, from)
       redirect.kind match {
-        case RedirectKind.Moved => triggerRefresh(); sendTo(target, command, asking = false, redirectsLeft - 1, complete, lease)
-        case RedirectKind.Ask   => sendTo(target, command, asking = true, redirectsLeft - 1, complete, lease)
+        case RedirectKind.Moved => triggerRefresh(); sendTo(target, command, asking = false, redirectsLeft - 1, complete, lease, cacheCtx)
+        case RedirectKind.Ask   => sendTo(target, command, asking = true, redirectsLeft - 1, complete, lease, cacheCtx)
       }
     }
 
   // the command provably never executed: refresh to adopt the promoted master, then re-route. Jittered backoff paces retries so an in-progress
   // failover is not hammered; redirectsLeft bounds it.
-  private def onUnreachable[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit, lease: DedicatedPool.Lease = null): Unit =
+  private def onUnreachable[A](
+    command: Command[A],
+    redirectsLeft: Int,
+    complete: Try[A] => Unit,
+    lease: DedicatedPool.Lease = null,
+    cacheCtx: Cached = null
+  ): Unit =
     if (redirectsLeft <= 0) complete(Failure(NotConnected()))
     else {
       refresh(force = true)
       val attempt = (cluster.maxRedirects - redirectsLeft).max(0)
-      scheduler.after(Backoff.jitteredMillis(reconnect, attempt, scheduler).millis)(dispatch(command, redirectsLeft - 1, complete, lease = lease))
+      scheduler.after(Backoff.jitteredMillis(reconnect, attempt, scheduler).millis)(
+        dispatch(command, redirectsLeft - 1, complete, allowReplica = cacheCtx == null, lease = lease, cacheCtx = cacheCtx)
+      )
     }
 
   // -TRYAGAIN is a transient mid-migration refusal: the slot mapping is still valid, so retry (bounded, jittered) without refreshing the topology.
@@ -602,27 +626,32 @@ final private[client] class ClusterLive(
     error: Throwable,
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    lease: DedicatedPool.Lease = null
+    lease: DedicatedPool.Lease = null,
+    cacheCtx: Cached = null
   ): Unit =
     if (redirectsLeft <= 0) complete(Failure(error))
     else {
       val attempt = (cluster.maxRedirects - redirectsLeft).max(0)
-      scheduler.after(Backoff.jitteredMillis(reconnect, attempt, scheduler).millis)(dispatch(command, redirectsLeft - 1, complete, lease = lease))
+      scheduler.after(Backoff.jitteredMillis(reconnect, attempt, scheduler).millis)(
+        dispatch(command, redirectsLeft - 1, complete, allowReplica = cacheCtx == null, lease = lease, cacheCtx = cacheCtx)
+      )
     }
 
-  private def onUnowned[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit, lease: DedicatedPool.Lease): Unit = {
+  private def onUnowned[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit, lease: DedicatedPool.Lease, cacheCtx: Cached): Unit = {
     refresh(force = false)
-    val topology = topologyRef.get()
+    val topology     = topologyRef.get()
+    val allowReplica = cacheCtx == null // cached reads are master-pinned
     topology.route(command) match {
       // re-apply the read policy: an eligible read must still go to a replica once the slot resolves, not be pinned to its master
-      case Route.ToNode(node, slot)                                                  =>
-        if (readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command)) sendRead(command, node, slot, redirectsLeft, complete)
-        else sendTo(node, command, asking = false, redirectsLeft, complete, lease)
+      case Route.ToNode(node, slot)                                                                  =>
+        if (allowReplica && readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command))
+          sendRead(command, node, slot, redirectsLeft, complete)
+        else sendTo(node, command, asking = false, redirectsLeft, complete, lease, cacheCtx)
       // strict Replica must not fall back to a master: refresh and retry (bounded), never sendToAny
-      case _ if readFrom == ReadFrom.Replica && ReadRouting.replicaEligible(command) =>
-        onUnreachable(command, redirectsLeft, complete, lease)
+      case _ if allowReplica && readFrom == ReadFrom.Replica && ReadRouting.replicaEligible(command) =>
+        onUnreachable(command, redirectsLeft, complete, lease, cacheCtx)
       // still unowned after refresh: any master, trusting its reply (a MOVED to follow, or CLUSTERDOWN)
-      case _                                                                         => sendToAny(topology, command, redirectsLeft, complete, lease)
+      case _                                                                                         => sendToAny(topology, command, redirectsLeft, complete, lease, cacheCtx)
     }
   }
 
@@ -1071,7 +1100,12 @@ final private[client] class ClusterLive(
   private def triggerRefresh(): Unit = offload(refresh(force = false))
 
   private def refresh(force: Boolean): Unit =
-    refreshThrottle(force)(querySlots(refreshCandidates()).foreach { case (from, shards) => adopt(from, shards) })
+    refreshThrottle(force) {
+      querySlots(refreshCandidates()) match {
+        case Some((from, shards)) => adopt(from, shards)
+        case None                 => if (cachingEnabled) masterPool.foreachEstablished(_.flushCache())
+      }
+    }
 
   private def refreshCandidates(): Vector[Node] = (masterPool.candidatesByLiveness ++ seeds).distinct
 
@@ -1113,6 +1147,11 @@ final private[client] class ClusterLive(
     val replicaNodes = resolved.iterator.flatMap(_.replicas).toSet
     replicaPool.retain(replicaNodes.contains)
     replicaCursors.keySet.removeIf(node => !masters.contains(node))
+    if (cachingEnabled)
+      newTopology.mastersLosingSlots(oldTopology).foreach { node =>
+        val nc = masterPool.existing(node)
+        if (nc != null) nc.flushCache()
+      }
     // re-home shard subscriptions only when slot ownership changed; else a forced refresh mid-failover loops (refresh -> adopt -> reconcile ->
     // refresh) at RTT. A classic subscription follows the cluster bus, so it re-homes only when its pinned master's socket drops, never here.
     if (!newTopology.sameOwnership(oldTopology)) subscriptions.onTopologyChanged()
@@ -1156,7 +1195,9 @@ private[client] object ClusterLive {
         config.pubsub.bufferSize,
         seeds,
         config.readFrom,
-        events
+        events,
+        config.clientCache.enabled,
+        config.clientCache.maxBytes
       )
       // translate discovery's handshake/TLS failures here rather than via mapError, which the per-backend CIO alias does not reconcile through
       // `Client`'s invariant type parameter

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -1112,7 +1112,8 @@ final private[client] class ClusterLive(
     refreshThrottle(force) {
       querySlots(refreshCandidates()) match {
         case Some((from, shards)) => adopt(from, shards)
-        case None                 => if (cachingEnabled) masterPool.foreachEstablished(_.flushCache())
+        // only a forced refresh treats unanswered CLUSTER SLOTS as lost topology worth flushing every cache for
+        case None                 => if (cachingEnabled && force) masterPool.foreachEstablished(_.flushCache())
       }
     }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -53,6 +53,8 @@ final private[client] class MultiplexedConnection private (
   // reconnect cadence, guarded by `lock` and persisted across generations so a flapping peer keeps backing off (see nextReconnectAttempt)
   private var reconnectAttempt: Int                = 0
   private var liveSinceMillis: Long                = -1L
+  // whether the live generation accepts CLIENT TRACKING; false makes cached reads run uncached
+  @volatile private var trackingActive             = true
 
   private[internal] def setOnLivenessLost(hook: () => Unit): Unit = onLivenessLost = hook
 
@@ -177,12 +179,25 @@ final private[client] class MultiplexedConnection private (
     locked { establishing = conn; if (state == State.Closed) conn.close() }
     try {
       conn.start()
+      var tracking = true
       // reserve(1) per command: submit does not self-increment, so this balances the retire() the reply will trigger. A half-open peer can
       // accept the socket yet never answer HELLO, so the runner bounds each wait and the reconnect loop can't stall on it forever.
-      Bootstrap.run(bootstrap, connectTimeout.toMillis, (c, cb) => { conn.reserve(1); conn.submit(c, cb) }, () => conn.close())
+      Bootstrap.run(
+        bootstrap,
+        connectTimeout.toMillis,
+        (c, cb) => { conn.reserve(1); conn.submit(c, cb) },
+        () => conn.close(),
+        onTolerated = c => if (isTracking(c)) tracking = false
+      )
+      trackingActive = tracking
       conn
     } finally locked { if (establishing eq conn) establishing = null }
   }
+
+  private def isTracking(command: Command[?]): Boolean =
+    command.name == "CLIENT" && command.args.headOption.exists(_.asUtf8String == "TRACKING")
+
+  private[internal] def flushCache(): Unit = { val c = locked(current); if (c != null) c.flushCache() }
 
   private def scheduleReconnect(attempt: Int): Unit = {
     reconnectAttempt = attempt
@@ -298,6 +313,8 @@ final private[client] class MultiplexedConnection private (
     // OPTIN tracking: a cached read writes [CLIENT CACHING YES, <read>] adjacently so only this read is tracked. The read is submitted with
     // an identity decoder so the raw reply Frame reaches the cache; each waiter decodes it with its own command's decoder.
     def cachedSubmit[A](command: Command[A], ttlMillis: Long, callback: Try[A] => Unit, deferred: () => CommandSpan): Unit = {
+      // tracking off: run uncached, releasing one of the two slots reserved for the (now unsent) caching prefix
+      if (!trackingActive) { release(1); uncached(command, callback, deferred); return }
       val commandBytes                = command.encode
       val keys                        = command.keys
       def deliver(frame: Frame): Unit = callback(decodeFrame(command, frame))
@@ -336,6 +353,26 @@ final private[client] class MultiplexedConnection private (
           }
       }
     }
+
+    private def uncached[A](command: Command[A], callback: Try[A] => Unit, deferred: () => CommandSpan): Unit = {
+      val span    = Events.startOrDefer(events, command, deferred)
+      node.foreach(Events.routeSpan(span, _))
+      val started = System.nanoTime()
+      submit(
+        command,
+        { (result: Try[A]) =>
+          if (events.enabled) {
+            val outcome = Outcome.of(result)
+            Events.settleSpan(span, outcome)
+            if (events.emitsEvents)
+              events.emit(SageEvent.CommandCompleted(command.name, node, FiniteDuration(System.nanoTime() - started, NANOSECONDS), outcome))
+          }
+          callback(result)
+        }
+      )
+    }
+
+    def flushCache(): Unit = cache.flush()
 
     def close(): Unit = {
       aborted = true

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -322,13 +322,13 @@ final private[client] class MultiplexedConnection private (
       cache.acquire(commandBytes, keys, scheduler.nowMillis, waiter) match {
         // a Hit serves locally; a Wait coalesces onto an in-flight fetch — both avoid a server round trip, so both are reported as a hit
         // and release the two slots reserved for the (now unsent) fetch
-        case ClientCache.Acquire.Hit(frame) =>
+        case ClientCache.Acquire.Hit(frame, cacheEpoch) =>
           release(2)
-          // don't serve a hit from a generation that was retired between the lookup and here
-          if (terminated) callback(Failure(ConnectionLost(mayHaveExecuted = false)))
+          // a flush between the lookup and here (topology change or connection drop) retires this hit
+          if (!cache.isCurrent(cacheEpoch)) callback(Failure(ConnectionLost(mayHaveExecuted = false)))
           else { if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name)); deliver(frame) }
-        case ClientCache.Acquire.Wait       => release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name))
-        case ClientCache.Acquire.Fetch      =>
+        case ClientCache.Acquire.Wait                   => release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name))
+        case ClientCache.Acquire.Fetch                  =>
           if (events.emitsEvents) events.emit(SageEvent.Cache.Miss(command.name))
           val span                        = Events.startOrDefer(events, command, deferred)
           node.foreach(Events.routeSpan(span, _))

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -187,15 +187,12 @@ final private[client] class MultiplexedConnection private (
         connectTimeout.toMillis,
         (c, cb) => { conn.reserve(1); conn.submit(c, cb) },
         () => conn.close(),
-        onTolerated = c => if (isTracking(c)) tracking = false
+        onTolerated = c => if (Connection.isClientTracking(c)) tracking = false
       )
       trackingActive = tracking
       conn
     } finally locked { if (establishing eq conn) establishing = null }
   }
-
-  private def isTracking(command: Command[?]): Boolean =
-    command.name == "CLIENT" && command.args.headOption.exists(_.asUtf8String == "TRACKING")
 
   private[internal] def flushCache(): Unit = { val c = locked(current); if (c != null) c.flushCache() }
 
@@ -325,7 +322,11 @@ final private[client] class MultiplexedConnection private (
       cache.acquire(commandBytes, keys, scheduler.nowMillis, waiter) match {
         // a Hit serves locally; a Wait coalesces onto an in-flight fetch — both avoid a server round trip, so both are reported as a hit
         // and release the two slots reserved for the (now unsent) fetch
-        case ClientCache.Acquire.Hit(frame) => release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name)); deliver(frame)
+        case ClientCache.Acquire.Hit(frame) =>
+          release(2)
+          // don't serve a hit from a generation that was retired between the lookup and here
+          if (terminated) callback(Failure(ConnectionLost(mayHaveExecuted = false)))
+          else { if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name)); deliver(frame) }
         case ClientCache.Acquire.Wait       => release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name))
         case ClientCache.Acquire.Fetch      =>
           if (events.emitsEvents) events.emit(SageEvent.Cache.Miss(command.name))
@@ -424,6 +425,8 @@ final private[client] class MultiplexedConnection private (
 
     private def onClosed(): Unit = {
       terminated = true
+      // a dropped connection loses all further invalidations, so its cache can no longer be trusted for a hit
+      cache.flush()
       var entry = pending.poll()
       while (entry != null) {
         entry.fail(ConnectionLost(mayHaveExecuted = true))

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -326,8 +326,8 @@ final private[client] class MultiplexedConnection private (
           // and release the two slots reserved for the (now unsent) fetch
           case ClientCache.Acquire.Hit(frame, epoch) =>
             if (cache.isCurrent(epoch)) { release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name)); deliver(frame) }
-            // a flush retired this hit mid-lookup: fail on a dead connection so the caller reroutes, else re-run as a local miss
-            else if (terminated) { release(2); callback(Failure(ConnectionLost(mayHaveExecuted = false))) }
+            // reroute a hit retired by a topology change or a dead connection; refetch here one retired by a server flush (ownership unchanged)
+            else if (terminated || cache.rerouteRetired(epoch)) { release(2); callback(Failure(ConnectionLost(mayHaveExecuted = false))) }
             else attempt()
           case ClientCache.Acquire.Wait              => release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name))
           case ClientCache.Acquire.Fetch             =>
@@ -370,7 +370,7 @@ final private[client] class MultiplexedConnection private (
       }
     }
 
-    def flushCache(): Unit = cache.flush()
+    def flushCache(): Unit = cache.flushForReroute()
 
     def close(): Unit = {
       aborted = true

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import java.util.concurrent.locks.ReentrantLock
 
+import scala.annotation.tailrec
 import scala.concurrent.duration.*
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
@@ -319,58 +320,54 @@ final private[client] class MultiplexedConnection private (
         case Success(frame) => deliver(frame)
         case Failure(error) => callback(Failure(error))
       }
-      cache.acquire(commandBytes, keys, scheduler.nowMillis, waiter) match {
-        // a Hit serves locally; a Wait coalesces onto an in-flight fetch — both avoid a server round trip, so both are reported as a hit
-        // and release the two slots reserved for the (now unsent) fetch
-        case ClientCache.Acquire.Hit(frame, cacheEpoch) =>
-          release(2)
-          // a flush between the lookup and here (topology change or connection drop) retires this hit
-          if (!cache.isCurrent(cacheEpoch)) callback(Failure(ConnectionLost(mayHaveExecuted = false)))
-          else { if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name)); deliver(frame) }
-        case ClientCache.Acquire.Wait                   => release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name))
-        case ClientCache.Acquire.Fetch                  =>
-          if (events.emitsEvents) events.emit(SageEvent.Cache.Miss(command.name))
-          val span                        = Events.startOrDefer(events, command, deferred)
-          node.foreach(Events.routeSpan(span, _))
-          val started                     = System.nanoTime()
-          val raw                         = Command[Frame](command.name, command.keyIndices, command.args, frame => Right(frame))
-          val onReply: Try[Frame] => Unit = { result =>
-            result match {
-              case Success(frame) => cache.store(commandBytes, keys, frame, scheduler.nowMillis, ttlMillis)
-              case Failure(error) => cache.fail(commandBytes, error)
+      @tailrec def attempt(): Unit    =
+        cache.acquire(commandBytes, keys, scheduler.nowMillis, waiter) match {
+          // a Hit serves locally; a Wait coalesces onto an in-flight fetch — both avoid a server round trip, so both are reported as a hit
+          // and release the two slots reserved for the (now unsent) fetch
+          case ClientCache.Acquire.Hit(frame, epoch) =>
+            if (cache.isCurrent(epoch)) { release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name)); deliver(frame) }
+            // a flush retired this hit mid-lookup: fail on a dead connection so the caller reroutes, else re-run as a local miss
+            else if (terminated) { release(2); callback(Failure(ConnectionLost(mayHaveExecuted = false))) }
+            else attempt()
+          case ClientCache.Acquire.Wait              => release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name))
+          case ClientCache.Acquire.Fetch             =>
+            if (events.emitsEvents) events.emit(SageEvent.Cache.Miss(command.name))
+            traced(command, deferred) { settle =>
+              val raw                         = Command[Frame](command.name, command.keyIndices, command.args, frame => Right(frame))
+              val onReply: Try[Frame] => Unit = { result =>
+                result match {
+                  case Success(frame) => cache.store(commandBytes, keys, frame, scheduler.nowMillis, ttlMillis)
+                  case Failure(error) => cache.fail(commandBytes, error)
+                }
+                // the outcome reflects the decoded reply, not the raw identity-decoded frame
+                settle(Outcome.of(result.flatMap(decodeFrame(command, _))))
+              }
+              try submitAll(Vector(Connection.clientCachingYes, raw), Vector(_ => (), onReply.asInstanceOf[Try[Any] => Unit]))
+              catch {
+                // nothing was sent: release the slots the entries won't retire, and fail the fetch as a reply failure would
+                case NonFatal(error) => release(2); onReply(Failure(error))
+              }
             }
-            if (events.enabled) {
-              // the outcome reflects the decoded reply, not the raw identity-decoded frame
-              val outcome = Outcome.of(result.flatMap(decodeFrame(command, _)))
-              Events.settleSpan(span, outcome)
-              if (events.emitsEvents)
-                events.emit(SageEvent.CommandCompleted(command.name, node, FiniteDuration(System.nanoTime() - started, NANOSECONDS), outcome))
-            }
-          }
-          try submitAll(Vector(Connection.clientCachingYes, raw), Vector(_ => (), onReply.asInstanceOf[Try[Any] => Unit]))
-          catch {
-            // nothing was sent: release the slots the entries won't retire, and fail the fetch as a reply failure would
-            case NonFatal(error) => release(2); onReply(Failure(error))
-          }
-      }
+        }
+      attempt()
     }
 
-    private def uncached[A](command: Command[A], callback: Try[A] => Unit, deferred: () => CommandSpan): Unit = {
+    private def uncached[A](command: Command[A], callback: Try[A] => Unit, deferred: () => CommandSpan): Unit =
+      traced(command, deferred)(settle => submit(command, (result: Try[A]) => { settle(Outcome.of(result)); callback(result) }))
+
+    // span and CommandCompleted bookkeeping around a server-bound submit; `send` is handed a settle hook to call with the outcome
+    private def traced(command: Command[?], deferred: () => CommandSpan)(send: ((=> Outcome) => Unit) => Unit): Unit = {
       val span    = Events.startOrDefer(events, command, deferred)
       node.foreach(Events.routeSpan(span, _))
       val started = System.nanoTime()
-      submit(
-        command,
-        { (result: Try[A]) =>
-          if (events.enabled) {
-            val outcome = Outcome.of(result)
-            Events.settleSpan(span, outcome)
-            if (events.emitsEvents)
-              events.emit(SageEvent.CommandCompleted(command.name, node, FiniteDuration(System.nanoTime() - started, NANOSECONDS), outcome))
-          }
-          callback(result)
+      send { outcome =>
+        if (events.enabled) {
+          val settled = outcome
+          Events.settleSpan(span, settled)
+          if (events.emitsEvents)
+            events.emit(SageEvent.CommandCompleted(command.name, node, FiniteDuration(System.nanoTime() - started, NANOSECONDS), settled))
         }
-      )
+      }
     }
 
     def flushCache(): Unit = cache.flush()

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
@@ -30,6 +30,8 @@ final private[client] class NodeClient(connection: MultiplexedConnection, pool: 
   def submitAll(commands: Vector[Command[?]], callbacks: Vector[Try[Any] => Unit]): Boolean =
     connection.submitAll(commands, callbacks)
 
+  def flushCache(): Unit = connection.flushCache()
+
   def acquireForTransaction(): DedicatedConnection = pool.acquireForTransaction()
 
   def releaseTransaction(connection: DedicatedConnection, reusable: Boolean): Unit = pool.releaseTransaction(connection, reusable)

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -57,6 +57,8 @@ final private[client] class NodePool(
 
   def firstLiveNode: Option[Node] = established.asScala.collectFirst { case (node, nc) if nc.isLive => node }
 
+  def foreachEstablished(f: NodeClient => Unit): Unit = established.values.forEach(nc => f(nc))
+
   // live nodes first, so a refresh prefers a known-good node
   def candidatesByLiveness: Vector[Node] = {
     val (live, others) = established.asScala.toVector.partition(_._2.isLive)

--- a/sage-client/shared/src/test/scala/sage/client/internal/BootstrapSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/BootstrapSpec.scala
@@ -47,6 +47,21 @@ class BootstrapSpec extends munit.FunSuite {
     assert(!closed, "connection must stay open when only library identification fails")
   }
 
+  test("a CLIENT TRACKING error is tolerated and reported, so a server that denies tracking still connects (ADR-0045)") {
+    val denied    = Failure(ServerError("ERR", "This instance has cluster support disabled"))
+    var closed    = false
+    var tolerated = Vector.empty[String]
+    Bootstrap.run(
+      Bootstrap.commands(None, 0, None) :+ Connection.clientTrackingOnOptin,
+      connectTimeoutMillis = 1000,
+      submit = (c, cb) => cb(if (c.name == "CLIENT" && c.args.head.asUtf8String == "TRACKING") denied else Success(())),
+      close = () => closed = true,
+      onTolerated = c => tolerated = tolerated :+ s"${c.name} ${c.args.head.asUtf8String}"
+    )
+    assert(!closed, "connection must stay open when only tracking is denied")
+    assertEquals(tolerated, Vector("CLIENT TRACKING"))
+  }
+
   test("a CLIENT SETINFO connection loss is NOT tolerated: it closes and throws") {
     var closed = false
     val thrown = intercept[ConnectionLost] {

--- a/sage-client/shared/src/test/scala/sage/client/internal/ClientCacheSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ClientCacheSpec.scala
@@ -13,6 +13,10 @@ class ClientCacheSpec extends munit.FunSuite {
     var slot: Option[Try[Frame]] = None
     ((r: Try[Frame]) => slot = Some(r), () => slot)
   }
+  private def hitFrame(acquired: ClientCache.Acquire): Frame              = acquired match {
+    case ClientCache.Acquire.Hit(frame, _) => frame
+    case other                             => fail(s"expected a hit, got $other")
+  }
 
   test("first miss fetches, a concurrent miss waits, and the stored reply reaches both") {
     val cache      = new ClientCache(1024)
@@ -24,14 +28,14 @@ class ClientCacheSpec extends munit.FunSuite {
     cache.store(cmd, Vector(key("foo")), frame("bar"), 0L, 1000L)
     assertEquals(get1(), Some(Success(frame("bar"))))
     assertEquals(get2(), Some(Success(frame("bar"))))
-    assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, _ => ()), ClientCache.Acquire.Hit(frame("bar")))
+    assertEquals(hitFrame(cache.acquire(cmd, Vector(key("foo")), 0L, _ => ())), frame("bar"))
   }
 
   test("absolute TTL: a hit before expiry, a refetch at expiry") {
     val cache = new ClientCache(1024)
     val cmd   = key("GET foo")
     cache.store(cmd, Vector(key("foo")), frame("bar"), 0L, 1000L)
-    assertEquals(cache.acquire(cmd, Vector(key("foo")), 999L, _ => ()), ClientCache.Acquire.Hit(frame("bar")))
+    assertEquals(hitFrame(cache.acquire(cmd, Vector(key("foo")), 999L, _ => ())), frame("bar"))
     assertEquals(cache.acquire(cmd, Vector(key("foo")), 1000L, _ => ()), ClientCache.Acquire.Fetch)
   }
 
@@ -52,6 +56,16 @@ class ClientCacheSpec extends munit.FunSuite {
     cache.store(cmd, Vector(key("foo")), frame("bar"), 0L, 10000L)
     cache.flush()
     assertEquals(cache.acquire(cmd, Vector(key("foo")), 0L, _ => ()), ClientCache.Acquire.Fetch)
+  }
+
+  test("a hit carries the epoch it was acquired under, and a flush retires it") {
+    val cache                             = new ClientCache(1024)
+    val cmd                               = key("GET foo")
+    cache.store(cmd, Vector(key("foo")), frame("bar"), 0L, 10000L)
+    val ClientCache.Acquire.Hit(_, epoch) = cache.acquire(cmd, Vector(key("foo")), 0L, _ => ()): @unchecked
+    assert(cache.isCurrent(epoch))
+    cache.flush()
+    assert(!cache.isCurrent(epoch))
   }
 
   test("an invalidation mid-flight delivers the reply but does not cache it") {
@@ -82,6 +96,6 @@ class ClientCacheSpec extends munit.FunSuite {
     cache.store(key("GET a"), Vector(key("a")), big, 0L, 10000L)
     cache.store(key("GET b"), Vector(key("b")), big, 0L, 10000L)
     assertEquals(cache.acquire(key("GET a"), Vector(key("a")), 0L, _ => ()), ClientCache.Acquire.Fetch) // evicted
-    assertEquals(cache.acquire(key("GET b"), Vector(key("b")), 0L, _ => ()), ClientCache.Acquire.Hit(big))
+    assertEquals(hitFrame(cache.acquire(key("GET b"), Vector(key("b")), 0L, _ => ())), big)
   }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/ClientCacheSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ClientCacheSpec.scala
@@ -68,6 +68,22 @@ class ClientCacheSpec extends munit.FunSuite {
     assert(!cache.isCurrent(epoch))
   }
 
+  test("a server flush retires a hit for refetch, a topology flush retires it for reroute") {
+    val cache                              = new ClientCache(1024)
+    val cmd                                = key("GET foo")
+    cache.store(cmd, Vector(key("foo")), frame("bar"), 0L, 10000L)
+    val ClientCache.Acquire.Hit(_, served) = cache.acquire(cmd, Vector(key("foo")), 0L, _ => ()): @unchecked
+    cache.flush()
+    assert(!cache.isCurrent(served))
+    assert(!cache.rerouteRetired(served), "a server flush leaves ownership unchanged: refetch, not reroute")
+
+    cache.store(cmd, Vector(key("foo")), frame("bar"), 0L, 10000L)
+    val ClientCache.Acquire.Hit(_, moved) = cache.acquire(cmd, Vector(key("foo")), 0L, _ => ()): @unchecked
+    cache.flushForReroute()
+    assert(!cache.isCurrent(moved))
+    assert(cache.rerouteRetired(moved), "a topology flush requires rerouting to the new owner")
+  }
+
   test("an invalidation mid-flight delivers the reply but does not cache it") {
     val cache      = new ClientCache(1024)
     val cmd        = key("GET foo")

--- a/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
@@ -624,6 +624,25 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     assertEquals(third, Some(Success(Some("baz"))))
   }
 
+  test("a null-payload invalidation push flushes the whole cache, and reads refetch on the same connection") {
+    val (connection, _, transports) = cachedConnection()
+    val get                         = Strings.get[String, String]("foo")
+
+    connection.cachedSubmit(get, 60000L, _ => ())
+    transports.head.emit(Frame.SimpleString("OK"))
+    transports.head.emit(Frame.BulkString(Bytes.utf8("bar")))
+    assertEquals(transports.head.written.length, 1)
+
+    transports.head.emit(Frame.Push(Vector(Frame.BulkString(Bytes.utf8("invalidate")), Frame.Null))) // FLUSHALL/tracking-drop form
+
+    var afterFlush: Option[Try[Option[String]]] = None
+    connection.cachedSubmit(get, 60000L, r => afterFlush = Some(r))
+    assertEquals(transports.head.written.length, 2) // flushed -> refetch
+    transports.head.emit(Frame.SimpleString("OK"))
+    transports.head.emit(Frame.BulkString(Bytes.utf8("baz")))
+    assertEquals(afterFlush, Some(Success(Some("baz"))))
+  }
+
   test("TTL expiry evicts a cached read independently of invalidations") {
     val (connection, scheduler, transports) = cachedConnection()
     val get                                 = Strings.get[String, String]("foo")

--- a/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
@@ -684,4 +684,42 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     assertEquals(tracer.log.head, "start:GET")
     assert(tracer.log.last.startsWith("settled:Failed"))
   }
+
+  test("a server that rejects CLIENT TRACKING degrades cached reads to uncached rather than failing (ADR-0045)") {
+    val scheduler                                       = new ManualScheduler
+    val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
+    val respond: Bytes => Seq[Frame]                    = payload => {
+      val text = payload.asUtf8String
+      if (text.contains("TRACKING")) Seq(Frame.SimpleError("ERR unknown subcommand TRACKING"))
+      else if (text.contains("GET")) Seq(Frame.BulkString(Bytes.utf8("bar")))
+      else Nil
+    }
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
+      val transport = new FakeTransport(onFrame, onClosed, respond)
+      transports += transport
+      transport
+    }
+    val connection                                      = MultiplexedConnection.connect(
+      factory,
+      scheduler,
+      Vector(Connection.clientTrackingOnOptin),
+      fixedBackoff,
+      noWatchdog,
+      1.second,
+      Duration.Zero,
+      cacheMaxBytes = 1L << 20
+    )
+    val get                                             = Strings.get[String, String]("foo")
+
+    var first: Option[Try[Option[String]]]  = None
+    connection.cachedSubmit(get, 60000L, r => first = Some(r))
+    var second: Option[Try[Option[String]]] = None
+    connection.cachedSubmit(get, 60000L, r => second = Some(r))
+
+    assertEquals(first, Some(Success(Some("bar"))))
+    assertEquals(second, Some(Success(Some("bar"))))
+    val writes = transports.head.written.map(_.asUtf8String)
+    assert(!writes.exists(_.contains("CACHING")), "no CLIENT CACHING YES when tracking is unavailable")
+    assertEquals(writes.count(_.contains("GET")), 2, "each cached read re-contacts the server: nothing is cached without tracking")
+  }
 }

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -164,6 +164,28 @@ class ClusterClientSpec extends munit.FunSuite {
     }
   }
 
+  test("a cached read that meets an ASK is an uncached one-shot: [ASKING, read] on the target, nothing stored") {
+    val slot      = Slot.of(Bytes.utf8("foo")).value
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      // the ASK target receives [ASKING, GET foo] (one payload, two replies); it must not receive CLIENT CACHING YES
+      else if (node == nodeB && text.contains("ASKING")) Seq(Frame.SimpleString("OK"), Frame.BulkString(Bytes.utf8("v")))
+      else if (text.contains("GET")) Seq(Frame.SimpleString("OK"), Frame.SimpleError(s"ASK $slot b:6379"))
+      else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA), caching = true)
+
+    val read = fixture.live.cached(Strings.get[String, String]("foo"), 1.minute)
+    read.unsafeRun.flatMap { first =>
+      read.unsafeRun.map { second =>
+        assertEquals(first, Some("v"))
+        assertEquals(second, Some("v"))
+        val bWrites = fixture.written(nodeB)
+        assertEquals(bWrites.count(_.contains("\r\nGET\r\n")), 2, "each read must reach the ASK target; nothing is cached")
+        assert(bWrites.forall(!_.contains("CACHING")), "the ASK one-shot must never send CLIENT CACHING YES")
+      }
+    }
+  }
+
   test("a command to an established node dispatches inline, with no zero-delay scheduler hop") {
     val counting  = new CountingScheduler
     val behaviour =

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -52,7 +52,8 @@ class ClusterClientSpec extends munit.FunSuite {
     unreachable: Set[Node] = Set.empty,
     readFrom: ReadFrom = ReadFrom.Master,
     connectGate: (Node, Int) => Unit = (_, _) => (), // blocks a node's nth transport creation, to park an establish mid-flight
-    scheduler: Scheduler = Scheduler.real
+    scheduler: Scheduler = Scheduler.real,
+    caching: Boolean = false
   ) {
 
     // accumulate every transport per node (a node has both a Multiplexed and, once a transaction pins, a Dedicated connection) so a refresh
@@ -74,6 +75,7 @@ class ClusterClientSpec extends munit.FunSuite {
           val text = payload.asUtf8String
           if (text.contains("HELLO"))
             if (unreachable(node) || flakyHello.remove(node)) Seq(Frame.SimpleError("ERR node is down")) else Seq(helloReply)
+          else if (text.contains("TRACKING")) Seq(Frame.SimpleString("OK"))
           else behaviour(node, text)
         }
         val transport                    = new FakeTransport(onFrame, onClosed, respond)
@@ -94,7 +96,9 @@ class ClusterClientSpec extends munit.FunSuite {
         ClusterConfig(),
         1024,
         seeds,
-        readFrom
+        readFrom,
+        cachingEnabled = caching,
+        cacheMaxBytes = if (caching) 1L << 20 else 0L
       )
 
     live.bootstrapTopology()
@@ -139,6 +143,24 @@ class ClusterClientSpec extends munit.FunSuite {
       assertEquals(result, Some(owner.host))
       assert(fixture.written(owner).exists(_.contains("GET")), "owner did not receive GET")
       assert(!fixture.written(other).exists(_.contains("GET")), "non-owner received GET")
+    }
+  }
+
+  test("a cached read routes to the slot's master as [CLIENT CACHING YES, read] and serves a repeat locally") {
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (text.contains("GET")) Seq(Frame.SimpleString("OK"), Frame.BulkString(Bytes.utf8(node.host))) // [CACHING, GET] batch → two replies
+      else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA), caching = true)
+
+    fixture.live.cached(Strings.get[String, String]("foo"), 1.minute).unsafeRun.flatMap { first =>
+      assertEquals(first, Some(nodeA.host))
+      assert(fixture.written(nodeA).exists(_.contains("CACHING")), "a cached read must send CLIENT CACHING YES")
+      val gets = fixture.written(nodeA).count(_.contains("\r\nGET\r\n"))
+      fixture.live.cached(Strings.get[String, String]("foo"), 1.minute).unsafeRun.map { second =>
+        assertEquals(second, Some(nodeA.host))
+        assertEquals(fixture.written(nodeA).count(_.contains("\r\nGET\r\n")), gets, "a repeat is served from the local cache, no new round-trip")
+      }
     }
   }
 

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -186,6 +186,31 @@ class ClusterClientSpec extends munit.FunSuite {
     }
   }
 
+  test("a MOVED retires the source master's whole cache, so a previously cached key can no longer serve a stale local hit") {
+    val moved     = new java.util.concurrent.atomic.AtomicBoolean(false)
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) // topology never changes, so only a flush keeps reads fresh
+      else if (node == nodeB && text.contains("GET")) Seq(Frame.SimpleString("OK"), Frame.BulkString(Bytes.utf8("fresh")))
+      else if (node == nodeA && text.contains("GET"))
+        if (moved.get) Seq(Frame.SimpleString("OK"), Frame.SimpleError("MOVED 0 b:6379"))
+        else Seq(Frame.SimpleString("OK"), Frame.BulkString(Bytes.utf8("stale")))
+      else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA), caching = true)
+
+    fixture.live.cached(Strings.get[String, String]("k1"), 1.minute).unsafeRun.flatMap { k1 =>
+      assertEquals(k1, Some("stale"))
+      moved.set(true)
+      // k2 (uncached) meets MOVED on nodeA, flushing nodeA's whole cache (k1 included) before retrying on nodeB
+      fixture.live.cached(Strings.get[String, String]("k2"), 1.minute).unsafeRun.flatMap { k2 =>
+        assertEquals(k2, Some("fresh"))
+        fixture.live.cached(Strings.get[String, String]("k1"), 1.minute).unsafeRun.map { k1Again =>
+          assertEquals(k1Again, Some("fresh"), "the MOVED must have retired k1's stale entry, forcing a refetch")
+          assert(fixture.written(nodeB).count(_.contains("\r\nGET\r\n")) >= 2, "both k2 and the re-fetched k1 must reach the new owner")
+        }
+      }
+    }
+  }
+
   test("a command to an established node dispatches inline, with no zero-delay scheduler hop") {
     val counting  = new CountingScheduler
     val behaviour =

--- a/sage-core/src/main/scala/sage/cluster/Topology.scala
+++ b/sage-core/src/main/scala/sage/cluster/Topology.scala
@@ -33,6 +33,18 @@ final private[sage] class ClusterTopology private (val shards: Vector[Shard], pr
   // the core only locates the owning shard; selecting a live replica and applying the read policy is the runtime's job
   def shardForSlot(slot: Slot): Option[Shard] = Option(shardOwners(slot.value))
 
+  // masters in `previous` that no longer own a slot they hold in this (new) topology
+  def mastersLosingSlots(previous: ClusterTopology): Set[Node] = {
+    val losing = mutable.Set.empty[Node]
+    var slot   = 0
+    while (slot < Slot.Count) {
+      val before = previous.owners(slot)
+      if (before != null && !before.equals(owners(slot))) losing += before
+      slot += 1
+    }
+    losing.toSet
+  }
+
   def route(command: Command[?]): Route =
     if (command.hasMalformedKeys) Route.Malformed
     else

--- a/sage-core/src/main/scala/sage/commands/Connection.scala
+++ b/sage-core/src/main/scala/sage/commands/Connection.scala
@@ -30,6 +30,9 @@ private[sage] object Connection {
   val clientCachingYes: Command[Unit] =
     Command("CLIENT", keyIndices = Command.NoKeys, args = Vector("CACHING", "YES").map(Bytes.utf8), decode = Decode.ok)
 
+  def isClientTracking(command: Command[?]): Boolean =
+    command.name == "CLIENT" && command.args.headOption.exists(_.asUtf8String == "TRACKING")
+
   def watch[K](first: K, rest: K*)(using keyCodec: KeyCodec[K]): Command[Unit] = {
     val keys = (first +: rest.toVector).map(keyCodec.encode)
     Command("WATCH", keyIndices = Vector.range(0, keys.length), args = keys, decode = Decode.ok)

--- a/sage-core/src/test/scala/sage/cluster/TopologySpec.scala
+++ b/sage-core/src/test/scala/sage/cluster/TopologySpec.scala
@@ -76,4 +76,14 @@ class TopologySpec extends munit.FunSuite {
     assert(!ab.sameOwnership(migrated), "a slot moving from b to a is a change")
     assert(!whole.sameOwnership(ab), "differing covered ranges are a change")
   }
+
+  test("mastersLosingSlots names only masters that gave up a slot, so a cache flush targets exactly them") {
+    val before = ClusterTopology.from(Vector(covering(a, 0, 100), covering(b, 101, 200)))
+    val after  = ClusterTopology.from(Vector(covering(a, 0, 150), covering(b, 151, 200)))
+    assertEquals(after.mastersLosingSlots(before), Set(b))
+    assert(!after.mastersLosingSlots(before).contains(a))
+    assertEquals(before.mastersLosingSlots(before), Set.empty[Node])
+    val shrunk = ClusterTopology.from(Vector(covering(a, 0, 100)))
+    assertEquals(shrunk.mastersLosingSlots(before), Set(b))
+  }
 }


### PR DESCRIPTION
Closes #199.

Extends transparent client-side caching to cluster deployments. Cache state stays scoped to the connection generation and the slot-owning master, so routing, invalidations, redirects, failover, and topology changes can never expose a stale result.

## What changed

- **Per-master cache.** Each slot-owning master's bundle enables `CLIENT TRACKING ON OPTIN` and owns an independent per-generation `ClientCache` sized by `clientCache.maxBytes`; its dedicated (transaction/blocking) connections keep the plain bootstrap. Replicas never track or cache.
- **Master-pinned, reuses the dispatch machine.** A `cached` read is always routed to the slot's master (whatever the `ReadFrom` policy) and flows through the existing dispatch/redirect state machine — only the leaf submit differs (`cachedSubmit` vs `submit`). A local hit short-circuits before routing; a miss and any `MOVED`/`ASK`/failover it meets keep the existing redirect bound and provably-not-executed retry semantics.
- **Topology-driven flush.** On a refresh, any surviving master that lost a slot has its cache flushed (closing the slot-returns staleness window); a refresh that cannot be trusted flushes every master's cache. Reconnect / connection replacement flush for free via the per-generation cache.
- **MOVED / ASK.** `MOVED` re-routes and caches on the settled new owner; `ASK` degrades to an uncached one-shot (`[ASKING, read]`, nothing stored) until the migration completes.
- **Graceful degradation.** `CLIENT TRACKING` is now best-effort at bootstrap in every topology: a server that speaks RESP3 but rejects tracking connects anyway and runs `cached` reads uncached, exactly as when caching is disabled.

Design is recorded in ADR-0045 (with ADR-0028 amended and the user docs updated).

## Tests

- Unit: `TopologySpec` (`mastersLosingSlots`), `MultiplexedConnectionSpec` (tracking-rejection degrade), `BootstrapSpec` (tracking tolerated), `ClusterClientSpec` (cached routing).
- Real-cluster integration on Redis and Valkey: `ClusterSuite` (single-node hit/miss/invalidation) and `ClusterFailoverSuite` (cached read follows `MOVED` after a reshard; cached read recovers from the promoted master after a failover).

Unit suites and all backend compiles are green; the integration suites run under the Docker-backed CI matrix.