### PR TITLE
Add a built-in distributed rate limiter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -173,7 +173,14 @@ lazy val integrationTests = (projectMatrix in file("integration-tests"))
     Test / testOptions += {
       val isAnchor     = moduleName.value.endsWith("-future")
       val isDesignated = moduleName.value.endsWith("-zio")
-      val onceOnly     = Set("sage.integration.commands.", "sage.integration.security.", "sage.integration.cluster.", "sage.integration.masterreplica.")
+      val onceOnly     =
+        Set(
+          "sage.integration.commands.",
+          "sage.integration.security.",
+          "sage.integration.cluster.",
+          "sage.integration.masterreplica.",
+          "sage.integration.ratelimit."
+        )
       Tests.Filter(name => !isAnchor && (isDesignated || !onceOnly.exists(name.startsWith)))
     }
   )

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -31,6 +31,7 @@ export default defineConfig({
           { text: 'Streams', link: '/streams' },
           { text: 'JSON', link: '/json' },
           { text: 'Client-side caching', link: '/client-side-caching' },
+          { text: 'Rate limiting', link: '/rate-limiting' },
           { text: 'Configuration', link: '/configuration' },
           { text: 'Error handling', link: '/error-handling' },
           { text: 'Observability', link: '/observability' },

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -18,7 +18,7 @@ Every sage failure is a `SageException`, a single sealed hierarchy you can match
 | `TimedOut(message)` | A blocking command or transaction waited past `dedicatedPool.acquireTimeout` for a free pooled connection. Not a per-command timeout; bound a command's own duration with your backend's timeout combinator. |
 | `TransactionDiscarded(message)` | A transaction was discarded server-side (`EXECABORT`); nothing ran. |
 | `NotCacheable(message)` | `cached` was given a command that cannot be safely cached. |
-| `InvalidArgument(message)` | An argument the API can never accept: an invalid configuration or rate-limit policy, a blocking or all-masters command in a pipeline or transaction, or a hand-built command a cluster client cannot route by key. A programming error, rejected before any server call. |
+| `InvalidArgument(message)` | An argument the API can never accept: an invalid configuration or rate-limit policy, a blocking command in a pipeline or transaction, or a command a cluster client cannot serve as routed (an all-masters command in a cluster pipeline, a cluster-wide result in a single-node transaction, a hand-built command it cannot route by key). A programming error, rejected before any server call. |
 
 ## Branching on the failure
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -18,6 +18,7 @@ Every sage failure is a `SageException`, a single sealed hierarchy you can match
 | `TimedOut(message)` | A blocking command or transaction waited past `dedicatedPool.acquireTimeout` for a free pooled connection. Not a per-command timeout; bound a command's own duration with your backend's timeout combinator. |
 | `TransactionDiscarded(message)` | A transaction was discarded server-side (`EXECABORT`); nothing ran. |
 | `NotCacheable(message)` | `cached` was given a command that cannot be safely cached. |
+| `InvalidArgument(message)` | An argument the API can never accept: an invalid configuration or rate-limit policy, a blocking or all-masters command in a pipeline or transaction, or a hand-built command a cluster client cannot route by key. A programming error, rejected before any server call. |
 
 ## Branching on the failure
 

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -42,9 +42,9 @@ RateLimit(permits = 100, per = 1.second, burst = 200) // 100/s sustained, bursti
 `Decision` is an ordinary returned value, never a thrown error: an admitted or rejected request is a normal outcome, not a failure.
 
 - `isAllowed`: whether the request was admitted.
-- `remainingOrZero`: tokens left in the bucket, or `0` when denied. Convenient for an `X-RateLimit-Remaining` header.
+- `remainingTokens`: tokens left in the bucket. A denial consumes nothing, so it reports the untouched balance. Convenient for an `X-RateLimit-Remaining` header.
 - `Allowed(remaining, resetAfter)`: `resetAfter` is the time until the bucket refills to full.
-- `Denied(retryAfter)`: `retryAfter` is the time until enough tokens are available. Convenient for a `Retry-After` header.
+- `Denied(remaining, retryAfter)`: `retryAfter` is the time until enough tokens are available. Convenient for a `Retry-After` header.
 
 There is no blocking `acquire`: `tryAcquire` never waits. To retry, sleep for `retryAfter` at the call site and try again.
 
@@ -52,7 +52,7 @@ Waits are reported at microsecond resolution. After an exceptionally large serve
 
 ## Peek and reset
 
-- `peek(subject)` reports the current standing without consuming. The bucket is still refilled by elapsed time, but no tokens are taken.
+- `peek(subject)` reports the current standing without consuming: `Allowed` while at least one token is available, otherwise `Denied` with the wait until one is. The bucket is still refilled by elapsed time, but no tokens are taken.
 - `reset(subject)` clears a subject's bucket, so its next request starts from full capacity.
 
 ## Cost and subjects
@@ -78,9 +78,9 @@ A policy and a `cost` must satisfy:
 - `capacity` greater than 0, `refillTokens` greater than 0, `refillPeriod` at least one microsecond.
 - `capacity`, `refillTokens`, and `refillPeriod` in microseconds each within `2^53` (the range a server-side Lua number represents exactly).
 - `capacity` multiplied by `refillPeriod` in microseconds within `2^53`, so the refill arithmetic stays exact on the server.
-- `cost` in the range `0` to `capacity`.
+- `cost` in the range `1` to `capacity`.
 
-Violations are a programming error, not a runtime outcome. On the `rateLimiter` factory path (`tryAcquire`, `peek`) a bad policy or cost fails with an `IllegalArgumentException` through the effect before any server call. On the composable `command` path the server rejects the call with an error and never modifies the bucket.
+Violations are a programming error, not a runtime outcome. On the `rateLimiter` factory path (`tryAcquire`, `peek`) a bad policy or cost fails with a typed `SageException.InvalidArgument` through the effect before any server call. On the composable `command` path the server rejects the call with an error and never modifies the bucket.
 
 ## When the store is unreachable
 

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,99 @@
+# Rate limiting
+
+A **rate limiter** caps how often something may happen: so many requests per second for an API key, a budget of login attempts per account, a fair-use quota per tenant. Sage ships one built in, so every client has it with no extra dependency.
+
+The limiter is **distributed**. Its state lives on the server, not in process memory, so the limit holds across every process pointed at the same server (they share the keyspace, not a connection). Each check runs its whole decide-and-consume cycle atomically on the server; in steady state that is a single round trip. The script is cached on the server, so a check pays a one-time load-and-retry only when the server has not cached it yet (a cold server, or after `SCRIPT FLUSH`), not per connection.
+
+`rateLimiter` binds a policy to the client. Each `tryAcquire` consumes tokens for a subject and returns a `Decision`.
+
+::: code-group
+
+```scala [Ox]
+val limiter  = client.rateLimiter[String](RateLimit.perSecond(100))
+val decision = limiter.tryAcquire("user:42")
+val allowed  = decision.isAllowed
+```
+
+```scala [ZIO · Cats Effect · Kyo · Pekko]
+val limiter = client.rateLimiter[String](RateLimit.perSecond(100))
+for {
+  decision <- limiter.tryAcquire("user:42")
+} yield decision.isAllowed
+```
+
+:::
+
+## The algorithm: token bucket
+
+Each subject has a **bucket** that holds up to `capacity` tokens and refills continuously over time. A `tryAcquire` takes `cost` tokens (one by default) when the bucket holds them, and is denied otherwise. `capacity` is the burst ceiling: a subject that has been idle can spend up to a full bucket at once, then is paced by the refill rate.
+
+Refill is smooth rather than stepped, so a caller regains its allowance gradually instead of all at once at a window boundary.
+
+Build a policy with the constructors:
+
+```scala
+RateLimit.perSecond(100)                              // 100 per second, bursting to 100
+RateLimit.perMinute(5000)                             // 5000 per minute, bursting to 5000
+RateLimit(permits = 100, per = 1.second, burst = 200) // 100/s sustained, bursting to 200
+```
+
+## Reading the decision
+
+`Decision` is an ordinary returned value, never a thrown error: an admitted or rejected request is a normal outcome, not a failure.
+
+- `isAllowed`: whether the request was admitted.
+- `remainingOrZero`: tokens left in the bucket, or `0` when denied. Convenient for an `X-RateLimit-Remaining` header.
+- `Allowed(remaining, resetAfter)`: `resetAfter` is the time until the bucket refills to full.
+- `Denied(retryAfter)`: `retryAfter` is the time until enough tokens are available. Convenient for a `Retry-After` header.
+
+There is no blocking `acquire`: `tryAcquire` never waits. To retry, sleep for `retryAfter` at the call site and try again.
+
+Waits are reported at microsecond resolution. After an exceptionally large server-clock rollback, a wait that cannot fit in a `FiniteDuration` saturates at `RateLimiter.maximumReportedWait`; the bucket's server-side expiry still covers the complete wait.
+
+## Peek and reset
+
+- `peek(subject)` reports the current standing without consuming. The bucket is still refilled by elapsed time, but no tokens are taken.
+- `reset(subject)` clears a subject's bucket, so its next request starts from full capacity.
+
+## Cost and subjects
+
+Pass `cost` to charge a heavier request more than one token:
+
+```scala
+limiter.tryAcquire("user:42", cost = 10)
+```
+
+A subject can be any type with a `KeyCodec`. It is encoded and prefixed with a namespace (`ratelimit` by default) to form the bucket's key. Give a custom namespace when more than one limiter runs against the same server:
+
+```scala
+client.rateLimiter[String](RateLimit.perSecond(100), namespace = "login")
+```
+
+While bucket state exists, it records the policy that created it. If a limiter keeps the same namespace but changes capacity or refill settings, each subject retains no more than its existing whole tokens or the new capacity, drops fractional credit, and begins refilling under the new policy. This conservative transition prevents overlapping old and new instances during a rolling deployment from repeatedly recreating full buckets. Full idle buckets expire quickly because retaining their state cannot affect decisions under the same policy; after expiry, a later policy sees a new subject and starts at its own capacity. Use distinct namespaces for independently active policies.
+
+## Valid policies
+
+A policy and a `cost` must satisfy:
+
+- `capacity` greater than 0, `refillTokens` greater than 0, `refillPeriod` at least one microsecond.
+- `capacity`, `refillTokens`, and `refillPeriod` in microseconds each within `2^53` (the range a server-side Lua number represents exactly).
+- `capacity` multiplied by `refillPeriod` in microseconds within `2^53`, so the refill arithmetic stays exact on the server.
+- `cost` in the range `0` to `capacity`.
+
+Violations are a programming error, not a runtime outcome. On the `rateLimiter` factory path (`tryAcquire`, `peek`) a bad policy or cost fails with an `IllegalArgumentException` through the effect before any server call. On the composable `command` path the server rejects the call with an error and never modifies the bucket.
+
+## When the store is unreachable
+
+A check reaches the server, so it can fail when the server is unreachable. The failure surfaces through the effect `F` for the caller to handle, exactly like any other command. The library hides nothing: decide there whether an outage should admit the request (availability first) or reject it (protection first).
+
+## The composable command
+
+`tryAcquire` runs on the client directly. To pipeline the check or run it yourself instead, `command` returns the underlying `Command` to pass to `client.run`:
+
+```scala
+client.run(limiter.command("user:42"))
+```
+
+## Topology
+
+The limiter works on every topology. A subject's whole state is one key, so it hashes to a single cluster slot with no hash-tag gymnastics and routes correctly on a standalone, master-replica, or cluster client with no change to your code.

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -86,6 +86,14 @@ Violations are a programming error, not a runtime outcome. On the `rateLimiter` 
 
 A check reaches the server, so it can fail when the server is unreachable. The failure surfaces through the effect `F` for the caller to handle, exactly like any other command. The library hides nothing: decide there whether an outage should admit the request (availability first) or reject it (protection first).
 
+## Capacity planning
+
+Every check is one cached-script request and one constant-time atomic operation on the server. It reads and rewrites one small hash and refreshes its expiry, so it consumes write throughput even when the decision is denied. Concurrent checks are automatically multiplexed by the client, but Redis or Valkey still executes each script serially and atomically.
+
+One key exists for each subject whose bucket is not full. Its expiry is the remaining time until that bucket can refill completely; a full bucket expires almost immediately. Active-key cardinality therefore depends mainly on the number of distinct subjects seen within a full-refill window. Long refill windows and high-cardinality subjects retain more state than short windows over a stable subject set.
+
+For a limiter on every application call, include its operations, memory, replication, and persistence traffic in the store's capacity test. Avoid retrying a denied decision in a tight loop, and use a dedicated deployment or enough cluster shards when limiter traffic would consume a material share of an application's existing store.
+
 ## The composable command
 
 `tryAcquire` runs on the client directly. To pipeline the check or run it yourself instead, `command` returns the underlying `Command` to pass to `client.run`:

--- a/examples/ce/src/main/scala/sage/examples/ce/RateLimiterExample.scala
+++ b/examples/ce/src/main/scala/sage/examples/ce/RateLimiterExample.scala
@@ -1,0 +1,24 @@
+package sage.examples.ce
+
+import cats.effect.IO
+
+import sage.*
+import sage.backend.*
+
+/**
+  * A distributed token-bucket rate limiter: `rateLimiter` binds a policy, each `tryAcquire` is one atomic allow/deny check on server-side state.
+  */
+object RateLimiterExample {
+
+  def run(client: SageClient): IO[Unit] = {
+    val limiter = client.rateLimiter[String](RateLimit.perMinute(2))
+    for {
+      first  <- limiter.tryAcquire("user:42")
+      second <- limiter.tryAcquire("user:42")
+      third  <- limiter.tryAcquire("user:42")
+      _      <- IO.println(s"1st allowed=${first.isAllowed} remaining=${first.remainingOrZero}")
+      _      <- IO.println(s"2nd allowed=${second.isAllowed} remaining=${second.remainingOrZero}")
+      _      <- IO.println(s"3rd allowed=${third.isAllowed}")
+    } yield ()
+  }
+}

--- a/examples/ce/src/main/scala/sage/examples/ce/RateLimiterExample.scala
+++ b/examples/ce/src/main/scala/sage/examples/ce/RateLimiterExample.scala
@@ -16,8 +16,8 @@ object RateLimiterExample {
       first  <- limiter.tryAcquire("user:42")
       second <- limiter.tryAcquire("user:42")
       third  <- limiter.tryAcquire("user:42")
-      _      <- IO.println(s"1st allowed=${first.isAllowed} remaining=${first.remainingOrZero}")
-      _      <- IO.println(s"2nd allowed=${second.isAllowed} remaining=${second.remainingOrZero}")
+      _      <- IO.println(s"1st allowed=${first.isAllowed} remaining=${first.remainingTokens}")
+      _      <- IO.println(s"2nd allowed=${second.isAllowed} remaining=${second.remainingTokens}")
       _      <- IO.println(s"3rd allowed=${third.isAllowed}")
     } yield ()
   }

--- a/examples/ce/src/main/scala/sage/examples/ce/Tour.scala
+++ b/examples/ce/src/main/scala/sage/examples/ce/Tour.scala
@@ -20,6 +20,7 @@ object Tour extends IOApp.Simple {
         TransactionsExample.run(client) *>
         PubSubExample.run(client) *>
         CachedReadsExample.run(client) *>
+        RateLimiterExample.run(client) *>
         StreamsExample.run(client)
     }
 }

--- a/examples/kyo/src/main/scala/sage/examples/kyo/RateLimiterExample.scala
+++ b/examples/kyo/src/main/scala/sage/examples/kyo/RateLimiterExample.scala
@@ -16,8 +16,8 @@ object RateLimiterExample {
       first  <- limiter.tryAcquire("user:42")
       second <- limiter.tryAcquire("user:42")
       third  <- limiter.tryAcquire("user:42")
-      _      <- Console.printLine(s"1st allowed=${first.isAllowed} remaining=${first.remainingOrZero}")
-      _      <- Console.printLine(s"2nd allowed=${second.isAllowed} remaining=${second.remainingOrZero}")
+      _      <- Console.printLine(s"1st allowed=${first.isAllowed} remaining=${first.remainingTokens}")
+      _      <- Console.printLine(s"2nd allowed=${second.isAllowed} remaining=${second.remainingTokens}")
       _      <- Console.printLine(s"3rd allowed=${third.isAllowed}")
     } yield ()
   }

--- a/examples/kyo/src/main/scala/sage/examples/kyo/RateLimiterExample.scala
+++ b/examples/kyo/src/main/scala/sage/examples/kyo/RateLimiterExample.scala
@@ -1,0 +1,24 @@
+package sage.examples.kyo
+
+import kyo.*
+
+import sage.*
+import sage.backend.*
+
+/**
+  * A distributed token-bucket rate limiter: `rateLimiter` binds a policy, each `tryAcquire` is one atomic allow/deny check on server-side state.
+  */
+object RateLimiterExample {
+
+  def run(client: SageClient): Unit < (Abort[Throwable] & Async) = {
+    val limiter = client.rateLimiter[String](RateLimit.perMinute(2))
+    for {
+      first  <- limiter.tryAcquire("user:42")
+      second <- limiter.tryAcquire("user:42")
+      third  <- limiter.tryAcquire("user:42")
+      _      <- Console.printLine(s"1st allowed=${first.isAllowed} remaining=${first.remainingOrZero}")
+      _      <- Console.printLine(s"2nd allowed=${second.isAllowed} remaining=${second.remainingOrZero}")
+      _      <- Console.printLine(s"3rd allowed=${third.isAllowed}")
+    } yield ()
+  }
+}

--- a/examples/kyo/src/main/scala/sage/examples/kyo/Tour.scala
+++ b/examples/kyo/src/main/scala/sage/examples/kyo/Tour.scala
@@ -22,6 +22,7 @@ object Tour extends KyoApp {
         _      <- TransactionsExample.run(client)
         _      <- PubSubExample.run(client)
         _      <- CachedReadsExample.run(client)
+        _      <- RateLimiterExample.run(client)
         _      <- StreamsExample.run(client)
       } yield ()
     }

