### PR TITLE
Pin master-replica topology to the supplied seeds

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,7 +64,7 @@ a `ServerError`.
 
 ## Master-replica
 
-Select `Topology.MasterReplica` with seed endpoints. Sage asks each its role, discovers the master and its replicas, sends writes to the master, and routes reads per the read policy:
+Select `Topology.MasterReplica` with seed endpoints. Sage asks each its role, sends writes to the master, and routes reads per the read policy:
 
 ```scala
 val config = SageConfig(
@@ -74,6 +74,19 @@ val config = SageConfig(
   readFrom = ReadFrom.ReplicaPreferred
 )
 ```
+
+### What sage connects to
+
+The number of endpoints you supply decides which nodes sage dials:
+
+| Seeds | Nodes sage dials |
+| --- | --- |
+| Several | exactly the endpoints you supplied, each classified by its own `ROLE`. No other address is ever contacted. |
+| One | that endpoint, plus the replica addresses its `ROLE` reply advertises that answer a connection. |
+
+List every endpoint for a managed deployment (ElastiCache, MemoryDB, Azure Cache, a Kubernetes service). Those expose stable names that survive node replacement, while the addresses `ROLE` advertises are per-node and often unreachable from the client, so passing both the primary and reader endpoints is what keeps reads on the reader endpoint.
+
+Either way an endpoint that cannot be reached is dropped rather than routed at, and a `Connection.ConnectFailed` event names it (see [Observability](observability.md)).
 
 ## Read routing
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,11 +82,15 @@ The number of endpoints you supply decides which nodes sage dials:
 | Seeds | Nodes sage dials |
 | --- | --- |
 | Several | exactly the endpoints you supplied, each classified by its own `ROLE`. No other address is ever contacted. |
-| One | that endpoint, plus the replica addresses its `ROLE` reply advertises that answer a connection. |
+| One | that endpoint, the master it names if it is itself a replica, and the replica addresses its `ROLE` reply advertises that answer a connection. |
 
 List every endpoint for a managed deployment (ElastiCache, MemoryDB, Azure Cache, a Kubernetes service). Those expose stable names that survive node replacement, while the addresses `ROLE` advertises are per-node and often unreachable from the client, so passing both the primary and reader endpoints is what keeps reads on the reader endpoint.
 
