### PR TITLE
Pin master-replica topology to supplied seeds

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,12 +79,13 @@ The number of endpoints decides where sage may connect:
 
 | Seeds | Nodes sage dials |
 | --- | --- |
-| Several | exactly the supplied endpoints, each classified by its own `ROLE`; addresses advertised by `ROLE` are ignored |
+| Several | exactly the supplied endpoints, each classified by its own `ROLE`; only replicas reporting `connected` are used, and addresses advertised by `ROLE` are ignored |
 | One | the supplied endpoint and the master or replicas discovered from its `ROLE` reply |
 
 Use several endpoints for managed deployments whose stable primary and reader names differ from the per-node addresses Redis advertises. An
 unreachable supplied endpoint is omitted when the roles are resolved, allowing a partially available deployment to connect. It can be considered
-again when an existing reconnect or routing failure triggers a later role refresh.
+again when an existing reconnect or routing failure triggers a later role refresh. A supplied replica that is still synchronizing is likewise
+omitted until a later event-driven refresh sees its own `ROLE` state become `connected`.
 
 ## Read routing
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,6 +87,9 @@ unreachable supplied endpoint is omitted when the roles are resolved, allowing a
 again when an existing reconnect or routing failure triggers a later role refresh. A supplied replica that is still synchronizing is likewise
 omitted until a later event-driven refresh sees its own `ROLE` state become `connected`.
 
+With `ReplicaPreferred`, a read that falls back to the master while no replica is known also schedules this throttled refresh. This lets an
+omitted reader return to service under otherwise healthy master-only traffic without adding background polling.
+
 ## Read routing
 
 `readFrom` governs which node a read-only command may run on, the same setting for both cluster and master-replica deployments:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,7 +64,7 @@ a `ServerError`.
 
 ## Master-replica
 
-Select `Topology.MasterReplica` with seed endpoints. Sage asks each its role, discovers the master and its replicas, sends writes to the master, and routes reads per the read policy:
+Select `Topology.MasterReplica` with seed endpoints. Sage discovers the nodes' roles, sends writes to the master, and routes reads per the read policy:
 
 ```scala
 val config = SageConfig(
@@ -74,6 +74,17 @@ val config = SageConfig(
   readFrom = ReadFrom.ReplicaPreferred
 )
 ```
+
+The number of endpoints decides where sage may connect:
+
+| Seeds | Nodes sage dials |
+| --- | --- |
+| Several | exactly the supplied endpoints, each classified by its own `ROLE`; addresses advertised by `ROLE` are ignored |
+| One | the supplied endpoint and the master or replicas discovered from its `ROLE` reply |
+
+Use several endpoints for managed deployments whose stable primary and reader names differ from the per-node addresses Redis advertises. An
+unreachable supplied endpoint is omitted when the roles are resolved, allowing a partially available deployment to connect. It can be considered
+again when an existing reconnect or routing failure triggers a later role refresh.
 
 ## Read routing
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -14,6 +14,7 @@ Register one or more `SageListener` on `SageConfig`, and each receives every `Sa
 | `CommandCompleted(name, node, duration, outcome)` | One logical command settled. `duration` is client-observed (including any cluster redirects/retries); `outcome` is `Succeeded` or `Failed(error)`. A cached read served locally yields no `CommandCompleted`. |
 | `Connection.Connected(node)` | The multiplexed connection connected, on the initial connect and on every reconnect. |
 | `Connection.Disconnected(node)` | A live connection was lost and the runtime began reconnecting. Graceful close is not reported. |
+| `Connection.ConnectFailed(node, error)` | A connection to a node could not be opened, naming the address and cause when routing or topology discovery handles the failure internally. |
 | `Cache.Hit(command)` / `Cache.Miss(command)` | A `cached` read was served locally, or had to fetch from the server. |
 | `TopologyChanged(masters)` | The cluster's slot-owning master set changed (a failover, or scaling a shard in or out). |
 
@@ -31,6 +32,7 @@ val metrics = new SageListener {
   def onEvent(event: SageEvent): Unit = event match {
     case CommandCompleted(name, _, duration, _) => // record latency
     case Connection.Disconnected(_)             => // bump a gauge
+    case Connection.ConnectFailed(node, error)  => // log the unreachable address
     case Cache.Hit(_)                           => // count a hit
     case Cache.Miss(_)                          => // count a miss
     case _                                      => ()

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -14,12 +14,13 @@ Register one or more `SageListener` on `SageConfig`, and each receives every `Sa
 | `CommandCompleted(name, node, duration, outcome)` | One logical command settled. `duration` is client-observed (including any cluster redirects/retries); `outcome` is `Succeeded` or `Failed(error)`. A cached read served locally yields no `CommandCompleted`. |
 | `Connection.Connected(node)` | The multiplexed connection connected, on the initial connect and on every reconnect. |
 | `Connection.Disconnected(node)` | A live connection was lost and the runtime began reconnecting. Graceful close is not reported. |
-| `Connection.ConnectFailed(node, error)` | A connection to a node could not be opened, naming the address and cause when routing or topology discovery handles the failure internally. |
+| `Connection.ConnectFailed(node, error)` | A connection could not be established, or the node could not be qualified during topology discovery. Names the address and cause, whether the failure is handled internally or also returned to the caller. |
 | `Cache.Hit(command)` / `Cache.Miss(command)` | A `cached` read was served locally, or had to fetch from the server. |
 | `TopologyChanged(masters)` | The cluster's slot-owning master set changed (a failover, or scaling a shard in or out). |
 
 Events carry no command arguments or payloads, so secrets such as `AUTH` credentials and user values never reach a listener. Where an event
 carries `node`, it is `Some` for cluster and master-replica clients (the relevant node) and `None` for a standalone client.
+Repeated pooled establishment failures for the same node produce one `ConnectFailed` until a connection to that node succeeds.
 
 ### Registering a listener
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -20,7 +20,8 @@ Register one or more `SageListener` on `SageConfig`, and each receives every `Sa
 
 Events carry no command arguments or payloads, so secrets such as `AUTH` credentials and user values never reach a listener. Where an event
 carries `node`, it is `Some` for cluster and master-replica clients (the relevant node) and `None` for a standalone client.
-Repeated pooled establishment failures for the same node produce one `ConnectFailed` until a connection to that node succeeds.
+Repeated connection-establishment and topology-qualification failures for the same node produce one `ConnectFailed` until a pooled connection
+to that node succeeds.
 
 ### Registering a listener
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -18,7 +18,8 @@ Register one or more `SageListener` on `SageConfig`, and each receives every `Sa
 | `Cache.Hit(command)` / `Cache.Miss(command)` | A `cached` read was served locally, or had to fetch from the server. |
 | `TopologyChanged(masters)` | The cluster's slot-owning master set changed (a failover, or scaling a shard in or out). |
 