--- a/examples/ox/src/main/scala/sage/examples/ox/RateLimiterExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/RateLimiterExample.scala
@@ -1,0 +1,22 @@
+package sage.examples.ox
+
+import ox.Ox
+
+import sage.*
+import sage.backend.*
+
+/**
+  * A distributed token-bucket rate limiter: `rateLimiter` binds a policy, each `tryAcquire` is one atomic allow/deny check on server-side state.
+  */
+object RateLimiterExample {
+
+  def run(client: SageClient)(using Ox): Unit = {
+    val limiter = client.rateLimiter[String](RateLimit.perMinute(2))
+    val first   = limiter.tryAcquire("user:42")
+    val second  = limiter.tryAcquire("user:42")
+    val third   = limiter.tryAcquire("user:42")
+    println(s"1st allowed=${first.isAllowed} remaining=${first.remainingOrZero}")
+    println(s"2nd allowed=${second.isAllowed} remaining=${second.remainingOrZero}")
+    println(s"3rd allowed=${third.isAllowed}")
+  }
+}

--- a/examples/ox/src/main/scala/sage/examples/ox/RateLimiterExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/RateLimiterExample.scala
@@ -15,8 +15,8 @@ object RateLimiterExample {
     val first   = limiter.tryAcquire("user:42")
     val second  = limiter.tryAcquire("user:42")
     val third   = limiter.tryAcquire("user:42")
-    println(s"1st allowed=${first.isAllowed} remaining=${first.remainingOrZero}")
-    println(s"2nd allowed=${second.isAllowed} remaining=${second.remainingOrZero}")
+    println(s"1st allowed=${first.isAllowed} remaining=${first.remainingTokens}")
+    println(s"2nd allowed=${second.isAllowed} remaining=${second.remainingTokens}")
     println(s"3rd allowed=${third.isAllowed}")
   }
 }

--- a/examples/ox/src/main/scala/sage/examples/ox/Tour.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/Tour.scala
@@ -18,6 +18,7 @@ import sage.backend.*
     TransactionsExample.run(client)
     PubSubExample.run(client)
     CachedReadsExample.run(client)
+    RateLimiterExample.run(client)
     StreamsExample.run(client)
   }
 }

--- a/examples/pekko/src/main/scala/sage/examples/pekko/RateLimiterExample.scala
+++ b/examples/pekko/src/main/scala/sage/examples/pekko/RateLimiterExample.scala
@@ -1,0 +1,25 @@
+package sage.examples.pekko
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import sage.*
+import sage.backend.*
+
+/**
+  * A distributed token-bucket rate limiter: `rateLimiter` binds a policy, each `tryAcquire` is one atomic allow/deny check on server-side state.
+  */
+object RateLimiterExample {
+
+  def run(client: SageClient)(using ExecutionContext): Future[Unit] = {
+    val limiter = client.rateLimiter[String](RateLimit.perMinute(2))
+    for {
+      first  <- limiter.tryAcquire("user:42")
+      second <- limiter.tryAcquire("user:42")
+      third  <- limiter.tryAcquire("user:42")
+    } yield {
+      println(s"1st allowed=${first.isAllowed} remaining=${first.remainingOrZero}")
+      println(s"2nd allowed=${second.isAllowed} remaining=${second.remainingOrZero}")
+      println(s"3rd allowed=${third.isAllowed}")
+    }
+  }
+}

--- a/examples/pekko/src/main/scala/sage/examples/pekko/RateLimiterExample.scala
+++ b/examples/pekko/src/main/scala/sage/examples/pekko/RateLimiterExample.scala
@@ -17,8 +17,8 @@ object RateLimiterExample {
       second <- limiter.tryAcquire("user:42")
       third  <- limiter.tryAcquire("user:42")
     } yield {
-      println(s"1st allowed=${first.isAllowed} remaining=${first.remainingOrZero}")
-      println(s"2nd allowed=${second.isAllowed} remaining=${second.remainingOrZero}")
+      println(s"1st allowed=${first.isAllowed} remaining=${first.remainingTokens}")
+      println(s"2nd allowed=${second.isAllowed} remaining=${second.remainingTokens}")
       println(s"3rd allowed=${third.isAllowed}")
     }
   }

--- a/examples/pekko/src/main/scala/sage/examples/pekko/Tour.scala
+++ b/examples/pekko/src/main/scala/sage/examples/pekko/Tour.scala
@@ -30,6 +30,7 @@ object Tour {
           _ <- TransactionsExample.run(client)
           _ <- PubSubExample.run(client)
           _ <- CachedReadsExample.run(client)
+          _ <- RateLimiterExample.run(client)
           _ <- StreamsExample.run(client)
         } yield ()
       }

--- a/examples/zio/src/main/scala/sage/examples/zio/RateLimiterExample.scala
+++ b/examples/zio/src/main/scala/sage/examples/zio/RateLimiterExample.scala
@@ -17,8 +17,8 @@ object RateLimiterExample {
         first  <- limiter.tryAcquire("user:42")
         second <- limiter.tryAcquire("user:42")
         third  <- limiter.tryAcquire("user:42")
-        _      <- Console.printLine(s"1st allowed=${first.isAllowed} remaining=${first.remainingOrZero}")
-        _      <- Console.printLine(s"2nd allowed=${second.isAllowed} remaining=${second.remainingOrZero}")
+        _      <- Console.printLine(s"1st allowed=${first.isAllowed} remaining=${first.remainingTokens}")
+        _      <- Console.printLine(s"2nd allowed=${second.isAllowed} remaining=${second.remainingTokens}")
         _      <- Console.printLine(s"3rd allowed=${third.isAllowed}")
       } yield ()
     }

--- a/examples/zio/src/main/scala/sage/examples/zio/RateLimiterExample.scala
+++ b/examples/zio/src/main/scala/sage/examples/zio/RateLimiterExample.scala
@@ -1,0 +1,25 @@
+package sage.examples.zio
+
+import zio.*
+
+import sage.*
+import sage.backend.*
+
+/**
+  * A distributed token-bucket rate limiter: `rateLimiter` binds a policy, each `tryAcquire` is one atomic allow/deny check on server-side state.
+  */
+object RateLimiterExample {
+
+  val run: ZIO[SageClient, Throwable, Unit] =
+    ZIO.serviceWithZIO[SageClient] { client =>
+      val limiter = client.rateLimiter[String](RateLimit.perMinute(2))
+      for {
+        first  <- limiter.tryAcquire("user:42")
+        second <- limiter.tryAcquire("user:42")
+        third  <- limiter.tryAcquire("user:42")
+        _      <- Console.printLine(s"1st allowed=${first.isAllowed} remaining=${first.remainingOrZero}")
+        _      <- Console.printLine(s"2nd allowed=${second.isAllowed} remaining=${second.remainingOrZero}")
+        _      <- Console.printLine(s"3rd allowed=${third.isAllowed}")
+      } yield ()
+    }
+}

--- a/examples/zio/src/main/scala/sage/examples/zio/Tour.scala
+++ b/examples/zio/src/main/scala/sage/examples/zio/Tour.scala
@@ -19,5 +19,6 @@ object Tour extends ZIOAppDefault {
       TransactionsExample.run *>
       PubSubExample.run *>
       CachedReadsExample.run *>
+      RateLimiterExample.run *>
       StreamsExample.run).provide(SageClient.layer(config))
 }

--- a/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
+++ b/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
@@ -1,5 +1,7 @@
 package sage.integration
 
+import scala.concurrent.duration.*
+
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
@@ -96,6 +98,25 @@ class CeSmokeSuite extends ServerSuite(Images.redis) {
               assertEquals(messages.map(_.channel).toSet, Set("smoke"))
               assertEquals(messages.map(_.payload).toList, List("m1", "m2", "m3"))
             }
+          }
+        }
+
+      program.unsafeRunSync()
+    }
+  }
+
+  test("client.rateLimiter admits up to capacity then denies") {
+    withContainers { server =>
+      val program: IO[Unit] =
+        SageClient.resource(configOf(server)).use { client =>
+          val rl = client.rateLimiter[String](RateLimit(capacity = 2, refillTokens = 1, refillPeriod = 1.hour))
+          for {
+            first  <- rl.tryAcquire("smoke")
+            second <- rl.tryAcquire("smoke")
+            denied <- rl.tryAcquire("smoke")
+          } yield {
+            assert(first.isAllowed && second.isAllowed, "the first two are admitted")
+            assert(!denied.isAllowed, "the third is denied once the bucket empties")
           }
         }
 

--- a/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
+++ b/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
@@ -157,4 +157,29 @@ class KyoSmokeSuite extends ServerSuite(Images.redis) {
       KyoApp.Unsafe.runAndBlock(15L.seconds)(program).getOrThrow
     }
   }
+
+  test("client.rateLimiter admits up to capacity then denies") {
+    withContainers { server =>
+      val program: Unit < (Scope & Abort[Throwable] & Async) =
+        for {
+          client <- SageClient.scoped(configOf(server))
+          rl      = client.rateLimiter[String](
+                      RateLimit(
+                        capacity = 2,
+                        refillTokens = 1,
+                        refillPeriod = scala.concurrent.duration.FiniteDuration(1L, java.util.concurrent.TimeUnit.HOURS)
+                      )
+                    )
+          first  <- rl.tryAcquire("smoke")
+          second <- rl.tryAcquire("smoke")
+          denied <- rl.tryAcquire("smoke")
+        } yield {
+          assert(first.isAllowed && second.isAllowed, "the first two are admitted")
+          assert(!denied.isAllowed, "the third is denied once the bucket empties")
+        }
+
+      import AllowUnsafe.embrace.danger
+      KyoApp.Unsafe.runAndBlock(15L.seconds)(program).getOrThrow
+    }
+  }
 }

--- a/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
+++ b/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
@@ -1,5 +1,9 @@
 package sage.integration
 
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.FiniteDuration
+
 import kyo.*
 
 import sage.*
@@ -163,13 +167,7 @@ class KyoSmokeSuite extends ServerSuite(Images.redis) {
       val program: Unit < (Scope & Abort[Throwable] & Async) =
         for {
           client <- SageClient.scoped(configOf(server))
-          rl      = client.rateLimiter[String](
-                      RateLimit(
-                        capacity = 2,
-                        refillTokens = 1,
-                        refillPeriod = scala.concurrent.duration.FiniteDuration(1L, java.util.concurrent.TimeUnit.HOURS)
-                      )
-                    )
+          rl      = client.rateLimiter[String](RateLimit(capacity = 2, refillTokens = 1, refillPeriod = FiniteDuration(1L, TimeUnit.HOURS)))
           first  <- rl.tryAcquire("smoke")
           second <- rl.tryAcquire("smoke")
           denied <- rl.tryAcquire("smoke")

--- a/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
+++ b/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
@@ -1,5 +1,7 @@
 package sage.integration
 
+import scala.concurrent.duration.*
+
 import ox.{fork, supervised}
 
 import sage.*
@@ -161,6 +163,20 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
         }
         val pairs  = client.zScanAll[String]("zscan", count = Some(10L)).runToList()
         assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
+      }
+    }
+  }
+
+  test("client.rateLimiter admits up to capacity then denies") {
+    withContainers { server =>
+      supervised {
+        val client = SageClient.scoped(configOf(server))
+        val rl     = client.rateLimiter[String](RateLimit(capacity = 2, refillTokens = 1, refillPeriod = 1.hour))
+        val first  = rl.tryAcquire("smoke")
+        val second = rl.tryAcquire("smoke")
+        val denied = rl.tryAcquire("smoke")
+        assert(first.isAllowed && second.isAllowed, "the first two are admitted")
+        assert(!denied.isAllowed, "the third is denied once the bucket empties")
       }
     }
   }

--- a/integration-tests/pekko/src/test/scala/sage/integration/PekkoSmokeSuite.scala
+++ b/integration-tests/pekko/src/test/scala/sage/integration/PekkoSmokeSuite.scala
@@ -151,8 +151,8 @@ class PekkoSmokeSuite extends ServerSuite(Images.redis) {
           e1 <- tailed
           e2 <- consumed
         } yield {
-          assert(e1.isInstanceOf[IllegalArgumentException], e1)
-          assert(e2.isInstanceOf[IllegalArgumentException], e2)
+          assert(e1.isInstanceOf[SageException.InvalidArgument], e1)
+          assert(e2.isInstanceOf[SageException.InvalidArgument], e2)
         }
       }
     }

--- a/integration-tests/pekko/src/test/scala/sage/integration/PekkoSmokeSuite.scala
+++ b/integration-tests/pekko/src/test/scala/sage/integration/PekkoSmokeSuite.scala
@@ -157,4 +157,20 @@ class PekkoSmokeSuite extends ServerSuite(Images.redis) {
       }
     }
   }
+
+  test("client.rateLimiter admits up to capacity then denies") {
+    withContainers { server =>
+      val (first, second, denied) = withClientMat(server) { (client, _, system) =>
+        given scala.concurrent.ExecutionContext = system.executionContext
+        val rl                                  = client.rateLimiter[String](RateLimit(capacity = 2, refillTokens = 1, refillPeriod = 1.hour))
+        for {
+          a <- rl.tryAcquire("smoke")
+          b <- rl.tryAcquire("smoke")
+          c <- rl.tryAcquire("smoke")
+        } yield (a, b, c)
+      }
+      assert(first.isAllowed && second.isAllowed, "the first two are admitted")
+      assert(!denied.isAllowed, "the third is denied once the bucket empties")
+    }
+  }
 }