-Either way an endpoint that cannot be reached is dropped rather than routed at, and a `Connection.ConnectFailed` event names it (see [Observability](observability.md)).
+Either way, a node that cannot be reached, or a replica whose replication stream is not caught up, is dropped rather than routed at, and a `Connection.ConnectFailed` event names it (see [Observability](observability.md)). A dropped node is re-probed periodically while the topology is degraded, so it returns on its own once it recovers.
+
+::: warning
+Supplying several seeds means they *are* the topology. If you previously passed several endpoints only for bootstrap redundancy and relied on discovery to find the rest of your replicas, list every replica endpoint you want reads to reach, or pass a single seed to keep discovering them.
+:::
 
 ## Read routing
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -14,6 +14,7 @@ Register one or more `SageListener` on `SageConfig`, and each receives every `Sa
 | `CommandCompleted(name, node, duration, outcome)` | One logical command settled. `duration` is client-observed (including any cluster redirects/retries); `outcome` is `Succeeded` or `Failed(error)`. A cached read served locally yields no `CommandCompleted`. |
 | `Connection.Connected(node)` | The multiplexed connection connected, on the initial connect and on every reconnect. |
 | `Connection.Disconnected(node)` | A live connection was lost and the runtime began reconnecting. Graceful close is not reported. |
+| `Connection.ConnectFailed(node, error)` | A connection to a node the runtime reached for on its own could not be opened, naming the address and the cause. The routing layer swallows the failure to fall back, so this is the only signal that an address is broken. |
 | `Cache.Hit(command)` / `Cache.Miss(command)` | A `cached` read was served locally, or had to fetch from the server. |
 | `TopologyChanged(masters)` | The cluster's slot-owning master set changed (a failover, or scaling a shard in or out). |
 
@@ -29,11 +30,12 @@ import sage.SageEvent.*
 
 val metrics = new SageListener {
   def onEvent(event: SageEvent): Unit = event match {
-    case CommandCompleted(name, _, duration, _) => // record latency
-    case Connection.Disconnected(_)             => // bump a gauge
-    case Cache.Hit(_)                           => // count a hit
-    case Cache.Miss(_)                          => // count a miss
-    case _                                      => ()
+    case CommandCompleted(name, _, duration, _)  => // record latency
+    case Connection.Disconnected(_)              => // bump a gauge
+    case Connection.ConnectFailed(node, error)   => // log the unreachable address
+    case Cache.Hit(_)                            => // count a hit
+    case Cache.Miss(_)                           => // count a miss
+    case _                                       => ()
   }
 }
 

--- a/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
+++ b/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
@@ -106,9 +106,10 @@ final case class ClusterConfig(
 )
 
 /**
-  * Master-replica tuning. `minRefreshInterval` throttles role re-discovery (`ROLE`/`INFO replication`) so a burst of `READONLY`s or
-  * reconnects triggers at most one discovery per window. There is no periodic poll: roles refresh only on reconnect and on a `READONLY`
-  * from the presumed master.
+  * Master-replica tuning. `minRefreshInterval` throttles role re-discovery (`ROLE`/`INFO replication`) so a burst of `READONLY`s or reconnects
+  * triggers at most one discovery per window. Roles refresh on reconnect and on a `READONLY` from the presumed master, never on a timer, with
+  * one exception: while a node has been dropped as unreachable, reads schedule a re-probe to put it back, no more often than this window and
+  * less often the longer it stays down.
   */
 final case class MasterReplicaConfig(
   minRefreshInterval: FiniteDuration = 5.seconds

--- a/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
@@ -1,6 +1,6 @@
 package sage.client.internal
 
-import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.{ArrayBlockingQueue, ConcurrentHashMap}
 
 import scala.concurrent.duration.{FiniteDuration, NANOSECONDS}
 import scala.util.Try
@@ -55,6 +55,8 @@ private[client] object Events {
     def emitsEvents: Boolean = listeners.nonEmpty
 
     private val queue             = if (listeners.isEmpty) null else new ArrayBlockingQueue[SageEvent](QueueDepth)
+    // nodes currently reported down, so ConnectFailed lands once per outage
+    private val down              = ConcurrentHashMap.newKeySet[Node]()
     @volatile private var running = true
 
     private val worker =
@@ -66,7 +68,12 @@ private[client] object Events {
         t
       }
 
-    def emit(event: SageEvent): Unit = if (queue != null) { val _ = queue.offer(event) }
+    def emit(event: SageEvent): Unit =
+      if (queue != null) event match {
+        case SageEvent.Connection.ConnectFailed(Some(node), _) => if (down.add(node)) { val _ = queue.offer(event) }
+        case SageEvent.Connection.Connected(Some(node))        => val _ = down.remove(node); val _ = queue.offer(event)
+        case _                                                 => val _ = queue.offer(event)
+      }
 
     def close(): Unit = if (worker != null) { running = false; worker.interrupt() }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -1,6 +1,6 @@
 package sage.client.internal
 
-import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap, CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.{AtomicInteger, AtomicLong, AtomicReference}
 import java.util.concurrent.locks.ReentrantLock
 
@@ -24,8 +24,9 @@ import sage.ratelimit.Decision
   * [[ReadFrom]] policy (round-robin, with the policy's fallback). The same `Client` type as standalone and cluster; only the topology selects
   * it.
   *
-  * Roles refresh only on events — a reconnect-driven command loss, a `READONLY` from the presumed master, or a read that can reach no
-  * candidate — throttled by `minRefreshInterval`, never on a timer. A write that meets a demoted master fails fast (kicking off a
+  * Roles refresh on events — a reconnect-driven command loss, a `READONLY` from the presumed master, or a read that can reach no candidate —
+  * throttled by `minRefreshInterval`, never on a timer. The one exception is a degraded topology: while a node has been dropped as unreachable,
+  * reads schedule a re-probe on a widening window, since nothing else would ever put it back. A write that meets a demoted master fails fast (kicking off a
   * re-discovery) so the caller's retry lands on the freshly-discovered master, mirroring the cluster runtime's `READONLY` disposition.
   */
 final private[client] class MasterReplicaLive(
@@ -72,9 +73,11 @@ final private[client] class MasterReplicaLive(
   private val subLock                                         = new ReentrantLock()
   @volatile private var subscriptions: SubscriptionConnection = null
 
-  private val refreshThrottle       = new RefreshThrottle(scheduler, minRefreshInterval.toMillis)
-  private val pruneRefreshDue       = new AtomicLong(0L)
-  @volatile private var prunedNodes = false
+  private val refreshThrottle    = new RefreshThrottle(scheduler, minRefreshInterval.toMillis)
+  private val degradedProbeDue   = new AtomicLong(0L)
+  private val degradedAttempt    = new AtomicInteger()
+  @volatile private var degraded = false
+  private val reportedDown       = ConcurrentHashMap.newKeySet[Node]()
 
   private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
 
@@ -82,33 +85,37 @@ final private[client] class MasterReplicaLive(
 
   /**
     * Several seeds are the topology itself, each classified by its own `ROLE`, and no other address is ever dialled. A lone seed cannot
-    * enumerate a deployment, so it discovers instead. Managed deployments need the former: their endpoint names are stable and reachable, while
-    * the per-node addresses `ROLE` advertises are often neither.
+    * enumerate a deployment, so it discovers from the `ROLE` reply instead.
     */
   private val pinnedToSeeds = seeds.sizeIs > 1
 
-  private[client] def bootstrapRoles(): Unit = {
-    val resolved = if (pinnedToSeeds) resolvePinned() else resolveDiscovered()
-    resolved match {
-      case Right((master, replicas)) => masterNodeRef.set(master); replicasRef.set(replicas)
-      case Left(error)               => closeAll(); throw error
+  private[client] def bootstrapRoles(): Unit =
+    resolve(seeds) match {
+      case Right(roles) => masterNodeRef.set(roles.master); replicasRef.set(roles.replicas)
+      case Left(error)  => closeAll(); throw error
     }
-  }
+
+  /**
+    * `discoveryCandidates` is consulted only when discovering, where a refresh widens the walk to the nodes it already knows.
+    */
+  private def resolve(discoveryCandidates: Vector[Node]): Either[Throwable, MasterReplicaLive.Roles] =
+    if (pinnedToSeeds) resolvePinned() else resolveDiscovered(discoveryCandidates)
 
   /**
     * Classifies each supplied endpoint by its own `ROLE`, keeping the endpoint itself as the address. Unreachable endpoints are dropped, since a
-    * partially available deployment must still connect; connecting requires that one of them reports the master role.
+    * partially available deployment must still connect, as is a replica whose replication stream is not caught up.
     */
-  private def resolvePinned(): Either[Throwable, (Node, Vector[Node])] = {
+  private def resolvePinned(): Either[Throwable, MasterReplicaLive.Roles] = {
     val (roles, lastError) = probeSeeds()
-    prunedNodes = roles.sizeIs < seeds.size
+    setDegraded(roles.sizeIs < seeds.size)
     roles.collectFirst { case (node, _: Role.Master) => node } match {
-      case Some(master)          => Right(master -> roles.collect { case (node, _: Role.Replica) => node })
-      case None if roles.isEmpty => Left(lastError)
+      case Some(master)          => Right(MasterReplicaLive.Roles(master, roles.collect(MasterReplicaLive.onlineReplica)))
+      case None if roles.isEmpty => Left(lastError.getOrElse(NotConnected()))
       case None                  =>
+        val cause = lastError.fold("")(error => s", last failure: ${error.getMessage}")
         Left(
           ConnectionFailed(
-            s"no supplied endpoint reports the master role (probed ${roles.size} of ${seeds.size}): expected briefly during a " +
+            s"no supplied endpoint reports the master role (probed ${roles.size} of ${seeds.size}$cause): expected briefly during a " +
               "failover, otherwise the master endpoint is missing from the seeds"
           )
         )
@@ -116,65 +123,132 @@ final private[client] class MasterReplicaLive(
   }
 
   /**
-    * Contacts seeds until one answers `ROLE`, taking the replica addresses from its reply. The last failure is reported when none answers, so the
-    * first connect surfaces a handshake/TLS error as a standalone connect would.
+    * Contacts candidates until one resolves a master, taking the replica addresses from its `ROLE` reply. Reports the connect failure that
+    * stopped it, so a handshake/TLS error surfaces as it would on a standalone connect, and distinguishes that from a node that answered but
+    * named no usable master.
     */
-  private def resolveDiscovered(): Either[Throwable, (Node, Vector[Node])] = {
-    var lastError: Throwable = NotConnected()
-    val candidates           = seeds.iterator
-    var resolved             = Option.empty[(Node, Vector[Node])]
-    while (resolved.isEmpty && candidates.hasNext) {
-      val seed = candidates.next()
-      try resolved = discoverFrom(seed)
-      catch { case NonFatal(error) => lastError = error }
+  private def resolveDiscovered(candidates: Vector[Node]): Either[Throwable, MasterReplicaLive.Roles] = {
+    var lastError = Option.empty[Throwable]
+    var answered  = false
+    var resolved  = Option.empty[MasterReplicaLive.Roles]
+    val walk      = candidates.iterator
+    while (resolved.isEmpty && walk.hasNext) {
+      val node = walk.next()
+      try {
+        val role = probeRole(node)
+        if (role.isDefined) { answered = true; markUp(node) }
+        resolved = role.flatMap(rolesFrom(node, _))
+      } catch { case NonFatal(error) => lastError = Some(error); reportDown(node, error) }
     }
-    resolved.toRight(lastError)
+    resolved.toRight(
+      lastError.getOrElse(
+        if (answered)
+          ConnectionFailed(
+            "a candidate answered but named no usable master: it reported the sentinel role, or the master it names did not answer as a master"
+          )
+        else NotConnected()
+      )
+    )
   }
 
-  private def probeSeeds(): (Vector[(Node, Role)], Throwable) = {
-    var lastError: Throwable = NotConnected()
-    val roles                = seeds.flatMap { seed =>
-      try probeRole(seed).map(seed -> _)
-      catch {
-        case NonFatal(error) => lastError = error; events.emit(SageEvent.Connection.ConnectFailed(Some(seed), error)); None
-      }
+  private def probeSeeds(): (Vector[(Node, Role)], Option[Throwable]) = {
+    val failure = new AtomicReference[Throwable](null)
+    val roles   = probeConcurrently(seeds) { seed =>
+      try { val role = probeRole(seed); if (role.isDefined) markUp(seed); role }
+      catch { case NonFatal(error) => val _ = failure.compareAndSet(null, error); reportDown(seed, error); None }
     }
-    (roles, lastError)
+    (roles, Option(failure.get()))
   }
 
-  // probes a node's ROLE; a master answers with its replica list, a replica points at its master (followed once), a sentinel is skipped
-  private def discoverFrom(node: Node): Option[(Node, Vector[Node])] =
-    probeRole(node).flatMap {
-      case Role.Master(_, replicas)       => Some(node -> reachable(replicas))
+  // a replica's master is followed once, never transitively
+  private def rolesFrom(node: Node, role: Role): Option[MasterReplicaLive.Roles] =
+    role match {
+      case Role.Master(_, replicas)       => Some(MasterReplicaLive.Roles(node, reachable(replicas)))
       case Role.Replica(host, port, _, _) =>
         val master = Node(host, port)
-        probeRole(master).collect { case Role.Master(_, replicas) => master -> reachable(replicas) }
+        try probeRole(master).collect { case Role.Master(_, replicas) => MasterReplicaLive.Roles(master, reachable(replicas)) }
+        catch { case NonFatal(error) => reportDown(master, error); None }
       case _: Role.Sentinel               => None
     }
 
   /**
-    * Drops advertised replica addresses that cannot be reached, so no read is ever routed at an address discovery already found dead.
+    * Drops advertised replica addresses that cannot be reached, so no read is routed at an address discovery already found dead. A node holding
+    * a live pooled connection counts as reachable without a probe.
     */
   private def reachable(advertised: Vector[ReplicaNode]): Vector[Node] = {
-    val kept = advertised.map(r => Node(r.host, r.port)).filter { node =>
-      try { connectProbe(node).close(); true }
-      catch {
-        case NonFatal(error) => events.emit(SageEvent.Connection.ConnectFailed(Some(node), error)); false
-      }
-    }
-    prunedNodes = kept.sizeIs < advertised.size
+    val nodes           = advertised.map(replica => Node(replica.host, replica.port))
+    val (live, unknown) = nodes.partition(node => replicaPool.existingLive(node).isDefined)
+    val answered        = probeConcurrently(unknown)(node => if (connects(node)) Some(()) else None).map(_._1).toSet
+    val kept            = nodes.filter(node => live.contains(node) || answered.contains(node))
+    setDegraded(kept.sizeIs < nodes.size)
     kept
   }
 
+  private def connects(node: Node): Boolean =
+    try { connectProbe(node).close(); markUp(node); true }
+    catch { case NonFatal(error) => reportDown(node, error); false }
+
   /**
-    * Only a refresh re-admits a pruned node, and a replica-preferring read that falls back to the master fires no other trigger.
+    * Probes every node at once under one shared deadline, so unreachable addresses cost one connect timeout rather than one apiece. A probe that
+    * has not answered by the deadline counts as unreachable, and still closes its own connection when it returns.
     */
-  private def refreshWhilePruned(): Unit =
-    if (prunedNodes) {
-      val now = scheduler.nowMillis
-      val due = pruneRefreshDue.get()
-      if (now >= due && pruneRefreshDue.compareAndSet(due, now + minRefreshInterval.toMillis)) triggerRefresh()
+  private def probeConcurrently[A](nodes: Vector[Node])(probe: Node => Option[A]): Vector[(Node, A)] =
+    if (nodes.sizeIs <= 1) nodes.flatMap(node => probe(node).map(node -> _))
+    else {
+      val answers = new ConcurrentHashMap[Node, A]()
+      val latch   = new CountDownLatch(nodes.size)
+      nodes.foreach { node =>
+        val _ = Thread
+          .ofVirtual()
+          .name("sage-probe")
+          .start { () =>
+            try
+              probe(node).foreach { answer =>
+                val _ = answers.put(node, answer)
+              }
+            finally latch.countDown()
+          }
+      }
+      // each probe bounds its own connect and its ROLE wait by connectTimeout, so twice that covers the slowest legitimate answer
+      val _       = latch.await(config.connectTimeout.toMillis * 2, TimeUnit.MILLISECONDS)
+      nodes.flatMap(node => Option(answers.get(node)).map(node -> _))
     }
+
+  /**
+    * A node that fails to establish after discovery leaves the roster; the degraded re-probe is what puts it back.
+    */
+  private def dropReplica(node: Node): Unit =
+    if (replicasRef.get().contains(node)) {
+      val _ = replicasRef.updateAndGet(_.filterNot(_ == node))
+      setDegraded(true)
+    }
+
+  private def setDegraded(value: Boolean): Unit = {
+    degraded = value
+    if (!value) { degradedAttempt.set(0); degradedProbeDue.set(0L) }
+  }
+
+  /**
+    * Only a refresh re-admits a dropped node, and a replica-preferring read that falls back to the master fires no other trigger. Consecutive
+    * failed re-probes widen the window.
+    */
+  private def refreshWhileDegraded(): Unit =
+    if (degraded) {
+      val now = scheduler.nowMillis
+      val due = degradedProbeDue.get()
+      if (now >= due && degradedProbeDue.compareAndSet(due, now + degradedWindowMillis)) {
+        val _ = degradedAttempt.incrementAndGet()
+        triggerRefresh()
+      }
+    }
+
+  private def degradedWindowMillis: Long =
+    minRefreshInterval.toMillis * (1L << math.min(degradedAttempt.get(), MasterReplicaLive.maxDegradedBackoffShift))
+
+  private def reportDown(node: Node, error: Throwable): Unit =
+    if (reportedDown.add(node)) events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
+
+  private def markUp(node: Node): Unit = { val _ = reportedDown.remove(node) }
 
   // a throwaway connection (must not leave a pooled one behind): a connect/handshake failure propagates so bootstrapRoles surfaces it like a
   // standalone connect; a node that handshakes but doesn't answer ROLE yields None
@@ -208,25 +282,13 @@ final private[client] class MasterReplicaLive(
   // forced, but single-flight may collapse this onto an in-flight refresh, so a stale masterNodeRef self-corrects on the next reconnect
   private def refreshRolesBeforeRehome(): Unit = refreshThrottle(force = true)(rediscover())
 
-  private def rediscover(): Unit = {
-    val resolved =
-      if (pinnedToSeeds) resolvePinned().toOption
-      else {
-        val candidates = (Option(masterNodeRef.get()).toVector ++ replicasRef.get() ++ seeds).distinct
-        candidates.iterator
-          .flatMap(n =>
-            try discoverFrom(n)
-            catch { case NonFatal(_) => None }
-          )
-          .nextOption()
-      }
-    resolved.foreach { case (master, replicas) =>
-      masterNodeRef.set(master)
-      replicasRef.set(replicas)
-      replicaPool.retain(replicas.toSet.contains)
-      masterPool.retain(_ == master)
+  private def rediscover(): Unit =
+    resolve((Option(masterNodeRef.get()).toVector ++ replicasRef.get() ++ seeds).distinct).foreach { roles =>
+      masterNodeRef.set(roles.master)
+      replicasRef.set(roles.replicas)
+      replicaPool.retain(roles.replicas.toSet.contains)
+      masterPool.retain(_ == roles.master)
     }
-  }
 
   // --- routing -------------------------------------------------------------------------------------------------------------------------
 
@@ -297,7 +359,7 @@ final private[client] class MasterReplicaLive(
 
   private def sendRead[A](command: Command[A], complete: Try[A] => Unit): Unit = {
     if (closed) { complete(Failure(NotConnected())); return }
-    refreshWhilePruned()
+    refreshWhileDegraded()
     val master     = masterNodeRef.get()
     val candidates = ReadRouting.candidates(readFrom, master, replicasRef.get(), cursor.getAndIncrement())
     tryRead(command, candidates, master, complete)
@@ -317,7 +379,7 @@ final private[client] class MasterReplicaLive(
             val nc =
               try pool.getOrEstablish(node)
               catch { case NonFatal(_) => null }
-            if (nc == null || !nc.isLive) tryRead(command, rest, master, complete)
+            if (nc == null || !nc.isLive) { if (!isMaster) dropReplica(node); tryRead(command, rest, master, complete) }
             else submitRead(nc, node, isMaster, command, rest, master, complete)
           }
       // nothing reached the wire, so no fault event fires: re-discover here or a strict-Replica read stays stuck on a stale replica set
@@ -392,7 +454,7 @@ final private[client] class MasterReplicaLive(
         }
         val master                                     = masterNodeRef.get()
         if (useReplica) {
-          refreshWhilePruned()
+          refreshWhileDegraded()
           val candidates = ReadRouting.candidates(readFrom, master, replicasRef.get(), cursor.getAndIncrement())
           liveEstablished(candidates, master) match {
             case Some((node, nc)) => submitOn(node, nc)
@@ -435,6 +497,7 @@ final private[client] class MasterReplicaLive(
         try pool.getOrEstablish(node)
         catch { case NonFatal(_) => null }
       if (nc != null && nc.isLive) return (node, nc)
+      if (node != master) dropReplica(node)
     }
     (null, null)
   }
@@ -527,6 +590,14 @@ final private[client] class MasterReplicaLive(
 }
 
 private[client] object MasterReplicaLive {
+
+  final private[client] case class Roles(master: Node, replicas: Vector[Node])
+
+  // the degraded re-probe window doubles out from minRefreshInterval, at most this many times
+  private val maxDegradedBackoffShift = 5
+
+  // ROLE's replication states are none/connect/connecting/sync/connected; only the last is caught up and safe to read from
+  private val onlineReplica: PartialFunction[(Node, Role), Node] = { case (node, replica: Role.Replica) if replica.state == "connected" => node }
 
   final private[client] class TxLease(val scope: Client.TxScope, val nc: NodeClient)
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -1,7 +1,7 @@
 package sage.client.internal
 
 import java.util.concurrent.{CountDownLatch, TimeUnit}
-import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong, AtomicReference}
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.concurrent.duration.*
@@ -10,12 +10,12 @@ import scala.util.control.NonFatal
 
 import kyo.compat.*
 
-import sage.{CommandSpan, Message, Outcome, PatternMessage, SageException}
-import sage.SageException.{ConnectionLost, InvalidArgument, NotConnected, TimedOut}
+import sage.{CommandSpan, Message, Outcome, PatternMessage, SageEvent, SageException}
+import sage.SageException.{ConnectionFailed, ConnectionLost, InvalidArgument, NotConnected, TimedOut}
 import sage.client.{ReadFrom, SageConfig}
 import sage.cluster.Node
 import sage.codec.ValueCodec
-import sage.commands.{Command, Connection, Pipeline, Role, Server}
+import sage.commands.{Command, Connection, Pipeline, ReplicaNode, Role, Server}
 import sage.ratelimit.Decision
 
 /**
@@ -72,44 +72,125 @@ final private[client] class MasterReplicaLive(
   private val subLock                                         = new ReentrantLock()
   @volatile private var subscriptions: SubscriptionConnection = null
 
-  private val refreshThrottle = new RefreshThrottle(scheduler, minRefreshInterval.toMillis)
+  private val refreshThrottle       = new RefreshThrottle(scheduler, minRefreshInterval.toMillis)
+  private val pruneRefreshDue       = new AtomicLong(0L)
+  @volatile private var prunedNodes = false
 
   private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
 
   // --- discovery -----------------------------------------------------------------------------------------------------------------------
 
-  // contacts seeds (and currently-known nodes) until one answers ROLE, resolving the master and its replicas; throws the last failure if
-  // none answers, so the first connect surfaces a handshake/TLS error like a standalone connect would
+  /**
+    * Several seeds are the topology itself, each classified by its own `ROLE`, and no other address is ever dialled. A lone seed cannot
+    * enumerate a deployment, so it discovers instead. Managed deployments need the former: their endpoint names are stable and reachable, while
+    * the per-node addresses `ROLE` advertises are often neither.
+    */
+  private val pinnedToSeeds = seeds.sizeIs > 1
+
   private[client] def bootstrapRoles(): Unit = {
+    val resolved = if (pinnedToSeeds) resolvePinned() else resolveDiscovered()
+    resolved match {
+      case Right((master, replicas)) => masterNodeRef.set(master); replicasRef.set(replicas)
+      case Left(error)               => closeAll(); throw error
+    }
+  }
+
+  /**
+    * Classifies each supplied endpoint by its own `ROLE`, keeping the endpoint itself as the address. Unreachable endpoints are dropped, since a
+    * partially available deployment must still connect; connecting requires that one of them reports the master role.
+    */
+  private def resolvePinned(): Either[Throwable, (Node, Vector[Node])] = {
+    val (roles, lastError) = probeSeeds()
+    prunedNodes = roles.sizeIs < seeds.size
+    roles.collectFirst { case (node, _: Role.Master) => node } match {
+      case Some(master)          => Right(master -> roles.collect { case (node, _: Role.Replica) => node })
+      case None if roles.isEmpty => Left(lastError)
+      case None                  =>
+        Left(
+          ConnectionFailed(
+            s"no supplied endpoint reports the master role (probed ${roles.size} of ${seeds.size}): expected briefly during a " +
+              "failover, otherwise the master endpoint is missing from the seeds"
+          )
+        )
+    }
+  }
+
+  /**
+    * Contacts seeds until one answers `ROLE`, taking the replica addresses from its reply. The last failure is reported when none answers, so the
+    * first connect surfaces a handshake/TLS error as a standalone connect would.
+    */
+  private def resolveDiscovered(): Either[Throwable, (Node, Vector[Node])] = {
     var lastError: Throwable = NotConnected()
     val candidates           = seeds.iterator
-    var done                 = false
-    while (!done && candidates.hasNext) {
+    var resolved             = Option.empty[(Node, Vector[Node])]
+    while (resolved.isEmpty && candidates.hasNext) {
       val seed = candidates.next()
-      try
-        resolveFrom(seed) match {
-          case Some((master, replicas)) => masterNodeRef.set(master); replicasRef.set(replicas); done = true
-          case None                     => ()
-        }
+      try resolved = discoverFrom(seed)
       catch { case NonFatal(error) => lastError = error }
     }
-    if (!done) { closeAll(); throw lastError }
+    resolved.toRight(lastError)
+  }
+
+  private def probeSeeds(): (Vector[(Node, Role)], Throwable) = {
+    var lastError: Throwable = NotConnected()
+    val roles                = seeds.flatMap { seed =>
+      try probeRole(seed).map(seed -> _)
+      catch {
+        case NonFatal(error) => lastError = error; events.emit(SageEvent.Connection.ConnectFailed(Some(seed), error)); None
+      }
+    }
+    (roles, lastError)
   }
 
   // probes a node's ROLE; a master answers with its replica list, a replica points at its master (followed once), a sentinel is skipped
-  private def resolveFrom(node: Node): Option[(Node, Vector[Node])] =
+  private def discoverFrom(node: Node): Option[(Node, Vector[Node])] =
     probeRole(node).flatMap {
-      case Role.Master(_, replicas)       => Some(node -> replicas.map(r => Node(r.host, r.port)))
+      case Role.Master(_, replicas)       => Some(node -> reachable(replicas))
       case Role.Replica(host, port, _, _) =>
         val master = Node(host, port)
-        probeRole(master).collect { case Role.Master(_, replicas) => master -> replicas.map(r => Node(r.host, r.port)) }
+        probeRole(master).collect { case Role.Master(_, replicas) => master -> reachable(replicas) }
       case _: Role.Sentinel               => None
+    }
+
+  /**
+    * Drops advertised replica addresses that cannot be reached, so no read is ever routed at an address discovery already found dead.
+    */
+  private def reachable(advertised: Vector[ReplicaNode]): Vector[Node] = {
+    val kept = advertised.map(r => Node(r.host, r.port)).filter { node =>
+      try { connectProbe(node).close(); true }
+      catch {
+        case NonFatal(error) => events.emit(SageEvent.Connection.ConnectFailed(Some(node), error)); false
+      }
+    }
+    prunedNodes = kept.sizeIs < advertised.size
+    kept
+  }
+
+  /**
+    * Only a refresh re-admits a pruned node, and a replica-preferring read that falls back to the master fires no other trigger.
+    */
+  private def refreshWhilePruned(): Unit =
+    if (prunedNodes) {
+      val now = scheduler.nowMillis
+      val due = pruneRefreshDue.get()
+      if (now >= due && pruneRefreshDue.compareAndSet(due, now + minRefreshInterval.toMillis)) triggerRefresh()
     }
 
   // a throwaway connection (must not leave a pooled one behind): a connect/handshake failure propagates so bootstrapRoles surfaces it like a
   // standalone connect; a node that handshakes but doesn't answer ROLE yields None
   private def probeRole(node: Node): Option[Role] = {
-    val nc = NodeClient.connect(
+    val nc = connectProbe(node)
+    try {
+      val latch   = new CountDownLatch(1)
+      val outcome = new AtomicReference[Try[Role]]()
+      nc.submit[Role](Server.role, asking = false, result => { outcome.set(result); latch.countDown() })
+      if (!latch.await(config.connectTimeout.toMillis, TimeUnit.MILLISECONDS)) None
+      else outcome.get() match { case Success(role) => Some(role); case Failure(_) => None }
+    } finally nc.close()
+  }
+
+  private def connectProbe(node: Node): NodeClient =
+    NodeClient.connect(
       nodeFactory(node),
       scheduler,
       bootstrap,
@@ -121,14 +202,6 @@ final private[client] class MasterReplicaLive(
       node = Some(node),
       events = events
     )
-    try {
-      val latch   = new CountDownLatch(1)
-      val outcome = new AtomicReference[Try[Role]]()
-      nc.submit[Role](Server.role, asking = false, result => { outcome.set(result); latch.countDown() })
-      if (!latch.await(config.connectTimeout.toMillis, TimeUnit.MILLISECONDS)) None
-      else outcome.get() match { case Success(role) => Some(role); case Failure(_) => None }
-    } finally nc.close()
-  }
 
   private def triggerRefresh(): Unit = offload(refreshThrottle(force = false)(rediscover()))
 
@@ -136,19 +209,23 @@ final private[client] class MasterReplicaLive(
   private def refreshRolesBeforeRehome(): Unit = refreshThrottle(force = true)(rediscover())
 
   private def rediscover(): Unit = {
-    val candidates = (Option(masterNodeRef.get()).toVector ++ replicasRef.get() ++ seeds).distinct
-    candidates.iterator
-      .flatMap(n =>
-        try resolveFrom(n)
-        catch { case NonFatal(_) => None }
-      )
-      .nextOption()
-      .foreach { case (master, replicas) =>
-        masterNodeRef.set(master)
-        replicasRef.set(replicas)
-        replicaPool.retain(replicas.toSet.contains)
-        masterPool.retain(_ == master)
+    val resolved =
+      if (pinnedToSeeds) resolvePinned().toOption
+      else {
+        val candidates = (Option(masterNodeRef.get()).toVector ++ replicasRef.get() ++ seeds).distinct
+        candidates.iterator
+          .flatMap(n =>
+            try discoverFrom(n)
+            catch { case NonFatal(_) => None }
+          )
+          .nextOption()
       }
+    resolved.foreach { case (master, replicas) =>
+      masterNodeRef.set(master)
+      replicasRef.set(replicas)
+      replicaPool.retain(replicas.toSet.contains)
+      masterPool.retain(_ == master)
+    }
   }
 
   // --- routing -------------------------------------------------------------------------------------------------------------------------
@@ -220,6 +297,7 @@ final private[client] class MasterReplicaLive(
 
   private def sendRead[A](command: Command[A], complete: Try[A] => Unit): Unit = {
     if (closed) { complete(Failure(NotConnected())); return }
+    refreshWhilePruned()
     val master     = masterNodeRef.get()
     val candidates = ReadRouting.candidates(readFrom, master, replicasRef.get(), cursor.getAndIncrement())
     tryRead(command, candidates, master, complete)
@@ -314,6 +392,7 @@ final private[client] class MasterReplicaLive(
         }
         val master                                     = masterNodeRef.get()
         if (useReplica) {
+          refreshWhilePruned()
           val candidates = ReadRouting.candidates(readFrom, master, replicasRef.get(), cursor.getAndIncrement())
           liveEstablished(candidates, master) match {
             case Some((node, nc)) => submitOn(node, nc)

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -73,11 +73,8 @@ final private[client] class MasterReplicaLive(
   private val subLock                                         = new ReentrantLock()
   @volatile private var subscriptions: SubscriptionConnection = null
 
-  private val refreshThrottle    = new RefreshThrottle(scheduler, minRefreshInterval.toMillis)
-  private val degradedProbeDue   = new AtomicLong(0L)
-  private val degradedAttempt    = new AtomicInteger()
-  @volatile private var degraded = false
-  private val reportedDown       = ConcurrentHashMap.newKeySet[Node]()
+  private val refreshThrottle = new RefreshThrottle(scheduler, minRefreshInterval.toMillis)
+  private val degraded        = new MasterReplicaLive.Degraded(scheduler, minRefreshInterval.toMillis)
 
   private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
 
@@ -107,11 +104,15 @@ final private[client] class MasterReplicaLive(
     */
   private def resolvePinned(): Either[Throwable, MasterReplicaLive.Roles] = {
     val (roles, lastError) = probeSeeds()
-    setDegraded(roles.sizeIs < seeds.size)
     roles.collectFirst { case (node, _: Role.Master) => node } match {
-      case Some(master)          => Right(MasterReplicaLive.Roles(master, roles.collect(MasterReplicaLive.onlineReplica)))
-      case None if roles.isEmpty => Left(lastError.getOrElse(NotConnected()))
+      case Some(master)          =>
+        val replicas = roles.collect { case (node, role) if role.isOnlineReplica => node }
+        // every seed but the master should be a usable replica
+        degraded.set(replicas.sizeIs < seeds.size - 1)
+        Right(MasterReplicaLive.Roles(master, replicas))
+      case None if roles.isEmpty => degraded.set(true); Left(lastError.getOrElse(NotConnected()))
       case None                  =>
+        degraded.set(true)
         val cause = lastError.fold("")(error => s", last failure: ${error.getMessage}")
         Left(
           ConnectionFailed(
@@ -136,9 +137,11 @@ final private[client] class MasterReplicaLive(
       val node = walk.next()
       try {
         val role = probeRole(node)
-        if (role.isDefined) { answered = true; markUp(node) }
+        if (role.isDefined) answered = true
         resolved = role.flatMap(rolesFrom(node, _))
-      } catch { case NonFatal(error) => lastError = Some(error); reportDown(node, error) }
+      } catch {
+        case NonFatal(error) => lastError = Some(error); events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
+      }
     }
     resolved.toRight(
       lastError.getOrElse(
@@ -154,8 +157,13 @@ final private[client] class MasterReplicaLive(
   private def probeSeeds(): (Vector[(Node, Role)], Option[Throwable]) = {
     val failure = new AtomicReference[Throwable](null)
     val roles   = probeConcurrently(seeds) { seed =>
-      try { val role = probeRole(seed); if (role.isDefined) markUp(seed); role }
-      catch { case NonFatal(error) => val _ = failure.compareAndSet(null, error); reportDown(seed, error); None }
+      try probeRole(seed)
+      catch {
+        case NonFatal(error) =>
+          val _ = failure.compareAndSet(null, error)
+          events.emit(SageEvent.Connection.ConnectFailed(Some(seed), error))
+          None
+      }
     }
     (roles, Option(failure.get()))
   }
@@ -167,7 +175,7 @@ final private[client] class MasterReplicaLive(
       case Role.Replica(host, port, _, _) =>
         val master = Node(host, port)
         try probeRole(master).collect { case Role.Master(_, replicas) => MasterReplicaLive.Roles(master, reachable(replicas)) }
-        catch { case NonFatal(error) => reportDown(master, error); None }
+        catch { case NonFatal(error) => events.emit(SageEvent.Connection.ConnectFailed(Some(master), error)); None }
       case _: Role.Sentinel               => None
     }
 
@@ -180,13 +188,13 @@ final private[client] class MasterReplicaLive(
     val (live, unknown) = nodes.partition(node => replicaPool.existingLive(node).isDefined)
     val answered        = probeConcurrently(unknown)(node => if (connects(node)) Some(()) else None).map(_._1).toSet
     val kept            = nodes.filter(node => live.contains(node) || answered.contains(node))
-    setDegraded(kept.sizeIs < nodes.size)
+    degraded.set(kept.sizeIs < nodes.size)
     kept
   }
 
   private def connects(node: Node): Boolean =
-    try { connectProbe(node).close(); markUp(node); true }
-    catch { case NonFatal(error) => reportDown(node, error); false }
+    try { connectProbe(node).close(); true }
+    catch { case NonFatal(error) => events.emit(SageEvent.Connection.ConnectFailed(Some(node), error)); false }
 
   /**
     * Probes every node at once under one shared deadline, so unreachable addresses cost one connect timeout rather than one apiece. A probe that
@@ -220,35 +228,13 @@ final private[client] class MasterReplicaLive(
   private def dropReplica(node: Node): Unit =
     if (replicasRef.get().contains(node)) {
       val _ = replicasRef.updateAndGet(_.filterNot(_ == node))
-      setDegraded(true)
+      degraded.set(true)
     }
-
-  private def setDegraded(value: Boolean): Unit = {
-    degraded = value
-    if (!value) { degradedAttempt.set(0); degradedProbeDue.set(0L) }
-  }
 
   /**
-    * Only a refresh re-admits a dropped node, and a replica-preferring read that falls back to the master fires no other trigger. Consecutive
-    * failed re-probes widen the window.
+    * Only a refresh re-admits a dropped node, and a replica-preferring read that falls back to the master fires no other trigger.
     */
-  private def refreshWhileDegraded(): Unit =
-    if (degraded) {
-      val now = scheduler.nowMillis
-      val due = degradedProbeDue.get()
-      if (now >= due && degradedProbeDue.compareAndSet(due, now + degradedWindowMillis)) {
-        val _ = degradedAttempt.incrementAndGet()
-        triggerRefresh()
-      }
-    }
-
-  private def degradedWindowMillis: Long =
-    minRefreshInterval.toMillis * (1L << math.min(degradedAttempt.get(), MasterReplicaLive.maxDegradedBackoffShift))
-
-  private def reportDown(node: Node, error: Throwable): Unit =
-    if (reportedDown.add(node)) events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
-
-  private def markUp(node: Node): Unit = { val _ = reportedDown.remove(node) }
+  private def refreshWhileDegraded(): Unit = if (degraded.probeDue()) triggerRefresh()
 
   // a throwaway connection (must not leave a pooled one behind): a connect/handshake failure propagates so bootstrapRoles surfaces it like a
   // standalone connect; a node that handshakes but doesn't answer ROLE yields None
@@ -596,8 +582,31 @@ private[client] object MasterReplicaLive {
   // the degraded re-probe window doubles out from minRefreshInterval, at most this many times
   private val maxDegradedBackoffShift = 5
 
-  // ROLE's replication states are none/connect/connecting/sync/connected; only the last is caught up and safe to read from
-  private val onlineReplica: PartialFunction[(Node, Role), Node] = { case (node, replica: Role.Replica) if replica.state == "connected" => node }
+  /**
+    * Whether the roster is missing a node, and when to re-probe for it. Consecutive re-probes that still find it missing widen the window;
+    * clearing the state resets it, so a node that comes back stops the probing.
+    */
+  final private class Degraded(scheduler: Scheduler, baseMillis: Long) {
+    private val due               = new AtomicLong(0L)
+    private val attempt           = new AtomicInteger()
+    @volatile private var missing = false
+
+    def set(value: Boolean): Unit = {
+      missing = value
+      if (!value) { attempt.set(0); due.set(0L) }
+    }
+
+    def probeDue(): Boolean =
+      if (!missing) false
+      else {
+        val now = scheduler.nowMillis
+        val at  = due.get()
+        if (now >= at && due.compareAndSet(at, now + baseMillis * (1L << math.min(attempt.get(), maxDegradedBackoffShift)))) {
+          val _ = attempt.incrementAndGet()
+          true
+        } else false
+      }
+  }
 
   final private[client] class TxLease(val scope: Client.TxScope, val nc: NodeClient)
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -7,6 +7,7 @@ import scala.collection.mutable
 import scala.concurrent.duration.*
 import scala.jdk.CollectionConverters.*
 
+import sage.SageEvent
 import sage.SageException.NotConnected
 import sage.client.{BackoffConfig, DedicatedPoolConfig, WatchdogConfig}
 import sage.cluster.Node
@@ -103,12 +104,14 @@ final private[client] class NodePool(
           )
         catch {
           case error: Throwable =>
-            locked {
+            val report = locked {
               val conn = connRef.get()
               if (conn != null) { val _ = establishing -= conn }
               if (pendingEstablish.get(node).exists(_ eq mine)) { val _ = pendingEstablish.remove(node) }
+              !closed
             }
             mine.fail(error)
+            if (report) events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
             throw error
         }
       // publish only if our token is still current: a retain, close, or newer attempt supersedes us, and the new client is discarded not leaked

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -261,18 +261,17 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     assert(!dialled.contains(advertisedReplica), s"a failover must not introduce a discovered address, dialled $dialled")
   }
 
-  test("a replica whose replication stream is not caught up is not used as a read target") {
-    val f = new Fixture(
-      seeds = Vector(primary, reader),
-      roles = Map(primary -> masterRole(), reader -> replicaRole(primary, state = "sync"))
-    )
+  test("a replica whose replication stream is not caught up is excluded, then re-admitted once it catches up") {
+    val roles = collection.mutable.Map[Node, Frame](primary -> masterRole(), reader -> replicaRole(primary, state = "sync"))
+    val f     = new Fixture(seeds = Vector(primary, reader), roles = roles, minRefreshInterval = 50.millis)
     f.live.bootstrapRoles()
 
     assertEquals(f.read(), 1L)
-    val served = f.readsServedBy(reader)
-    f.close()
+    assertEquals(f.readsServedBy(reader), 0, "a resyncing replica serves a partial dataset, so reads must stay on the master")
 
-    assertEquals(served, 0, "a resyncing replica serves a partial dataset, so reads must stay on the master")
+    roles(reader) = replicaRole(primary, state = "connected")
+    f.awaitTrue({ val _ = f.read(); f.readsServedBy(reader) > 0 }, "reads should return to the replica once it has caught up")
+    f.close()
   }
 
   test("a replica that fails to establish after discovery leaves the roster instead of costing every read") {

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -1,0 +1,255 @@
+package sage.client
+
+import java.io.IOException
+import java.util.concurrent.ConcurrentLinkedQueue
+
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+
+import kyo.compat.*
+
+import sage.{Bytes, SageEvent, SageListener}
+import sage.SageException.ConnectionFailed
+import sage.client.internal.{Events, FakeTransport, MasterReplicaLive, MultiplexedConnection, Scheduler}
+import sage.cluster.Node
+import sage.commands.{Command, Connection}
+import sage.protocol.Frame
+
+class MasterReplicaTopologySpec extends munit.FunSuite {
+
+  private val primary           = Node("primary-endpoint", 6379)
+  private val reader            = Node("reader-endpoint", 6379)
+  private val advertisedReplica = Node("10.0.0.7", 6379)
+
+  private val helloReply: Frame =
+    Frame.Map(
+      Vector(
+        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
+        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
+        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
+        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
+      )
+    )
+
+  private def masterRole(replicas: Node*): Frame =
+    Frame.Array(
+      Vector(
+        Frame.BulkString(Bytes.utf8("master")),
+        Frame.Integer(0L),
+        Frame.Array(
+          replicas.toVector.map(r =>
+            Frame.Array(
+              Vector(
+                Frame.BulkString(Bytes.utf8(r.host)),
+                Frame.BulkString(Bytes.utf8(r.port.toString)),
+                Frame.BulkString(Bytes.utf8("0"))
+              )
+            )
+          )
+        )
+      )
+    )
+
+  private def replicaRole(master: Node): Frame =
+    Frame.Array(
+      Vector(
+        Frame.BulkString(Bytes.utf8("slave")),
+        Frame.BulkString(Bytes.utf8(master.host)),
+        Frame.Integer(master.port.toLong),
+        Frame.BulkString(Bytes.utf8("connected")),
+        Frame.Integer(0L)
+      )
+    )
+
+  private val zscore: Command[Long] =
+    Command("ZSCORE", Command.NoKeys, Vector.empty, (_: Frame) => Right(1L), isReadOnly = true)
+
+  final private class Fixture(
+    seeds: Vector[Node],
+    roles: collection.Map[Node, Frame],
+    unreachable: collection.Set[Node] = Set.empty,
+    readFrom: ReadFrom = ReadFrom.ReplicaPreferred,
+    events: Events = Events.disabled,
+    minRefreshInterval: FiniteDuration = 1.second
+  ) {
+    private val dials      = new ConcurrentLinkedQueue[Node]()
+    private val transports = new ConcurrentLinkedQueue[(Node, FakeTransport)]()
+
+    private val factory: Node => MultiplexedConnection.TransportFactory = node =>
+      (onFrame, onClosed) => {
+        val _                            = dials.add(node)
+        if (unreachable(node)) throw new IOException(s"cannot reach $node")
+        val respond: Bytes => Seq[Frame] = payload => {
+          val text = payload.asUtf8String
+          if (text.contains("HELLO")) Seq(helloReply)
+          else if (text.contains("ROLE")) roles.get(node).toSeq
+          else if (text.contains("ZSCORE")) Seq(Frame.Integer(1L))
+          else Seq(Frame.SimpleString("OK"))
+        }
+        val transport                    = new FakeTransport(onFrame, onClosed, respond)
+        val _                            = transports.add(node -> transport)
+        transport
+      }
+
+    val live: MasterReplicaLive = new MasterReplicaLive(
+      factory,
+      Scheduler.real,
+      Vector(Connection.hello(None)),
+      SageConfig(readFrom = readFrom, connectTimeout = 500.millis),
+      seeds,
+      minRefreshInterval,
+      events
+    )
+
+    def dialled: Vector[Node] = dials.asScala.toVector
+
+    def readsServedBy(node: Node): Int =
+      transports.asScala.toVector.collect { case (n, t) if n == node => t.written.count(_.asUtf8String.contains("ZSCORE")) }.sum
+
+    def read(): Long = scala.concurrent.Await.result(live.run(zscore).unsafeRun, 30.seconds)
+
+    def timedRead(): Long = {
+      val start = System.nanoTime()
+      val _     = read()
+      (System.nanoTime() - start) / 1000000L
+    }
+
+    def close(): Unit = { val _ = scala.concurrent.Await.result(live.close.unsafeRun, 30.seconds) }
+  }
+
+  test("several seeds pin the topology to the supplied endpoints, and a ROLE-reported address is never dialled") {
+    val f = new Fixture(
+      seeds = Vector(primary, reader),
+      roles = Map(primary -> masterRole(advertisedReplica), reader -> replicaRole(primary), advertisedReplica -> replicaRole(primary)),
+      unreachable = Set(advertisedReplica)
+    )
+    f.live.bootstrapRoles()
+
+    assertEquals(f.read(), 1L)
+    assertEquals(f.read(), 1L)
+    val dialled = f.dialled
+    val served  = f.readsServedBy(reader)
+    f.close()
+
+    assertEquals(served, 2, "both reads should be served by the supplied reader endpoint")
+    assert(!dialled.contains(advertisedReplica), s"the ROLE-reported address must never be dialled, dialled $dialled")
+  }
+
+  test("a single seed keeps discovery, taking replica addresses from the ROLE reply") {
+    val f = new Fixture(
+      seeds = Vector(primary),
+      roles = Map(primary -> masterRole(advertisedReplica), advertisedReplica -> replicaRole(primary))
+    )
+    f.live.bootstrapRoles()
+
+    assertEquals(f.read(), 1L)
+    val served = f.readsServedBy(advertisedReplica)
+    f.close()
+
+    assertEquals(served, 1, "a lone seed should discover its replica and read from it")
+  }
+
+  test("a discovered replica that cannot be reached is dropped, so reads stop dialling it") {
+    val f = new Fixture(
+      seeds = Vector(primary),
+      roles = Map(primary -> masterRole(advertisedReplica), advertisedReplica -> replicaRole(primary)),
+      unreachable = Set(advertisedReplica),
+      minRefreshInterval = 1.hour
+    )
+    f.live.bootstrapRoles()
+
+    Vector.fill(5)(f.read()).foreach(r => assertEquals(r, 1L))
+    val dials = f.dialled.count(_ == advertisedReplica)
+    f.close()
+
+    assertEquals(f.readsServedBy(advertisedReplica), 0, "a dead replica must not serve reads")
+    assert(dials <= 2, s"a dead replica should cost a discovery probe and at most one refresh probe, not one dial per read, got $dials")
+  }
+
+  test("an unreachable supplied endpoint is dropped, so a partially available deployment still connects") {
+    val f = new Fixture(
+      seeds = Vector(primary, reader),
+      roles = Map(primary -> masterRole(), reader -> replicaRole(primary)),
+      unreachable = Set(reader)
+    )
+    f.live.bootstrapRoles()
+
+    assertEquals(f.read(), 1L, "with no reachable replica the read falls back to the master")
+    f.close()
+  }
+
+  test("a pruned replica is re-admitted once it becomes reachable again") {
+    val down = collection.mutable.Set[Node](advertisedReplica)
+    val f    = new Fixture(
+      seeds = Vector(primary),
+      roles = Map(primary -> masterRole(advertisedReplica), advertisedReplica -> replicaRole(primary)),
+      unreachable = down,
+      minRefreshInterval = 100.millis
+    )
+    f.live.bootstrapRoles()
+    assertEquals(f.read(), 1L)
+    assertEquals(f.readsServedBy(advertisedReplica), 0, "a dead replica must not serve reads")
+
+    down.clear()
+    val deadline = System.nanoTime() + 5.seconds.toNanos
+    while (f.readsServedBy(advertisedReplica) == 0 && System.nanoTime() < deadline) {
+      val _ = f.read()
+      Thread.sleep(50)
+    }
+    val served   = f.readsServedBy(advertisedReplica)
+    f.close()
+
+    assert(served > 0, "reads should return to the replica once it is reachable and a refresh re-admits it")
+  }
+
+  test("seeds that report no master fail the connect with an actionable error") {
+    val f     = new Fixture(
+      seeds = Vector(reader, advertisedReplica),
+      roles = Map(reader -> replicaRole(primary), advertisedReplica -> replicaRole(primary))
+    )
+    val error = intercept[ConnectionFailed](f.live.bootstrapRoles())
+    assert(error.getMessage.contains("missing from the seeds"), s"unhelpful message: ${error.getMessage}")
+  }
+
+  test("re-resolving after a failover moves the roles between the same pinned endpoints") {
+    val roles = collection.mutable.Map[Node, Frame](primary -> masterRole(advertisedReplica), reader -> replicaRole(primary))
+    val f     = new Fixture(seeds = Vector(primary, reader), roles = roles, unreachable = Set(advertisedReplica))
+    f.live.bootstrapRoles()
+    assertEquals(f.read(), 1L)
+    assert(f.dialled.contains(reader), "the reader endpoint should serve reads before the failover")
+
+    roles(primary) = replicaRole(reader)
+    roles(reader) = masterRole(advertisedReplica)
+    f.live.bootstrapRoles()
+
+    assertEquals(f.read(), 1L)
+    val dialled = f.dialled
+    f.close()
+    assert(!dialled.contains(advertisedReplica), s"a failover must not introduce a discovered address, dialled $dialled")
+  }
+
+  test("a connect that fails names the address in a ConnectFailed event") {
+    val seen     = new ConcurrentLinkedQueue[SageEvent.Connection.ConnectFailed]()
+    val listener = new SageListener {
+      def onEvent(event: SageEvent): Unit = event match {
+        case e: SageEvent.Connection.ConnectFailed => val _ = seen.add(e)
+        case _                                     => ()
+      }
+    }
+    val f        = new Fixture(
+      seeds = Vector(primary, reader),
+      roles = Map(primary -> masterRole(), reader -> replicaRole(primary)),
+      unreachable = Set(reader),
+      events = Events(Vector(listener))
+    )
+    f.live.bootstrapRoles()
+
+    val deadline = System.nanoTime() + 2.seconds.toNanos
+    while (seen.isEmpty && System.nanoTime() < deadline) Thread.sleep(10)
+    f.close()
+
+    val failures = seen.asScala.toVector
+    assertEquals(failures.map(_.node), Vector(Some(reader)), s"the failing address should be reported, got $failures")
+    assert(failures.head.error.isInstanceOf[IOException], s"the cause should be carried: ${failures.head.error}")
+  }
+}

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -50,40 +50,55 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
       )
     )
 
-  private def replicaRole(master: Node): Frame =
+  private def replicaRole(master: Node, state: String = "connected"): Frame =
     Frame.Array(
       Vector(
         Frame.BulkString(Bytes.utf8("slave")),
         Frame.BulkString(Bytes.utf8(master.host)),
         Frame.Integer(master.port.toLong),
-        Frame.BulkString(Bytes.utf8("connected")),
+        Frame.BulkString(Bytes.utf8(state)),
         Frame.Integer(0L)
       )
     )
 
+  private val connectTimeout = 500.millis
+
   private val zscore: Command[Long] =
     Command("ZSCORE", Command.NoKeys, Vector.empty, (_: Frame) => Right(1L), isReadOnly = true)
+
+  private val zadd: Command[Long] =
+    Command("ZADD", Command.NoKeys, Vector.empty, (_: Frame) => Right(1L), isReadOnly = false)
 
   final private class Fixture(
     seeds: Vector[Node],
     roles: collection.Map[Node, Frame],
     unreachable: collection.Set[Node] = Set.empty,
+    blackholed: collection.Set[Node] = Set.empty,
+    failAfterDials: Map[Node, Int] = Map.empty,
     readFrom: ReadFrom = ReadFrom.ReplicaPreferred,
     events: Events = Events.disabled,
     minRefreshInterval: FiniteDuration = 1.second
   ) {
-    private val dials      = new ConcurrentLinkedQueue[Node]()
-    private val transports = new ConcurrentLinkedQueue[(Node, FakeTransport)]()
+
+    @volatile var writesFailReadonly = false
+    private val dials                = new ConcurrentLinkedQueue[Node]()
+    private val transports           = new ConcurrentLinkedQueue[(Node, FakeTransport)]()
 
     private val factory: Node => MultiplexedConnection.TransportFactory = node =>
       (onFrame, onClosed) => {
         val _                            = dials.add(node)
+        failAfterDials.get(node).foreach { limit =>
+          if (dials.asScala.count(_ == node) > limit) throw new IOException(s"cannot reach $node")
+        }
+        if (blackholed(node)) { Thread.sleep(connectTimeout.toMillis); throw new IOException(s"blackholed $node") }
         if (unreachable(node)) throw new IOException(s"cannot reach $node")
         val respond: Bytes => Seq[Frame] = payload => {
           val text = payload.asUtf8String
           if (text.contains("HELLO")) Seq(helloReply)
           else if (text.contains("ROLE")) roles.get(node).toSeq
           else if (text.contains("ZSCORE")) Seq(Frame.Integer(1L))
+          else if (text.contains("ZADD"))
+            if (writesFailReadonly) Seq(Frame.SimpleError("READONLY You can't write against a read only replica.")) else Seq(Frame.Integer(1L))
           else Seq(Frame.SimpleString("OK"))
         }
         val transport                    = new FakeTransport(onFrame, onClosed, respond)
@@ -95,7 +110,7 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
       factory,
       Scheduler.real,
       Vector(Connection.hello(None)),
-      SageConfig(readFrom = readFrom, connectTimeout = 500.millis),
+      SageConfig(readFrom = readFrom, connectTimeout = connectTimeout),
       seeds,
       minRefreshInterval,
       events
@@ -107,6 +122,14 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
       transports.asScala.toVector.collect { case (n, t) if n == node => t.written.count(_.asUtf8String.contains("ZSCORE")) }.sum
 
     def read(): Long = scala.concurrent.Await.result(live.run(zscore).unsafeRun, 30.seconds)
+
+    def write(): scala.util.Try[Long] = scala.util.Try(scala.concurrent.Await.result(live.run(zadd).unsafeRun, 30.seconds))
+
+    def awaitTrue(cond: => Boolean, clue: String): Unit = {
+      val deadline = System.nanoTime() + 10.seconds.toNanos
+      while (!cond && System.nanoTime() < deadline) Thread.sleep(25)
+      assert(cond, clue)
+    }
 
     def timedRead(): Long = {
       val start = System.nanoTime()
@@ -211,21 +234,113 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     assert(error.getMessage.contains("missing from the seeds"), s"unhelpful message: ${error.getMessage}")
   }
 
-  test("re-resolving after a failover moves the roles between the same pinned endpoints") {
+  test("a failover re-homes the pinned endpoints through the refresh a READONLY triggers") {
     val roles = collection.mutable.Map[Node, Frame](primary -> masterRole(advertisedReplica), reader -> replicaRole(primary))
-    val f     = new Fixture(seeds = Vector(primary, reader), roles = roles, unreachable = Set(advertisedReplica))
+    val f     = new Fixture(
+      seeds = Vector(primary, reader),
+      roles = roles,
+      unreachable = Set(advertisedReplica),
+      minRefreshInterval = 50.millis
+    )
     f.live.bootstrapRoles()
     assertEquals(f.read(), 1L)
-    assert(f.dialled.contains(reader), "the reader endpoint should serve reads before the failover")
+    assert(f.readsServedBy(reader) > 0, "the reader endpoint should serve reads before the failover")
 
     roles(primary) = replicaRole(reader)
     roles(reader) = masterRole(advertisedReplica)
+    f.writesFailReadonly = true
+    assert(f.write().isFailure, "a write to the demoted master should fail")
+
+    val servedBefore = f.readsServedBy(primary)
+    f.awaitTrue(
+      { val _ = f.read(); f.readsServedBy(primary) > servedBefore },
+      "reads should move to the demoted endpoint once the refresh re-homes the roles"
+    )
+    val dialled      = f.dialled
+    f.close()
+    assert(!dialled.contains(advertisedReplica), s"a failover must not introduce a discovered address, dialled $dialled")
+  }
+
+  test("a replica whose replication stream is not caught up is not used as a read target") {
+    val f = new Fixture(
+      seeds = Vector(primary, reader),
+      roles = Map(primary -> masterRole(), reader -> replicaRole(primary, state = "sync"))
+    )
     f.live.bootstrapRoles()
 
     assertEquals(f.read(), 1L)
-    val dialled = f.dialled
+    val served = f.readsServedBy(reader)
     f.close()
-    assert(!dialled.contains(advertisedReplica), s"a failover must not introduce a discovered address, dialled $dialled")
+
+    assertEquals(served, 0, "a resyncing replica serves a partial dataset, so reads must stay on the master")
+  }
+
+  test("a replica that fails to establish after discovery leaves the roster instead of costing every read") {
+    // the discovery probe is its first dial and succeeds; the read path's establish is the second and fails
+    val f = new Fixture(
+      seeds = Vector(primary),
+      roles = Map(primary -> masterRole(advertisedReplica), advertisedReplica -> replicaRole(primary)),
+      failAfterDials = Map(advertisedReplica -> 1),
+      minRefreshInterval = 1.hour
+    )
+    f.live.bootstrapRoles()
+
+    Vector.fill(5)(f.read()).foreach(r => assertEquals(r, 1L))
+    val dials = f.dialled.count(_ == advertisedReplica)
+    f.close()
+
+    // one discovery probe, one failed establish, and the one immediate re-probe the degraded state schedules
+    assert(dials <= 3, s"the replica should leave the roster after its first failed establish, dialled $dials times")
+  }
+
+  test("unreachable endpoints are probed concurrently, so they cost one connect timeout rather than one each") {
+    val dead  = Vector(Node("10.0.0.7", 6379), Node("10.0.0.8", 6379), Node("10.0.0.9", 6379))
+    val f     = new Fixture(
+      seeds = Vector(primary),
+      roles = Map(primary -> masterRole(dead*)),
+      blackholed = dead.toSet
+    )
+    val start = System.nanoTime()
+    f.live.bootstrapRoles()
+    val took  = (System.nanoTime() - start) / 1000000L
+    assertEquals(f.read(), 1L)
+    f.close()
+
+    assert(took < 3 * connectTimeout.toMillis, s"three blackholed addresses should cost about one connect timeout, took ${took}ms")
+  }
+
+  test("a reachable seed that names no usable master fails with ConnectionFailed, not NotConnected") {
+    val f     = new Fixture(
+      seeds = Vector(primary),
+      roles = Map(primary -> Frame.Array(Vector(Frame.BulkString(Bytes.utf8("sentinel")), Frame.Array(Vector.empty))))
+    )
+    val error = intercept[ConnectionFailed](f.live.bootstrapRoles())
+    assert(error.getMessage.contains("named no usable master"), s"unhelpful message: ${error.getMessage}")
+  }
+
+  test("a node that stays unreachable is reported once, not on every probe") {
+    val seen     = new ConcurrentLinkedQueue[SageEvent.Connection.ConnectFailed]()
+    val listener = new SageListener {
+      def onEvent(event: SageEvent): Unit = event match {
+        case e: SageEvent.Connection.ConnectFailed => val _ = seen.add(e)
+        case _                                     => ()
+      }
+    }
+    val f        = new Fixture(
+      seeds = Vector(primary),
+      roles = Map(primary -> masterRole(advertisedReplica), advertisedReplica -> replicaRole(primary)),
+      unreachable = Set(advertisedReplica),
+      events = Events(Vector(listener)),
+      minRefreshInterval = 50.millis
+    )
+    f.live.bootstrapRoles()
+    Vector.fill(10)(f.read()).foreach(r => assertEquals(r, 1L))
+    Thread.sleep(500)
+    val _        = f.read()
+    f.close()
+
+    val forReplica = seen.asScala.toVector.count(_.node.contains(advertisedReplica))
+    assertEquals(forReplica, 1, s"a node that stays down should be reported once per outage, got $forReplica reports")
   }
 
   test("a connect that fails names the address in a ConnectFailed event") {

--- a/sage-core/src/main/scala/sage/SageEvent.scala
+++ b/sage-core/src/main/scala/sage/SageEvent.scala
@@ -45,13 +45,13 @@ object SageEvent {
     final case class ReconnectFailed(node: Option[Node], error: Throwable) extends Connection
 
     /**
-      * A connection to a specific node could not be opened, naming the address that failed and why. Fired for a node the runtime reaches for on
-      * its own — a replica it routes a read to, a seed it classifies during discovery, a cluster node it must reach — where the caller sees only
-      * a fallback or a generic failure and would otherwise have no way to learn which address is broken. Distinct from [[ReconnectFailed]],
-      * which concerns an already-established connection being restored, and from the initial connect, whose failure reaches the caller directly.
+      * A connection to a specific node could not be opened, naming the address that failed and why. Fired wherever the runtime dials a node
+      * itself — a replica it routes a read to, a seed it classifies, a node the cluster topology names — including while a client is still
+      * connecting, where several nodes are dialled and the caller's single failure names none of them. Distinct from [[ReconnectFailed]], which
+      * concerns restoring an already-established connection.
       *
-      * Worth logging at warn: an address that fails *slowly* (dropped packets, a stalled DNS lookup or TLS handshake) costs every command that
-      * considers that node the whole `connectTimeout`, and this event is the only signal that it is happening.
+      * A node that stays unreachable is reported once per outage rather than on every attempt. Worth logging at warn: an address that fails
+      * *slowly* (dropped packets, a stalled DNS lookup or TLS handshake) costs the whole `connectTimeout` wherever it is dialled.
       */
     final case class ConnectFailed(node: Option[Node], error: Throwable) extends Connection
   }

--- a/sage-core/src/main/scala/sage/SageEvent.scala
+++ b/sage-core/src/main/scala/sage/SageEvent.scala
@@ -43,6 +43,17 @@ object SageEvent {
       * the caller already sees.
       */
     final case class ReconnectFailed(node: Option[Node], error: Throwable) extends Connection
+
+    /**
+      * A connection to a specific node could not be opened, naming the address that failed and why. Fired for a node the runtime reaches for on
+      * its own — a replica it routes a read to, a seed it classifies during discovery, a cluster node it must reach — where the caller sees only
+      * a fallback or a generic failure and would otherwise have no way to learn which address is broken. Distinct from [[ReconnectFailed]],
+      * which concerns an already-established connection being restored, and from the initial connect, whose failure reaches the caller directly.
+      *
+      * Worth logging at warn: an address that fails *slowly* (dropped packets, a stalled DNS lookup or TLS handshake) costs every command that
+      * considers that node the whole `connectTimeout`, and this event is the only signal that it is happening.
+      */
+    final case class ConnectFailed(node: Option[Node], error: Throwable) extends Connection
   }
 
   /**

--- a/sage-core/src/main/scala/sage/commands/Server.scala
+++ b/sage-core/src/main/scala/sage/commands/Server.scala
@@ -27,6 +27,16 @@ enum Role {
   case Master(replicationOffset: Long, replicas: Vector[ReplicaNode])
   case Replica(masterHost: String, masterPort: Int, state: String, replicationOffset: Long)
   case Sentinel(masterNames: Vector[String])
+
+  /**
+    * Whether this is a replica whose replication stream has caught up, and so holds the full dataset. `ROLE` reports a replica's link as one of
+    * `none`, `connect`, `connecting`, `sync` or `connected`, and only the last means caught up; the others are mid-handshake or mid-transfer,
+    * where the node still answers reads from a partial dataset unless the server is configured to refuse them.
+    */
+  def isOnlineReplica: Boolean = this match {
+    case Replica(_, _, state, _) => state == "connected"
+    case _                       => false
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

Master-replica kept the supplied endpoint for the **master** but replaced the **replicas** with the addresses out of the master's `ROLE` reply:

```scala
case Role.Master(_, replicas) => Some(node -> replicas.map(r => Node(r.host, r.port)))
```

So a caller who listed every endpoint still had reads routed at addresses they never supplied. On a managed deployment those per-node addresses are typically unreachable from the client, and such an address fails *slowly* rather than being refused, so every replica-eligible read burned the whole `connectTimeout` (10s by default) before falling back to the master.

The symptom: reads uniformly ~10s slow, writes and `MasterPreferred` reads unaffected, at any traffic level, nothing in the logs.

## Solution

Seed count selects how the topology is built:

| Seeds | Nodes dialled |
| --- | --- |
| Several | exactly the supplied endpoints, each classified by its own `ROLE`. No other address is contacted. |
| One | that endpoint, plus the advertised replica addresses that answer a connection. |

An endpoint that cannot be reached is dropped rather than routed at, so a partially available deployment still connects. Because a pruned node is only re-admitted by a refresh, and a replica-preferring read that falls back to the master fires no other trigger, a read schedules a throttled re-probe while anything is pruned.

Roles are still discovered rather than asserted: the endpoint set is fixed and only the roles move between them across a failover. Seeds that report no master fail with `ConnectionFailed` rather than `InvalidArgument`, since that state is expected briefly during a failover.

Adds `SageEvent.Connection.ConnectFailed(node, error)`, naming an address that could not be connected to. The routing layer swallows an establish failure in order to fall back, so the failing address was previously invisible. This is a new case in the sealed `Connection` hierarchy, so an exhaustive listener match without a catch-all needs updating.

## Tests

`MasterReplicaTopologySpec`, 8 cases: pinning routes reads to the supplied endpoint and never dials an advertised one; a single seed still discovers and reads from its replica; an unreachable discovered replica is dropped and stops being dialled per read; a pruned replica is re-admitted once reachable; an unreachable supplied endpoint still connects; no master among seeds fails with a clear error; failover moves roles between the same pinned endpoints; `ConnectFailed` names the address.

All seven client cells and core green.