-Events carry no command arguments or payloads, so secrets such as `AUTH` credentials and user values never reach a listener. `node` is `Some` in a cluster (the relevant master) and `None` on a standalone server.
+Events carry no command arguments or payloads, so secrets such as `AUTH` credentials and user values never reach a listener. Where an event
+carries `node`, it is `Some` for cluster and master-replica clients (the relevant node) and `None` for a standalone client.
 
 ### Registering a listener
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -18,10 +18,8 @@ Register one or more `SageListener` on `SageConfig`, and each receives every `Sa
 | `Cache.Hit(command)` / `Cache.Miss(command)` | A `cached` read was served locally, or had to fetch from the server. |
 | `TopologyChanged(masters)` | The cluster's slot-owning master set changed (a failover, or scaling a shard in or out). |
 
-Events carry no command arguments or payloads, so secrets such as `AUTH` credentials and user values never reach a listener. Where an event
-carries `node`, it is `Some` for cluster and master-replica clients (the relevant node) and `None` for a standalone client.
-Repeated connection-establishment and topology-qualification failures for the same node produce one `ConnectFailed` until a pooled connection
-to that node succeeds.
+Events carry no command arguments or payloads, so secrets such as `AUTH` credentials and user values never reach a listener. Where an event carries `node`, it is `Some` for cluster and master-replica clients (the relevant node) and `None` for a standalone client.
+Repeated connection-establishment and topology-qualification failures for the same node produce one `ConnectFailed` until a pooled connection to that node succeeds.
 
 ### Registering a listener
 

--- a/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
+++ b/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
@@ -106,9 +106,8 @@ final case class ClusterConfig(
 )
 
 /**
-  * Master-replica tuning. `minRefreshInterval` throttles role re-discovery (`ROLE`/`INFO replication`) so a burst of `READONLY`s or
-  * reconnects triggers at most one discovery per window. There is no periodic poll: roles refresh only on reconnect and on a `READONLY`
-  * from the presumed master.
+  * Master-replica tuning. `minRefreshInterval` throttles role re-discovery (`ROLE`/`INFO replication`) so a burst of `READONLY`s, reconnects,
+  * or replica-preferred reads with no known replica triggers at most one discovery per window. There is no periodic poll.
   */
 final case class MasterReplicaConfig(
   minRefreshInterval: FiniteDuration = 5.seconds

--- a/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
@@ -1,6 +1,7 @@
 package sage.client.internal
 
 import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.ConcurrentHashMap
 
 import scala.concurrent.duration.{FiniteDuration, NANOSECONDS}
 import scala.util.Try
@@ -55,6 +56,7 @@ private[client] object Events {
     def emitsEvents: Boolean = listeners.nonEmpty
 
     private val queue             = if (listeners.isEmpty) null else new ArrayBlockingQueue[SageEvent](QueueDepth)
+    private val failedConnections = ConcurrentHashMap.newKeySet[Node]()
     @volatile private var running = true
 
     private val worker =
@@ -66,7 +68,17 @@ private[client] object Events {
         t
       }
 
-    def emit(event: SageEvent): Unit = if (queue != null) { val _ = queue.offer(event) }
+    def emit(event: SageEvent): Unit =
+      if (queue != null)
+        event match {
+          case failure @ SageEvent.Connection.ConnectFailed(Some(node), _) =>
+            if (failedConnections.add(node) && !queue.offer(failure)) { val _ = failedConnections.remove(node) }
+          case connected @ SageEvent.Connection.Connected(Some(node))      =>
+            val _ = failedConnections.remove(node)
+            val _ = queue.offer(connected)
+          case _                                                           =>
+            val _ = queue.offer(event)
+        }
 
     def close(): Unit = if (worker != null) { running = false; worker.interrupt() }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -79,8 +79,8 @@ final private[client] class MasterReplicaLive(
 
   // --- discovery -----------------------------------------------------------------------------------------------------------------------
 
-  // Several supplied endpoints are the topology itself: keep their addresses and discover only their roles. A lone seed retains the original
-  // discovery behavior, following the addresses in ROLE.
+  // several supplied endpoints are the topology itself: keep their addresses and discover only their roles; a lone seed retains the original
+  // discovery behavior, following the addresses in ROLE
   private val pinnedToSeeds = seeds.sizeIs > 1
 
   private[client] def bootstrapRoles(): Unit =
@@ -91,8 +91,8 @@ final private[client] class MasterReplicaLive(
       }
     else bootstrapDiscovered()
 
-  // Classifies every supplied endpoint by its own ROLE. An endpoint that cannot be opened is omitted, but reported because the successful
-  // topology resolution otherwise hides its failure from the caller.
+  // classifies every supplied endpoint by its own ROLE; an endpoint that cannot be opened is omitted, but reported because the successful
+  // topology resolution otherwise hides its failure from the caller
   private def resolvePinned(): Either[Throwable, (Node, Vector[Node])] = {
     var lastError: Throwable = NotConnected()
     val roles                = seeds.flatMap { seed =>
@@ -111,7 +111,7 @@ final private[client] class MasterReplicaLive(
     }
   }
 
-  // Contacts seeds until one answers ROLE, resolving the master and its advertised replicas. This is the original single-seed discovery path.
+  // contacts seeds until one answers ROLE, resolving the master and its advertised replicas; this is the original single-seed discovery path
   private def bootstrapDiscovered(): Unit = {
     var lastError: Throwable = NotConnected()
     val candidates           = seeds.iterator

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -95,16 +95,16 @@ final private[client] class MasterReplicaLive(
   private def resolvePinned(): Either[Throwable, (Node, Vector[Node])] = {
     var lastError: Throwable = NotConnected()
     val roles                = seeds.flatMap { seed =>
-      try probeRole(seed).map(seed -> _)
+      try probeRole(seed, reportConnectFailure = true).map(seed -> _)
       catch {
         case NonFatal(error) =>
           lastError = error
-          events.emit(SageEvent.Connection.ConnectFailed(Some(seed), error))
           None
       }
     }
     roles.collectFirst { case (node, _: Role.Master) => node } match {
-      case Some(master)          => Right(master -> roles.collect { case (node, _: Role.Replica) => node })
+      case Some(master)          =>
+        Right(master -> roles.collect { case (node, replica: Role.Replica) if replica.state == "connected" => node })
       case None if roles.isEmpty => Left(lastError)
       case None                  => Left(ConnectionFailed("no supplied endpoint reports the master role"))
     }
@@ -128,30 +128,39 @@ final private[client] class MasterReplicaLive(
   }
 
   // probes a node's ROLE; a master answers with its replica list, a replica points at its master (followed once), a sentinel is skipped
-  private def resolveFrom(node: Node): Option[(Node, Vector[Node])] =
-    probeRole(node).flatMap {
+  private def resolveFrom(node: Node, reportConnectFailure: Boolean = false): Option[(Node, Vector[Node])] =
+    probeRole(node, reportConnectFailure).flatMap {
       case Role.Master(_, replicas)       => Some(node -> replicas.map(r => Node(r.host, r.port)))
       case Role.Replica(host, port, _, _) =>
         val master = Node(host, port)
-        probeRole(master).collect { case Role.Master(_, replicas) => master -> replicas.map(r => Node(r.host, r.port)) }
+        probeRole(master, reportConnectFailure).collect { case Role.Master(_, replicas) =>
+          master -> replicas.map(r => Node(r.host, r.port))
+        }
       case _: Role.Sentinel               => None
     }
 
   // a throwaway connection (must not leave a pooled one behind): a connect/handshake failure propagates so bootstrapRoles surfaces it like a
   // standalone connect; a node that handshakes but doesn't answer ROLE yields None
-  private def probeRole(node: Node): Option[Role] = {
-    val nc = NodeClient.connect(
-      nodeFactory(node),
-      scheduler,
-      bootstrap,
-      config.reconnect,
-      config.watchdog,
-      config.connectTimeout,
-      config.closeTimeout,
-      config.dedicatedPool,
-      node = Some(node),
-      events = events
-    )
+  private def probeRole(node: Node, reportConnectFailure: Boolean): Option[Role] = {
+    val nc =
+      try
+        NodeClient.connect(
+          nodeFactory(node),
+          scheduler,
+          bootstrap,
+          config.reconnect,
+          config.watchdog,
+          config.connectTimeout,
+          config.closeTimeout,
+          config.dedicatedPool,
+          node = Some(node),
+          events = events
+        )
+      catch {
+        case NonFatal(error) =>
+          if (reportConnectFailure) events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
+          throw error
+      }
     try {
       val latch   = new CountDownLatch(1)
       val outcome = new AtomicReference[Try[Role]]()
@@ -173,7 +182,7 @@ final private[client] class MasterReplicaLive(
         val candidates = (Option(masterNodeRef.get()).toVector ++ replicasRef.get() ++ seeds).distinct
         candidates.iterator
           .flatMap(n =>
-            try resolveFrom(n)
+            try resolveFrom(n, reportConnectFailure = true)
             catch { case NonFatal(_) => None }
           )
           .nextOption()

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -1,6 +1,6 @@
 package sage.client.internal
 
-import java.util.concurrent.{CountDownLatch, TimeoutException, TimeUnit}
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import java.util.concurrent.locks.ReentrantLock
 
@@ -25,9 +25,9 @@ import sage.ratelimit.Decision
   * it.
   *
   * Roles refresh only on events — a reconnect-driven command loss, a `READONLY` from the presumed master, a read that can reach no candidate,
-  * or a replica-preferred read when no replica is known — throttled by `minRefreshInterval`, never on a timer. A write that meets a demoted
-  * master fails fast (kicking off a re-discovery) so the caller's retry lands on the freshly-discovered master, mirroring the cluster runtime's
-  * `READONLY` disposition.
+  * or a replica-preferred read/pipeline when no replica is known — throttled by `minRefreshInterval`, never on a timer. A write that meets a
+  * demoted master fails fast (kicking off a re-discovery) so the caller's retry lands on the freshly-discovered master, mirroring the cluster
+  * runtime's `READONLY` disposition.
   */
 final private[client] class MasterReplicaLive(
   nodeFactory: Node => MultiplexedConnection.TransportFactory,
@@ -105,7 +105,7 @@ final private[client] class MasterReplicaLive(
     }
     roles.collectFirst { case (node, _: Role.Master) => node } match {
       case Some(master)          =>
-        Right(master -> roles.collect { case (node, replica: Role.Replica) if replica.state == "connected" => node })
+        Right(master -> roles.collect { case (node, role) if role.isConnectedReplica => node })
       case None if roles.isEmpty => Left(lastError)
       case None                  => Left(ConnectionFailed("no supplied endpoint reports the master role"))
     }
@@ -155,7 +155,7 @@ final private[client] class MasterReplicaLive(
           config.closeTimeout,
           config.dedicatedPool,
           node = Some(node),
-          events = events
+          events = Events.disabled
         )
       catch {
         case NonFatal(error) =>
@@ -167,12 +167,14 @@ final private[client] class MasterReplicaLive(
       val outcome = new AtomicReference[Try[Role]]()
       nc.submit[Role](Server.role, asking = false, result => { outcome.set(result); latch.countDown() })
       if (!latch.await(config.connectTimeout.toMillis, TimeUnit.MILLISECONDS)) {
-        val error = new TimeoutException(s"ROLE timed out after ${config.connectTimeout.toMillis}ms")
+        val error = TimedOut(s"ROLE timed out after ${config.connectTimeout.toMillis}ms")
         reportProbeFailure(node, error, reportConnectFailure)
         None
       } else
         outcome.get() match {
-          case Success(role)  => Some(role)
+          case Success(role)  =>
+            events.emit(SageEvent.Connection.Connected(Some(node)))
+            Some(role)
           case Failure(error) =>
             reportProbeFailure(node, error, reportConnectFailure)
             None
@@ -183,7 +185,7 @@ final private[client] class MasterReplicaLive(
   private def reportProbeFailure(node: Node, error: Throwable, enabled: Boolean): Unit =
     if (enabled) events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
 
-  private def triggerRefresh(): Unit = offload(refreshThrottle(force = false)(rediscover()))
+  private def triggerRefresh(): Unit = refreshThrottle.trigger(rediscover())
 
   // forced, but single-flight may collapse this onto an in-flight refresh, so a stale masterNodeRef self-corrects on the next reconnect
   private def refreshRolesBeforeRehome(): Unit = refreshThrottle(force = true)(rediscover())
@@ -373,7 +375,9 @@ final private[client] class MasterReplicaLive(
         }
         val master                                     = masterNodeRef.get()
         if (useReplica) {
-          val candidates = ReadRouting.candidates(readFrom, master, replicasRef.get(), cursor.getAndIncrement())
+          val replicas   = replicasRef.get()
+          if (readFrom == ReadFrom.ReplicaPreferred && replicas.isEmpty) triggerRefresh()
+          val candidates = ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement())
           liveEstablished(candidates, master) match {
             case Some((node, nc)) => submitOn(node, nc)
             case None             => offload { val (node, nc) = establishRead(candidates, master); submitOn(node, nc) }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -189,10 +189,8 @@ final private[client] class MasterReplicaLive(
   // forced, but single-flight may collapse this onto an in-flight refresh, so a stale masterNodeRef self-corrects on the next reconnect
   private def refreshRolesBeforeRehome(): Unit = refreshThrottle(force = true)(rediscover())
 
-  private def rediscover(): Unit = {
-    val candidates = (Option(masterNodeRef.get()).toVector ++ replicasRef.get() ++ seeds).distinct
-    resolveTopology(candidates).foreach(installTopology)
-  }
+  private def rediscover(): Unit =
+    resolveTopology((Option(masterNodeRef.get()).toVector ++ replicasRef.get() ++ seeds).distinct).foreach(installTopology)
 
   private def installTopology(topology: MasterReplicaLive.ResolvedTopology): Unit = {
     masterNodeRef.set(topology.master)

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -84,16 +84,18 @@ final private[client] class MasterReplicaLive(
   private val pinnedToSeeds = seeds.sizeIs > 1
 
   private[client] def bootstrapRoles(): Unit =
-    if (pinnedToSeeds)
-      resolvePinned() match {
-        case Right((master, replicas)) => masterNodeRef.set(master); replicasRef.set(replicas)
-        case Left(error)               => closeAll(); throw error
-      }
-    else bootstrapDiscovered()
+    resolveTopology(seeds) match {
+      case Right(topology) => installTopology(topology)
+      case Left(error)     => closeAll(); throw error
+    }
+
+  private def resolveTopology(discoveredCandidates: => Vector[Node]): Either[Throwable, MasterReplicaLive.ResolvedTopology] =
+    if (pinnedToSeeds) resolvePinned()
+    else resolveDiscovered(discoveredCandidates)
 
   // classifies every supplied endpoint by its own ROLE; an endpoint that cannot be opened is omitted, but reported because the successful
   // topology resolution otherwise hides its failure from the caller
-  private def resolvePinned(): Either[Throwable, (Node, Vector[Node])] = {
+  private def resolvePinned(): Either[Throwable, MasterReplicaLive.ResolvedTopology] = {
     var lastError: Throwable = NotConnected()
     val roles                = seeds.flatMap { seed =>
       try probeRole(seed).map(seed -> _)
@@ -105,37 +107,36 @@ final private[client] class MasterReplicaLive(
     }
     roles.collectFirst { case (node, _: Role.Master) => node } match {
       case Some(master)          =>
-        Right(master -> roles.collect { case (node, role) if role.isConnectedReplica => node })
+        Right(MasterReplicaLive.ResolvedTopology(master, roles.collect { case (node, role) if role.isConnectedReplica => node }))
       case None if roles.isEmpty => Left(lastError)
       case None                  => Left(ConnectionFailed("no supplied endpoint reports the master role"))
     }
   }
 
   // contacts seeds until one answers ROLE, resolving the master and its advertised replicas; this is the original single-seed discovery path
-  private def bootstrapDiscovered(): Unit = {
+  private def resolveDiscovered(candidates: Vector[Node]): Either[Throwable, MasterReplicaLive.ResolvedTopology] = {
     var lastError: Throwable = NotConnected()
-    val candidates           = seeds.iterator
-    var done                 = false
-    while (!done && candidates.hasNext) {
-      val seed = candidates.next()
+    val it                   = candidates.iterator
+    while (it.hasNext) {
+      val seed = it.next()
       try
         resolveFrom(seed) match {
-          case Some((master, replicas)) => masterNodeRef.set(master); replicasRef.set(replicas); done = true
-          case None                     => ()
+          case Some(topology) => return Right(topology)
+          case None           => ()
         }
       catch { case NonFatal(error) => lastError = error }
     }
-    if (!done) { closeAll(); throw lastError }
+    Left(lastError)
   }
 
   // probes a node's ROLE; a master answers with its replica list, a replica points at its master (followed once), a sentinel is skipped
-  private def resolveFrom(node: Node): Option[(Node, Vector[Node])] =
+  private def resolveFrom(node: Node): Option[MasterReplicaLive.ResolvedTopology] =
     probeRole(node).flatMap {
-      case Role.Master(_, replicas)       => Some(node -> replicas.map(r => Node(r.host, r.port)))
+      case Role.Master(_, replicas)       => Some(MasterReplicaLive.ResolvedTopology(node, replicas.map(r => Node(r.host, r.port))))
       case Role.Replica(host, port, _, _) =>
         val master = Node(host, port)
         probeRole(master).collect { case Role.Master(_, replicas) =>
-          master -> replicas.map(r => Node(r.host, r.port))
+          MasterReplicaLive.ResolvedTopology(master, replicas.map(r => Node(r.host, r.port)))
         }
       case _: Role.Sentinel               => None
     }
@@ -189,23 +190,15 @@ final private[client] class MasterReplicaLive(
   private def refreshRolesBeforeRehome(): Unit = refreshThrottle(force = true)(rediscover())
 
   private def rediscover(): Unit = {
-    val resolved =
-      if (pinnedToSeeds) resolvePinned().toOption
-      else {
-        val candidates = (Option(masterNodeRef.get()).toVector ++ replicasRef.get() ++ seeds).distinct
-        candidates.iterator
-          .flatMap(n =>
-            try resolveFrom(n)
-            catch { case NonFatal(_) => None }
-          )
-          .nextOption()
-      }
-    resolved.foreach { case (master, replicas) =>
-      masterNodeRef.set(master)
-      replicasRef.set(replicas)
-      replicaPool.retain(replicas.toSet.contains)
-      masterPool.retain(_ == master)
-    }
+    val candidates = (Option(masterNodeRef.get()).toVector ++ replicasRef.get() ++ seeds).distinct
+    resolveTopology(candidates).foreach(installTopology)
+  }
+
+  private def installTopology(topology: MasterReplicaLive.ResolvedTopology): Unit = {
+    masterNodeRef.set(topology.master)
+    replicasRef.set(topology.replicas)
+    replicaPool.retain(topology.replicas.toSet.contains)
+    masterPool.retain(_ == topology.master)
   }
 
   // --- routing -------------------------------------------------------------------------------------------------------------------------
@@ -278,10 +271,14 @@ final private[client] class MasterReplicaLive(
   private def sendRead[A](command: Command[A], complete: Try[A] => Unit): Unit = {
     if (closed) { complete(Failure(NotConnected())); return }
     val master     = masterNodeRef.get()
-    val replicas   = replicasRef.get()
-    if (readFrom == ReadFrom.ReplicaPreferred && replicas.isEmpty) triggerRefresh()
-    val candidates = ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement())
+    val candidates = readCandidates(master)
     tryRead(command, candidates, master, complete)
+  }
+
+  private def readCandidates(master: Node): Vector[Node] = {
+    val replicas = replicasRef.get()
+    if (readFrom == ReadFrom.ReplicaPreferred && replicas.isEmpty) triggerRefresh()
+    ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement())
   }
 
   private def tryRead[A](command: Command[A], candidates: Vector[Node], master: Node, complete: Try[A] => Unit): Unit =
@@ -373,9 +370,7 @@ final private[client] class MasterReplicaLive(
         }
         val master                                     = masterNodeRef.get()
         if (useReplica) {
-          val replicas   = replicasRef.get()
-          if (readFrom == ReadFrom.ReplicaPreferred && replicas.isEmpty) triggerRefresh()
-          val candidates = ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement())
+          val candidates = readCandidates(master)
           liveEstablished(candidates, master) match {
             case Some((node, nc)) => submitOn(node, nc)
             case None             => offload { val (node, nc) = establishRead(candidates, master); submitOn(node, nc) }
@@ -509,6 +504,8 @@ final private[client] class MasterReplicaLive(
 }
 
 private[client] object MasterReplicaLive {
+
+  final private[client] case class ResolvedTopology(master: Node, replicas: Vector[Node])
 
   final private[client] class TxLease(val scope: Client.TxScope, val nc: NodeClient)
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -119,7 +119,7 @@ final private[client] class MasterReplicaLive(
     while (!done && candidates.hasNext) {
       val seed = candidates.next()
       try
-        resolveFrom(seed) match {
+        resolveFrom(seed, reportConnectFailure = true) match {
           case Some((master, replicas)) => masterNodeRef.set(master); replicasRef.set(replicas); done = true
           case None                     => ()
         }
@@ -129,7 +129,7 @@ final private[client] class MasterReplicaLive(
   }
 
   // probes a node's ROLE; a master answers with its replica list, a replica points at its master (followed once), a sentinel is skipped
-  private def resolveFrom(node: Node, reportConnectFailure: Boolean = false): Option[(Node, Vector[Node])] =
+  private def resolveFrom(node: Node, reportConnectFailure: Boolean): Option[(Node, Vector[Node])] =
     probeRole(node, reportConnectFailure).flatMap {
       case Role.Master(_, replicas)       => Some(node -> replicas.map(r => Node(r.host, r.port)))
       case Role.Replica(host, port, _, _) =>
@@ -172,9 +172,7 @@ final private[client] class MasterReplicaLive(
         None
       } else
         outcome.get() match {
-          case Success(role)  =>
-            events.emit(SageEvent.Connection.Connected(Some(node)))
-            Some(role)
+          case Success(role)  => Some(role)
           case Failure(error) =>
             reportProbeFailure(node, error, reportConnectFailure)
             None

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -96,7 +96,7 @@ final private[client] class MasterReplicaLive(
   private def resolvePinned(): Either[Throwable, (Node, Vector[Node])] = {
     var lastError: Throwable = NotConnected()
     val roles                = seeds.flatMap { seed =>
-      try probeRole(seed, reportConnectFailure = true).map(seed -> _)
+      try probeRole(seed).map(seed -> _)
       catch {
         case NonFatal(error) =>
           lastError = error
@@ -119,7 +119,7 @@ final private[client] class MasterReplicaLive(
     while (!done && candidates.hasNext) {
       val seed = candidates.next()
       try
-        resolveFrom(seed, reportConnectFailure = true) match {
+        resolveFrom(seed) match {
           case Some((master, replicas)) => masterNodeRef.set(master); replicasRef.set(replicas); done = true
           case None                     => ()
         }
@@ -129,12 +129,12 @@ final private[client] class MasterReplicaLive(
   }
 
   // probes a node's ROLE; a master answers with its replica list, a replica points at its master (followed once), a sentinel is skipped
-  private def resolveFrom(node: Node, reportConnectFailure: Boolean): Option[(Node, Vector[Node])] =
-    probeRole(node, reportConnectFailure).flatMap {
+  private def resolveFrom(node: Node): Option[(Node, Vector[Node])] =
+    probeRole(node).flatMap {
       case Role.Master(_, replicas)       => Some(node -> replicas.map(r => Node(r.host, r.port)))
       case Role.Replica(host, port, _, _) =>
         val master = Node(host, port)
-        probeRole(master, reportConnectFailure).collect { case Role.Master(_, replicas) =>
+        probeRole(master).collect { case Role.Master(_, replicas) =>
           master -> replicas.map(r => Node(r.host, r.port))
         }
       case _: Role.Sentinel               => None
@@ -142,7 +142,7 @@ final private[client] class MasterReplicaLive(
 
   // a throwaway connection (must not leave a pooled one behind): a connect/handshake failure propagates so bootstrapRoles surfaces it like a
   // standalone connect; a node that handshakes but doesn't answer ROLE yields None
-  private def probeRole(node: Node, reportConnectFailure: Boolean): Option[Role] = {
+  private def probeRole(node: Node): Option[Role] = {
     val nc =
       try
         NodeClient.connect(
@@ -159,7 +159,7 @@ final private[client] class MasterReplicaLive(
         )
       catch {
         case NonFatal(error) =>
-          reportProbeFailure(node, error, reportConnectFailure)
+          reportProbeFailure(node, error)
           throw error
       }
     try {
@@ -168,20 +168,20 @@ final private[client] class MasterReplicaLive(
       nc.submit[Role](Server.role, asking = false, result => { outcome.set(result); latch.countDown() })
       if (!latch.await(config.connectTimeout.toMillis, TimeUnit.MILLISECONDS)) {
         val error = TimedOut(s"ROLE timed out after ${config.connectTimeout.toMillis}ms")
-        reportProbeFailure(node, error, reportConnectFailure)
+        reportProbeFailure(node, error)
         None
       } else
         outcome.get() match {
           case Success(role)  => Some(role)
           case Failure(error) =>
-            reportProbeFailure(node, error, reportConnectFailure)
+            reportProbeFailure(node, error)
             None
         }
     } finally nc.close()
   }
 
-  private def reportProbeFailure(node: Node, error: Throwable, enabled: Boolean): Unit =
-    if (enabled) events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
+  private def reportProbeFailure(node: Node, error: Throwable): Unit =
+    events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
 
   private def triggerRefresh(): Unit = refreshThrottle.trigger(rediscover())
 
@@ -195,7 +195,7 @@ final private[client] class MasterReplicaLive(
         val candidates = (Option(masterNodeRef.get()).toVector ++ replicasRef.get() ++ seeds).distinct
         candidates.iterator
           .flatMap(n =>
-            try resolveFrom(n, reportConnectFailure = true)
+            try resolveFrom(n)
             catch { case NonFatal(_) => None }
           )
           .nextOption()

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -10,8 +10,8 @@ import scala.util.control.NonFatal
 
 import kyo.compat.*
 
-import sage.{CommandSpan, Message, Outcome, PatternMessage, SageException}
-import sage.SageException.{ConnectionLost, InvalidArgument, NotConnected, TimedOut}
+import sage.{CommandSpan, Message, Outcome, PatternMessage, SageEvent, SageException}
+import sage.SageException.{ConnectionFailed, ConnectionLost, InvalidArgument, NotConnected, TimedOut}
 import sage.client.{ReadFrom, SageConfig}
 import sage.cluster.Node
 import sage.codec.ValueCodec
@@ -78,9 +78,40 @@ final private[client] class MasterReplicaLive(
 
   // --- discovery -----------------------------------------------------------------------------------------------------------------------
 
-  // contacts seeds (and currently-known nodes) until one answers ROLE, resolving the master and its replicas; throws the last failure if
-  // none answers, so the first connect surfaces a handshake/TLS error like a standalone connect would
-  private[client] def bootstrapRoles(): Unit = {
+  // Several supplied endpoints are the topology itself: keep their addresses and discover only their roles. A lone seed retains the original
+  // discovery behavior, following the addresses in ROLE.
+  private val pinnedToSeeds = seeds.sizeIs > 1
+
+  private[client] def bootstrapRoles(): Unit =
+    if (pinnedToSeeds)
+      resolvePinned() match {
+        case Right((master, replicas)) => masterNodeRef.set(master); replicasRef.set(replicas)
+        case Left(error)               => closeAll(); throw error
+      }
+    else bootstrapDiscovered()
+
+  // Classifies every supplied endpoint by its own ROLE. An endpoint that cannot be opened is omitted, but reported because the successful
+  // topology resolution otherwise hides its failure from the caller.
+  private def resolvePinned(): Either[Throwable, (Node, Vector[Node])] = {
+    var lastError: Throwable = NotConnected()
+    val roles                = seeds.flatMap { seed =>
+      try probeRole(seed).map(seed -> _)
+      catch {
+        case NonFatal(error) =>
+          lastError = error
+          events.emit(SageEvent.Connection.ConnectFailed(Some(seed), error))
+          None
+      }
+    }
+    roles.collectFirst { case (node, _: Role.Master) => node } match {
+      case Some(master)          => Right(master -> roles.collect { case (node, _: Role.Replica) => node })
+      case None if roles.isEmpty => Left(lastError)
+      case None                  => Left(ConnectionFailed("no supplied endpoint reports the master role"))
+    }
+  }
+
+  // Contacts seeds until one answers ROLE, resolving the master and its advertised replicas. This is the original single-seed discovery path.
+  private def bootstrapDiscovered(): Unit = {
     var lastError: Throwable = NotConnected()
     val candidates           = seeds.iterator
     var done                 = false
@@ -136,19 +167,23 @@ final private[client] class MasterReplicaLive(
   private def refreshRolesBeforeRehome(): Unit = refreshThrottle(force = true)(rediscover())
 
   private def rediscover(): Unit = {
-    val candidates = (Option(masterNodeRef.get()).toVector ++ replicasRef.get() ++ seeds).distinct
-    candidates.iterator
-      .flatMap(n =>
-        try resolveFrom(n)
-        catch { case NonFatal(_) => None }
-      )
-      .nextOption()
-      .foreach { case (master, replicas) =>
-        masterNodeRef.set(master)
-        replicasRef.set(replicas)
-        replicaPool.retain(replicas.toSet.contains)
-        masterPool.retain(_ == master)
+    val resolved =
+      if (pinnedToSeeds) resolvePinned().toOption
+      else {
+        val candidates = (Option(masterNodeRef.get()).toVector ++ replicasRef.get() ++ seeds).distinct
+        candidates.iterator
+          .flatMap(n =>
+            try resolveFrom(n)
+            catch { case NonFatal(_) => None }
+          )
+          .nextOption()
       }
+    resolved.foreach { case (master, replicas) =>
+      masterNodeRef.set(master)
+      replicasRef.set(replicas)
+      replicaPool.retain(replicas.toSet.contains)
+      masterPool.retain(_ == master)
+    }
   }
 
   // --- routing -------------------------------------------------------------------------------------------------------------------------

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -1,6 +1,6 @@
 package sage.client.internal
 
-import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.{CountDownLatch, TimeoutException, TimeUnit}
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import java.util.concurrent.locks.ReentrantLock
 
@@ -24,9 +24,10 @@ import sage.ratelimit.Decision
   * [[ReadFrom]] policy (round-robin, with the policy's fallback). The same `Client` type as standalone and cluster; only the topology selects
   * it.
   *
-  * Roles refresh only on events — a reconnect-driven command loss, a `READONLY` from the presumed master, or a read that can reach no
-  * candidate — throttled by `minRefreshInterval`, never on a timer. A write that meets a demoted master fails fast (kicking off a
-  * re-discovery) so the caller's retry lands on the freshly-discovered master, mirroring the cluster runtime's `READONLY` disposition.
+  * Roles refresh only on events — a reconnect-driven command loss, a `READONLY` from the presumed master, a read that can reach no candidate,
+  * or a replica-preferred read when no replica is known — throttled by `minRefreshInterval`, never on a timer. A write that meets a demoted
+  * master fails fast (kicking off a re-discovery) so the caller's retry lands on the freshly-discovered master, mirroring the cluster runtime's
+  * `READONLY` disposition.
   */
 final private[client] class MasterReplicaLive(
   nodeFactory: Node => MultiplexedConnection.TransportFactory,
@@ -158,17 +159,29 @@ final private[client] class MasterReplicaLive(
         )
       catch {
         case NonFatal(error) =>
-          if (reportConnectFailure) events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
+          reportProbeFailure(node, error, reportConnectFailure)
           throw error
       }
     try {
       val latch   = new CountDownLatch(1)
       val outcome = new AtomicReference[Try[Role]]()
       nc.submit[Role](Server.role, asking = false, result => { outcome.set(result); latch.countDown() })
-      if (!latch.await(config.connectTimeout.toMillis, TimeUnit.MILLISECONDS)) None
-      else outcome.get() match { case Success(role) => Some(role); case Failure(_) => None }
+      if (!latch.await(config.connectTimeout.toMillis, TimeUnit.MILLISECONDS)) {
+        val error = new TimeoutException(s"ROLE timed out after ${config.connectTimeout.toMillis}ms")
+        reportProbeFailure(node, error, reportConnectFailure)
+        None
+      } else
+        outcome.get() match {
+          case Success(role)  => Some(role)
+          case Failure(error) =>
+            reportProbeFailure(node, error, reportConnectFailure)
+            None
+        }
     } finally nc.close()
   }
+
+  private def reportProbeFailure(node: Node, error: Throwable, enabled: Boolean): Unit =
+    if (enabled) events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
 
   private def triggerRefresh(): Unit = offload(refreshThrottle(force = false)(rediscover()))
 
@@ -265,7 +278,9 @@ final private[client] class MasterReplicaLive(
   private def sendRead[A](command: Command[A], complete: Try[A] => Unit): Unit = {
     if (closed) { complete(Failure(NotConnected())); return }
     val master     = masterNodeRef.get()
-    val candidates = ReadRouting.candidates(readFrom, master, replicasRef.get(), cursor.getAndIncrement())
+    val replicas   = replicasRef.get()
+    if (readFrom == ReadFrom.ReplicaPreferred && replicas.isEmpty) triggerRefresh()
+    val candidates = ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement())
     tryRead(command, candidates, master, complete)
   }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -35,13 +35,14 @@ final private[client] class NodePool(
   dedicatedBootstrap: Option[Vector[Command[?]]] = None
 ) {
 
-  private val lock             = new ReentrantLock()
+  private val lock                   = new ReentrantLock()
   // lock-free reads; every mutation stays under `lock`
-  private val established      = new java.util.concurrent.ConcurrentHashMap[Node, NodeClient]()
-  private val pendingEstablish = mutable.HashMap.empty[Node, NodePool.Establish]
+  private val established            = new java.util.concurrent.ConcurrentHashMap[Node, NodeClient]()
+  private val pendingEstablish       = mutable.HashMap.empty[Node, NodePool.Establish]
   // connections whose socket is still being opened, so close() can abort one still connecting
-  private val establishing     = mutable.Set.empty[MultiplexedConnection]
-  @volatile private var closed = false
+  private val establishing           = mutable.Set.empty[MultiplexedConnection]
+  private val reportedConnectFailure = mutable.Set.empty[Node]
+  @volatile private var closed       = false
 
   private inline def locked[A](inline body: A): A = {
     lock.lock()
@@ -108,7 +109,7 @@ final private[client] class NodePool(
               val conn = connRef.get()
               if (conn != null) { val _ = establishing -= conn }
               if (pendingEstablish.get(node).exists(_ eq mine)) { val _ = pendingEstablish.remove(node) }
-              !closed
+              !closed && reportedConnectFailure.add(node)
             }
             mine.fail(error)
             if (report) events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
@@ -120,7 +121,7 @@ final private[client] class NodePool(
         if (conn != null) { val _ = establishing -= conn }
         val current = pendingEstablish.get(node).exists(_ eq mine)
         if (current) { val _ = pendingEstablish.remove(node) }
-        if (current && !closed) { established.put(node, nc); true }
+        if (current && !closed) { established.put(node, nc); val _ = reportedConnectFailure -= node; true }
         else false
       }
       if (publish) { mine.succeed(nc); nc }
@@ -133,6 +134,7 @@ final private[client] class NodePool(
     val (gone, rejected) = locked {
       val absent          = established.keySet.asScala.toVector.filterNot(keep).flatMap(node => Option(established.remove(node)))
       val rejectedPending = pendingEstablish.keysIterator.filterNot(keep).toVector.flatMap(node => pendingEstablish.remove(node))
+      reportedConnectFailure.filterInPlace(keep)
       (absent, rejectedPending)
     }
     gone.foreach(nc => scheduler.after(Duration.Zero)(nc.close()))
@@ -147,6 +149,7 @@ final private[client] class NodePool(
       val inFlight = establishing.toVector
       established.clear()
       pendingEstablish.clear()
+      reportedConnectFailure.clear()
       (snap, pending, inFlight)
     }
     // release callers blocked on an in-flight connect now, rather than stranding them for the connect timeout; the establisher still

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -35,14 +35,13 @@ final private[client] class NodePool(
   dedicatedBootstrap: Option[Vector[Command[?]]] = None
 ) {
 
-  private val lock                   = new ReentrantLock()
+  private val lock             = new ReentrantLock()
   // lock-free reads; every mutation stays under `lock`
-  private val established            = new java.util.concurrent.ConcurrentHashMap[Node, NodeClient]()
-  private val pendingEstablish       = mutable.HashMap.empty[Node, NodePool.Establish]
+  private val established      = new java.util.concurrent.ConcurrentHashMap[Node, NodeClient]()
+  private val pendingEstablish = mutable.HashMap.empty[Node, NodePool.Establish]
   // connections whose socket is still being opened, so close() can abort one still connecting
-  private val establishing           = mutable.Set.empty[MultiplexedConnection]
-  private val reportedConnectFailure = mutable.Set.empty[Node]
-  @volatile private var closed       = false
+  private val establishing     = mutable.Set.empty[MultiplexedConnection]
+  @volatile private var closed = false
 
   private inline def locked[A](inline body: A): A = {
     lock.lock()
@@ -105,14 +104,13 @@ final private[client] class NodePool(
           )
         catch {
           case error: Throwable =>
-            val report = locked {
+            locked {
               val conn = connRef.get()
               if (conn != null) { val _ = establishing -= conn }
               if (pendingEstablish.get(node).exists(_ eq mine)) { val _ = pendingEstablish.remove(node) }
-              !closed && reportedConnectFailure.add(node)
             }
             mine.fail(error)
-            if (report) events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
+            if (!closed) events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
             throw error
         }
       // publish only if our token is still current: a retain, close, or newer attempt supersedes us, and the new client is discarded not leaked
@@ -121,7 +119,7 @@ final private[client] class NodePool(
         if (conn != null) { val _ = establishing -= conn }
         val current = pendingEstablish.get(node).exists(_ eq mine)
         if (current) { val _ = pendingEstablish.remove(node) }
-        if (current && !closed) { established.put(node, nc); val _ = reportedConnectFailure -= node; true }
+        if (current && !closed) { established.put(node, nc); true }
         else false
       }
       if (publish) { mine.succeed(nc); nc }
@@ -134,7 +132,6 @@ final private[client] class NodePool(
     val (gone, rejected) = locked {
       val absent          = established.keySet.asScala.toVector.filterNot(keep).flatMap(node => Option(established.remove(node)))
       val rejectedPending = pendingEstablish.keysIterator.filterNot(keep).toVector.flatMap(node => pendingEstablish.remove(node))
-      reportedConnectFailure.filterInPlace(keep)
       (absent, rejectedPending)
     }
     gone.foreach(nc => scheduler.after(Duration.Zero)(nc.close()))
@@ -149,7 +146,6 @@ final private[client] class NodePool(
       val inFlight = establishing.toVector
       established.clear()
       pendingEstablish.clear()
-      reportedConnectFailure.clear()
       (snap, pending, inFlight)
     }
     // release callers blocked on an in-flight connect now, rather than stranding them for the connect timeout; the establisher still

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -7,6 +7,7 @@ import scala.collection.mutable
 import scala.concurrent.duration.*
 import scala.jdk.CollectionConverters.*
 
+import sage.SageEvent
 import sage.SageException.NotConnected
 import sage.client.{BackoffConfig, DedicatedPoolConfig, WatchdogConfig}
 import sage.cluster.Node
@@ -103,12 +104,14 @@ final private[client] class NodePool(
           )
         catch {
           case error: Throwable =>
-            locked {
+            val report = locked {
               val conn = connRef.get()
               if (conn != null) { val _ = establishing -= conn }
               if (pendingEstablish.get(node).exists(_ eq mine)) { val _ = pendingEstablish.remove(node) }
+              !closed
             }
             mine.fail(error)
+            if (report) events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
             throw error
         }
       // publish only if our token is still current: a retain, close, or newer attempt supersedes us, and the new client is discarded not leaked

--- a/sage-client/shared/src/main/scala/sage/client/internal/RefreshThrottle.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/RefreshThrottle.scala
@@ -2,6 +2,8 @@ package sage.client.internal
 
 import java.util.concurrent.locks.ReentrantLock
 
+import scala.concurrent.duration.Duration
+
 /**
   * Single-flight, throttled discovery: collapses concurrent refreshes onto one in-flight run (others block until it finishes) and skips a
   * run that lands within `minRefreshMs` of the last, unless `force`. Shared by the cluster and master-replica runtimes, which differ only in
@@ -14,21 +16,37 @@ final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: 
   private var refreshing    = false
   private var lastRefreshMs = scheduler.nowMillis - minRefreshMs
 
-  def apply(force: Boolean)(work: => Unit): Unit = {
-    lock.lock()
-    val mine =
-      try
-        if (refreshing) { while (refreshing) done.awaitUninterruptibly(); false }
-        else if (!force && scheduler.nowMillis - lastRefreshMs < minRefreshMs) false
-        else { refreshing = true; true }
-      finally lock.unlock()
+  def apply(force: Boolean)(work: => Unit): Unit =
+    if (claim(force, wait = true)) run(work)
 
-    if (mine)
-      try work
-      finally {
-        lock.lock()
-        try { refreshing = false; lastRefreshMs = scheduler.nowMillis; done.signalAll() }
-        finally lock.unlock()
+  /**
+    * Schedules a non-forced refresh only when this call claims the throttle. Unlike [[apply]], callers never wait for an in-flight refresh.
+    */
+  def trigger(work: => Unit): Unit =
+    if (claim(force = false, wait = false))
+      try scheduler.after(Duration.Zero)(run(work))
+      catch {
+        case error: Throwable =>
+          finish()
+          throw error
       }
+
+  private def claim(force: Boolean, wait: Boolean): Boolean = {
+    lock.lock()
+    try
+      if (refreshing && wait) { while (refreshing) done.awaitUninterruptibly(); false }
+      else if (refreshing || (!force && scheduler.nowMillis - lastRefreshMs < minRefreshMs)) false
+      else { refreshing = true; true }
+    finally lock.unlock()
+  }
+
+  private def run(work: => Unit): Unit =
+    try work
+    finally finish()
+
+  private def finish(): Unit = {
+    lock.lock()
+    try { refreshing = false; lastRefreshMs = scheduler.nowMillis; done.signalAll() }
+    finally lock.unlock()
   }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/ConnectFailureRecorder.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ConnectFailureRecorder.scala
@@ -1,0 +1,29 @@
+package sage.client.internal
+
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
+
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+
+import sage.{SageEvent, SageListener}
+
+final private[sage] class ConnectFailureRecorder {
+
+  private val delivered = new CountDownLatch(1)
+  private val seen      = new ConcurrentLinkedQueue[SageEvent.Connection.ConnectFailed]()
+
+  val events: Events = Events(
+    Vector(
+      new SageListener {
+        def onEvent(event: SageEvent): Unit = event match {
+          case failure: SageEvent.Connection.ConnectFailed => val _ = seen.add(failure); delivered.countDown()
+          case _                                           => ()
+        }
+      }
+    )
+  )
+
+  def await(timeout: FiniteDuration = 2.seconds): Boolean = delivered.await(timeout.toNanos, TimeUnit.NANOSECONDS)
+
+  def failures: Vector[SageEvent.Connection.ConnectFailed] = seen.asScala.toVector
+}

--- a/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
@@ -1,5 +1,6 @@
 package sage.client.internal
 
+import java.io.IOException
 import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
 
 import scala.collection.mutable
@@ -101,6 +102,27 @@ class EventsSpec extends munit.FunSuite {
       bus.close()
     }
     assert(seen.get() <= 1100, s"expected drops, retained ${seen.get()}")
+  }
+
+  test("ConnectFailed is emitted once per node outage and resets on Connected") {
+    val node      = Node("reader", 6379)
+    val other     = Node("other", 6379)
+    val delivered = new CountDownLatch(4)
+    val listener  = new Capturing(delivered)
+    val bus       = Events(Vector(listener))
+    try {
+      bus.emit(SageEvent.Connection.ConnectFailed(Some(node), new IOException("first")))
+      bus.emit(SageEvent.Connection.ConnectFailed(Some(node), new IOException("duplicate")))
+      bus.emit(SageEvent.Connection.ConnectFailed(Some(other), new IOException("other")))
+      bus.emit(SageEvent.Connection.Connected(Some(node)))
+      bus.emit(SageEvent.Connection.ConnectFailed(Some(node), new IOException("new outage")))
+
+      assert(delivered.await(2, TimeUnit.SECONDS), s"expected four connection events, got ${listener.received.asScala.toVector}")
+      Thread.sleep(50)
+      val received = listener.received.asScala.toVector
+      assertEquals(received.map(_.asInstanceOf[SageEvent.Connection].node), Vector(Some(node), Some(other), Some(node), Some(node)))
+      assertEquals(received.count(_.isInstanceOf[SageEvent.Connection.ConnectFailed]), 3)
+    } finally bus.close()
   }
 
   test("a listener interrupted during shutdown drain still delivers to peers and completes the drain") {

--- a/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
@@ -215,6 +215,7 @@ class NodePoolSpec extends munit.FunSuite {
     val node      = Node("unreachable", 6379)
     val seen      = new ConcurrentLinkedQueue[SageEvent.Connection.ConnectFailed]()
     val delivered = new CountDownLatch(1)
+    val failing   = new AtomicReference(true)
     val events    = Events(
       Vector(
         new SageListener {
@@ -225,14 +226,33 @@ class NodePoolSpec extends munit.FunSuite {
         }
       )
     )
-    val pool      = newPool(_ => (_, _) => throw new IOException("refused"), events)
+    val pool      = newPool(
+      _ =>
+        (onFrame, onClosed) =>
+          if (failing.get()) throw new IOException("refused")
+          else new FakeTransport(onFrame, onClosed, respond),
+      events
+    )
 
     try {
       intercept[IOException](pool.getOrEstablish(node))
       assert(delivered.await(2, TimeUnit.SECONDS), "ConnectFailed was not delivered")
-      val failure = seen.peek()
+      intercept[IOException](pool.getOrEstablish(node))
+      val deadline = System.nanoTime() + 250.millis.toNanos
+      while (seen.size() == 1 && System.nanoTime() < deadline) Thread.sleep(10)
+      val failure  = seen.peek()
       assertEquals(failure.node, Some(node))
       assert(failure.error.isInstanceOf[IOException], s"unexpected cause: ${failure.error}")
+      assertEquals(seen.size(), 1, "the same establishment outage should be reported only once")
+
+      failing.set(false)
+      val _                = pool.getOrEstablish(node)
+      pool.retain(_ => false)
+      failing.set(true)
+      intercept[IOException](pool.getOrEstablish(node))
+      val recoveryDeadline = System.nanoTime() + 2.seconds.toNanos
+      while (seen.size() < 2 && System.nanoTime() < recoveryDeadline) Thread.sleep(10)
+      assertEquals(seen.size(), 2, "a new outage after a successful connection should be reported")
     } finally {
       pool.close()
       events.close()

--- a/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
@@ -1,13 +1,13 @@
 package sage.client.internal
 
 import java.io.IOException
-import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference, AtomicReferenceArray}
 
 import scala.concurrent.duration.*
 import scala.util.Try
 
-import sage.{Bytes, SageEvent, SageListener}
+import sage.Bytes
 import sage.SageException.NotConnected
 import sage.client.{BackoffConfig, DedicatedPoolConfig, WatchdogConfig}
 import sage.cluster.Node
@@ -212,38 +212,27 @@ class NodePoolSpec extends munit.FunSuite {
   }
 
   test("a failed establishment reports the node and cause through ConnectFailed") {
-    val node      = Node("unreachable", 6379)
-    val seen      = new ConcurrentLinkedQueue[SageEvent.Connection.ConnectFailed]()
-    val delivered = new CountDownLatch(1)
-    val failing   = new AtomicReference(true)
-    val events    = Events(
-      Vector(
-        new SageListener {
-          def onEvent(event: SageEvent): Unit = event match {
-            case failure: SageEvent.Connection.ConnectFailed => seen.add(failure); delivered.countDown()
-            case _                                           => ()
-          }
-        }
-      )
-    )
-    val pool      = newPool(
+    val node     = Node("unreachable", 6379)
+    val recorder = new ConnectFailureRecorder
+    val failing  = new AtomicReference(true)
+    val pool     = newPool(
       _ =>
         (onFrame, onClosed) =>
           if (failing.get()) throw new IOException("refused")
           else new FakeTransport(onFrame, onClosed, respond),
-      events
+      recorder.events
     )
 
     try {
       intercept[IOException](pool.getOrEstablish(node))
-      assert(delivered.await(2, TimeUnit.SECONDS), "ConnectFailed was not delivered")
+      assert(recorder.await(), "ConnectFailed was not delivered")
       intercept[IOException](pool.getOrEstablish(node))
       val deadline = System.nanoTime() + 250.millis.toNanos
-      while (seen.size() == 1 && System.nanoTime() < deadline) Thread.sleep(10)
-      val failure  = seen.peek()
+      while (recorder.failures.size == 1 && System.nanoTime() < deadline) Thread.sleep(10)
+      val failure  = recorder.failures.head
       assertEquals(failure.node, Some(node))
       assert(failure.error.isInstanceOf[IOException], s"unexpected cause: ${failure.error}")
-      assertEquals(seen.size(), 1, "the same establishment outage should be reported only once")
+      assertEquals(recorder.failures.size, 1, "the same establishment outage should be reported only once")
 
       failing.set(false)
       val _                = pool.getOrEstablish(node)
@@ -251,11 +240,11 @@ class NodePoolSpec extends munit.FunSuite {
       failing.set(true)
       intercept[IOException](pool.getOrEstablish(node))
       val recoveryDeadline = System.nanoTime() + 2.seconds.toNanos
-      while (seen.size() < 2 && System.nanoTime() < recoveryDeadline) Thread.sleep(10)
-      assertEquals(seen.size(), 2, "a new outage after a successful connection should be reported")
+      while (recorder.failures.size < 2 && System.nanoTime() < recoveryDeadline) Thread.sleep(10)
+      assertEquals(recorder.failures.size, 2, "a new outage after a successful connection should be reported")
     } finally {
       pool.close()
-      events.close()
+      recorder.events.close()
     }
   }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
@@ -1,12 +1,13 @@
 package sage.client.internal
 
-import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.io.IOException
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference, AtomicReferenceArray}
 
 import scala.concurrent.duration.*
 import scala.util.Try
 
-import sage.Bytes
+import sage.{Bytes, SageEvent, SageListener}
 import sage.SageException.NotConnected
 import sage.client.{BackoffConfig, DedicatedPoolConfig, WatchdogConfig}
 import sage.cluster.Node
@@ -28,7 +29,7 @@ class NodePoolSpec extends munit.FunSuite {
   private def respond(payload: Bytes): Seq[Frame] =
     if (payload.asUtf8String.contains("HELLO")) Seq(helloReply) else Nil
 
-  private def newPool(factory: Node => MultiplexedConnection.TransportFactory): NodePool =
+  private def newPool(factory: Node => MultiplexedConnection.TransportFactory, events: Events = Events.disabled): NodePool =
     new NodePool(
       factory,
       Scheduler.real,
@@ -37,7 +38,8 @@ class NodePoolSpec extends munit.FunSuite {
       WatchdogConfig(enabled = false),
       1.second,
       Duration.Zero,
-      DedicatedPoolConfig()
+      DedicatedPoolConfig(),
+      events = events
     )
 
   // gates the nth connect attempt: it signals `reached(n)`, blocks until `release(n)`, then opens a transport captured at `transport(n)`
@@ -207,5 +209,33 @@ class NodePoolSpec extends munit.FunSuite {
     assert(!establishing.isAlive, "close must abort the in-flight establishment, not wait out the connect")
     assert(connecting.get().wasClosed, "close must abort the establishing transport")
     assert(result.get() != null && result.get().isFailure, s"the aborted establisher should fail: ${result.get()}")
+  }
+
+  test("a failed establishment reports the node and cause through ConnectFailed") {
+    val node      = Node("unreachable", 6379)
+    val seen      = new ConcurrentLinkedQueue[SageEvent.Connection.ConnectFailed]()
+    val delivered = new CountDownLatch(1)
+    val events    = Events(
+      Vector(
+        new SageListener {
+          def onEvent(event: SageEvent): Unit = event match {
+            case failure: SageEvent.Connection.ConnectFailed => seen.add(failure); delivered.countDown()
+            case _                                           => ()
+          }
+        }
+      )
+    )
+    val pool      = newPool(_ => (_, _) => throw new IOException("refused"), events)
+
+    try {
+      intercept[IOException](pool.getOrEstablish(node))
+      assert(delivered.await(2, TimeUnit.SECONDS), "ConnectFailed was not delivered")
+      val failure = seen.peek()
+      assertEquals(failure.node, Some(node))
+      assert(failure.error.isInstanceOf[IOException], s"unexpected cause: ${failure.error}")
+    } finally {
+      pool.close()
+      events.close()
+    }
   }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/RefreshThrottleSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/RefreshThrottleSpec.scala
@@ -1,0 +1,43 @@
+package sage.client.internal
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+class RefreshThrottleSpec extends munit.FunSuite {
+
+  test("a non-blocking trigger schedules once while a refresh is in flight without changing blocking callers") {
+    val scheduler = new CountingScheduler
+    val throttle  = new RefreshThrottle(scheduler, minRefreshMs = 0L)
+    val started   = new CountDownLatch(1)
+    val release   = new CountDownLatch(1)
+    val finished  = new CountDownLatch(1)
+
+    throttle.trigger {
+      started.countDown()
+      release.await()
+      finished.countDown()
+    }
+    assert(started.await(2, TimeUnit.SECONDS), "the triggered refresh did not start")
+
+    var i = 0
+    while (i < 1000) {
+      throttle.trigger(fail("an in-flight trigger must not evaluate later work"))
+      i += 1
+    }
+    assertEquals(scheduler.zeroDelays.get(), 1, "an in-flight refresh should own the only scheduler offload")
+
+    val blockingStarted = new CountDownLatch(1)
+    val blockingDone    = new CountDownLatch(1)
+    val waiter          = Thread.ofVirtual().start { () =>
+      blockingStarted.countDown()
+      throttle(force = false)(())
+      blockingDone.countDown()
+    }
+    assert(blockingStarted.await(2, TimeUnit.SECONDS), "the blocking caller did not start")
+    assert(!blockingDone.await(100, TimeUnit.MILLISECONDS), "the existing blocking entry point must still wait for the in-flight refresh")
+
+    release.countDown()
+    assert(finished.await(2, TimeUnit.SECONDS), "the triggered refresh did not finish")
+    assert(blockingDone.await(2, TimeUnit.SECONDS), "the blocking caller did not resume")
+    waiter.join()
+  }
+}

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -12,7 +12,7 @@ import scala.util.Try
 import kyo.compat.*
 
 import sage.{Bytes, SageEvent, SageListener}
-import sage.SageException.{ConnectionFailed, TimedOut}
+import sage.SageException.{ConnectionFailed, NotConnected, TimedOut}
 import sage.client.internal.{Events, FakeTransport, MasterReplicaLive, MultiplexedConnection, Scheduler}
 import sage.cluster.Node
 import sage.commands.{Command, Connection}
@@ -169,6 +169,59 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     assertEquals(fixture.read(), 1L)
     assertEquals(fixture.readsServedBy(advertisedReplica), 1)
     fixture.close()
+  }
+
+  test("throwaway ROLE probes do not report Connected") {
+    val connected = new ConcurrentLinkedQueue[SageEvent.Connection.Connected]()
+    val events    = Events(
+      Vector(
+        new SageListener {
+          def onEvent(event: SageEvent): Unit = event match {
+            case event: SageEvent.Connection.Connected => val _ = connected.add(event)
+            case _                                     => ()
+          }
+        }
+      )
+    )
+    val fixture   = new Fixture(
+      seeds = Vector(primary, reader),
+      initialRoles = Map(primary -> masterRole(), reader -> replicaRole(primary)),
+      events = events
+    )
+
+    fixture.live.bootstrapRoles()
+    fixture.close()
+
+    assertEquals(connected.asScala.toVector, Vector.empty)
+  }
+
+  test("a single seed ROLE timeout is returned and reported") {
+    val failures  = new ConcurrentLinkedQueue[SageEvent.Connection.ConnectFailed]()
+    val delivered = new CountDownLatch(1)
+    val events    = Events(
+      Vector(
+        new SageListener {
+          def onEvent(event: SageEvent): Unit = event match {
+            case failure: SageEvent.Connection.ConnectFailed =>
+              val _ = failures.add(failure)
+              delivered.countDown()
+            case _                                           => ()
+          }
+        }
+      )
+    )
+    val fixture   = new Fixture(
+      seeds = Vector(primary),
+      initialRoles = Map.empty,
+      events = events
+    )
+
+    intercept[NotConnected](fixture.live.bootstrapRoles())
+    assert(delivered.await(2, TimeUnit.SECONDS), "the singleton ROLE timeout was not reported")
+    val failure   = failures.peek()
+
+    assertEquals(failure.node, Some(primary))
+    assert(failure.error.isInstanceOf[TimedOut], s"unexpected cause: ${failure.error}")
   }
 
   test("an unreachable supplied endpoint is omitted and reported while the available topology connects") {

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -1,0 +1,238 @@
+package sage.client
+
+import java.io.IOException
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+import scala.util.Try
+
+import kyo.compat.*
+
+import sage.{Bytes, SageEvent, SageListener}
+import sage.SageException.ConnectionFailed
+import sage.client.internal.{Events, FakeTransport, MasterReplicaLive, MultiplexedConnection, Scheduler}
+import sage.cluster.Node
+import sage.commands.{Command, Connection}
+import sage.protocol.Frame
+
+class MasterReplicaTopologySpec extends munit.FunSuite {
+
+  private val primary           = Node("primary-endpoint", 6379)
+  private val reader            = Node("reader-endpoint", 6379)
+  private val advertisedReplica = Node("10.0.0.7", 6379)
+
+  private val helloReply: Frame =
+    Frame.Map(
+      Vector(
+        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
+        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
+        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
+        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
+      )
+    )
+
+  private def masterRole(replicas: Node*): Frame =
+    Frame.Array(
+      Vector(
+        Frame.BulkString(Bytes.utf8("master")),
+        Frame.Integer(0L),
+        Frame.Array(
+          replicas.toVector.map(replica =>
+            Frame.Array(
+              Vector(
+                Frame.BulkString(Bytes.utf8(replica.host)),
+                Frame.BulkString(Bytes.utf8(replica.port.toString)),
+                Frame.BulkString(Bytes.utf8("0"))
+              )
+            )
+          )
+        )
+      )
+    )
+
+  private def replicaRole(master: Node): Frame =
+    Frame.Array(
+      Vector(
+        Frame.BulkString(Bytes.utf8("slave")),
+        Frame.BulkString(Bytes.utf8(master.host)),
+        Frame.Integer(master.port.toLong),
+        Frame.BulkString(Bytes.utf8("connected")),
+        Frame.Integer(0L)
+      )
+    )
+
+  private val readCommand: Command[Long] =
+    Command("ZSCORE", Command.NoKeys, Vector.empty, (_: Frame) => Right(1L), isReadOnly = true)
+
+  private val writeCommand: Command[Long] =
+    Command("ZADD", Command.NoKeys, Vector.empty, (_: Frame) => Right(1L), isReadOnly = false)
+
+  final private class Fixture(
+    seeds: Vector[Node],
+    initialRoles: Map[Node, Frame],
+    unreachable: Set[Node] = Set.empty,
+    events: Events = Events.disabled,
+    minRefreshInterval: FiniteDuration = 50.millis
+  ) {
+
+    val roles                                                           = TrieMap.from(initialRoles)
+    @volatile var writesFailReadonly                                    = false
+    private val dials                                                   = new ConcurrentLinkedQueue[Node]()
+    private val transports                                              = new ConcurrentLinkedQueue[(Node, FakeTransport)]()
+    private val factory: Node => MultiplexedConnection.TransportFactory = node =>
+      (onFrame, onClosed) => {
+        val _                            = dials.add(node)
+        if (unreachable(node)) throw new IOException(s"cannot reach $node")
+        val respond: Bytes => Seq[Frame] = payload => {
+          val text = payload.asUtf8String
+          if (text.contains("HELLO")) Seq(helloReply)
+          else if (text.contains("ROLE")) roles.get(node).toSeq
+          else if (text.contains("ZSCORE")) Seq(Frame.Integer(1L))
+          else if (text.contains("ZADD") && writesFailReadonly)
+            Seq(Frame.SimpleError("READONLY You can't write against a read only replica."))
+          else if (text.contains("ZADD")) Seq(Frame.Integer(1L))
+          else Seq(Frame.SimpleString("OK"))
+        }
+        val transport                    = new FakeTransport(onFrame, onClosed, respond)
+        val _                            = transports.add(node -> transport)
+        transport
+      }
+
+    val live = new MasterReplicaLive(
+      factory,
+      Scheduler.real,
+      Vector(Connection.hello(None)),
+      SageConfig(readFrom = ReadFrom.ReplicaPreferred, connectTimeout = 500.millis),
+      seeds,
+      minRefreshInterval,
+      events
+    )
+
+    def dialled: Vector[Node] = dials.asScala.toVector
+
+    def readsServedBy(node: Node): Int =
+      transports.asScala.toVector.collect { case (`node`, transport) =>
+        transport.written.count(_.asUtf8String.contains("ZSCORE"))
+      }.sum
+
+    def read(): Long =
+      scala.concurrent.Await.result(live.run(readCommand).unsafeRun, 10.seconds)
+
+    def write(): Try[Long] =
+      Try(scala.concurrent.Await.result(live.run(writeCommand).unsafeRun, 10.seconds))
+
+    def awaitTrue(condition: => Boolean, clue: String): Unit = {
+      val deadline = System.nanoTime() + 5.seconds.toNanos
+      while (!condition && System.nanoTime() < deadline) Thread.sleep(25)
+      assert(condition, clue)
+    }
+
+    def close(): Unit =
+      scala.concurrent.Await.result(live.close.unsafeRun, 10.seconds)
+  }
+
+  test("several seeds keep the supplied addresses and never dial a ROLE-advertised address") {
+    val fixture = new Fixture(
+      seeds = Vector(primary, reader),
+      initialRoles = Map(
+        primary           -> masterRole(advertisedReplica),
+        reader            -> replicaRole(primary),
+        advertisedReplica -> replicaRole(primary)
+      ),
+      unreachable = Set(advertisedReplica)
+    )
+    fixture.live.bootstrapRoles()
+
+    assertEquals(fixture.read(), 1L)
+    assertEquals(fixture.readsServedBy(reader), 1)
+    val dialled = fixture.dialled
+    fixture.close()
+
+    assert(!dialled.contains(advertisedReplica), s"advertised address must not be dialled: $dialled")
+  }
+
+  test("a single seed retains advertised-replica discovery") {
+    val fixture = new Fixture(
+      seeds = Vector(primary),
+      initialRoles = Map(primary -> masterRole(advertisedReplica), advertisedReplica -> replicaRole(primary))
+    )
+    fixture.live.bootstrapRoles()
+
+    assertEquals(fixture.read(), 1L)
+    assertEquals(fixture.readsServedBy(advertisedReplica), 1)
+    fixture.close()
+  }
+
+  test("an unreachable supplied endpoint is omitted and reported while the available topology connects") {
+    val failures  = new ConcurrentLinkedQueue[SageEvent.Connection.ConnectFailed]()
+    val delivered = new CountDownLatch(1)
+    val events    = Events(
+      Vector(
+        new SageListener {
+          def onEvent(event: SageEvent): Unit = event match {
+            case failure: SageEvent.Connection.ConnectFailed =>
+              val _ = failures.add(failure)
+              delivered.countDown()
+            case _                                           => ()
+          }
+        }
+      )
+    )
+    val fixture   = new Fixture(
+      seeds = Vector(primary, reader),
+      initialRoles = Map(primary -> masterRole(), reader -> replicaRole(primary)),
+      unreachable = Set(reader),
+      events = events
+    )
+    fixture.live.bootstrapRoles()
+
+    assertEquals(fixture.read(), 1L)
+    assert(delivered.await(2, TimeUnit.SECONDS), "ConnectFailed was not delivered")
+    val failure = failures.peek()
+    fixture.close()
+
+    assertEquals(failure.node, Some(reader))
+    assert(failure.error.isInstanceOf[IOException], s"unexpected cause: ${failure.error}")
+  }
+
+  test("several reachable seeds with no master fail as a connection problem") {
+    val fixture = new Fixture(
+      seeds = Vector(reader, advertisedReplica),
+      initialRoles = Map(reader -> replicaRole(primary), advertisedReplica -> replicaRole(primary))
+    )
+
+    val error = intercept[ConnectionFailed](fixture.live.bootstrapRoles())
+    assert(error.getMessage.contains("no supplied endpoint reports the master role"), error.getMessage)
+  }
+
+  test("a role refresh moves master and replica roles only between the pinned endpoints") {
+    val fixture = new Fixture(
+      seeds = Vector(primary, reader),
+      initialRoles = Map(primary -> masterRole(advertisedReplica), reader -> replicaRole(primary)),
+      unreachable = Set(advertisedReplica)
+    )
+    fixture.live.bootstrapRoles()
+    assertEquals(fixture.read(), 1L)
+    assertEquals(fixture.readsServedBy(reader), 1)
+
+    fixture.roles.update(primary, replicaRole(reader))
+    fixture.roles.update(reader, masterRole(advertisedReplica))
+    fixture.writesFailReadonly = true
+    assert(fixture.write().isFailure, "a write to the demoted master should fail")
+
+    val before  = fixture.readsServedBy(primary)
+    fixture.awaitTrue(
+      {
+        val _ = fixture.read()
+        fixture.readsServedBy(primary) > before
+      },
+      "the refresh did not move reads to the demoted endpoint"
+    )
+    val dialled = fixture.dialled
+    fixture.close()
+
+    assert(!dialled.contains(advertisedReplica), s"refresh introduced an advertised address: $dialled")
+  }
+}

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -1,7 +1,7 @@
 package sage.client
 
 import java.io.IOException
-import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeoutException, TimeUnit}
 
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
@@ -105,7 +105,7 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
       factory,
       Scheduler.real,
       Vector(Connection.hello(None)),
-      SageConfig(readFrom = ReadFrom.ReplicaPreferred, connectTimeout = 500.millis),
+      SageConfig(readFrom = ReadFrom.ReplicaPreferred, connectTimeout = 500.millis, closeTimeout = Duration.Zero),
       seeds,
       minRefreshInterval,
       events
@@ -124,8 +124,8 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     def write(): Try[Long] =
       Try(scala.concurrent.Await.result(live.run(writeCommand).unsafeRun, 10.seconds))
 
-    def awaitTrue(condition: => Boolean, clue: String): Unit = {
-      val deadline = System.nanoTime() + 5.seconds.toNanos
+    def awaitTrue(condition: => Boolean, clue: String, timeout: FiniteDuration = 5.seconds): Unit = {
+      val deadline = System.nanoTime() + timeout.toNanos
       while (!condition && System.nanoTime() < deadline) Thread.sleep(25)
       assert(condition, clue)
     }
@@ -198,6 +198,62 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     assert(failure.error.isInstanceOf[IOException], s"unexpected cause: ${failure.error}")
   }
 
+  test("replica-preferred reads reconsider a supplied endpoint after it becomes reachable") {
+    val down    = mutable.Set(reader)
+    val fixture = new Fixture(
+      seeds = Vector(primary, reader),
+      initialRoles = Map(primary -> masterRole(), reader -> replicaRole(primary)),
+      unreachable = down,
+      minRefreshInterval = 10.millis
+    )
+    fixture.live.bootstrapRoles()
+
+    assertEquals(fixture.read(), 1L)
+    assertEquals(fixture.readsServedBy(primary), 1)
+    assertEquals(fixture.readsServedBy(reader), 0)
+
+    down -= reader
+    fixture.awaitTrue(
+      {
+        val _ = fixture.read()
+        fixture.readsServedBy(reader) > 0
+      },
+      "replica-preferred reads did not reconsider the recovered endpoint",
+      timeout = 1.second
+    )
+    fixture.close()
+  }
+
+  test("a supplied endpoint that handshakes but does not answer ROLE is reported") {
+    val failures  = new ConcurrentLinkedQueue[SageEvent.Connection.ConnectFailed]()
+    val delivered = new CountDownLatch(1)
+    val events    = Events(
+      Vector(
+        new SageListener {
+          def onEvent(event: SageEvent): Unit = event match {
+            case failure: SageEvent.Connection.ConnectFailed =>
+              val _ = failures.add(failure)
+              delivered.countDown()
+            case _                                           => ()
+          }
+        }
+      )
+    )
+    val fixture   = new Fixture(
+      seeds = Vector(primary, reader),
+      initialRoles = Map(primary -> masterRole()),
+      events = events
+    )
+    fixture.live.bootstrapRoles()
+
+    assert(delivered.await(2, TimeUnit.SECONDS), "the ROLE timeout was not reported")
+    val failure = failures.peek()
+    fixture.close()
+
+    assertEquals(failure.node, Some(reader))
+    assert(failure.error.isInstanceOf[TimeoutException], s"unexpected cause: ${failure.error}")
+  }
+
   test("a singleton refresh reports the address whose connection failed, including a replica's advertised master") {
     val failures  = new ConcurrentLinkedQueue[SageEvent.Connection.ConnectFailed]()
     val delivered = new CountDownLatch(2)
@@ -247,15 +303,14 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     assertEquals(fixture.readsServedBy(reader), 0)
 
     fixture.roles.update(reader, replicaRole(primary, state = "connected"))
-    fixture.writesFailReadonly = true
-    assert(fixture.write().isFailure, "READONLY should trigger a later role refresh")
 
     fixture.awaitTrue(
       {
         val _ = fixture.read()
         fixture.readsServedBy(reader) > 0
       },
-      "the connected replica was not admitted after the refresh"
+      "replica-preferred reads did not reconsider the connected replica",
+      timeout = 1.second
     )
     fixture.close()
   }

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -1,7 +1,7 @@
 package sage.client
 
 import java.io.IOException
-import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
+import java.util.concurrent.ConcurrentLinkedQueue
 
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
@@ -11,9 +11,9 @@ import scala.util.Try
 
 import kyo.compat.*
 
-import sage.{Bytes, SageEvent, SageListener}
+import sage.{Bytes, SageEvent}
 import sage.SageException.{ConnectionFailed, NotConnected, TimedOut}
-import sage.client.internal.{Events, FakeTransport, MasterReplicaLive, MultiplexedConnection, Scheduler}
+import sage.client.internal.{ConnectFailureRecorder, Events, FakeTransport, MasterReplicaLive, MultiplexedConnection, Scheduler}
 import sage.cluster.Node
 import sage.commands.{Command, Connection}
 import sage.protocol.Frame
@@ -197,60 +197,34 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
   }
 
   test("a single seed ROLE timeout is returned and reported") {
-    val failures  = new ConcurrentLinkedQueue[SageEvent.Connection.ConnectFailed]()
-    val delivered = new CountDownLatch(1)
-    val events    = Events(
-      Vector(
-        new SageListener {
-          def onEvent(event: SageEvent): Unit = event match {
-            case failure: SageEvent.Connection.ConnectFailed =>
-              val _ = failures.add(failure)
-              delivered.countDown()
-            case _                                           => ()
-          }
-        }
-      )
-    )
-    val fixture   = new Fixture(
+    val recorder = new ConnectFailureRecorder
+    val fixture  = new Fixture(
       seeds = Vector(primary),
       initialRoles = Map.empty,
-      events = events
+      events = recorder.events
     )
 
     intercept[NotConnected](fixture.live.bootstrapRoles())
-    assert(delivered.await(2, TimeUnit.SECONDS), "the singleton ROLE timeout was not reported")
-    val failure   = failures.peek()
+    assert(recorder.await(), "the singleton ROLE timeout was not reported")
+    val failure  = recorder.failures.head
 
     assertEquals(failure.node, Some(primary))
     assert(failure.error.isInstanceOf[TimedOut], s"unexpected cause: ${failure.error}")
   }
 
   test("an unreachable supplied endpoint is omitted and reported while the available topology connects") {
-    val failures  = new ConcurrentLinkedQueue[SageEvent.Connection.ConnectFailed]()
-    val delivered = new CountDownLatch(1)
-    val events    = Events(
-      Vector(
-        new SageListener {
-          def onEvent(event: SageEvent): Unit = event match {
-            case failure: SageEvent.Connection.ConnectFailed =>
-              val _ = failures.add(failure)
-              delivered.countDown()
-            case _                                           => ()
-          }
-        }
-      )
-    )
-    val fixture   = new Fixture(
+    val recorder = new ConnectFailureRecorder
+    val fixture  = new Fixture(
       seeds = Vector(primary, reader),
       initialRoles = Map(primary -> masterRole(), reader -> replicaRole(primary)),
       unreachable = Set(reader),
-      events = events
+      events = recorder.events
     )
     fixture.live.bootstrapRoles()
 
     assertEquals(fixture.read(), 1L)
-    assert(delivered.await(2, TimeUnit.SECONDS), "ConnectFailed was not delivered")
-    val failure = failures.peek()
+    assert(recorder.await(), "ConnectFailed was not delivered")
+    val failure = recorder.failures.head
     fixture.close()
 
     assertEquals(failure.node, Some(reader))
@@ -284,29 +258,16 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
   }
 
   test("a supplied endpoint that handshakes but does not answer ROLE is reported") {
-    val failures  = new ConcurrentLinkedQueue[SageEvent.Connection.ConnectFailed]()
-    val delivered = new CountDownLatch(1)
-    val events    = Events(
-      Vector(
-        new SageListener {
-          def onEvent(event: SageEvent): Unit = event match {
-            case failure: SageEvent.Connection.ConnectFailed =>
-              val _ = failures.add(failure)
-              delivered.countDown()
-            case _                                           => ()
-          }
-        }
-      )
-    )
-    val fixture   = new Fixture(
+    val recorder = new ConnectFailureRecorder
+    val fixture  = new Fixture(
       seeds = Vector(primary, reader),
       initialRoles = Map(primary -> masterRole()),
-      events = events
+      events = recorder.events
     )
     fixture.live.bootstrapRoles()
 
-    assert(delivered.await(2, TimeUnit.SECONDS), "the ROLE timeout was not reported")
-    val failure = failures.peek()
+    assert(recorder.await(), "the ROLE timeout was not reported")
+    val failure = recorder.failures.head
     fixture.close()
 
     assertEquals(failure.node, Some(reader))
@@ -314,26 +275,13 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
   }
 
   test("a singleton refresh reports a failed address once when discovery reaches it directly and through a replica") {
-    val failures  = new ConcurrentLinkedQueue[SageEvent.Connection.ConnectFailed]()
-    val delivered = new CountDownLatch(1)
-    val events    = Events(
-      Vector(
-        new SageListener {
-          def onEvent(event: SageEvent): Unit = event match {
-            case failure: SageEvent.Connection.ConnectFailed =>
-              val _ = failures.add(failure)
-              delivered.countDown()
-            case _                                           => ()
-          }
-        }
-      )
-    )
-    val down      = mutable.Set.empty[Node]
-    val fixture   = new Fixture(
+    val recorder = new ConnectFailureRecorder
+    val down     = mutable.Set.empty[Node]
+    val fixture  = new Fixture(
       seeds = Vector(primary),
       initialRoles = Map(primary -> masterRole(reader), reader -> replicaRole(primary)),
       unreachable = down,
-      events = events
+      events = recorder.events
     )
     fixture.live.bootstrapRoles()
     assert(fixture.write().isSuccess, "the master pool should be established before discovery connections fail")
@@ -342,9 +290,9 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     fixture.writesFailReadonly = true
     assert(fixture.write().isFailure, "READONLY should trigger a singleton role refresh")
 
-    assert(delivered.await(2, TimeUnit.SECONDS), s"expected the failed address, got ${failures.asScala.toVector}")
+    assert(recorder.await(), s"expected the failed address, got ${recorder.failures}")
     Thread.sleep(50)
-    val reported = failures.asScala.toVector
+    val reported = recorder.failures
     fixture.close()
 
     assertEquals(reported.map(_.node), Vector(Some(primary)))

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -4,6 +4,7 @@ import java.io.IOException
 import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
 
 import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
 import scala.concurrent.duration.*
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
@@ -52,13 +53,13 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
       )
     )
 
-  private def replicaRole(master: Node): Frame =
+  private def replicaRole(master: Node, state: String = "connected"): Frame =
     Frame.Array(
       Vector(
         Frame.BulkString(Bytes.utf8("slave")),
         Frame.BulkString(Bytes.utf8(master.host)),
         Frame.Integer(master.port.toLong),
-        Frame.BulkString(Bytes.utf8("connected")),
+        Frame.BulkString(Bytes.utf8(state)),
         Frame.Integer(0L)
       )
     )
@@ -72,7 +73,7 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
   final private class Fixture(
     seeds: Vector[Node],
     initialRoles: Map[Node, Frame],
-    unreachable: Set[Node] = Set.empty,
+    unreachable: collection.Set[Node] = Set.empty,
     events: Events = Events.disabled,
     minRefreshInterval: FiniteDuration = 50.millis
   ) {
@@ -195,6 +196,68 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
 
     assertEquals(failure.node, Some(reader))
     assert(failure.error.isInstanceOf[IOException], s"unexpected cause: ${failure.error}")
+  }
+
+  test("a singleton refresh reports the address whose connection failed, including a replica's advertised master") {
+    val failures  = new ConcurrentLinkedQueue[SageEvent.Connection.ConnectFailed]()
+    val delivered = new CountDownLatch(2)
+    val events    = Events(
+      Vector(
+        new SageListener {
+          def onEvent(event: SageEvent): Unit = event match {
+            case failure: SageEvent.Connection.ConnectFailed =>
+              val _ = failures.add(failure)
+              delivered.countDown()
+            case _                                           => ()
+          }
+        }
+      )
+    )
+    val down      = mutable.Set.empty[Node]
+    val fixture   = new Fixture(
+      seeds = Vector(primary),
+      initialRoles = Map(primary -> masterRole(reader), reader -> replicaRole(primary)),
+      unreachable = down,
+      events = events
+    )
+    fixture.live.bootstrapRoles()
+    assert(fixture.write().isSuccess, "the master pool should be established before discovery connections fail")
+
+    down += primary
+    fixture.writesFailReadonly = true
+    assert(fixture.write().isFailure, "READONLY should trigger a singleton role refresh")
+
+    assert(delivered.await(2, TimeUnit.SECONDS), s"expected direct and replica-follow failures, got ${failures.asScala.toVector}")
+    val reported = failures.asScala.toVector
+    fixture.close()
+
+    assertEquals(reported.map(_.node), Vector(Some(primary), Some(primary)))
+    assert(reported.forall(_.error.isInstanceOf[IOException]), s"unexpected causes: ${reported.map(_.error)}")
+  }
+
+  test("a pinned replica is not used until its own ROLE state is connected") {
+    val fixture = new Fixture(
+      seeds = Vector(primary, reader),
+      initialRoles = Map(primary -> masterRole(reader), reader -> replicaRole(primary, state = "sync"))
+    )
+    fixture.live.bootstrapRoles()
+
+    assertEquals(fixture.read(), 1L)
+    assertEquals(fixture.readsServedBy(primary), 1)
+    assertEquals(fixture.readsServedBy(reader), 0)
+
+    fixture.roles.update(reader, replicaRole(primary, state = "connected"))
+    fixture.writesFailReadonly = true
+    assert(fixture.write().isFailure, "READONLY should trigger a later role refresh")
+
+    fixture.awaitTrue(
+      {
+        val _ = fixture.read()
+        fixture.readsServedBy(reader) > 0
+      },
+      "the connected replica was not admitted after the refresh"
+    )
+    fixture.close()
   }
 
   test("several reachable seeds with no master fail as a connection problem") {

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -1,7 +1,7 @@
 package sage.client
 
 import java.io.IOException
-import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeoutException, TimeUnit}
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
 
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
@@ -12,7 +12,7 @@ import scala.util.Try
 import kyo.compat.*
 
 import sage.{Bytes, SageEvent, SageListener}
-import sage.SageException.ConnectionFailed
+import sage.SageException.{ConnectionFailed, TimedOut}
 import sage.client.internal.{Events, FakeTransport, MasterReplicaLive, MultiplexedConnection, Scheduler}
 import sage.cluster.Node
 import sage.commands.{Command, Connection}
@@ -87,10 +87,11 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
         val _                            = dials.add(node)
         if (unreachable(node)) throw new IOException(s"cannot reach $node")
         val respond: Bytes => Seq[Frame] = payload => {
-          val text = payload.asUtf8String
+          val text  = payload.asUtf8String
+          val reads = text.sliding("ZSCORE".length).count(_ == "ZSCORE")
           if (text.contains("HELLO")) Seq(helloReply)
           else if (text.contains("ROLE")) roles.get(node).toSeq
-          else if (text.contains("ZSCORE")) Seq(Frame.Integer(1L))
+          else if (reads > 0) Seq.fill(reads)(Frame.Integer(1L))
           else if (text.contains("ZADD") && writesFailReadonly)
             Seq(Frame.SimpleError("READONLY You can't write against a read only replica."))
           else if (text.contains("ZADD")) Seq(Frame.Integer(1L))
@@ -123,6 +124,10 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
 
     def write(): Try[Long] =
       Try(scala.concurrent.Await.result(live.run(writeCommand).unsafeRun, 10.seconds))
+
+    def readPipeline(): Unit = {
+      val _ = scala.concurrent.Await.result(live.pipeline(Seq(readCommand, readCommand)).unsafeRun, 10.seconds)
+    }
 
     def awaitTrue(condition: => Boolean, clue: String, timeout: FiniteDuration = 5.seconds): Unit = {
       val deadline = System.nanoTime() + timeout.toNanos
@@ -251,12 +256,12 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     fixture.close()
 
     assertEquals(failure.node, Some(reader))
-    assert(failure.error.isInstanceOf[TimeoutException], s"unexpected cause: ${failure.error}")
+    assert(failure.error.isInstanceOf[TimedOut], s"unexpected cause: ${failure.error}")
   }
 
-  test("a singleton refresh reports the address whose connection failed, including a replica's advertised master") {
+  test("a singleton refresh reports a failed address once when discovery reaches it directly and through a replica") {
     val failures  = new ConcurrentLinkedQueue[SageEvent.Connection.ConnectFailed]()
-    val delivered = new CountDownLatch(2)
+    val delivered = new CountDownLatch(1)
     val events    = Events(
       Vector(
         new SageListener {
@@ -283,11 +288,12 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     fixture.writesFailReadonly = true
     assert(fixture.write().isFailure, "READONLY should trigger a singleton role refresh")
 
-    assert(delivered.await(2, TimeUnit.SECONDS), s"expected direct and replica-follow failures, got ${failures.asScala.toVector}")
+    assert(delivered.await(2, TimeUnit.SECONDS), s"expected the failed address, got ${failures.asScala.toVector}")
+    Thread.sleep(50)
     val reported = failures.asScala.toVector
     fixture.close()
 
-    assertEquals(reported.map(_.node), Vector(Some(primary), Some(primary)))
+    assertEquals(reported.map(_.node), Vector(Some(primary)))
     assert(reported.forall(_.error.isInstanceOf[IOException]), s"unexpected causes: ${reported.map(_.error)}")
   }
 
@@ -310,6 +316,30 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
         fixture.readsServedBy(reader) > 0
       },
       "replica-preferred reads did not reconsider the connected replica",
+      timeout = 1.second
+    )
+    fixture.close()
+  }
+
+  test("replica-preferred pipelines reconsider a supplied endpoint after its ROLE state becomes connected") {
+    val fixture = new Fixture(
+      seeds = Vector(primary, reader),
+      initialRoles = Map(primary -> masterRole(reader), reader -> replicaRole(primary, state = "sync")),
+      minRefreshInterval = 10.millis
+    )
+    fixture.live.bootstrapRoles()
+
+    fixture.readPipeline()
+    assertEquals(fixture.readsServedBy(primary), 1)
+    assertEquals(fixture.readsServedBy(reader), 0)
+
+    fixture.roles.update(reader, replicaRole(primary, state = "connected"))
+    fixture.awaitTrue(
+      {
+        fixture.readPipeline()
+        fixture.readsServedBy(reader) > 0
+      },
+      "replica-preferred pipelines did not reconsider the connected replica",
       timeout = 1.second
     )
     fixture.close()

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -173,16 +173,17 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
 
   test("throwaway ROLE probes do not report Connected") {
     val connected = new ConcurrentLinkedQueue[SageEvent.Connection.Connected]()
-    val events    = Events(
-      Vector(
-        new SageListener {
-          def onEvent(event: SageEvent): Unit = event match {
-            case event: SageEvent.Connection.Connected => val _ = connected.add(event)
-            case _                                     => ()
-          }
-        }
-      )
-    )
+    val events    = new Events {
+      def enabled: Boolean             = true
+      def emitsEvents: Boolean         = true
+      def tracer                       = None
+      def serverNode                   = None
+      def close(): Unit                = ()
+      def emit(event: SageEvent): Unit = event match {
+        case event: SageEvent.Connection.Connected => val _ = connected.add(event)
+        case _                                     => ()
+      }
+    }
     val fixture   = new Fixture(
       seeds = Vector(primary, reader),
       initialRoles = Map(primary -> masterRole(), reader -> replicaRole(primary)),

--- a/sage-core/src/main/scala/sage/SageEvent.scala
+++ b/sage-core/src/main/scala/sage/SageEvent.scala
@@ -47,7 +47,7 @@ object SageEvent {
     /**
       * An attempt to establish a connection to a specific node, or to qualify it during topology discovery, failed. Names the address and cause,
       * and may accompany a failure returned to the caller or one handled internally. Distinct from [[ReconnectFailed]], which concerns restoring
-      * an already-established connection. Repeated failures for the same node are collapsed until that node connects successfully.
+      * an already-established connection. Repeated failures for the same node are collapsed until it establishes a pooled connection.
       */
     final case class ConnectFailed(node: Option[Node], error: Throwable) extends Connection
   }

--- a/sage-core/src/main/scala/sage/SageEvent.scala
+++ b/sage-core/src/main/scala/sage/SageEvent.scala
@@ -43,6 +43,12 @@ object SageEvent {
       * the caller already sees.
       */
     final case class ReconnectFailed(node: Option[Node], error: Throwable) extends Connection
+
+    /**
+      * A connection to a specific node could not be opened, naming the address and cause when routing or topology discovery handles the failure
+      * internally. Distinct from [[ReconnectFailed]], which concerns restoring an already-established connection.
+      */
+    final case class ConnectFailed(node: Option[Node], error: Throwable) extends Connection
   }
 
   /**

--- a/sage-core/src/main/scala/sage/SageEvent.scala
+++ b/sage-core/src/main/scala/sage/SageEvent.scala
@@ -26,7 +26,7 @@ object SageEvent {
   /**
     * The Multiplexed Connection's lifecycle. `Connected` fires on the initial connect and on every successful reconnect; `Disconnected`
     * fires when a live connection is lost unexpectedly and the runtime begins reconnecting. Graceful close and individual reconnect attempts
-    * are not reported. `node` is `Some` in cluster (the master this connection serves) and `None` on standalone.
+    * are not reported. `node` is `Some` for cluster and master-replica clients (the node this connection serves) and `None` for standalone.
     */
   sealed trait Connection extends SageEvent {
     def node: Option[Node]

--- a/sage-core/src/main/scala/sage/SageEvent.scala
+++ b/sage-core/src/main/scala/sage/SageEvent.scala
@@ -45,8 +45,9 @@ object SageEvent {
     final case class ReconnectFailed(node: Option[Node], error: Throwable) extends Connection
 
     /**
-      * A connection to a specific node could not be opened, naming the address and cause when routing or topology discovery handles the failure
-      * internally. Distinct from [[ReconnectFailed]], which concerns restoring an already-established connection.
+      * An attempt to establish a connection to a specific node, or to qualify it during topology discovery, failed. Names the address and cause,
+      * and may accompany a failure returned to the caller or one handled internally. Distinct from [[ReconnectFailed]], which concerns restoring
+      * an already-established connection.
       */
     final case class ConnectFailed(node: Option[Node], error: Throwable) extends Connection
   }

--- a/sage-core/src/main/scala/sage/SageEvent.scala
+++ b/sage-core/src/main/scala/sage/SageEvent.scala
@@ -47,7 +47,7 @@ object SageEvent {
     /**
       * An attempt to establish a connection to a specific node, or to qualify it during topology discovery, failed. Names the address and cause,
       * and may accompany a failure returned to the caller or one handled internally. Distinct from [[ReconnectFailed]], which concerns restoring
-      * an already-established connection.
+      * an already-established connection. Repeated failures for the same node are collapsed until that node connects successfully.
       */
     final case class ConnectFailed(node: Option[Node], error: Throwable) extends Connection
   }

--- a/sage-core/src/main/scala/sage/commands/Server.scala
+++ b/sage-core/src/main/scala/sage/commands/Server.scala
@@ -27,6 +27,11 @@ enum Role {
   case Master(replicationOffset: Long, replicas: Vector[ReplicaNode])
   case Replica(masterHost: String, masterPort: Int, state: String, replicationOffset: Long)
   case Sentinel(masterNames: Vector[String])
+
+  private[sage] def isConnectedReplica: Boolean = this match {
+    case Replica(_, _, "connected", _) => true
+    case _                             => false
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

With several master-replica seeds, sage kept the supplied master endpoint but replaced replica endpoints with addresses advertised by `ROLE`. Managed services often advertise per-node addresses that clients cannot reach, so replica-eligible reads could spend the full `connectTimeout` before falling back.

Pinning replica addresses to the supplied seeds also changes where replica eligibility comes from. A master's `ROLE` reply lists only replicas whose replication link is online, while a replica reports its own role during synchronization. Accepting every self-reported replica could therefore route reads to a partial dataset.

An endpoint omitted because it was unreachable or still synchronizing could remain excluded indefinitely under `ReplicaPreferred`: fallback reads still reached the healthy master, so the existing exhausted-roster refresh trigger never ran. Topology probes that connected but timed out or failed on `ROLE` were also omitted without an event, while repeated pooled establishment failures could emit `ConnectFailed` at read rate.

## Change

- Treat several supplied endpoints as the authoritative topology, using `ROLE` only to classify their roles.
- Admit a pinned replica only when its own `ROLE` state is `connected`, preserving the master-side online-replica guarantee.
- When `ReplicaPreferred` has no known replica, let fallback reads and replica-eligible pipelines schedule a non-blocking, throttled role refresh so omitted readers can return under healthy-master traffic without per-read thread pile-up.
- Preserve the existing single-seed discovery behavior.
- Omit unreachable supplied endpoints so a partially available deployment can connect.
- Emit `SageEvent.Connection.ConnectFailed(node, error)` at the exact failed address for both connection establishment and topology qualification failures, including caller-visible bootstrap failures and `ROLE` timeout/failure.
- Coalesce repeated connection-establishment and topology-qualification failures per node until that node establishes a pooled connection.
- Keep throwaway topology probes out of the public `Connected` lifecycle; only serving pooled connections emit that event and reset failure coalescing.
- Document seed-count, replica-state, demand-driven recovery, node attribution, and `ConnectFailed` behavior.

This intentionally does not add background topology polling or concurrent probing. Recovery remains request/event-driven and is bounded by `minRefreshInterval`.

## Validation

- `sbt testUnit`
- `sbt check`
- Focused `MasterReplicaTopologySpec`, `RefreshThrottleSpec`, `EventsSpec`, and `NodePoolSpec` coverage, including regressions for both omitted-reader paths, pipeline-only recovery, non-blocking refresh coalescing, `ROLE` timeout reporting, lifecycle-event boundaries, and per-outage event deduplication
- `git diff --check`