--- a/integration-tests/shared/src/test/scala/sage/integration/ratelimit/RateLimiterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/ratelimit/RateLimiterSuite.scala
@@ -1,0 +1,327 @@
+package sage.integration.ratelimit
+
+import scala.concurrent.duration.*
+
+import kyo.compat.*
+
+import sage.SageException.ServerError
+import sage.commands.Ttl
+import sage.integration.{Images, ServerSuite}
+import sage.ratelimit.{Decision, RateLimit, RateLimiter}
+
+abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
+
+  private def limit(capacity: Long) = RateLimit(capacity, refillTokens = 1, refillPeriod = 1.hour)
+
+  test("admits up to capacity, then denies (via client.rateLimiter)") {
+    withClient { client =>
+      val rl = client.rateLimiter[String](limit(3))
+      for {
+        d1 <- rl.tryAcquire("admit")
+        d2 <- rl.tryAcquire("admit")
+        d3 <- rl.tryAcquire("admit")
+        d4 <- rl.tryAcquire("admit")
+      } yield {
+        assert(d1.isAllowed, "1st allowed")
+        assert(d3.isAllowed && d3.remainingOrZero == 0L, "3rd allowed, empties bucket")
+        assert(!d4.isAllowed, "4th denied")
+        d4 match {
+          case Decision.Denied(retryAfter) => assert(retryAfter > Duration.Zero)
+          case other                       => fail(s"expected Denied, got $other")
+        }
+      }
+    }
+  }
+
+  test("cost consumes multiple tokens") {
+    withClient { client =>
+      val rl = client.rateLimiter[String](limit(5))
+      for {
+        first  <- rl.tryAcquire("cost", cost = 3)
+        second <- rl.tryAcquire("cost", cost = 3)
+      } yield {
+        assert(first.isAllowed && first.remainingOrZero == 2L, "cost 3 of 5 leaves 2")
+        assert(!second.isAllowed, "second cost-3 exceeds the 2 left")
+      }
+    }
+  }
+
+  test("peek reports without consuming") {
+    withClient { client =>
+      val rl = client.rateLimiter[String](limit(3))
+      for {
+        _      <- rl.tryAcquire("peek")
+        peeked <- rl.peek("peek")
+        after  <- rl.tryAcquire("peek")
+      } yield {
+        assertEquals(peeked.remainingOrZero, 2L)
+        assert(after.isAllowed && after.remainingOrZero == 1L, "peek left the 2 tokens intact")
+      }
+    }
+  }
+
+  test("reset refills the bucket") {
+    withClient { client =>
+      val rl = client.rateLimiter[String](limit(1))
+      for {
+        first  <- rl.tryAcquire("reset")
+        denied <- rl.tryAcquire("reset")
+        _      <- rl.reset("reset")
+        again  <- rl.tryAcquire("reset")
+      } yield {
+        assert(first.isAllowed)
+        assert(!denied.isAllowed)
+        assert(again.isAllowed, "reset restored capacity")
+      }
+    }
+  }
+
+  test("the computed sha matches the server's, and EVALSHA runs once loaded") {
+    withClient { client =>
+      val rl = RateLimiter[String](limit(2))
+      for {
+        loaded <- client.scriptLoad(RateLimiter.script)
+        first  <- client.run(rl.evalSha("es", 1))
+        second <- client.run(rl.evalSha("es", 1))
+      } yield {
+        assertEquals(loaded, RateLimiter.sha)
+        assert(first.isAllowed && first.remainingOrZero == 1L)
+        assert(second.isAllowed && second.remainingOrZero == 0L)
+      }
+    }
+  }
+
+  test("composable escape hatch: run a RateLimiter Command directly (plain EVAL)") {
+    withClient { client =>
+      val rl = RateLimiter[String](limit(1))
+      for {
+        allowed <- client.run(rl.tryAcquire("cmd"))
+        denied  <- client.run(rl.tryAcquire("cmd"))
+      } yield {
+        assert(allowed.isAllowed)
+        assert(!denied.isAllowed)
+      }
+    }
+  }
+
+  test("the composable EVAL guard and validate agree on every policy and cost rule") {
+    withClient { client =>
+      val cases: List[(RateLimit, Long)]                                   = List(
+        RateLimit(3, 1, 1.hour)                     -> 1L,
+        RateLimit(3, 1, 1.hour)                     -> 0L,
+        RateLimit(3, 1, 1.hour)                     -> 3L,
+        RateLimit(0, 1, 1.hour)                     -> 1L,
+        RateLimit(3, 0, 1.hour)                     -> 1L,
+        RateLimit(3, 1, 500.nanos)                  -> 1L,
+        RateLimit(9007199254740993L, 1, 1.hour)     -> 1L, // 2^53 + 1
+        RateLimit(3, 9007199254740993L, 1.hour)     -> 1L,
+        RateLimit(3, 1, 9007199254740993L.micros)   -> 1L,
+        RateLimit(1_000_000_000L, 1, 10000.seconds) -> 1L,
+        RateLimit(3, 1, 3002399751580331L.micros)   -> 1L, // 3x = 2^53 + 1
+        RateLimit(3, 1, 1.hour)                     -> 4L,
+        RateLimit(3, 1, 1.hour)                     -> -1L,
+        RateLimit(3, 1, 1.hour)                     -> 9007199254740993L
+      )
+      def serverRejects(rl: RateLimiter[String], cost: Long): CIO[Boolean] =
+        client.run(rl.tryAcquire("k", cost)).map(_ => false).recover {
+          case ServerError("SAGE", _) => CIO.value(true)
+          case other                  => CIO.fail(other)
+        }
+      def loop(remaining: List[((RateLimit, Long), Int)]): CIO[Unit]       =
+        remaining match {
+          case Nil                        => CIO.value(())
+          case ((limit, cost), i) :: tail =>
+            val rl = RateLimiter[String](limit, namespace = s"conform$i")
+            serverRejects(rl, cost).flatMap { rejected =>
+              assertEquals(rejected, rl.validate(cost).isDefined, s"case $i: $limit cost=$cost")
+              loop(tail)
+            }
+        }
+      loop(cases.zipWithIndex)
+    }
+  }
+
+  test("RateLimiterClient.command exposes the same composable check") {
+    withClient { client =>
+      val rl = client.rateLimiter[String](limit(1))
+      for {
+        allowed <- client.run(rl.command("cmd-client"))
+        denied  <- client.run(rl.command("cmd-client"))
+      } yield {
+        assert(allowed.isAllowed)
+        assert(!denied.isAllowed)
+      }
+    }
+  }
+
+  test("accrues at the exact rate even at a large capacity") {
+    withClient { client =>
+      val rl = RateLimiter[String](RateLimit(capacity = 1_000_000_000L, refillTokens = 1000, refillPeriod = 1.second))
+      val t0 = 7_000_000_000_000L
+      for {
+        _    <- client.run(rl.tryAcquireAt("big", 1_000_000_000L, t0))
+        half <- client.run(rl.tryAcquireAt("big", 500, t0 + 500_000L))
+        rest <- client.run(rl.tryAcquireAt("big", 500, t0 + 1_000_000L))
+        over <- client.run(rl.tryAcquireAt("big", 1, t0 + 1_000_000L))
+      } yield {
+        assert(half.isAllowed && half.remainingOrZero == 0L, "0.5s accrues exactly 500 tokens")
+        assert(rest.isAllowed && rest.remainingOrZero == 0L, "the next 0.5s accrues the other 500")
+        assert(!over.isAllowed, "and no more than the rate allows")
+      }
+    }
+  }
+
+  test("refills continuously as injected time advances") {
+    withClient { client =>
+      val rl = RateLimiter[String](RateLimit(capacity = 10, refillTokens = 10, refillPeriod = 1.second))
+      val t0 = 2_000_000_000_000L
+      for {
+        drain   <- client.run(rl.tryAcquireAt("refill", 10, t0))
+        denied  <- client.run(rl.tryAcquireAt("refill", 1, t0))
+        partial <- client.run(rl.tryAcquireAt("refill", 3, t0 + 300_000L))
+        empty   <- client.run(rl.tryAcquireAt("refill", 1, t0 + 300_000L))
+      } yield {
+        assert(drain.isAllowed && drain.remainingOrZero == 0L, "cost 10 empties a 10-token bucket")
+        assert(!denied.isAllowed, "no tokens have refilled at t0")
+        assert(partial.isAllowed && partial.remainingOrZero == 0L, "0.3s refills exactly 3 tokens")
+        assert(!empty.isAllowed, "and no more")
+      }
+    }
+  }
+
+  test("a backward server clock does not double-credit refill") {
+    withClient { client =>
+      val rl = RateLimiter[String](RateLimit(capacity = 10, refillTokens = 10, refillPeriod = 1.second))
+      val t0 = 5_000_000_000_000L
+      for {
+        _        <- client.run(rl.tryAcquireAt("clock", 10, t0))
+        backward <- client.run(rl.tryAcquireAt("clock", 1, t0 - 500_000L))
+        recover  <- client.run(rl.tryAcquireAt("clock", 1, t0 + 100_000L))
+        extra    <- client.run(rl.tryAcquireAt("clock", 1, t0 + 100_000L))
+      } yield {
+        assert(!backward.isAllowed, "a regressed clock credits nothing")
+        assert(recover.isAllowed && recover.remainingOrZero == 0L, "credit resumes from the high-water mark, not doubled")
+        assert(!extra.isAllowed)
+      }
+    }
+  }
+
+  test("a non-integer refill rate credits whole tokens exactly and never re-counts elapsed time") {
+    withClient { client =>
+      val rl = RateLimiter[String](RateLimit(capacity = 10, refillTokens = 3, refillPeriod = 1.second))
+      val t0 = 3_000_000_000_000L
+      for {
+        _      <- client.run(rl.tryAcquireAt("frac", 10, t0))
+        early  <- client.run(rl.tryAcquireAt("frac", 1, t0 + 333_333L))
+        repeat <- client.run(rl.tryAcquireAt("frac", 1, t0 + 333_333L))
+        one    <- client.run(rl.tryAcquireAt("frac", 1, t0 + 333_334L))
+      } yield {
+        assert(!early.isAllowed, "just under 1/3 s accrues no whole token")
+        assert(!repeat.isAllowed, "the same timestamp does not mint from re-counted elapsed")
+        assert(one.isAllowed && one.remainingOrZero == 0L, "one whole token at 333_334 micros, no more")
+      }
+    }
+  }
+
+  test("a clock rollback folds the catch-up interval into retryAfter and the key's TTL") {
+    withClient { client =>
+      val rl = RateLimiter[String](RateLimit(capacity = 1, refillTokens = 1, refillPeriod = 1.second))
+      val t0 = 8_000_000_000_000L
+      for {
+        _      <- client.run(rl.tryAcquireAt("roll", 1, t0))
+        rolled <- client.run(rl.tryAcquireAt("roll", 1, t0 - 4_000_000L))
+        pttl   <- client.pTtl("9:ratelimit:roll")
+      } yield {
+        rolled match {
+          case Decision.Denied(retryAfter) => assertEquals(retryAfter, 5.seconds)
+          case other                       => fail(s"expected Denied, got $other")
+        }
+        pttl match {
+          case Ttl.Expires(remaining) => assert(remaining > 2.seconds && remaining <= 5.seconds, s"pttl was $remaining")
+          case other                  => fail(s"expected an expiry, got $other")
+        }
+      }
+    }
+  }
+
+  test("a large refill period and odd rollback retain the exact reported wait past 2^53") {
+    withClient { client =>
+      val period = 1L << 53
+      val rl     = RateLimiter[String](RateLimit(capacity = 1, refillTokens = 1, refillPeriod = period.micros))
+      val t0     = 9_000_000_000_000L
+      for {
+        _      <- client.run(rl.tryAcquireAt("big-period", 1, t0))
+        rolled <- client.run(rl.tryAcquireAt("big-period", 1, t0 - 9L))
+      } yield rolled match {
+        case Decision.Denied(retryAfter) => assertEquals(retryAfter, (period + 9L).micros)
+        case other                       => fail(s"expected Denied, got $other")
+      }
+    }
+  }
+
+  test("reusing a namespace with alternating policies never mints a fresh bucket") {
+    withClient { client =>
+      val original  = RateLimiter[String](RateLimit(capacity = 10, refillTokens = 10, refillPeriod = 1.second), namespace = "policy")
+      val tightened = RateLimiter[String](RateLimit(capacity = 1, refillTokens = 1, refillPeriod = 1.second), namespace = "policy")
+      val t0        = 6_000_000_000_000L
+      for {
+        old       <- client.run(original.tryAcquireAt("same-subject", 1, t0))
+        firstNew  <- client.run(tightened.tryAcquireAt("same-subject", 1, t0))
+        oldAgain  <- client.run(original.tryAcquireAt("same-subject", 1, t0))
+        secondNew <- client.run(tightened.tryAcquireAt("same-subject", 1, t0))
+        rolled    <- client.run(original.tryAcquireAt("same-subject", 1, t0 - 500_000L))
+        recovered <- client.run(original.tryAcquireAt("same-subject", 1, t0))
+      } yield {
+        assertEquals(old.remainingOrZero, 9L)
+        assert(firstNew.isAllowed && firstNew.remainingOrZero == 0L, "old credit is capped at the tightened capacity")
+        assert(!oldAgain.isAllowed, "the old policy cannot recreate a full bucket during an overlapping deployment")
+        assert(!secondNew.isAllowed, "alternating policy signatures cannot mint tokens")
+        assert(!rolled.isAllowed, "a policy switch during clock rollback credits nothing")
+        assert(!recovered.isAllowed, "clock recovery only reaches the preserved high-water mark")
+      }
+    }
+  }
+
+  test("malformed bucket fields are rejected instead of granting tokens") {
+    withClient { client =>
+      val rl                                      = RateLimiter[String](limit(1))
+      def rejected(subject: String): CIO[Boolean] =
+        client.run(rl.tryAcquireAt(subject, 1, 4_000_000_000_000L)).map(_ => false).recover {
+          case ServerError("SAGE", message) if message.contains("invalid rate-limit state") => CIO.value(true)
+          case other                                                                        => CIO.fail(other)
+        }
+      for {
+        _            <- client.run(rl.tryAcquireAt("missing", 1, 4_000_000_000_000L))
+        _            <- client.hDel("9:ratelimit:missing", "ts")
+        missingField <- rejected("missing")
+        _            <- client.run(rl.tryAcquireAt("out-of-range", 1, 4_000_000_000_000L))
+        _            <- client.hSet("9:ratelimit:out-of-range", ("t", "2"))
+        outOfRange   <- rejected("out-of-range")
+        _            <- client.run(rl.tryAcquireAt("full-with-fraction", 1, 4_000_000_000_000L))
+        _            <- client.hSet("9:ratelimit:full-with-fraction", ("t", "1"), ("f", "1"))
+        fullFraction <- rejected("full-with-fraction")
+      } yield {
+        assert(missingField, "a missing field must not restore capacity")
+        assert(outOfRange, "out-of-range tokens must not exceed capacity")
+        assert(fullFraction, "a full bucket must not carry fractional refill credit")
+      }
+    }
+  }
+
+  test("an already-full bucket reports zero time to full") {
+    withClient { client =>
+      val rl = RateLimiter[String](RateLimit(capacity = 5, refillTokens = 5, refillPeriod = 1.second))
+      for {
+        peeked <- client.run(rl.peek("full"))
+      } yield peeked match {
+        case Decision.Allowed(remaining, resetAfter) =>
+          assertEquals(remaining, 5L)
+          assertEquals(resetAfter, Duration.Zero)
+        case other                                   => fail(s"expected Allowed, got $other")
+      }
+    }
+  }
+}
+
+class RedisRateLimiterSuite  extends RateLimiterSuite(Images.redis)
+class ValkeyRateLimiterSuite extends RateLimiterSuite(Images.valkey)

--- a/integration-tests/shared/src/test/scala/sage/integration/ratelimit/RateLimiterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/ratelimit/RateLimiterSuite.scala
@@ -13,6 +13,8 @@ abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
 
   private def limit(capacity: Long) = RateLimit(capacity, refillTokens = 1, refillPeriod = 1.hour)
 
+  private def bucketKey(subject: String) = s"9:ratelimit:$subject"
+
   test("admits up to capacity, then denies (via client.rateLimiter)") {
     withClient { client =>
       val rl = client.rateLimiter[String](limit(3))
@@ -23,11 +25,13 @@ abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
         d4 <- rl.tryAcquire("admit")
       } yield {
         assert(d1.isAllowed, "1st allowed")
-        assert(d3.isAllowed && d3.remainingOrZero == 0L, "3rd allowed, empties bucket")
+        assert(d3.isAllowed && d3.remainingTokens == 0L, "3rd allowed, empties bucket")
         assert(!d4.isAllowed, "4th denied")
         d4 match {
-          case Decision.Denied(retryAfter) => assert(retryAfter > Duration.Zero)
-          case other                       => fail(s"expected Denied, got $other")
+          case Decision.Denied(remaining, retryAfter) =>
+            assertEquals(remaining, 0L)
+            assert(retryAfter > Duration.Zero)
+          case other                                  => fail(s"expected Denied, got $other")
         }
       }
     }
@@ -40,8 +44,8 @@ abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
         first  <- rl.tryAcquire("cost", cost = 3)
         second <- rl.tryAcquire("cost", cost = 3)
       } yield {
-        assert(first.isAllowed && first.remainingOrZero == 2L, "cost 3 of 5 leaves 2")
-        assert(!second.isAllowed, "second cost-3 exceeds the 2 left")
+        assert(first.isAllowed && first.remainingTokens == 2L, "cost 3 of 5 leaves 2")
+        assert(!second.isAllowed && second.remainingTokens == 2L, "second cost-3 exceeds the 2 left, which stay untouched")
       }
     }
   }
@@ -54,8 +58,23 @@ abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
         peeked <- rl.peek("peek")
         after  <- rl.tryAcquire("peek")
       } yield {
-        assertEquals(peeked.remainingOrZero, 2L)
-        assert(after.isAllowed && after.remainingOrZero == 1L, "peek left the 2 tokens intact")
+        assert(peeked.isAllowed && peeked.remainingTokens == 2L)
+        assert(after.isAllowed && after.remainingTokens == 1L, "peek left the 2 tokens intact")
+      }
+    }
+  }
+
+  test("peek on an empty bucket is denied, still consuming nothing") {
+    withClient { client =>
+      val rl = client.rateLimiter[String](limit(1))
+      for {
+        _      <- rl.tryAcquire("peek-empty")
+        peeked <- rl.peek("peek-empty")
+      } yield peeked match {
+        case Decision.Denied(remaining, retryAfter) =>
+          assertEquals(remaining, 0L)
+          assert(retryAfter > Duration.Zero, "reports the wait until one token is available")
+        case other                                  => fail(s"expected Denied, got $other")
       }
     }
   }
@@ -85,8 +104,22 @@ abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
         second <- client.run(rl.evalSha("es", 1))
       } yield {
         assertEquals(loaded, RateLimiter.sha)
-        assert(first.isAllowed && first.remainingOrZero == 1L)
-        assert(second.isAllowed && second.remainingOrZero == 0L)
+        assert(first.isAllowed && first.remainingTokens == 1L)
+        assert(second.isAllowed && second.remainingTokens == 0L)
+      }
+    }
+  }
+
+  test("the native EVALSHA path recovers from NOSCRIPT by loading the script and retrying") {
+    withClient { client =>
+      val rl = client.rateLimiter[String](limit(2), namespace = "noscript")
+      for {
+        _      <- client.scriptFlush()
+        first  <- rl.tryAcquire("cold")
+        second <- rl.tryAcquire("cold")
+      } yield {
+        assert(first.isAllowed && first.remainingTokens == 1L, "a cold server is recovered by one load-and-retry")
+        assert(second.isAllowed && second.remainingTokens == 0L, "the loaded script then serves EVALSHA directly")
       }
     }
   }
@@ -164,8 +197,8 @@ abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
         rest <- client.run(rl.tryAcquireAt("big", 500, t0 + 1_000_000L))
         over <- client.run(rl.tryAcquireAt("big", 1, t0 + 1_000_000L))
       } yield {
-        assert(half.isAllowed && half.remainingOrZero == 0L, "0.5s accrues exactly 500 tokens")
-        assert(rest.isAllowed && rest.remainingOrZero == 0L, "the next 0.5s accrues the other 500")
+        assert(half.isAllowed && half.remainingTokens == 0L, "0.5s accrues exactly 500 tokens")
+        assert(rest.isAllowed && rest.remainingTokens == 0L, "the next 0.5s accrues the other 500")
         assert(!over.isAllowed, "and no more than the rate allows")
       }
     }
@@ -181,9 +214,9 @@ abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
         partial <- client.run(rl.tryAcquireAt("refill", 3, t0 + 300_000L))
         empty   <- client.run(rl.tryAcquireAt("refill", 1, t0 + 300_000L))
       } yield {
-        assert(drain.isAllowed && drain.remainingOrZero == 0L, "cost 10 empties a 10-token bucket")
+        assert(drain.isAllowed && drain.remainingTokens == 0L, "cost 10 empties a 10-token bucket")
         assert(!denied.isAllowed, "no tokens have refilled at t0")
-        assert(partial.isAllowed && partial.remainingOrZero == 0L, "0.3s refills exactly 3 tokens")
+        assert(partial.isAllowed && partial.remainingTokens == 0L, "0.3s refills exactly 3 tokens")
         assert(!empty.isAllowed, "and no more")
       }
     }
@@ -200,7 +233,7 @@ abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
         extra    <- client.run(rl.tryAcquireAt("clock", 1, t0 + 100_000L))
       } yield {
         assert(!backward.isAllowed, "a regressed clock credits nothing")
-        assert(recover.isAllowed && recover.remainingOrZero == 0L, "credit resumes from the high-water mark, not doubled")
+        assert(recover.isAllowed && recover.remainingTokens == 0L, "credit resumes from the high-water mark, not doubled")
         assert(!extra.isAllowed)
       }
     }
@@ -218,7 +251,7 @@ abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
       } yield {
         assert(!early.isAllowed, "just under 1/3 s accrues no whole token")
         assert(!repeat.isAllowed, "the same timestamp does not mint from re-counted elapsed")
-        assert(one.isAllowed && one.remainingOrZero == 0L, "one whole token at 333_334 micros, no more")
+        assert(one.isAllowed && one.remainingTokens == 0L, "one whole token at 333_334 micros, no more")
       }
     }
   }
@@ -230,11 +263,11 @@ abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
       for {
         _      <- client.run(rl.tryAcquireAt("roll", 1, t0))
         rolled <- client.run(rl.tryAcquireAt("roll", 1, t0 - 4_000_000L))
-        pttl   <- client.pTtl("9:ratelimit:roll")
+        pttl   <- client.pTtl(bucketKey("roll"))
       } yield {
         rolled match {
-          case Decision.Denied(retryAfter) => assertEquals(retryAfter, 5.seconds)
-          case other                       => fail(s"expected Denied, got $other")
+          case Decision.Denied(_, retryAfter) => assertEquals(retryAfter, 5.seconds)
+          case other                          => fail(s"expected Denied, got $other")
         }
         pttl match {
           case Ttl.Expires(remaining) => assert(remaining > 2.seconds && remaining <= 5.seconds, s"pttl was $remaining")
@@ -253,8 +286,8 @@ abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
         _      <- client.run(rl.tryAcquireAt("big-period", 1, t0))
         rolled <- client.run(rl.tryAcquireAt("big-period", 1, t0 - 9L))
       } yield rolled match {
-        case Decision.Denied(retryAfter) => assertEquals(retryAfter, (period + 9L).micros)
-        case other                       => fail(s"expected Denied, got $other")
+        case Decision.Denied(_, retryAfter) => assertEquals(retryAfter, (period + 9L).micros)
+        case other                          => fail(s"expected Denied, got $other")
       }
     }
   }
@@ -272,8 +305,8 @@ abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
         rolled    <- client.run(original.tryAcquireAt("same-subject", 1, t0 - 500_000L))
         recovered <- client.run(original.tryAcquireAt("same-subject", 1, t0))
       } yield {
-        assertEquals(old.remainingOrZero, 9L)
-        assert(firstNew.isAllowed && firstNew.remainingOrZero == 0L, "old credit is capped at the tightened capacity")
+        assertEquals(old.remainingTokens, 9L)
+        assert(firstNew.isAllowed && firstNew.remainingTokens == 0L, "old credit is capped at the tightened capacity")
         assert(!oldAgain.isAllowed, "the old policy cannot recreate a full bucket during an overlapping deployment")
         assert(!secondNew.isAllowed, "alternating policy signatures cannot mint tokens")
         assert(!rolled.isAllowed, "a policy switch during clock rollback credits nothing")
@@ -292,13 +325,13 @@ abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
         }
       for {
         _            <- client.run(rl.tryAcquireAt("missing", 1, 4_000_000_000_000L))
-        _            <- client.hDel("9:ratelimit:missing", "ts")
+        _            <- client.hDel(bucketKey("missing"), "ts")
         missingField <- rejected("missing")
         _            <- client.run(rl.tryAcquireAt("out-of-range", 1, 4_000_000_000_000L))
-        _            <- client.hSet("9:ratelimit:out-of-range", ("t", "2"))
+        _            <- client.hSet(bucketKey("out-of-range"), ("t", "2"))
         outOfRange   <- rejected("out-of-range")
         _            <- client.run(rl.tryAcquireAt("full-with-fraction", 1, 4_000_000_000_000L))
-        _            <- client.hSet("9:ratelimit:full-with-fraction", ("t", "1"), ("f", "1"))
+        _            <- client.hSet(bucketKey("full-with-fraction"), ("t", "1"), ("f", "1"))
         fullFraction <- rejected("full-with-fraction")
       } yield {
         assert(missingField, "a missing field must not restore capacity")

--- a/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
+++ b/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
@@ -239,4 +239,24 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
       Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
     }
   }
+
+  test("client.rateLimiter admits up to capacity then denies") {
+    withContainers { server =>
+      val program: Task[Unit] =
+        ZIO.scoped {
+          for {
+            client <- SageClient.scoped(configOf(server))
+            rl      = client.rateLimiter[String](RateLimit(capacity = 2, refillTokens = 1, refillPeriod = FiniteDuration(1L, TimeUnit.HOURS)))
+            first  <- rl.tryAcquire("smoke")
+            second <- rl.tryAcquire("smoke")
+            denied <- rl.tryAcquire("smoke")
+          } yield {
+            assert(first.isAllowed && second.isAllowed, "the first two are admitted")
+            assert(!denied.isAllowed, "the third is denied once the bucket empties")
+          }
+        }
+
+      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    }
+  }
 }

--- a/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
@@ -11,7 +11,7 @@ import org.apache.pekko.actor.typed.ActorSystem
 import org.apache.pekko.stream.{KillSwitches, Materializer, SystemMaterializer, UniqueKillSwitch}
 import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source}
 
-import sage.{Message, PatternMessage}
+import sage.{Message, PatternMessage, SageException}
 import sage.client.SageConfig
 import sage.client.internal.{Client, LoweredClient, Paged, ScanStep, ScanTarget, Subscription}
 import sage.codec.{KeyCodec, ValueCodec}
@@ -249,11 +249,11 @@ object SageClient {
     ran.transformWith(result => client.close.transformWith(_ => Future.fromTry(result)))
   }
 
-  private[backend] def boundedPoll(block: BlockTimeout, method: String): Either[IllegalArgumentException, BlockTimeout] =
+  private[backend] def boundedPoll(block: BlockTimeout, method: String): Either[SageException.InvalidArgument, BlockTimeout] =
     block match {
       case BlockTimeout.Forever =>
         Left(
-          new IllegalArgumentException(
+          SageException.InvalidArgument(
             s"$method cannot use BlockTimeout.Forever on the Pekko backend; Future cannot interrupt an in-flight blocking read"
           )
         )

--- a/sage-client/shared/src/main/scala/sage/client/RateLimiterClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/RateLimiterClient.scala
@@ -1,0 +1,32 @@
+package sage.client
+
+import sage.client.internal.{Client, RateLimitExecutor}
+import sage.commands.Command
+import sage.ratelimit.{Decision, RateLimiter}
+
+/**
+  * A rate limiter bound to a client, returned by `client.rateLimiter(...)`. Checks come back in the backend's own effect `F`.
+  */
+final class RateLimiterClient[F[_], K] private[sage] (client: Client[F, ?], executor: RateLimitExecutor[K]) {
+
+  /**
+    * Consume `cost` tokens for `subject` if available, returning [[Decision.Allowed]] with the tokens left, otherwise [[Decision.Denied]].
+    */
+  def tryAcquire(subject: K, cost: Long = 1): F[Decision] = client.rateLimitAcquire(executor, subject, cost)
+
+  /**
+    * Report the current standing for `subject` without consuming.
+    */
+  def peek(subject: K): F[Decision] = client.rateLimitAcquire(executor, subject, RateLimiter.peekCost)
+
+  /**
+    * Clear `subject`'s bucket, so its next request starts from full capacity.
+    */
+  def reset(subject: K): F[Unit] = client.run(executor.resetCommand(subject))
+
+  /**
+    * An equivalent plain-`EVAL` [[sage.commands.Command]] for pipelining or running yourself. Unlike native [[tryAcquire]], it does not use
+    * the cached-script `EVALSHA` fast path.
+    */
+  def command(subject: K, cost: Long = 1): Command[Decision] = executor.command(subject, cost)
+}

--- a/sage-client/shared/src/main/scala/sage/client/RateLimiterClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/RateLimiterClient.scala
@@ -10,7 +10,7 @@ import sage.ratelimit.{Decision, RateLimiter}
 final class RateLimiterClient[F[_], K] private[sage] (client: Client[F, ?], executor: RateLimitExecutor[K]) {
 
   /**
-    * Consume `cost` tokens for `subject` if available, returning [[Decision.Allowed]] with the tokens left, otherwise [[Decision.Denied]].
+    * Consume `cost` tokens for `subject` if available, returning a [[Decision]]: `Allowed` with the tokens left, otherwise `Denied`.
     */
   def tryAcquire(subject: K, cost: Long = 1): F[Decision] = client.rateLimitAcquire(executor, subject, cost)
 

--- a/sage-client/shared/src/main/scala/sage/client/RateLimiterClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/RateLimiterClient.scala
@@ -2,7 +2,7 @@ package sage.client
 
 import sage.client.internal.{Client, RateLimitExecutor}
 import sage.commands.Command
-import sage.ratelimit.{Decision, RateLimiter}
+import sage.ratelimit.Decision
 
 /**
   * A rate limiter bound to a client, returned by `client.rateLimiter(...)`. Checks come back in the backend's own effect `F`.
@@ -12,12 +12,13 @@ final class RateLimiterClient[F[_], K] private[sage] (client: Client[F, ?], exec
   /**
     * Consume `cost` tokens for `subject` if available, returning a [[Decision]]: `Allowed` with the tokens left, otherwise `Denied`.
     */
-  def tryAcquire(subject: K, cost: Long = 1): F[Decision] = client.rateLimitAcquire(executor, subject, cost)
+  def tryAcquire(subject: K, cost: Long = 1): F[Decision] = client.rateLimitAcquire(executor, subject, cost, peek = false)
 
   /**
-    * Report the current standing for `subject` without consuming.
+    * Report the current standing for `subject` without consuming: `Allowed` while at least one token is available, otherwise `Denied`
+    * with the wait until one is.
     */
-  def peek(subject: K): F[Decision] = client.rateLimitAcquire(executor, subject, RateLimiter.peekCost)
+  def peek(subject: K): F[Decision] = client.rateLimitAcquire(executor, subject, cost = 1, peek = true)
 
   /**
     * Clear `subject`'s bucket, so its next request starts from full capacity.

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -13,11 +13,12 @@ import kyo.compat.*
 
 import sage.{Bytes, CommandSpan, Message, Outcome, PatternMessage, SageEvent, SageException}
 import sage.SageException.*
-import sage.client.{AuthConfig, BackoffConfig, DedicatedPoolConfig, Endpoint, PubSubConfig, ReadFrom, SageConfig, Topology, WatchdogConfig}
+import sage.client.*
 import sage.cluster.Node
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.*
 import sage.protocol.Frame
+import sage.ratelimit.{Decision, RateLimit, RateLimiter}
 
 /**
   * The command surface shared by [[Client]] and [[TransactionScope]]: every command as a concrete method delegating to [[run]], so anything
@@ -2221,6 +2222,18 @@ trait Client[F[_], K] extends CommandRunner[F, K] {
   def transaction[A](body: TransactionScope[F, K] => F[A]): F[A]
 
   /**
+    * A distributed token-bucket rate limiter over this connection, with subject key type `RK`. See [[RateLimiterClient]].
+    */
+  def rateLimiter[RK](limit: RateLimit, namespace: String = RateLimiter.defaultNamespace)(
+    using KeyCodec[RK]
+  ): RateLimiterClient[F, RK] =
+    new RateLimiterClient[F, RK](this, RateLimitExecutor(RateLimiter[RK](limit, namespace)))
+
+  // default is a plain EVAL; native backends override for EVALSHA in LoweredClient
+  private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long): F[Decision] =
+    executor.eval(this, subject, cost)
+
+  /**
     * Subscribes to classic channels, returning a [[Subscription]] handle the backend wraps into its native stream of [[Message]]s.
     */
   def subscribeChannels[V: ValueCodec](channel: String, rest: String*): F[Subscription[F, Message[V]]]
@@ -2255,17 +2268,19 @@ trait Client[F[_], K] extends CommandRunner[F, K] {
   override def as[K2](using KeyCodec[K2]): Client[F, K2] = {
     val self = this
     new Client[F, K2] {
-      def run[A](command: Command[A]): F[A]                                     = self.run(command)
-      def cached[A](command: Command[A], ttl: FiniteDuration): F[A]             = self.cached(command, ttl)
-      private[sage] def pipeline[Out, R](p: Pipeline[Out, R]): F[Out]           = self.pipeline(p)
-      private[sage] def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R]      = self.pipelineAttempt(p)
-      def transaction[A](body: TransactionScope[F, K2] => F[A]): F[A]           = self.transaction(scope => body(scope.as[K2]))
-      def subscribeChannels[V: ValueCodec](channel: String, rest: String*)      = self.subscribeChannels(channel, rest*)
-      def subscribePatterns[V: ValueCodec](pattern: String, rest: String*)      = self.subscribePatterns(pattern, rest*)
-      def subscribeShardChannels[V: ValueCodec](channel: String, rest: String*) = self.subscribeShardChannels(channel, rest*)
-      private[sage] def scanTargets: F[Vector[ScanTarget]]                      = self.scanTargets
-      private[sage] def runOn[A](target: ScanTarget, command: Command[A]): F[A] = self.runOn(target, command)
-      def close: F[Unit]                                                        = self.close
+      def run[A](command: Command[A]): F[A]                                                                                  = self.run(command)
+      def cached[A](command: Command[A], ttl: FiniteDuration): F[A]                                                          = self.cached(command, ttl)
+      private[sage] def pipeline[Out, R](p: Pipeline[Out, R]): F[Out]                                                        = self.pipeline(p)
+      private[sage] def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R]                                                   = self.pipelineAttempt(p)
+      def transaction[A](body: TransactionScope[F, K2] => F[A]): F[A]                                                        = self.transaction(scope => body(scope.as[K2]))
+      def subscribeChannels[V: ValueCodec](channel: String, rest: String*)                                                   = self.subscribeChannels(channel, rest*)
+      def subscribePatterns[V: ValueCodec](pattern: String, rest: String*)                                                   = self.subscribePatterns(pattern, rest*)
+      def subscribeShardChannels[V: ValueCodec](channel: String, rest: String*)                                              = self.subscribeShardChannels(channel, rest*)
+      private[sage] def scanTargets: F[Vector[ScanTarget]]                                                                   = self.scanTargets
+      private[sage] def runOn[A](target: ScanTarget, command: Command[A]): F[A]                                              = self.runOn(target, command)
+      override private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long): F[Decision] =
+        self.rateLimitAcquire(executor, subject, cost)
+      def close: F[Unit]                                                                                                     = self.close
     }
   }
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2229,9 +2229,8 @@ trait Client[F[_], K] extends CommandRunner[F, K] {
   ): RateLimiterClient[F, RK] =
     new RateLimiterClient[F, RK](this, RateLimitExecutor(RateLimiter[RK](limit, namespace)))
 
-  // default is a plain EVAL; native backends override for EVALSHA in LoweredClient
-  private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long): F[Decision] =
-    executor.eval(this, subject, cost)
+  // implementations validate client-side, then run the cached-script EVALSHA path
+  private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long, peek: Boolean): F[Decision]
 
   /**
     * Subscribes to classic channels, returning a [[Subscription]] handle the backend wraps into its native stream of [[Message]]s.
@@ -2268,19 +2267,19 @@ trait Client[F[_], K] extends CommandRunner[F, K] {
   override def as[K2](using KeyCodec[K2]): Client[F, K2] = {
     val self = this
     new Client[F, K2] {
-      def run[A](command: Command[A]): F[A]                                                                                  = self.run(command)
-      def cached[A](command: Command[A], ttl: FiniteDuration): F[A]                                                          = self.cached(command, ttl)
-      private[sage] def pipeline[Out, R](p: Pipeline[Out, R]): F[Out]                                                        = self.pipeline(p)
-      private[sage] def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R]                                                   = self.pipelineAttempt(p)
-      def transaction[A](body: TransactionScope[F, K2] => F[A]): F[A]                                                        = self.transaction(scope => body(scope.as[K2]))
-      def subscribeChannels[V: ValueCodec](channel: String, rest: String*)                                                   = self.subscribeChannels(channel, rest*)
-      def subscribePatterns[V: ValueCodec](pattern: String, rest: String*)                                                   = self.subscribePatterns(pattern, rest*)
-      def subscribeShardChannels[V: ValueCodec](channel: String, rest: String*)                                              = self.subscribeShardChannels(channel, rest*)
-      private[sage] def scanTargets: F[Vector[ScanTarget]]                                                                   = self.scanTargets
-      private[sage] def runOn[A](target: ScanTarget, command: Command[A]): F[A]                                              = self.runOn(target, command)
-      override private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long): F[Decision] =
-        self.rateLimitAcquire(executor, subject, cost)
-      def close: F[Unit]                                                                                                     = self.close
+      def run[A](command: Command[A]): F[A]                                                                                        = self.run(command)
+      def cached[A](command: Command[A], ttl: FiniteDuration): F[A]                                                                = self.cached(command, ttl)
+      private[sage] def pipeline[Out, R](p: Pipeline[Out, R]): F[Out]                                                              = self.pipeline(p)
+      private[sage] def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R]                                                         = self.pipelineAttempt(p)
+      def transaction[A](body: TransactionScope[F, K2] => F[A]): F[A]                                                              = self.transaction(scope => body(scope.as[K2]))
+      def subscribeChannels[V: ValueCodec](channel: String, rest: String*)                                                         = self.subscribeChannels(channel, rest*)
+      def subscribePatterns[V: ValueCodec](pattern: String, rest: String*)                                                         = self.subscribePatterns(pattern, rest*)
+      def subscribeShardChannels[V: ValueCodec](channel: String, rest: String*)                                                    = self.subscribeShardChannels(channel, rest*)
+      private[sage] def scanTargets: F[Vector[ScanTarget]]                                                                         = self.scanTargets
+      private[sage] def runOn[A](target: ScanTarget, command: Command[A]): F[A]                                                    = self.runOn(target, command)
+      private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long, peek: Boolean): F[Decision] =
+        self.rateLimitAcquire(executor, subject, cost, peek)
+      def close: F[Unit]                                                                                                           = self.close
     }
   }
 }
@@ -2338,7 +2337,7 @@ object Client {
     */
   def connect(config: SageConfig): CIO[Client[CIO, String]] =
     validate(config) match {
-      case Some(problem) => CIO.fail(new IllegalArgumentException(problem))
+      case Some(problem) => CIO.fail(InvalidArgument(problem))
       case None          =>
         config.topology match {
           case Topology.Standalone(endpoint)                => connectStandalone(config, endpoint)
@@ -2349,8 +2348,7 @@ object Client {
         }
     }
 
-  // a misconfigured client is a programmer error, surfaced through the connect effect (never thrown from a constructor) and deliberately
-  // outside the sealed hierarchy, like the other usage guards
+  // a misconfigured client is a programmer error, surfaced through the connect effect rather than thrown from a constructor
   private def validate(config: SageConfig): Option[String] = {
     // pingInterval/pingTimeout are inert when the watchdog is disabled, so don't reject them then
     val watchdog =
@@ -2519,6 +2517,9 @@ object Client {
 
     def runOn[A](target: ScanTarget, command: Command[A]): CIO[A] = run(command)
 
+    private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long, peek: Boolean): CIO[Decision] =
+      executor.evalSha(this, subject, cost, peek)
+
     private[sage] def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out] =
       submitPipeline(p).flatMap(TxSupport.collapseStrict(_, p.toOut))
 
@@ -2547,7 +2548,7 @@ object Client {
       if (p.commands.isEmpty)
         CIO.value(Vector.empty)
       else if (p.commands.exists(_.isBlocking))
-        CIO.fail(new IllegalArgumentException("a Pipeline cannot carry blocking commands; run them individually on the client"))
+        CIO.fail(InvalidArgument("a Pipeline cannot carry blocking commands; run them individually on the client"))
       else
         CIO.async { complete =>
           Client.submitBatchOnOne(events, p.commands, Events.startSpans(events, p.commands), connection.submitAll, complete)
@@ -2674,7 +2675,7 @@ object Client {
       if (isReleased)
         CIO.fail(TxSupport.scopeReleasedError)
       else if (command.isBlocking)
-        CIO.fail(new IllegalArgumentException("a Transaction cannot run blocking commands; run them individually on the client"))
+        CIO.fail(InvalidArgument("a Transaction cannot run blocking commands; run them individually on the client"))
       else
         CIO.async[A] { complete =>
           val tracked = Events.trackSpan(events, command, complete)
@@ -2706,7 +2707,7 @@ object Client {
       else if (p.commands.isEmpty && !armed.get)
         CIO.value(Some(Vector.empty))
       else if (p.commands.exists(_.isBlocking))
-        CIO.fail(new IllegalArgumentException("a Transaction cannot carry blocking commands; run them individually on the client"))
+        CIO.fail(InvalidArgument("a Transaction cannot carry blocking commands; run them individually on the client"))
       else
         CIO
           .async[Vector[Frame]] { complete =>

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -13,12 +13,13 @@ import scala.util.control.NonFatal
 import kyo.compat.*
 
 import sage.{Bytes, CommandSpan, Message, PatternMessage, SageEvent, SageException}
-import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, NotConnected, ServerError}
+import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, InvalidArgument, NotConnected, ServerError}
 import sage.client.{BackoffConfig, ClusterConfig, DedicatedPoolConfig, ReadFrom, SageConfig, WatchdogConfig}
 import sage.cluster.{ClusterTopology, Node, NodeGroup, Redirect, RedirectKind, Rejected, Route, Shard, Slot, SplitPlan}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.{BroadcastReduce, Cluster, Command, Connection, Pipeline, Reply}
 import sage.protocol.Frame
+import sage.ratelimit.Decision
 
 /**
   * The cluster runtime: one [[NodeClient]] bundle per master, a refreshable [[ClusterTopology]], and the routing/redirect/failover state
@@ -145,6 +146,9 @@ final private[client] class ClusterLive(
           dispatch(command, cluster.maxRedirects, complete, allowReplica = false, cacheCtx = Cached(ttl.toMillis, deferred))
         )
       }
+
+  private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long, peek: Boolean): CIO[Decision] =
+    executor.evalSha(this, subject, cost, peek)
 
   // SCAN cursors are node-local, so a full SCAN must sweep every slot-owning master; a reshard mid-scan can still miss or duplicate keys
   def scanTargets: CIO[Vector[ScanTarget]] =
@@ -680,8 +684,8 @@ final private[client] class ClusterLive(
   private def crossSlot(name: String, slots: Set[Slot]): CrossSlot =
     CrossSlot(s"$name: keys span ${slots.size} slots; a single command must touch exactly one")
 
-  private def malformedKeys(name: String): IllegalArgumentException =
-    new IllegalArgumentException(s"$name: declared key positions fall outside its arguments")
+  private def malformedKeys(name: String): InvalidArgument =
+    InvalidArgument(s"$name: declared key positions fall outside its arguments")
 
   // a transaction never follows a redirect, so the caller's retry depends on the topology actually refreshing — bypass the throttle window
   // (single-flight still collapses concurrent refreshes); ordinary commands re-route, so they use the throttled triggerRefresh
@@ -694,14 +698,12 @@ final private[client] class ClusterLive(
       CIO.value(Vector.empty)
     // a blocking command is a programmer error: fail the whole effect up front, never a single position
     else if (p.commands.exists(_.isBlocking))
-      CIO.fail(new IllegalArgumentException("a Pipeline cannot carry blocking commands; run them individually on the client"))
+      CIO.fail(InvalidArgument("a Pipeline cannot carry blocking commands; run them individually on the client"))
     // a Pipeline batches per node, so an all-masters command (SCRIPT LOAD, FUNCTION LOAD, KEYS, …) would touch one node only and either
     // break a later key-routed EVALSHA/FCALL or return a partial keyspace; fail up front rather than partially apply it
     else if (p.commands.exists(_.allMasters))
       CIO.fail(
-        new IllegalArgumentException(
-          "a Pipeline cannot carry an all-masters command (e.g. SCRIPT LOAD, FUNCTION LOAD, KEYS); run it individually on the client"
-        )
+        InvalidArgument("a Pipeline cannot carry an all-masters command (e.g. SCRIPT LOAD, FUNCTION LOAD, KEYS); run it individually on the client")
       )
     else
       CIO.async { complete =>
@@ -888,10 +890,10 @@ final private[client] class ClusterLive(
 
     def run[A](command: Command[A]): CIO[A] =
       if (command.isBlocking)
-        CIO.fail(new IllegalArgumentException("a Transaction cannot run blocking commands; run them individually on the client"))
+        CIO.fail(InvalidArgument("a Transaction cannot run blocking commands; run them individually on the client"))
       else if (command.requiresClusterWideTxResult)
         CIO.fail(
-          new IllegalArgumentException(
+          InvalidArgument(
             s"${command.name} returns a cluster-wide result that a single-node Transaction cannot produce; run it individually on the client"
           )
         )
@@ -946,10 +948,10 @@ final private[client] class ClusterLive(
       else if (p.commands.isEmpty && !armed.get)
         CIO.value(Some(Vector.empty))
       else if (p.commands.exists(_.isBlocking))
-        CIO.fail(new IllegalArgumentException("a Transaction cannot carry blocking commands; run them individually on the client"))
+        CIO.fail(InvalidArgument("a Transaction cannot carry blocking commands; run them individually on the client"))
       else if (p.commands.exists(_.requiresClusterWideTxResult))
         CIO.fail(
-          new IllegalArgumentException(
+          InvalidArgument(
             "a Transaction cannot carry a command that returns a cluster-wide result; run it individually on the client"
           )
         )

--- a/sage-client/shared/src/main/scala/sage/client/internal/LoweredClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LoweredClient.scala
@@ -7,6 +7,7 @@ import kyo.compat.*
 import sage.{Message, PatternMessage}
 import sage.codec.{KeyCodec, ValueCodec}
 import sage.commands.{Command, Pipeline}
+import sage.ratelimit.Decision
 
 /**
   * Lowers the runtime's [[Client]] from the kyo-compat carrier `CIO` to a Backend's native effect `F`, written once for every Backend. A
@@ -43,6 +44,9 @@ abstract class LoweredClient[F[_]](underlying: Client[CIO, String]) extends Clie
   final private[sage] def scanTargets: F[Vector[ScanTarget]] = lower(underlying.scanTargets)
 
   final private[sage] def runOn[A](target: ScanTarget, command: Command[A]): F[A] = lower(underlying.runOn(target, command))
+
+  final override private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long): F[Decision] =
+    lower(executor.evalSha(underlying, subject, cost))
 
   final def close: F[Unit] = lower(underlying.close)
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/LoweredClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LoweredClient.scala
@@ -45,8 +45,8 @@ abstract class LoweredClient[F[_]](underlying: Client[CIO, String]) extends Clie
 
   final private[sage] def runOn[A](target: ScanTarget, command: Command[A]): F[A] = lower(underlying.runOn(target, command))
 
-  final override private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long): F[Decision] =
-    lower(executor.evalSha(underlying, subject, cost))
+  final private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long, peek: Boolean): F[Decision] =
+    lower(underlying.rateLimitAcquire(executor, subject, cost, peek))
 
   final def close: F[Unit] = lower(underlying.close)
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -11,11 +11,12 @@ import scala.util.control.NonFatal
 import kyo.compat.*
 
 import sage.{CommandSpan, Message, Outcome, PatternMessage, SageException}
-import sage.SageException.{ConnectionLost, NotConnected, TimedOut}
+import sage.SageException.{ConnectionLost, InvalidArgument, NotConnected, TimedOut}
 import sage.client.{ReadFrom, SageConfig}
 import sage.cluster.Node
 import sage.codec.ValueCodec
 import sage.commands.{Command, Connection, Pipeline, Role, Server}
+import sage.ratelimit.Decision
 
 /**
   * The master-replica runtime: a non-cluster deployment of one master and its replicas, discovered from seeds by asking each its `ROLE`.
@@ -297,7 +298,7 @@ final private[client] class MasterReplicaLive(
   private def submitPipeline[Out, R](p: Pipeline[Out, R]): CIO[Vector[Either[SageException, Any]]] =
     if (p.commands.isEmpty) CIO.value(Vector.empty)
     else if (p.commands.exists(_.isBlocking))
-      CIO.fail(new IllegalArgumentException("a Pipeline cannot carry blocking commands; run them individually on the client"))
+      CIO.fail(InvalidArgument("a Pipeline cannot carry blocking commands; run them individually on the client"))
     else
       CIO.async { complete =>
         val spans                                      = Events.startSpans(events, p.commands)
@@ -430,6 +431,9 @@ final private[client] class MasterReplicaLive(
 
   def scanTargets: CIO[Vector[ScanTarget]]                      = CIO.value(Vector(ScanTarget.any))
   def runOn[A](target: ScanTarget, command: Command[A]): CIO[A] = run(command)
+
+  private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long, peek: Boolean): CIO[Decision] =
+    executor.evalSha(this, subject, cost, peek)
 
   def close: CIO[Unit] = CIO.blocking(closeAll())
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/RateLimitExecutor.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/RateLimitExecutor.scala
@@ -2,27 +2,24 @@ package sage.client.internal
 
 import kyo.compat.*
 
-import sage.SageException.ServerError
+import sage.SageException.{InvalidArgument, ServerError}
 import sage.commands.Command
 import sage.ratelimit.{Decision, RateLimiter}
 
 /**
-  * Runs one bound limiter. [[eval]] sends the whole script each call; [[evalSha]] validates, runs by digest, and reloads once on a `NOSCRIPT`.
+  * Runs one bound limiter: [[evalSha]] validates, runs by digest, and reloads the script once on a `NOSCRIPT`.
   */
 final private[client] class RateLimitExecutor[K](definition: RateLimiter[K]) {
-
-  def eval[F[_]](runner: CommandRunner[F, ?], subject: K, cost: Long): F[Decision] =
-    runner.run(definition.tryAcquire(subject, cost))
 
   def command(subject: K, cost: Long): Command[Decision] = definition.tryAcquire(subject, cost)
 
   def resetCommand(subject: K): Command[Unit] = definition.reset(subject)
 
-  def evalSha(runner: CommandRunner[CIO, String], subject: K, cost: Long): CIO[Decision] =
+  def evalSha(runner: CommandRunner[CIO, String], subject: K, cost: Long, peek: Boolean): CIO[Decision] =
     definition.validate(cost) match {
-      case Some(problem) => CIO.fail(new IllegalArgumentException(s"invalid rate limiter: $problem"))
+      case Some(problem) => CIO.fail(InvalidArgument(problem))
       case None          =>
-        val check = definition.evalSha(subject, cost)
+        val check = definition.evalSha(subject, cost, peek)
         runner.run(check).recover {
           case ServerError(code, _) if code == "NOSCRIPT" => runner.run(definition.loadCommand).flatMap(_ => runner.run(check))
           case other                                      => CIO.fail(other)

--- a/sage-client/shared/src/main/scala/sage/client/internal/RateLimitExecutor.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/RateLimitExecutor.scala
@@ -1,0 +1,31 @@
+package sage.client.internal
+
+import kyo.compat.*
+
+import sage.SageException.ServerError
+import sage.commands.Command
+import sage.ratelimit.{Decision, RateLimiter}
+
+/**
+  * Runs one bound limiter. [[eval]] sends the whole script each call; [[evalSha]] validates, runs by digest, and reloads once on a `NOSCRIPT`.
+  */
+final private[client] class RateLimitExecutor[K](definition: RateLimiter[K]) {
+
+  def eval[F[_]](runner: CommandRunner[F, ?], subject: K, cost: Long): F[Decision] =
+    runner.run(definition.tryAcquire(subject, cost))
+
+  def command(subject: K, cost: Long): Command[Decision] = definition.tryAcquire(subject, cost)
+
+  def resetCommand(subject: K): Command[Unit] = definition.reset(subject)
+
+  def evalSha(runner: CommandRunner[CIO, String], subject: K, cost: Long): CIO[Decision] =
+    definition.validate(cost) match {
+      case Some(problem) => CIO.fail(new IllegalArgumentException(s"invalid rate limiter: $problem"))
+      case None          =>
+        val check = definition.evalSha(subject, cost)
+        runner.run(check).recover {
+          case ServerError(code, _) if code == "NOSCRIPT" => runner.run(definition.loadCommand).flatMap(_ => runner.run(check))
+          case other                                      => CIO.fail(other)
+        }
+    }
+}

--- a/sage-client/shared/src/main/scala/sage/client/internal/TxSupport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/TxSupport.scala
@@ -68,7 +68,7 @@ private[internal] object TxSupport {
       case _                          => None
     }
 
-  // a programmer error, deliberately outside the sealed hierarchy (like the blocking-command guard): a scope captured past its block
+  // a state error, not an argument, so deliberately outside the sealed hierarchy: a scope captured past its block
   def scopeReleasedError: IllegalStateException =
     new IllegalStateException("transaction scope used after its block returned")
 

--- a/sage-client/shared/src/main/scala/sage/exports.scala
+++ b/sage-client/shared/src/main/scala/sage/exports.scala
@@ -27,6 +27,7 @@ export sage.client.{
   TrustSource,
   WatchdogConfig
 }
+export sage.client.RateLimiterClient
 // the cluster node a Listener observes (SageEvent), the only cluster type users name
 export sage.cluster.Node
 // codec typeclasses (built-in givens live in their companions, already in implicit scope)
@@ -135,3 +136,5 @@ export sage.commands.{as, asArray, asArrayOf, asLong, asString}
 export sage.commands.{Attempt, BroadcastReduce, Command, Commands, Execution}
 // raw-Frame escape hatch for eval/fcall replies
 export sage.protocol.Frame
+// built-in token-bucket rate limiter
+export sage.ratelimit.{Decision, RateLimit, RateLimiter}

--- a/sage-client/shared/src/test/scala/sage/client/internal/RateLimitFallbackSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/RateLimitFallbackSpec.scala
@@ -1,0 +1,75 @@
+package sage.client.internal
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.*
+
+import kyo.compat.*
+
+import sage.SageException.ServerError
+import sage.commands.Command
+import sage.ratelimit.{Decision, RateLimit, RateLimiter}
+
+class RateLimitFallbackSpec extends munit.FunSuite {
+
+  private given ExecutionContext = munitExecutionContext
+
+  private def executor(limit: RateLimit = RateLimit.perSecond(10)) =
+    new RateLimitExecutor[String](RateLimiter[String](limit))
+
+  test("a NOSCRIPT loads the script once and retries the EVALSHA") {
+    var loads    = 0
+    var evalShas = 0
+    val runner   = new CommandRunner[CIO, String] {
+      def run[A](command: Command[A]): CIO[A] = command.name match {
+        case "EVALSHA" =>
+          evalShas += 1
+          if (loads == 0) CIO.fail(ServerError("NOSCRIPT", ""))
+          else CIO.value(Decision.Allowed(3, 1.second).asInstanceOf[A])
+        case "SCRIPT"  => loads += 1; CIO.value("sha".asInstanceOf[A])
+        case other     => CIO.fail(ServerError("ERR", s"unexpected $other"))
+      }
+    }
+    for {
+      result <- executor().evalSha(runner, "k", 1).unsafeRun
+    } yield {
+      assertEquals(result, Decision.Allowed(3, 1.second))
+      assertEquals(loads, 1)
+      assertEquals(evalShas, 2)
+    }
+  }
+
+  test("a non-NOSCRIPT error propagates and never loads") {
+    var loads  = 0
+    val runner = new CommandRunner[CIO, String] {
+      def run[A](command: Command[A]): CIO[A] =
+        if (command.name == "SCRIPT") { loads += 1; CIO.value("sha".asInstanceOf[A]) }
+        else CIO.fail(ServerError("WRONGTYPE", "nope"))
+    }
+    for {
+      failed <- executor().evalSha(runner, "k", 1).unsafeRun.failed
+    } yield {
+      failed match {
+        case e: ServerError => assertEquals(e.code, "WRONGTYPE")
+        case other          => fail(s"expected ServerError, got $other")
+      }
+      assertEquals(loads, 0)
+    }
+  }
+
+  test("a misconfigured policy fails through the effect without touching the runner") {
+    var calls  = 0
+    val runner = new CommandRunner[CIO, String] {
+      def run[A](command: Command[A]): CIO[A] = { calls += 1; CIO.fail(ServerError("ERR", "should not run")) }
+    }
+    val bad    = new RateLimitExecutor[String](RateLimiter[String](RateLimit(0, 1, 1.second)))
+    for {
+      failed <- bad.evalSha(runner, "k", 1).unsafeRun.failed
+    } yield {
+      failed match {
+        case e: IllegalArgumentException => assert(e.getMessage.contains("capacity must be > 0"), e.getMessage)
+        case other                       => fail(s"expected IllegalArgumentException, got $other")
+      }
+      assertEquals(calls, 0)
+    }
+  }
+}

--- a/sage-client/shared/src/test/scala/sage/client/internal/RateLimitFallbackSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/RateLimitFallbackSpec.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration.*
 
 import kyo.compat.*
 
-import sage.SageException.ServerError
+import sage.SageException.{InvalidArgument, ServerError}
 import sage.commands.Command
 import sage.ratelimit.{Decision, RateLimit, RateLimiter}
 
@@ -30,7 +30,7 @@ class RateLimitFallbackSpec extends munit.FunSuite {
       }
     }
     for {
-      result <- executor().evalSha(runner, "k", 1).unsafeRun
+      result <- executor().evalSha(runner, "k", 1, peek = false).unsafeRun
     } yield {
       assertEquals(result, Decision.Allowed(3, 1.second))
       assertEquals(loads, 1)
@@ -46,7 +46,7 @@ class RateLimitFallbackSpec extends munit.FunSuite {
         else CIO.fail(ServerError("WRONGTYPE", "nope"))
     }
     for {
-      failed <- executor().evalSha(runner, "k", 1).unsafeRun.failed
+      failed <- executor().evalSha(runner, "k", 1, peek = false).unsafeRun.failed
     } yield {
       failed match {
         case e: ServerError => assertEquals(e.code, "WRONGTYPE")
@@ -63,11 +63,11 @@ class RateLimitFallbackSpec extends munit.FunSuite {
     }
     val bad    = new RateLimitExecutor[String](RateLimiter[String](RateLimit(0, 1, 1.second)))
     for {
-      failed <- bad.evalSha(runner, "k", 1).unsafeRun.failed
+      failed <- bad.evalSha(runner, "k", 1, peek = false).unsafeRun.failed
     } yield {
       failed match {
-        case e: IllegalArgumentException => assert(e.getMessage.contains("capacity must be > 0"), e.getMessage)
-        case other                       => fail(s"expected IllegalArgumentException, got $other")
+        case e: InvalidArgument => assert(e.getMessage.contains("capacity must be > 0"), e.getMessage)
+        case other              => fail(s"expected InvalidArgument, got $other")
       }
       assertEquals(calls, 0)
     }

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration.*
 import kyo.compat.*
 
 import sage.Bytes
-import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, NotConnected, ServerError}
+import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, InvalidArgument, NotConnected, ServerError}
 import sage.client.internal.{ClusterLive, CountingScheduler, FakeTransport, MultiplexedConnection, Scheduler}
 import sage.cluster.{Node, Slot}
 import sage.commands.{BroadcastReduce, Command, Connection, Json, JsonPath, Keys, Scripting, Server, Strings}
@@ -1115,7 +1115,7 @@ class ClusterClientSpec extends munit.FunSuite {
       .unsafeRun
       .failed
       .map { error =>
-        assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+        assert(error.isInstanceOf[InvalidArgument], s"unexpected error: $error")
         assert(!fixture.written(nodeA).exists(_.contains("DBSIZE")), "a rejected DBSIZE must not reach the wire")
       }
   }
@@ -1129,7 +1129,7 @@ class ClusterClientSpec extends munit.FunSuite {
       .unsafeRun
       .failed
       .map { error =>
-        assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+        assert(error.isInstanceOf[InvalidArgument], s"unexpected error: $error")
         assert(!fixture.written(nodeA).exists(_.contains("MULTI")), "a rejected exec must not open MULTI")
       }
   }

--- a/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
@@ -9,7 +9,7 @@ import scala.jdk.CollectionConverters.*
 import kyo.compat.*
 
 import sage.{Bytes, Outcome, SageEvent, SageListener}
-import sage.SageException.{ConnectionFailed, NotConnected, UnsupportedServer}
+import sage.SageException.{ConnectionFailed, InvalidArgument, NotConnected, UnsupportedServer}
 import sage.client.internal.{Client, Events, FakeTransport, ManualScheduler, MultiplexedConnection}
 import sage.commands.{Command, Execution, Server}
 import sage.protocol.Frame
@@ -75,31 +75,31 @@ class ConnectSpec extends munit.FunSuite {
 
   test("readFrom = Replica on a Standalone topology is rejected before connecting") {
     Client.connect(SageConfig(readFrom = ReadFrom.Replica)).unsafeRun.failed.map { error =>
-      assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+      assert(error.isInstanceOf[InvalidArgument], s"unexpected error: $error")
     }
   }
 
   test("a MasterReplica topology with no seeds is rejected") {
     Client.connect(SageConfig(topology = Topology.MasterReplica(Vector.empty))).unsafeRun.failed.map { error =>
-      assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+      assert(error.isInstanceOf[InvalidArgument], s"unexpected error: $error")
     }
   }
 
   test("a non-positive finite dedicatedPool.idleTimeout is rejected by validation, not thrown after connecting") {
     Client.connect(SageConfig(dedicatedPool = DedicatedPoolConfig(idleTimeout = Duration.Zero))).unsafeRun.failed.map { error =>
-      assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+      assert(error.isInstanceOf[InvalidArgument], s"unexpected error: $error")
     }
   }
 
   test("a non-finite, non-Inf dedicatedPool.idleTimeout (MinusInf) is rejected; only Duration.Inf disables the sweep") {
     Client.connect(SageConfig(dedicatedPool = DedicatedPoolConfig(idleTimeout = Duration.MinusInf))).unsafeRun.failed.map { error =>
-      assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+      assert(error.isInstanceOf[InvalidArgument], s"unexpected error: $error")
     }
   }
 
   test("clientCache.maxBytes <= 0 with caching enabled is rejected by validation") {
     Client.connect(SageConfig(clientCache = CacheConfig(enabled = true, maxBytes = 0L))).unsafeRun.failed.map { error =>
-      assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+      assert(error.isInstanceOf[InvalidArgument], s"unexpected error: $error")
     }
   }
 
@@ -111,8 +111,8 @@ class ConnectSpec extends munit.FunSuite {
       .unsafeRun
       .map(_ => assert(true))
       .recover {
-        case _: IllegalArgumentException => fail("ReplicaPreferred on Standalone should pass validation")
-        case _                           => assert(true) // a connect failure (no server) is fine; only validation matters here
+        case _: InvalidArgument => fail("ReplicaPreferred on Standalone should pass validation")
+        case _                  => assert(true) // a connect failure (no server) is fine; only validation matters here
       }
   }
 
@@ -161,7 +161,7 @@ class ConnectSpec extends munit.FunSuite {
     val (factory, transport) = scripted(helloThenPong)
     val blocking             = Vector(Command("BLPOP", Command.NoKeys, Vector.empty, _ => Right(()), Execution.Blocking))
     Client.connectWith(factory).flatMap(_.pipeline(blocking)).unsafeRun.failed.map { error =>
-      assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+      assert(error.isInstanceOf[InvalidArgument], s"unexpected error: $error")
       assertEquals(transport().written.count(_.asUtf8String.contains("BLPOP")), 0)
     }
   }
@@ -198,7 +198,7 @@ class ConnectSpec extends munit.FunSuite {
 
   test("a sub-millisecond duration is rejected before connecting rather than truncating to 0ms") {
     Client.connect(SageConfig(connectTimeout = 500.micros)).unsafeRun.failed.map { error =>
-      assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+      assert(error.isInstanceOf[InvalidArgument], s"unexpected error: $error")
       assert(error.getMessage.contains("at least 1ms"), s"unexpected message: ${error.getMessage}")
     }
   }

--- a/sage-client/zio/src/test/scala/sage/client/TransactionSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/TransactionSpec.scala
@@ -5,7 +5,7 @@ import scala.concurrent.ExecutionContext
 import kyo.compat.*
 
 import sage.Bytes
-import sage.SageException.{ServerError, TransactionDiscarded}
+import sage.SageException.{InvalidArgument, ServerError, TransactionDiscarded}
 import sage.client.internal.{Client, FakeTransport, MultiplexedConnection}
 import sage.commands.{Command, Commands, Execution}
 import sage.protocol.Frame
@@ -161,7 +161,7 @@ class TransactionSpec extends munit.FunSuite {
     val factory  = scripted(Seq(ok))
     val blocking = Vector(Command("BLPOP", Command.NoKeys, Vector.empty, _ => Right(()), Execution.Blocking))
     Client.connectWith(factory).flatMap(_.transaction(_.exec(blocking))).unsafeRun.failed.map { error =>
-      assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+      assert(error.isInstanceOf[InvalidArgument], s"unexpected error: $error")
     }
   }
 
@@ -169,7 +169,7 @@ class TransactionSpec extends munit.FunSuite {
     val (factory, transport) = capturing(scripted(Seq(ok)))
     val blocking             = Command("BLPOP", Command.NoKeys, Vector.empty, _ => Right(()), Execution.Blocking)
     Client.connectWith(factory).flatMap(_.transaction(_.run(blocking))).unsafeRun.failed.map { error =>
-      assert(error.isInstanceOf[IllegalArgumentException], s"unexpected error: $error")
+      assert(error.isInstanceOf[InvalidArgument], s"unexpected error: $error")
       assert(!transport().written.exists(_.asUtf8String.contains("BLPOP")), "the blocking command must not reach the socket")
     }
   }

--- a/sage-core/src/main/scala/sage/SageException.scala
+++ b/sage-core/src/main/scala/sage/SageException.scala
@@ -99,4 +99,11 @@ object SageException {
     * an invalidation push (only by TTL), so it is rejected rather than silently allowed to go stale.
     */
   final case class NotCacheable(message: String) extends SageException(message)
+
+  /**
+    * An argument the API can never accept: an invalid configuration or rate-limit policy, a blocking or all-masters command in a pipeline
+    * or transaction, or a hand-built command whose declared key positions fall outside its arguments (rejected when a cluster client must
+    * route it by key). A programming error to fix at the call site, not a runtime outcome to retry.
+    */
+  final case class InvalidArgument(message: String) extends SageException(message)
 }

--- a/sage-core/src/main/scala/sage/SageException.scala
+++ b/sage-core/src/main/scala/sage/SageException.scala
@@ -101,9 +101,10 @@ object SageException {
   final case class NotCacheable(message: String) extends SageException(message)
 
   /**
-    * An argument the API can never accept: an invalid configuration or rate-limit policy, a blocking or all-masters command in a pipeline
-    * or transaction, or a hand-built command whose declared key positions fall outside its arguments (rejected when a cluster client must
-    * route it by key). A programming error to fix at the call site, not a runtime outcome to retry.
+    * An argument the API can never accept: an invalid configuration or rate-limit policy, a blocking command in a pipeline or transaction,
+    * or a command a cluster client cannot serve as routed (an all-masters command in a cluster pipeline, a cluster-wide result in a
+    * single-node transaction, declared key positions falling outside a hand-built command's arguments). A programming error to fix at the
+    * call site, not a runtime outcome to retry.
     */
   final case class InvalidArgument(message: String) extends SageException(message)
 }

--- a/sage-core/src/main/scala/sage/ratelimit/Decision.scala
+++ b/sage-core/src/main/scala/sage/ratelimit/Decision.scala
@@ -1,0 +1,32 @@
+package sage.ratelimit
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * The outcome of a rate-limit check: an ordinary returned value, not an error.
+  */
+enum Decision {
+
+  /**
+    * Admitted, with `remaining` tokens left and `resetAfter` until the bucket refills to full.
+    */
+  case Allowed(remaining: Long, resetAfter: FiniteDuration)
+
+  /**
+    * Rejected, with `retryAfter` until enough tokens are available.
+    */
+  case Denied(retryAfter: FiniteDuration)
+
+  def isAllowed: Boolean = this match {
+    case _: Allowed => true
+    case _: Denied  => false
+  }
+
+  /**
+    * Tokens left in the bucket, or `0` when denied.
+    */
+  def remainingOrZero: Long = this match {
+    case Allowed(remaining, _) => remaining
+    case _: Denied             => 0L
+  }
+}

--- a/sage-core/src/main/scala/sage/ratelimit/Decision.scala
+++ b/sage-core/src/main/scala/sage/ratelimit/Decision.scala
@@ -13,9 +13,9 @@ enum Decision {
   case Allowed(remaining: Long, resetAfter: FiniteDuration)
 
   /**
-    * Rejected, with `retryAfter` until enough tokens are available.
+    * Rejected, with the untouched `remaining` balance (a denial consumes nothing) and `retryAfter` until enough tokens are available.
     */
-  case Denied(retryAfter: FiniteDuration)
+  case Denied(remaining: Long, retryAfter: FiniteDuration)
 
   def isAllowed: Boolean = this match {
     case _: Allowed => true
@@ -23,10 +23,10 @@ enum Decision {
   }
 
   /**
-    * Tokens left in the bucket, or `0` when denied.
+    * Tokens left in the bucket; a denial consumes nothing, so this is the untouched balance.
     */
-  def remainingOrZero: Long = this match {
+  def remainingTokens: Long = this match {
     case Allowed(remaining, _) => remaining
-    case _: Denied             => 0L
+    case Denied(remaining, _)  => remaining
   }
 }

--- a/sage-core/src/main/scala/sage/ratelimit/RateLimit.scala
+++ b/sage-core/src/main/scala/sage/ratelimit/RateLimit.scala
@@ -1,0 +1,29 @@
+package sage.ratelimit
+
+import scala.concurrent.duration.*
+
+/**
+  * A token-bucket policy: up to `capacity` tokens, refilled at `refillTokens` per `refillPeriod`.
+  */
+final case class RateLimit(capacity: Long, refillTokens: Long, refillPeriod: FiniteDuration) {
+
+  def refillPeriodMicros: Long = refillPeriod.toMicros
+}
+
+object RateLimit {
+
+  /**
+    * `permits` requests per second, bursting up to `permits`.
+    */
+  def perSecond(permits: Long): RateLimit = RateLimit(permits, permits, 1.second)
+
+  /**
+    * `permits` requests per minute, bursting up to `permits`.
+    */
+  def perMinute(permits: Long): RateLimit = RateLimit(permits, permits, 1.minute)
+
+  /**
+    * `permits` tokens refilled every `per`, bursting up to `burst`.
+    */
+  def apply(permits: Long, per: FiniteDuration, burst: Long): RateLimit = RateLimit(burst, permits, per)
+}

--- a/sage-core/src/main/scala/sage/ratelimit/RateLimiter.scala
+++ b/sage-core/src/main/scala/sage/ratelimit/RateLimiter.scala
@@ -1,0 +1,244 @@
+package sage.ratelimit
+
+import scala.concurrent.duration.*
+
+import sage.Bytes
+import sage.SageException.DecodeError
+import sage.codec.KeyCodec
+import sage.commands.*
+
+/**
+  * A distributed token-bucket rate limiter. Each method returns a pure [[sage.commands.Command]] the caller runs through their client, so it
+  * works on every backend. A subject's state is one hash key (a single cluster slot); the check-refill-consume cycle is an atomic Lua script
+  * reading the server clock. While a subject's bucket state exists, changing the policy under the same namespace conservatively carries
+  * forward no more than the existing whole tokens or the new capacity, so overlapping deployments cannot recreate full buckets. An idle
+  * full bucket is expired and therefore starts as a new bucket under a later policy.
+  */
+final case class RateLimiter[K](limit: RateLimit, namespace: String = RateLimiter.defaultNamespace)(using keyCodec: KeyCodec[K]) {
+
+  /**
+    * Consume `cost` tokens for `subject` if the bucket holds them, returning [[Decision.Allowed]] with the tokens left, otherwise
+    * [[Decision.Denied]] with the time until `cost` tokens are available. Non-blocking: it never waits.
+    */
+  def tryAcquire(subject: K, cost: Long = 1): Command[Decision] = eval(RateLimiter.Invocation.Eval, subject, cost)
+
+  /**
+    * Report the current standing for `subject` without consuming: the bucket is still refilled by elapsed time, but no tokens are taken.
+    */
+  def peek(subject: K): Command[Decision] = eval(RateLimiter.Invocation.Eval, subject, RateLimiter.peekCost)
+
+  /**
+    * Clear `subject`'s bucket, so its next request starts from full capacity.
+    */
+  def reset(subject: K): Command[Unit] =
+    Command("DEL", Command.FirstKey, Vector(keyBytes(subject)), _ => Right(()))
+
+  private val capacityText       = limit.capacity.toString
+  private val refillTokensText   = limit.refillTokens.toString
+  private val refillPeriodMicros = limit.refillPeriodMicros
+  private val refillPeriodText   = refillPeriodMicros.toString
+  private val policyArgs         =
+    Vector(capacityText, refillTokensText, refillPeriodText, s"$capacityText:$refillTokensText:$refillPeriodText").map(Bytes.utf8)
+  private val keyPrefix          = {
+    val ns = Bytes.utf8(namespace)
+    Bytes.concat(Vector(Bytes.utf8(s"${ns.length}:"), ns, Bytes.utf8(":")))
+  }
+  private val policyProblem      =
+    if (limit.capacity <= 0) Some("capacity must be > 0")
+    else if (limit.refillTokens <= 0) Some("refillTokens must be > 0")
+    else if (refillPeriodMicros < 1) Some("refillPeriod must be at least 1 microsecond")
+    else if (limit.capacity > RateLimiter.maxExactInt) Some(s"capacity must be <= ${RateLimiter.maxExactInt} (Lua number precision)")
+    else if (limit.refillTokens > RateLimiter.maxExactInt) Some(s"refillTokens must be <= ${RateLimiter.maxExactInt} (Lua number precision)")
+    else if (refillPeriodMicros > RateLimiter.maxExactInt)
+      Some(s"refillPeriod must be <= ${RateLimiter.maxExactInt} microseconds (Lua number precision)")
+    else if (BigInt(limit.capacity) * refillPeriodMicros > BigInt(RateLimiter.maxExactInt))
+      Some(s"capacity times refillPeriod must be <= ${RateLimiter.maxExactInt} microseconds (so refill math stays exact)")
+    else None
+
+  private[sage] def validate(cost: Long): Option[String] =
+    policyProblem.orElse {
+      if (cost < 0) Some("cost must be >= 0")
+      else if (cost > limit.capacity) Some(s"cost $cost cannot exceed capacity ${limit.capacity}")
+      else None
+    }
+
+  private[sage] def evalSha(subject: K, cost: Long): Command[Decision] = eval(RateLimiter.Invocation.EvalSha, subject, cost)
+
+  // test-only: drive the script's clock with an explicit timestamp
+  private[sage] def tryAcquireAt(subject: K, cost: Long, nowMicros: Long): Command[Decision] =
+    eval(RateLimiter.Invocation.Eval, subject, cost, Some(nowMicros))
+
+  private[sage] def loadCommand: Command[String] = Scripting.scriptLoad(RateLimiter.script)
+
+  // length-framing keeps namespace `a` + subject `b:c` distinct from namespace `a:b` + subject `c`
+  private def keyBytes(subject: K): Bytes = Bytes.concat(Vector(keyPrefix, keyCodec.encode(subject)))
+
+  private def eval(invocation: RateLimiter.Invocation, subject: K, cost: Long, now: Option[Long] = None): Command[Decision] = {
+    val requestArgs = Vector(cost.toString, now.fold("")(_.toString)).map(Bytes.utf8) // empty injected time => server TIME
+    val argv        = policyArgs ++ requestArgs
+    val allArgs     = Vector(invocation.scriptReference, RateLimiter.oneKeyArgument, keyBytes(subject)) ++ argv
+    val keyIndices  = Vector(2)                                                       // 0 = script/sha, 1 = numkeys, 2 = the single key
+    Command(invocation.verb, keyIndices, allArgs, RateLimiter.decode, Execution.Ordinary)
+  }
+}
+
+object RateLimiter {
+
+  // Reply: [allowed, remaining, catchupMicros, retryMicros, resetMicros] (catch-up kept separate so Scala sums the parts past Lua's 2^53).
+  // State hash: `t` tokens, `ts` last-refill micros, `f` sub-token remainder, `v` policy signature. ARGV[6] overrides server TIME for tests.
+  val script: String =
+    """local capacity = tonumber(ARGV[1])
+      |local refill_tokens = tonumber(ARGV[2])
+      |local refill_period = tonumber(ARGV[3])
+      |local cost = tonumber(ARGV[5])
+      |local injected = ARGV[6]
+      |
+      |-- last guard for the EVAL path; each field is bounded on its raw decimal string so a value just past 2^53 is rejected, not rounded in
+      |local max_exact = 9007199254740992 -- 2^53
+      |local function within_exact(s)
+      |  local n = string.len(s)
+      |  if n > 16 then return false end
+      |  if n < 16 then return true end
+      |  return s <= '9007199254740992'
+      |end
+      |local function stored_integer(s)
+      |  return type(s) == 'string' and string.match(s, '^%d+$') ~= nil and within_exact(s)
+      |end
+      |-- 2^53+1 is the only integer a double rounds down to 2^53, and it is odd, so reject an odd product that reads as 2^53
+      |local product = capacity * refill_period
+      |local product_over = product > max_exact or (product == max_exact and capacity % 2 == 1 and refill_period % 2 == 1)
+      |if capacity <= 0 or refill_tokens < 1 or refill_period < 1
+      |   or not within_exact(ARGV[1]) or not within_exact(ARGV[2]) or not within_exact(ARGV[3]) or not within_exact(ARGV[5])
+      |   or product_over
+      |   or cost < 0 or cost > capacity then
+      |  return redis.error_reply('SAGE invalid rate-limit policy or cost')
+      |end
+      |
+      |local now
+      |if injected ~= '' then
+      |  now = tonumber(injected)
+      |else
+      |  local t = redis.call('TIME')
+      |  now = tonumber(t[1]) * 1000000 + tonumber(t[2])
+      |end
+      |
+      |local state = redis.call('HMGET', KEYS[1], 't', 'ts', 'f', 'v')
+      |local state_absent = not state[1] and not state[2] and not state[3] and not state[4]
+      |local tokens = tonumber(state[1])
+      |local ts = tonumber(state[2])
+      |local frac = tonumber(state[3])
+      |local policy_changed = state[4] ~= ARGV[4]
+      |if state_absent then
+      |  tokens = capacity
+      |  ts = now
+      |  frac = 0
+      |elseif not stored_integer(state[1]) or not stored_integer(state[2]) or not stored_integer(state[3])
+      |   or (not policy_changed and (tokens > capacity or frac >= refill_period or (tokens == capacity and frac ~= 0))) then
+      |  return redis.error_reply('SAGE invalid rate-limit state')
+      |elseif policy_changed then
+      |  -- keep only compatible whole-token credit; never refill merely because old and new policy instances alternate
+      |  if tokens > capacity then tokens = capacity end
+      |  if now > ts then ts = now end
+      |  frac = 0
+      |end
+      |
+      |-- refill by whole tokens, carrying the sub-token remainder in `frac`. Compare elapsed against the fill time, not elapsed * refill_tokens,
+      |-- so that product is only formed when it is < capacity * refill_period and stays exact. A regressed clock (now <= ts) credits nothing.
+      |if now > ts then
+      |  local space = capacity - tokens
+      |  if space <= 0 then
+      |    frac = 0
+      |  else
+      |    local need = space * refill_period - frac
+      |    if now - ts >= math.ceil(need / refill_tokens) then
+      |      tokens = capacity
+      |      frac = 0
+      |    else
+      |      local units = (now - ts) * refill_tokens + frac
+      |      local gained = math.floor(units / refill_period)
+      |      frac = units - gained * refill_period
+      |      tokens = tokens + gained
+      |    end
+      |  end
+      |  ts = now
+      |end
+      |
+      |-- a regressed clock leaves ts ahead of now; return this catch-up separately so Scala sums the parts past 2^53
+      |local catchup = 0
+      |if ts > now then catchup = ts - now end
+      |
+      |local allowed = 0
+      |local retry_wait = 0
+      |if tokens >= cost then
+      |  tokens = tokens - cost
+      |  allowed = 1
+      |else
+      |  retry_wait = math.ceil(((cost - tokens) * refill_period - frac) / refill_tokens)
+      |end
+      |
+      |redis.call('HSET', KEYS[1],
+      |  't', string.format('%.0f', tokens), 'ts', string.format('%.0f', ts), 'f', string.format('%.0f', frac),
+      |  'v', ARGV[4])
+      |local reset_wait = 0
+      |local timed_catchup = 0
+      |if tokens < capacity then
+      |  timed_catchup = catchup
+      |  reset_wait = math.ceil(((capacity - tokens) * refill_period - frac) / refill_tokens)
+      |end
+      |-- sum the TTL in millisecond quotient/remainder form, rounding up, so it stays exact and never expires before the bucket could refill
+      |local ttl = math.floor(timed_catchup / 1000) + math.floor(reset_wait / 1000)
+      |local leftover_micros = timed_catchup % 1000 + reset_wait % 1000
+      |ttl = ttl + math.ceil(leftover_micros / 1000)
+      |if ttl < 1 then ttl = 1 end
+      |redis.call('PEXPIRE', KEYS[1], ttl)
+      |
+      |return { allowed, tokens, timed_catchup, retry_wait, reset_wait }
+      |""".stripMargin
+
+  private[sage] val sha: String = {
+    val digest = java.security.MessageDigest.getInstance("SHA-1").digest(script.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+    digest.iterator.map(b => f"${b & 0xff}%02x").mkString
+  }
+
+  /**
+    * The greatest retry/reset duration returned; a wait beyond it (severe clock rollback) saturates here, while the TTL still covers it.
+    */
+  val maximumReportedWait: FiniteDuration = (Long.MaxValue / 1000L).micros
+
+  private val maximumReportedWaitMicros: Long = maximumReportedWait.toMicros
+
+  private def waitDuration(catchup: Long, refill: Long): Either[DecodeError, FiniteDuration] =
+    if (catchup < 0 || refill < 0) Left(DecodeError("non-negative rate-limit timing components", s"$catchup and $refill microseconds"))
+    else if (catchup > maximumReportedWaitMicros || refill > maximumReportedWaitMicros - catchup) Right(maximumReportedWait)
+    else Right((catchup + refill).micros)
+
+  private val decode: sage.protocol.Frame => Either[DecodeError, Decision] = frame =>
+    frame.asArray.flatMap {
+      case Vector(allowedFrame, remainingFrame, catchupFrame, retryFrame, resetFrame) =>
+        for {
+          allowed    <- allowedFrame.asLong
+          remaining  <- remainingFrame.asLong
+          catchup    <- catchupFrame.asLong
+          retry      <- retryFrame.asLong
+          reset      <- resetFrame.asLong
+          retryAfter <- waitDuration(catchup, retry)
+          resetAfter <- waitDuration(catchup, reset)
+        } yield if (allowed == 1L) Decision.Allowed(remaining, resetAfter) else Decision.Denied(retryAfter)
+      case other                                                                      =>
+        Left(DecodeError("rate-limit reply [allowed, remaining, catchup, retry, reset]", s"array of ${other.length} elements"))
+    }
+
+  private[sage] val defaultNamespace: String = "ratelimit"
+
+  private[sage] val peekCost: Long = 0L
+
+  // Lua numbers are IEEE doubles, so integers (and capacity * refillPeriod) are held to 2^53 to stay exact
+  private[sage] val maxExactInt: Long = 1L << 53
+
+  private val oneKeyArgument: Bytes = Bytes.utf8("1")
+
+  private enum Invocation(val verb: String, val scriptReference: Bytes) {
+    case Eval    extends Invocation("EVAL", Bytes.utf8(script))
+    case EvalSha extends Invocation("EVALSHA", Bytes.utf8(sha))
+  }
+}

--- a/sage-core/src/main/scala/sage/ratelimit/RateLimiter.scala
+++ b/sage-core/src/main/scala/sage/ratelimit/RateLimiter.scala
@@ -20,12 +20,13 @@ final case class RateLimiter[K](limit: RateLimit, namespace: String = RateLimite
     * Consume `cost` tokens for `subject` if the bucket holds them, returning [[Decision.Allowed]] with the tokens left, otherwise
     * [[Decision.Denied]] with the time until `cost` tokens are available. Non-blocking: it never waits.
     */
-  def tryAcquire(subject: K, cost: Long = 1): Command[Decision] = eval(RateLimiter.Invocation.Eval, subject, cost)
+  def tryAcquire(subject: K, cost: Long = 1): Command[Decision] = eval(RateLimiter.Invocation.Eval, subject, cost, peek = false)
 
   /**
-    * Report the current standing for `subject` without consuming: the bucket is still refilled by elapsed time, but no tokens are taken.
+    * Report the current standing for `subject` without consuming: [[Decision.Allowed]] while at least one token is available, otherwise
+    * [[Decision.Denied]] with the wait until one is. The bucket is still refilled by elapsed time, but no tokens are taken.
     */
-  def peek(subject: K): Command[Decision] = eval(RateLimiter.Invocation.Eval, subject, RateLimiter.peekCost)
+  def peek(subject: K): Command[Decision] = eval(RateLimiter.Invocation.Eval, subject, cost = 1, peek = true)
 
   /**
     * Clear `subject`'s bucket, so its next request starts from full capacity.
@@ -60,27 +61,25 @@ final case class RateLimiter[K](limit: RateLimit, namespace: String = RateLimite
   private[sage] def validate(cost: Long): Option[String] = policyProblem match {
     case problem @ Some(_) => problem
     case None              =>
-      if (cost < 0) Some("cost must be >= 0")
+      if (cost < 1) Some("cost must be >= 1")
       else if (cost > limit.capacity) Some(s"cost $cost cannot exceed capacity ${limit.capacity}")
       else None
   }
 
-  private[sage] def evalSha(subject: K, cost: Long): Command[Decision] = eval(RateLimiter.Invocation.EvalSha, subject, cost)
+  private[sage] def evalSha(subject: K, cost: Long, peek: Boolean = false): Command[Decision] =
+    eval(RateLimiter.Invocation.EvalSha, subject, cost, peek)
 
   // test-only: drive the script's clock with an explicit timestamp
   private[sage] def tryAcquireAt(subject: K, cost: Long, nowMicros: Long): Command[Decision] =
-    eval(RateLimiter.Invocation.Eval, subject, cost, Some(nowMicros))
+    eval(RateLimiter.Invocation.Eval, subject, cost, peek = false, Some(nowMicros))
 
   private[sage] def loadCommand: Command[String] = Scripting.scriptLoad(RateLimiter.script)
 
   // length-framing keeps namespace `a` + subject `b:c` distinct from namespace `a:b` + subject `c`
   private def keyBytes(subject: K): Bytes = Bytes.concat(Vector(keyPrefix, keyCodec.encode(subject)))
 
-  private def eval(invocation: RateLimiter.Invocation, subject: K, cost: Long, now: Option[Long] = None): Command[Decision] = {
-    val costArgument =
-      if (cost == 1L) RateLimiter.defaultCostArgument
-      else if (cost == RateLimiter.peekCost) RateLimiter.peekCostArgument
-      else Bytes.utf8(cost.toString)
+  private def eval(invocation: RateLimiter.Invocation, subject: K, cost: Long, peek: Boolean, now: Option[Long] = None): Command[Decision] = {
+    val costArgument = if (cost == 1L) RateLimiter.defaultCostArgument else Bytes.utf8(cost.toString)
     val nowArgument  = now match {
       case None        => Bytes.empty // empty injected time => server TIME
       case Some(value) => Bytes.utf8(value.toString)
@@ -94,7 +93,8 @@ final case class RateLimiter[K](limit: RateLimit, namespace: String = RateLimite
       periodArgument,
       policySignatureArgument,
       costArgument,
-      nowArgument
+      nowArgument,
+      if (peek) RateLimiter.peekArgument else Bytes.empty
     )
     Command(invocation.verb, RateLimiter.scriptKeyIndices, allArgs, RateLimiter.decode, Execution.Ordinary)
   }
@@ -103,13 +103,15 @@ final case class RateLimiter[K](limit: RateLimit, namespace: String = RateLimite
 object RateLimiter {
 
   // Reply: [allowed, remaining, catchupMicros, retryMicros, resetMicros] (catch-up kept separate so Scala sums the parts past Lua's 2^53).
-  // State hash: `t` tokens, `ts` last-refill micros, `f` sub-token remainder, `v` policy signature. ARGV[6] overrides server TIME for tests.
+  // State hash: `t` tokens, `ts` last-refill micros, `f` sub-token remainder, `v` policy signature. ARGV[6] overrides server TIME for
+  // tests; ARGV[7] = '1' is a peek: decide on `cost`, consume nothing.
   val script: String =
     """local capacity = tonumber(ARGV[1])
       |local refill_tokens = tonumber(ARGV[2])
       |local refill_period = tonumber(ARGV[3])
       |local cost = tonumber(ARGV[5])
       |local injected = ARGV[6]
+      |local is_peek = ARGV[7] == '1'
       |
       |-- last guard for the EVAL path; each field is bounded on its raw decimal string so a value just past 2^53 is rejected, not rounded in
       |local max_exact = 9007199254740992 -- 2^53
@@ -128,7 +130,7 @@ object RateLimiter {
       |if capacity <= 0 or refill_tokens < 1 or refill_period < 1
       |   or not within_exact(ARGV[1]) or not within_exact(ARGV[2]) or not within_exact(ARGV[3]) or not within_exact(ARGV[5])
       |   or product_over
-      |   or cost < 0 or cost > capacity then
+      |   or cost < 1 or cost > capacity then
       |  return redis.error_reply('SAGE invalid rate-limit policy or cost')
       |end
       |
@@ -188,7 +190,7 @@ object RateLimiter {
       |local allowed = 0
       |local retry_wait = 0
       |if tokens >= cost then
-      |  tokens = tokens - cost
+      |  if not is_peek then tokens = tokens - cost end
       |  allowed = 1
       |else
       |  retry_wait = math.ceil(((cost - tokens) * refill_period - frac) / refill_tokens)
@@ -241,14 +243,12 @@ object RateLimiter {
           reset      <- resetFrame.asLong
           retryAfter <- waitDuration(catchup, retry)
           resetAfter <- waitDuration(catchup, reset)
-        } yield if (allowed == 1L) Decision.Allowed(remaining, resetAfter) else Decision.Denied(retryAfter)
+        } yield if (allowed == 1L) Decision.Allowed(remaining, resetAfter) else Decision.Denied(remaining, retryAfter)
       case other                                                                      =>
         Left(DecodeError("rate-limit reply [allowed, remaining, catchup, retry, reset]", s"array of ${other.length} elements"))
     }
 
   private[sage] val defaultNamespace: String = "ratelimit"
-
-  private[sage] val peekCost: Long = 0L
 
   // Lua numbers are IEEE doubles, so integers (and capacity * refillPeriod) are held to 2^53 to stay exact
   private[sage] val maxExactInt: Long = 1L << 53
@@ -256,7 +256,7 @@ object RateLimiter {
   private val scriptKeyIndices: Vector[Int] = Vector(2) // 0 = script/sha, 1 = numkeys, 2 = the single key
   private val oneKeyArgument: Bytes         = Bytes.utf8("1")
   private val defaultCostArgument: Bytes    = Bytes.utf8("1")
-  private val peekCostArgument: Bytes       = Bytes.utf8("0")
+  private val peekArgument: Bytes           = Bytes.utf8("1")
 
   private enum Invocation(val verb: String, val scriptReference: Bytes) {
     case Eval    extends Invocation("EVAL", Bytes.utf8(script))

--- a/sage-core/src/main/scala/sage/ratelimit/RateLimiter.scala
+++ b/sage-core/src/main/scala/sage/ratelimit/RateLimiter.scala
@@ -33,17 +33,19 @@ final case class RateLimiter[K](limit: RateLimit, namespace: String = RateLimite
   def reset(subject: K): Command[Unit] =
     Command("DEL", Command.FirstKey, Vector(keyBytes(subject)), _ => Right(()))
 
-  private val capacityText       = limit.capacity.toString
-  private val refillTokensText   = limit.refillTokens.toString
-  private val refillPeriodMicros = limit.refillPeriodMicros
-  private val refillPeriodText   = refillPeriodMicros.toString
-  private val policyArgs         =
-    Vector(capacityText, refillTokensText, refillPeriodText, s"$capacityText:$refillTokensText:$refillPeriodText").map(Bytes.utf8)
-  private val keyPrefix          = {
+  private val capacityText            = limit.capacity.toString
+  private val refillTokensText        = limit.refillTokens.toString
+  private val refillPeriodMicros      = limit.refillPeriodMicros
+  private val refillPeriodText        = refillPeriodMicros.toString
+  private val capacityArgument        = Bytes.utf8(capacityText)
+  private val refillArgument          = Bytes.utf8(refillTokensText)
+  private val periodArgument          = Bytes.utf8(refillPeriodText)
+  private val policySignatureArgument = Bytes.utf8(s"$capacityText:$refillTokensText:$refillPeriodText")
+  private val keyPrefix               = {
     val ns = Bytes.utf8(namespace)
     Bytes.concat(Vector(Bytes.utf8(s"${ns.length}:"), ns, Bytes.utf8(":")))
   }
-  private val policyProblem      =
+  private val policyProblem           =
     if (limit.capacity <= 0) Some("capacity must be > 0")
     else if (limit.refillTokens <= 0) Some("refillTokens must be > 0")
     else if (refillPeriodMicros < 1) Some("refillPeriod must be at least 1 microsecond")
@@ -55,12 +57,13 @@ final case class RateLimiter[K](limit: RateLimit, namespace: String = RateLimite
       Some(s"capacity times refillPeriod must be <= ${RateLimiter.maxExactInt} microseconds (so refill math stays exact)")
     else None
 
-  private[sage] def validate(cost: Long): Option[String] =
-    policyProblem.orElse {
+  private[sage] def validate(cost: Long): Option[String] = policyProblem match {
+    case problem @ Some(_) => problem
+    case None              =>
       if (cost < 0) Some("cost must be >= 0")
       else if (cost > limit.capacity) Some(s"cost $cost cannot exceed capacity ${limit.capacity}")
       else None
-    }
+  }
 
   private[sage] def evalSha(subject: K, cost: Long): Command[Decision] = eval(RateLimiter.Invocation.EvalSha, subject, cost)
 
@@ -74,11 +77,26 @@ final case class RateLimiter[K](limit: RateLimit, namespace: String = RateLimite
   private def keyBytes(subject: K): Bytes = Bytes.concat(Vector(keyPrefix, keyCodec.encode(subject)))
 
   private def eval(invocation: RateLimiter.Invocation, subject: K, cost: Long, now: Option[Long] = None): Command[Decision] = {
-    val requestArgs = Vector(cost.toString, now.fold("")(_.toString)).map(Bytes.utf8) // empty injected time => server TIME
-    val argv        = policyArgs ++ requestArgs
-    val allArgs     = Vector(invocation.scriptReference, RateLimiter.oneKeyArgument, keyBytes(subject)) ++ argv
-    val keyIndices  = Vector(2)                                                       // 0 = script/sha, 1 = numkeys, 2 = the single key
-    Command(invocation.verb, keyIndices, allArgs, RateLimiter.decode, Execution.Ordinary)
+    val costArgument =
+      if (cost == 1L) RateLimiter.defaultCostArgument
+      else if (cost == RateLimiter.peekCost) RateLimiter.peekCostArgument
+      else Bytes.utf8(cost.toString)
+    val nowArgument  = now match {
+      case None        => Bytes.empty // empty injected time => server TIME
+      case Some(value) => Bytes.utf8(value.toString)
+    }
+    val allArgs      = Vector(
+      invocation.scriptReference,
+      RateLimiter.oneKeyArgument,
+      keyBytes(subject),
+      capacityArgument,
+      refillArgument,
+      periodArgument,
+      policySignatureArgument,
+      costArgument,
+      nowArgument
+    )
+    Command(invocation.verb, RateLimiter.scriptKeyIndices, allArgs, RateLimiter.decode, Execution.Ordinary)
   }
 }
 
@@ -235,7 +253,10 @@ object RateLimiter {
   // Lua numbers are IEEE doubles, so integers (and capacity * refillPeriod) are held to 2^53 to stay exact
   private[sage] val maxExactInt: Long = 1L << 53
 
-  private val oneKeyArgument: Bytes = Bytes.utf8("1")
+  private val scriptKeyIndices: Vector[Int] = Vector(2) // 0 = script/sha, 1 = numkeys, 2 = the single key
+  private val oneKeyArgument: Bytes         = Bytes.utf8("1")
+  private val defaultCostArgument: Bytes    = Bytes.utf8("1")
+  private val peekCostArgument: Bytes       = Bytes.utf8("0")
 
   private enum Invocation(val verb: String, val scriptReference: Bytes) {
     case Eval    extends Invocation("EVAL", Bytes.utf8(script))

--- a/sage-core/src/test/scala/sage/ratelimit/RateLimiterSpec.scala
+++ b/sage-core/src/test/scala/sage/ratelimit/RateLimiterSpec.scala
@@ -20,8 +20,9 @@ class RateLimiterSpec extends munit.FunSuite {
     assertEquals(command.keyIndices, Vector(2))
     assert(command.args(2).sameBytes(Bytes.utf8("9:ratelimit:user")))     // length-framed namespace
     assertEquals(command.args(1).asUtf8String, "1")                       // numkeys
-    assertEquals(command.args.last.asUtf8String, "")                      // injected time empty => server TIME
-    assertEquals(command.args(command.args.length - 2).asUtf8String, "2") // cost
+    assertEquals(command.args.last.asUtf8String, "")                      // empty peek flag => consume
+    assertEquals(command.args(command.args.length - 2).asUtf8String, "")  // injected time empty => server TIME
+    assertEquals(command.args(command.args.length - 3).asUtf8String, "2") // cost
   }
 
   test("a custom namespace prefixes the key") {
@@ -32,18 +33,18 @@ class RateLimiterSpec extends munit.FunSuite {
     assertEquals(limiter.tryAcquire("u").decode(reply(1, 8, 0, 0, 500000)), Right(Decision.Allowed(8, 500000.micros)))
   }
 
-  test("decode maps a denied reply to Denied with retry-after") {
-    assertEquals(limiter.tryAcquire("u").decode(reply(0, 0, 0, 250000, 1000000)), Right(Decision.Denied(250000.micros)))
+  test("decode maps a denied reply to Denied with the untouched balance and retry-after") {
+    assertEquals(limiter.tryAcquire("u").decode(reply(0, 5, 0, 250000, 1000000)), Right(Decision.Denied(5, 250000.micros)))
   }
 
   test("decode combines exact timing components and saturates only at the documented maximum") {
     val maxExact    = 1L << 53
     val pastMaximum = RateLimiter.maximumReportedWait.toMicros - maxExact + 1L
     assertEquals(RateLimiter.maximumReportedWait.toMicros, Long.MaxValue / 1000L)
-    assertEquals(limiter.tryAcquire("u").decode(reply(0, 0, 9, maxExact, 0)), Right(Decision.Denied((maxExact + 9).micros)))
+    assertEquals(limiter.tryAcquire("u").decode(reply(0, 0, 9, maxExact, 0)), Right(Decision.Denied(0, (maxExact + 9).micros)))
     assertEquals(
       limiter.tryAcquire("u").decode(reply(0, 0, maxExact, pastMaximum, 0)),
-      Right(Decision.Denied(RateLimiter.maximumReportedWait))
+      Right(Decision.Denied(0, RateLimiter.maximumReportedWait))
     )
   }
 
@@ -52,8 +53,10 @@ class RateLimiterSpec extends munit.FunSuite {
     assert(limiter.tryAcquire("u").decode(Frame.Array(Vector(Frame.Integer(1)))).isLeft)
   }
 
-  test("peek builds a zero-cost check") {
-    assertEquals(limiter.peek("u").args(limiter.peek("u").args.length - 2).asUtf8String, "0")
+  test("peek builds a cost-1 probe that consumes nothing") {
+    val command = limiter.peek("u")
+    assertEquals(command.args(command.args.length - 3).asUtf8String, "1") // cost
+    assertEquals(command.args.last.asUtf8String, "1")                     // peek flag
   }
 
   test("reset builds a DEL on the namespaced key") {
@@ -77,9 +80,9 @@ class RateLimiterSpec extends munit.FunSuite {
 
   test("Decision helpers") {
     assert(Decision.Allowed(5, 1.second).isAllowed)
-    assertEquals(Decision.Allowed(5, 1.second).remainingOrZero, 5L)
-    assert(!Decision.Denied(1.second).isAllowed)
-    assertEquals(Decision.Denied(1.second).remainingOrZero, 0L)
+    assertEquals(Decision.Allowed(5, 1.second).remainingTokens, 5L)
+    assert(!Decision.Denied(2, 1.second).isAllowed)
+    assertEquals(Decision.Denied(2, 1.second).remainingTokens, 2L)
   }
 
   test("RateLimit smart constructors") {
@@ -89,7 +92,6 @@ class RateLimiterSpec extends munit.FunSuite {
 
   test("validate accepts a usable policy and cost") {
     assertEquals(limiter.validate(1), None)
-    assertEquals(limiter.validate(0), None) // peek
     assertEquals(RateLimiter[String](RateLimit.perSecond(10)).validate(10), None)
   }
 
@@ -117,7 +119,8 @@ class RateLimiterSpec extends munit.FunSuite {
       RateLimiter[String](RateLimit(3, 1, 3002399751580331L.micros)).validate(1),
       Some("capacity times refillPeriod must be <= 9007199254740992 microseconds (so refill math stays exact)")
     )
-    assertEquals(limiter.validate(-1), Some("cost must be >= 0"))
+    assertEquals(limiter.validate(0), Some("cost must be >= 1"))
+    assertEquals(limiter.validate(-1), Some("cost must be >= 1"))
     assertEquals(limiter.validate(11), Some("cost 11 cannot exceed capacity 10"))
   }
 

--- a/sage-core/src/test/scala/sage/ratelimit/RateLimiterSpec.scala
+++ b/sage-core/src/test/scala/sage/ratelimit/RateLimiterSpec.scala
@@ -1,0 +1,129 @@
+package sage.ratelimit
+
+import scala.concurrent.duration.*
+
+import sage.Bytes
+import sage.protocol.Frame
+
+class RateLimiterSpec extends munit.FunSuite {
+
+  private val limiter = RateLimiter[String](RateLimit.perSecond(10))
+
+  private def reply(allowed: Long, remaining: Long, catchup: Long, retry: Long, reset: Long): Frame =
+    Frame.Array(
+      Vector(Frame.Integer(allowed), Frame.Integer(remaining), Frame.Integer(catchup), Frame.Integer(retry), Frame.Integer(reset))
+    )
+
+  test("tryAcquire builds an EVAL command routed on the single namespaced key") {
+    val command = limiter.tryAcquire("user", cost = 2)
+    assertEquals(command.name, "EVAL")
+    assertEquals(command.keyIndices, Vector(2))
+    assert(command.args(2).sameBytes(Bytes.utf8("9:ratelimit:user")))     // length-framed namespace
+    assertEquals(command.args(1).asUtf8String, "1")                       // numkeys
+    assertEquals(command.args.last.asUtf8String, "")                      // injected time empty => server TIME
+    assertEquals(command.args(command.args.length - 2).asUtf8String, "2") // cost
+  }
+
+  test("a custom namespace prefixes the key") {
+    assert(RateLimiter[String](RateLimit.perSecond(1), "api").tryAcquire("k").args(2).sameBytes(Bytes.utf8("3:api:k")))
+  }
+
+  test("decode maps an allowed reply to Allowed with remaining and reset") {
+    assertEquals(limiter.tryAcquire("u").decode(reply(1, 8, 0, 0, 500000)), Right(Decision.Allowed(8, 500000.micros)))
+  }
+
+  test("decode maps a denied reply to Denied with retry-after") {
+    assertEquals(limiter.tryAcquire("u").decode(reply(0, 0, 0, 250000, 1000000)), Right(Decision.Denied(250000.micros)))
+  }
+
+  test("decode combines exact timing components and saturates only at the documented maximum") {
+    val maxExact    = 1L << 53
+    val pastMaximum = RateLimiter.maximumReportedWait.toMicros - maxExact + 1L
+    assertEquals(RateLimiter.maximumReportedWait.toMicros, Long.MaxValue / 1000L)
+    assertEquals(limiter.tryAcquire("u").decode(reply(0, 0, 9, maxExact, 0)), Right(Decision.Denied((maxExact + 9).micros)))
+    assertEquals(
+      limiter.tryAcquire("u").decode(reply(0, 0, maxExact, pastMaximum, 0)),
+      Right(Decision.Denied(RateLimiter.maximumReportedWait))
+    )
+  }
+
+  test("decode rejects a reply of the wrong shape") {
+    assert(limiter.tryAcquire("u").decode(Frame.Integer(1)).isLeft)
+    assert(limiter.tryAcquire("u").decode(Frame.Array(Vector(Frame.Integer(1)))).isLeft)
+  }
+
+  test("peek builds a zero-cost check") {
+    assertEquals(limiter.peek("u").args(limiter.peek("u").args.length - 2).asUtf8String, "0")
+  }
+
+  test("reset builds a DEL on the namespaced key") {
+    val command = limiter.reset("u")
+    assertEquals(command.name, "DEL")
+    assert(command.args.head.sameBytes(Bytes.utf8("9:ratelimit:u")))
+  }
+
+  test("evalSha builds an EVALSHA command carrying the script sha") {
+    val command = limiter.evalSha("u", 1)
+    assertEquals(command.name, "EVALSHA")
+    assertEquals(command.args.head.asUtf8String, RateLimiter.sha)
+    assertEquals(command.keyIndices, Vector(2))
+  }
+
+  test("loadCommand is SCRIPT LOAD and sha is a 40-char hex digest") {
+    assertEquals(limiter.loadCommand.name, "SCRIPT")
+    assertEquals(RateLimiter.sha.length, 40)
+    assert(RateLimiter.sha.forall(c => c.isDigit || ('a' to 'f').contains(c)))
+  }
+
+  test("Decision helpers") {
+    assert(Decision.Allowed(5, 1.second).isAllowed)
+    assertEquals(Decision.Allowed(5, 1.second).remainingOrZero, 5L)
+    assert(!Decision.Denied(1.second).isAllowed)
+    assertEquals(Decision.Denied(1.second).remainingOrZero, 0L)
+  }
+
+  test("RateLimit smart constructors") {
+    assertEquals(RateLimit.perSecond(10), RateLimit(10, 10, 1.second))
+    assertEquals(RateLimit(100, 1.minute, burst = 200), RateLimit(200, 100, 1.minute))
+  }
+
+  test("validate accepts a usable policy and cost") {
+    assertEquals(limiter.validate(1), None)
+    assertEquals(limiter.validate(0), None) // peek
+    assertEquals(RateLimiter[String](RateLimit.perSecond(10)).validate(10), None)
+  }
+
+  test("validate reports the first problem with the policy or cost") {
+    assertEquals(RateLimiter[String](RateLimit(0, 1, 1.second)).validate(1), Some("capacity must be > 0"))
+    assertEquals(RateLimiter[String](RateLimit(10, 0, 1.second)).validate(1), Some("refillTokens must be > 0"))
+    assertEquals(RateLimiter[String](RateLimit(10, 1, 500.nanos)).validate(1), Some("refillPeriod must be at least 1 microsecond"))
+    assertEquals(
+      RateLimiter[String](RateLimit((1L << 53) + 1, 1, 1.second)).validate(1),
+      Some("capacity must be <= 9007199254740992 (Lua number precision)")
+    )
+    assertEquals(
+      RateLimiter[String](RateLimit(10, (1L << 53) + 1, 1.second)).validate(1),
+      Some("refillTokens must be <= 9007199254740992 (Lua number precision)")
+    )
+    assertEquals(
+      RateLimiter[String](RateLimit(10, 1, 9100000000000000L.micros)).validate(1),
+      Some("refillPeriod must be <= 9007199254740992 microseconds (Lua number precision)")
+    )
+    assertEquals(
+      RateLimiter[String](RateLimit(1000000000L, 1, 10000.seconds)).validate(1),
+      Some("capacity times refillPeriod must be <= 9007199254740992 microseconds (so refill math stays exact)")
+    )
+    assertEquals( // 3 * 3002399751580331 = 2^53 + 1
+      RateLimiter[String](RateLimit(3, 1, 3002399751580331L.micros)).validate(1),
+      Some("capacity times refillPeriod must be <= 9007199254740992 microseconds (so refill math stays exact)")
+    )
+    assertEquals(limiter.validate(-1), Some("cost must be >= 0"))
+    assertEquals(limiter.validate(11), Some("cost 11 cannot exceed capacity 10"))
+  }
+
+  test("a length-framed namespace keeps prefix-colliding namespaces from sharing a bucket") {
+    val a = RateLimiter[String](RateLimit.perSecond(1), "a").tryAcquire("b:c").args(2)
+    val b = RateLimiter[String](RateLimit.perSecond(1), "a:b").tryAcquire("c").args(2)
+    assert(!a.sameBytes(b), "namespace `a`/subject `b:c` must not collide with namespace `a:b`/subject `c`")
+  }
+}


### PR DESCRIPTION
## What

A built-in token-bucket rate limiter, shipped in `sage-core` (`sage.ratelimit`) and surfaced on the client as `client.rateLimiter(...)`. No new module and no extra dependency.

Each check is an atomic Lua script keyed on one hash per subject (a single cluster slot), reading the server clock so concurrent callers on skewed machines cannot double-spend. Every client path validates locally and runs the check through `EVALSHA` (loading the script once on a `NOSCRIPT`); the composable escape hatch runs plain `EVAL`.

## API

```scala
val limiter  = client.rateLimiter[String](RateLimit.perSecond(100))
val decision = limiter.tryAcquire("user:42")
// Decision.Allowed(remaining, resetAfter) | Decision.Denied(remaining, retryAfter)
```

- `RateLimit` policy with `perSecond` / `perMinute` / `apply(permits, per, burst)` constructors
- `tryAcquire` / `peek` / `reset`, plus `command` returning the raw `Command` for pipelining
- `peek` is a non-consuming probe: `Allowed` while at least one token is available, otherwise `Denied` with the wait until one is
- `Decision` is a returned value, never a thrown error; a denial also carries the untouched `remaining` balance (`remainingTokens`, ready for an `X-RateLimit-Remaining` header); store failures surface through the effect `F`

## Correctness

- Integer-exact refill that carries the sub-token remainder, so elapsed time is neither double-counted nor dropped
- All intermediates held within `2^53` (validated `capacity * refillPeriod`) so Lua's double arithmetic stays exact; the `2^53` bounds are checked on the raw decimal string and by parity so a value one past the limit is rejected, not rounded into range
- Clock-rollback catch-up folded into `retryAfter`, `resetAfter`, and the key TTL, so a regressed server clock cannot expire a bucket early
- A policy signature in the stored state, so changing the policy under the same namespace never recreates a full bucket
- A bad policy or cost (`1` to `capacity`) fails before any server call with a typed `SageException.InvalidArgument` on every client path; the Lua guard rejects the same violations on the composable path

## Typed usage guards

The pre-flight validation introduced `SageException.InvalidArgument`, and the existing usage guards moved onto it: `connect` config validation, blocking commands in pipelines and transactions, all-masters commands in cluster pipelines, cluster-wide results in cluster transactions, cluster key routing, and the Pekko `BlockTimeout.Forever` guard. Programmer errors now land in the typed error channel on ZIO and Kyo instead of dying as defects.

## Docs and tests

- `docs/rate-limiting.md` and a sidebar entry; the new exception in the `docs/error-handling.md` hierarchy table
- A `RateLimiterExample` wired into the Tour for all five backends
- Unit specs (`RateLimiterSpec`, `RateLimitFallbackSpec`) and a shared integration suite run against both Redis and Valkey, including cold-server `NOSCRIPT` recovery through the real client wiring
