### PR TITLE
Harden cluster recovery semantics

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,7 +37,17 @@ val config = SageConfig(
 ```
 
 Seeds bootstrap discovery only. Once the topology is known, sage routes to the nodes the cluster reports; any one seed answering is enough.
+Bootstrap requires at least one reported slot owner. A reachable node whose `CLUSTER SLOTS` reply is empty fails with
+`ClusterUnavailable`, while a non-cluster server's own error is preserved instead of being reported as a connection failure. A later refresh
+that briefly sees no slot owners keeps the last usable topology rather than retiring every known node.
 Set `database` to a non-zero value for a Valkey 9+ cluster configured with a sufficiently large `cluster-databases` setting. Sage issues `SELECT` while establishing every node connection, including after reconnects and redirects. Servers without numbered cluster database support reject the connection.
+
+Topology refresh is event-driven rather than periodic. `MOVED`, unreachable owners, transaction ownership faults, subscription re-homing,
+and replica-policy fallbacks trigger discovery. Ordinary triggers are throttled by `ClusterConfig.minRefreshInterval`; recovery paths for a
+command known not to have reached the server and transaction re-pinning force a single-flight refresh outside that interval.
+
+All-masters broadcasts fail as a whole if any master fails. When a failure proves a request was not sent, sage refreshes topology for the
+next call but does not replay successful masters; callers may retry the whole broadcast only when repeating its successful portions is safe.
 
 ### Hash tags
 
@@ -131,7 +141,7 @@ The remaining fields tune connection lifecycle, pooling, and observability. Each
 | `reconnect` (`BackoffConfig`) | exponential reconnect backoff with full jitter | `50.millis` to `5.seconds`, ×2 |
 | `watchdog` (`WatchdogConfig`) | idle-connection liveness ping (death detector) | ping every `60.seconds`, `30.seconds` timeout |
 | `closeTimeout` | how long `close` waits for in-flight commands on the multiplexed connection to drain (blocking commands and transactions on the dedicated pool are force-closed at once) | `5.seconds` |
-| `dedicatedPool` (`DedicatedPoolConfig`) | the pool behind blocking commands and transactions | max `8`, acquire `5.seconds`, idle `30.seconds` |
+| `dedicatedPool` (`DedicatedPoolConfig`) | the pool behind blocking commands and transactions; in cluster mode the limit is per master | max `8` per master, acquire `5.seconds`, idle `30.seconds` |
 | `pubsub` (`PubSubConfig`) | per-subscription message buffer size | `128` |
 | `clientCache` (`CacheConfig`) | client-side caching on/off and size cap | enabled, `64 MB` |
 | `clientName` | `CLIENT SETNAME`, shown in `CLIENT LIST` / `CLIENT INFO` | none |
@@ -150,6 +160,9 @@ val config = SageConfig(
   clientName = Some("orders-service")
 )
 ```
+
+For a cluster with `N` masters, the maximum number of Dedicated Connections is `N × dedicatedPool.maxConnections` (in addition to each
+master's multiplexed connection). Replica reads do not consume this pool: blocking commands and transactions remain master-routed.
 
 Disable client-side caching where the server permits ordinary commands but denies `CLIENT TRACKING` (some proxies and ACL setups); `cached` reads then run without caching, keeping the call portable:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,17 +37,12 @@ val config = SageConfig(
 ```
 
 Seeds bootstrap discovery only. Once the topology is known, sage routes to the nodes the cluster reports; any one seed answering is enough.
-Bootstrap requires at least one reported slot owner. A reachable node whose `CLUSTER SLOTS` reply is empty fails with
-`ClusterUnavailable`, while a non-cluster server's own error is preserved instead of being reported as a connection failure. A later refresh
-that briefly sees no slot owners keeps the last usable topology rather than retiring every known node.
+Bootstrap requires at least one reported slot owner. A reachable node whose `CLUSTER SLOTS` reply is empty fails with `ClusterUnavailable`, while a non-cluster server's own error is preserved instead of being reported as a connection failure. A later refresh that briefly sees no slot owners keeps the last usable topology rather than retiring every known node.
 Set `database` to a non-zero value for a Valkey 9+ cluster configured with a sufficiently large `cluster-databases` setting. Sage issues `SELECT` while establishing every node connection, including after reconnects and redirects. Servers without numbered cluster database support reject the connection.
 
-Topology refresh is event-driven rather than periodic. `MOVED`, unreachable owners, transaction ownership faults, subscription re-homing,
-and replica-policy fallbacks trigger discovery. Ordinary triggers are throttled by `ClusterConfig.minRefreshInterval`; recovery paths for a
-command known not to have reached the server and transaction re-pinning force a single-flight refresh outside that interval.
+Topology refresh is event-driven rather than periodic. `MOVED`, unreachable owners, transaction ownership faults, subscription re-homing, and replica-policy fallbacks trigger discovery. Ordinary triggers are throttled by `ClusterConfig.minRefreshInterval`; recovery paths for a command known not to have reached the server and transaction re-pinning force a single-flight refresh outside that interval.
 
-All-masters broadcasts fail as a whole if any master fails. When a failure proves a request was not sent, sage refreshes topology for the
-next call but does not replay successful masters; callers may retry the whole broadcast only when repeating its successful portions is safe.
+All-masters broadcasts fail as a whole if any master fails. When a failure proves a request was not sent, sage refreshes topology for the next call but does not replay successful masters; callers may retry the whole broadcast only when repeating its successful portions is safe.
 
 ### Hash tags
 
@@ -161,8 +156,7 @@ val config = SageConfig(
 )
 ```
 
-For a cluster with `N` masters, the maximum number of Dedicated Connections is `N × dedicatedPool.maxConnections` (in addition to each
-master's multiplexed connection). Replica reads do not consume this pool: blocking commands and transactions remain master-routed.
+For a cluster with `N` masters, the maximum number of Dedicated Connections is `N × dedicatedPool.maxConnections` (in addition to each master's multiplexed connection). Replica reads do not consume this pool: blocking commands and transactions remain master-routed.
 
 Disable client-side caching where the server permits ordinary commands but denies `CLIENT TRACKING` (some proxies and ACL setups); `cached` reads then run without caching, keeping the call portable:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,12 +37,7 @@ val config = SageConfig(
 ```
 
 Seeds bootstrap discovery only. Once the topology is known, sage routes to the nodes the cluster reports; any one seed answering is enough.
-Bootstrap requires at least one reported slot owner. A reachable node whose `CLUSTER SLOTS` reply is empty fails with `ClusterUnavailable`, while a non-cluster server's own error is preserved instead of being reported as a connection failure. A later refresh that briefly sees no slot owners keeps the last usable topology rather than retiring every known node.
 Set `database` to a non-zero value for a Valkey 9+ cluster configured with a sufficiently large `cluster-databases` setting. Sage issues `SELECT` while establishing every node connection, including after reconnects and redirects. Servers without numbered cluster database support reject the connection.
-
-Topology refresh is event-driven rather than periodic. `MOVED`, unreachable owners, transaction ownership faults, subscription re-homing, and replica-policy fallbacks trigger discovery. Ordinary triggers are throttled by `ClusterConfig.minRefreshInterval`; recovery paths for a command known not to have reached the server and transaction re-pinning force a single-flight refresh outside that interval.
-
-All-masters broadcasts fail as a whole if any master fails. When a failure proves a request was not sent, sage refreshes topology for the next call but does not replay successful masters; callers may retry the whole broadcast only when repeating its successful portions is safe.
 
 ### Hash tags
 
@@ -155,8 +150,6 @@ val config = SageConfig(
   clientName = Some("orders-service")
 )
 ```
-
-For a cluster with `N` masters, the maximum number of Dedicated Connections is `N × dedicatedPool.maxConnections` (in addition to each master's multiplexed connection). Replica reads do not consume this pool: blocking commands and transactions remain master-routed.
 
 Disable client-side caching where the server permits ordinary commands but denies `CLIENT TRACKING` (some proxies and ACL setups); `cached` reads then run without caching, keeping the call portable:
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -19,7 +19,7 @@ Every sage failure is a `SageException`, a single sealed hierarchy you can match
 | `TimedOut(message)` | A blocking command or transaction waited past `dedicatedPool.acquireTimeout` for a free pooled connection. Not a per-command timeout; bound a command's own duration with your backend's timeout combinator. |
 | `TransactionDiscarded(message)` | A transaction was discarded server-side (`EXECABORT`); nothing ran. |
 | `NotCacheable(message)` | `cached` was given a command that cannot be safely cached. |
-| `InvalidArgument(message)` | An argument the API can never accept: an invalid configuration or rate-limit policy, a blocking command in a pipeline or transaction, a node-local command without an explicit `runOn` target, or a command a cluster client cannot otherwise serve as routed (an all-masters command in a cluster pipeline, a cluster-wide result in a single-node transaction, a hand-built command it cannot route by key). A programming error, rejected before any server call. |
+| `InvalidArgument(message)` | An argument the API can never accept: an invalid configuration or rate-limit policy, a blocking command in a pipeline or transaction, or a command a cluster client cannot serve as routed (an all-masters command in a cluster pipeline, a cluster-wide result in a single-node transaction, a hand-built command it cannot route by key). A programming error, rejected before any server call. |
 
 ## Branching on the failure
 
@@ -46,7 +46,7 @@ def classify(e: SageException): String = e match {
 - `false` means the command was never sent, so retrying is always safe.
 - `true` means it was already in flight when the connection dropped, so the server may or may not have applied it. A non-idempotent command (an `INCR`, an `LPUSH`) is then not safe to blindly retry; an idempotent one (a `SET` to a fixed value) is.
 
-Sage never retries an ambiguous in-flight loss for you, and it does not queue commands while disconnected (see [What happens when the connection drops?](/faq#what-happens-when-the-connection-drops)). Cluster redirects, commands known not to have been sent, and explicit temporary refusals such as `TRYAGAIN`, `CLUSTERDOWN`, and `LOADING` have bounded internal recovery because the server did not execute them. This flag gives you what you need to decide about every other retry.
+Sage never retries an ambiguous in-flight loss or queues commands while disconnected. Cluster redirects, commands known not to have been sent, and explicit transient refusals use bounded internal recovery. See [What happens when the connection drops?](/faq#what-happens-when-the-connection-drops).
 
 ::: warning
 When `mayHaveExecuted` is `true`, do not blindly retry a non-idempotent command: it may already have run. Retry only when the command is idempotent, or make it so first.

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -12,13 +12,14 @@ Every sage failure is a `SageException`, a single sealed hierarchy you can match
 | `ConnectionFailed(message)` | The initial connection could not be established (host unreachable, connection refused, or connect timeout). Distinct from `ConnectionLost`, which is a live connection dropping. |
 | `ConnectionLost(mayHaveExecuted)` | The connection dropped around this command. |
 | `NotConnected()` | The client was never started, or has been closed. |
+| `ClusterUnavailable(message)` | A cluster endpoint was reachable, but no usable slot owners were available, so keyed commands cannot currently be routed. |
 | `UnsupportedServer(message)` | The server rejected `HELLO 3` (it predates RESP3, or is a RESP2-only proxy). |
 | `TlsError(message)` | TLS could not be established (rejected certificate or unusable trust material). |
 | `CrossSlot(message)` | An unsupported multi-key command or a transaction touched keys in more than one cluster slot. `MGET`, `MSET`, `EXISTS`, `DEL`, `UNLINK`, and `TOUCH` are transparently split outside transactions. |
 | `TimedOut(message)` | A blocking command or transaction waited past `dedicatedPool.acquireTimeout` for a free pooled connection. Not a per-command timeout; bound a command's own duration with your backend's timeout combinator. |
 | `TransactionDiscarded(message)` | A transaction was discarded server-side (`EXECABORT`); nothing ran. |
 | `NotCacheable(message)` | `cached` was given a command that cannot be safely cached. |
-| `InvalidArgument(message)` | An argument the API can never accept: an invalid configuration or rate-limit policy, a blocking command in a pipeline or transaction, or a command a cluster client cannot serve as routed (an all-masters command in a cluster pipeline, a cluster-wide result in a single-node transaction, a hand-built command it cannot route by key). A programming error, rejected before any server call. |
+| `InvalidArgument(message)` | An argument the API can never accept: an invalid configuration or rate-limit policy, a blocking command in a pipeline or transaction, a node-local command without an explicit `runOn` target, or a command a cluster client cannot otherwise serve as routed (an all-masters command in a cluster pipeline, a cluster-wide result in a single-node transaction, a hand-built command it cannot route by key). A programming error, rejected before any server call. |
 
 ## Branching on the failure
 
@@ -45,7 +46,7 @@ def classify(e: SageException): String = e match {
 - `false` means the command was never sent, so retrying is always safe.
 - `true` means it was already in flight when the connection dropped, so the server may or may not have applied it. A non-idempotent command (an `INCR`, an `LPUSH`) is then not safe to blindly retry; an idempotent one (a `SET` to a fixed value) is.
 
-Sage does not retry for you, and it does not queue commands while disconnected (see [What happens when the connection drops?](/faq#what-happens-when-the-connection-drops)). This flag gives you what you need to decide.
+Sage never retries an ambiguous in-flight loss for you, and it does not queue commands while disconnected (see [What happens when the connection drops?](/faq#what-happens-when-the-connection-drops)). Cluster redirects, commands known not to have been sent, and explicit temporary refusals such as `TRYAGAIN`, `CLUSTERDOWN`, and `LOADING` have bounded internal recovery because the server did not execute them. This flag gives you what you need to decide about every other retry.
 
 ::: warning
 When `mayHaveExecuted` is `true`, do not blindly retry a non-idempotent command: it may already have run. Retry only when the command is idempotent, or make it so first.

--- a/docs/pipelines-transactions.md
+++ b/docs/pipelines-transactions.md
@@ -124,6 +124,7 @@ A few rules follow from how Redis transactions work:
 - **A queueing-phase rejection discards the whole transaction**, so nothing runs.
 - **An execution-phase error leaves the other commands committed.** Redis does not roll back, so those errors surface per position, like a pipeline.
 - **In a cluster, every key in the transaction must hash to one slot** (use a [hash tag](/configuration#hash-tags) to force that). A pipeline has no such restriction for commands with documented cross-slot support.
+- **A cluster transaction never follows a redirect.** It surfaces the ownership error and refreshes topology in the background so a caller retry can re-pin the whole block atomically. During live resharding an `ASK` does not change the recorded owner, so bound and pace application-level transaction retries; an unbounded loop can keep retrying until the migration ends.
 
 ## Which to use
 

--- a/docs/pipelines-transactions.md
+++ b/docs/pipelines-transactions.md
@@ -124,7 +124,7 @@ A few rules follow from how Redis transactions work:
 - **A queueing-phase rejection discards the whole transaction**, so nothing runs.
 - **An execution-phase error leaves the other commands committed.** Redis does not roll back, so those errors surface per position, like a pipeline.
 - **In a cluster, every key in the transaction must hash to one slot** (use a [hash tag](/configuration#hash-tags) to force that). A pipeline has no such restriction for commands with documented cross-slot support.
-- **A cluster transaction never follows a redirect.** It surfaces the ownership error and refreshes topology in the background so a caller retry can re-pin the whole block atomically. During live resharding an `ASK` does not change the recorded owner, so bound and pace application-level transaction retries; an unbounded loop can keep retrying until the migration ends.
+- **A cluster transaction never follows a redirect.** It surfaces the ownership error and refreshes topology so a caller retry can re-pin the whole block. Pace application-level retries during live resharding.
 
 ## Which to use
 

--- a/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
+++ b/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
@@ -29,7 +29,8 @@ final case class WatchdogConfig(
 
 /**
   * The on-demand pool of Dedicated Connections for blocking commands. `acquireTimeout` bounds only the wait for a free slot, never a
-  * command's own block timeout; idle connections are evicted after `idleTimeout` (`Duration.Inf` keeps them forever).
+  * command's own block timeout; idle connections are evicted after `idleTimeout` (`Duration.Inf` keeps them forever). In cluster mode each
+  * master owns one such pool, so `maxConnections` is a per-master limit rather than a client-wide total.
   */
 final case class DedicatedPoolConfig(
   maxConnections: Int = 8,
@@ -97,8 +98,10 @@ final case class CacheConfig(enabled: Boolean = true, maxBytes: Long = 64L * 102
 final case class Endpoint(host: String = "localhost", port: Int = 6379)
 
 /**
-  * Cluster tuning. `maxRedirects` bounds how many `MOVED`/`ASK` hops a single command follows before failing (the same default as
-  * lettuce); `minRefreshInterval` throttles topology refreshes so a redirect storm triggers at most one `CLUSTER SLOTS` per window.
+  * Cluster tuning. `maxRedirects` bounds how many `MOVED`/`ASK` hops or transient server refusals a single command follows before failing
+  * (the same default as lettuce for redirects); `minRefreshInterval` throttles ordinary event-driven topology refreshes so a redirect storm
+  * triggers at most one `CLUSTER SLOTS` per window. Recovery paths that know a command was not sent, and transaction faults whose caller must
+  * re-pin, force refresh outside that interval while still collapsing concurrent refreshes.
   */
 final case class ClusterConfig(
   maxRedirects: Int = 5,

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -13,7 +13,7 @@ import scala.util.control.NonFatal
 import kyo.compat.*
 
 import sage.{Bytes, CommandSpan, Message, PatternMessage, SageEvent, SageException}
-import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, InvalidArgument, NotConnected, ServerError}
+import sage.SageException.{ClusterUnavailable, ConnectionLost, CrossSlot, DecodeError, InvalidArgument, NotConnected, ServerError}
 import sage.client.{BackoffConfig, ClusterConfig, DedicatedPoolConfig, ReadFrom, SageConfig, WatchdogConfig}
 import sage.cluster.{ClusterTopology, Node, NodeGroup, Redirect, RedirectKind, Rejected, Route, Shard, Slot, SplitPlan}
 import sage.codec.{KeyCodec, ValueCodec}
@@ -104,19 +104,22 @@ final private[client] class ClusterLive(
 
   // if no seed answers, throws the last failure so the first connect surfaces a handshake/TLS error like a standalone connect, not None
   private[client] def bootstrapTopology(): Unit = {
-    var lastError: Throwable = NotConnected()
-    val candidates           = seeds.iterator
+    var lastError: Throwable          = NotConnected()
+    var lastDiscoveryError: Throwable = null
+    val candidates                    = seeds.iterator
     while (candidates.hasNext) {
       val node = candidates.next()
       try
         querySlotsVia(getOrEstablish(node)) match {
-          case Some(shards) => adopt(node, shards); return
-          case None         => ()
+          case Right(shards) if shards.nonEmpty => adopt(node, shards); return
+          case Right(_)                         =>
+            lastDiscoveryError = ClusterUnavailable(s"cluster seed ${node.host}:${node.port} reported no slot owners")
+          case Left(error)                      => lastDiscoveryError = error
         }
       catch { case NonFatal(error) => lastError = error }
     }
     closeAll()
-    throw lastError
+    throw Option(lastDiscoveryError).getOrElse(lastError)
   }
 
   def run[A](command: Command[A]): CIO[A] = {
@@ -361,6 +364,7 @@ final private[client] class ClusterLive(
   // walk the policy's ordered candidates, falling through on connection loss; strict Replica with no live replica exhausts to NotConnected
   private def sendRead[A](command: Command[A], master: Node, slot: Slot, redirectsLeft: Int, complete: Try[A] => Unit): Unit = {
     val replicas = topologyRef.get().shardForSlot(slot).map(_.replicas).getOrElse(Vector.empty)
+    if (readFrom == ReadFrom.ReplicaPreferred && replicas.isEmpty) triggerRefresh()
     val cursor   = replicaCursors.computeIfAbsent(master, _ => new java.util.concurrent.atomic.AtomicInteger())
     tryReadCandidates(command, ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement()), master, redirectsLeft, complete)
   }
@@ -370,6 +374,7 @@ final private[client] class ClusterLive(
     pickNode(topology) match {
       case Some(master) =>
         val replicas = topology.shards.iterator.flatMap(_.replicas).toVector.distinct
+        if (readFrom == ReadFrom.ReplicaPreferred && replicas.isEmpty) triggerRefresh()
         tryReadCandidates(
           command,
           ReadRouting.candidates(readFrom, master, replicas, keylessCursor.getAndIncrement()),
@@ -432,18 +437,34 @@ final private[client] class ClusterLive(
         redirect.kind match {
           // strict Replica must not follow ASK onto the importing master (the migrating key is on no replica); MOVED refreshes and re-dispatches
           case RedirectKind.Ask                         =>
-            if (readFrom == ReadFrom.Replica) complete(Failure(NotConnected()))
+            if (readFrom == ReadFrom.Replica) { Events.attributeNode(complete, node); complete(Failure(error)) }
             else onRedirect(node, redirect, command, redirectsLeft, complete)
           case RedirectKind.Moved if redirectsLeft <= 0 =>
-            complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
+            complete(Failure(redirectFailure(redirect)))
           case RedirectKind.Moved                       => refresh(force = true); offload(dispatch(command, redirectsLeft - 1, complete))
         }
       case Fault.Lost(false)                =>
-        if (rest.nonEmpty) tryReadCandidates(command, rest, master, redirectsLeft, complete) else onUnreachable(command, redirectsLeft, complete)
+        if (rest.nonEmpty) continueRead(command, node, rest, master, redirectsLeft, complete)
+        else onUnreachable(command, redirectsLeft, complete)
       case Fault.TryAgain                   => onTryAgain(command, error, redirectsLeft, complete)
+      case Fault.TemporarilyUnavailable     =>
+        if (rest.nonEmpty) continueRead(command, node, rest, master, redirectsLeft, complete)
+        else onTryAgain(command, error, redirectsLeft, complete)
       case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error))
       case Fault.Fatal                      => Events.attributeNode(complete, node); complete(Failure(error))
     }
+
+  private def continueRead[A](
+    command: Command[A],
+    failedNode: Node,
+    rest: Vector[Node],
+    master: Node,
+    redirectsLeft: Int,
+    complete: Try[A] => Unit
+  ): Unit = {
+    if (readFrom == ReadFrom.ReplicaPreferred && failedNode != master && rest.contains(master)) triggerRefresh()
+    tryReadCandidates(command, rest, master, redirectsLeft, complete)
+  }
 
   private def broadcast[A](topology: ClusterTopology, command: Command[A], complete: Try[A] => Unit, resolve: Node => NodeClient): Unit =
     command.broadcast match {
@@ -464,7 +485,7 @@ final private[client] class ClusterLive(
       def settle(result: Try[A]): Unit = {
         result match {
           case Success(_) => firstValue.compareAndSet(null, result)
-          case Failure(e) => firstError.compareAndSet(null, e)
+          case Failure(e) => refreshBroadcastTopology(e); firstError.compareAndSet(null, e)
         }
         if (remaining.decrementAndGet() == 0)
           complete(Option(firstError.get()).map(Failure(_)).getOrElse(firstValue.get()))
@@ -497,7 +518,7 @@ final private[client] class ClusterLive(
       def settle(index: Int, result: Try[Frame]): Unit = {
         result match {
           case Success(frame) => frames.set(index, frame)
-          case Failure(e)     => firstError.compareAndSet(null, e)
+          case Failure(e)     => refreshBroadcastTopology(e); firstError.compareAndSet(null, e)
         }
         if (remaining.decrementAndGet() == 0)
           Option(firstError.get()) match {
@@ -528,6 +549,12 @@ final private[client] class ClusterLive(
     })
 
   private def decodeMerged[A](command: Command[A], merged: Frame): Try[A] = Reply.decode(command, merged)
+
+  private def refreshBroadcastTopology(error: Throwable): Unit =
+    Fault.categorize(error) match {
+      case Fault.Lost(false) => triggerRefresh()
+      case _                 => ()
+    }
 
   private def sendToAny[A](
     topology: ClusterTopology,
@@ -594,6 +621,7 @@ final private[client] class ClusterLive(
       case Fault.Redirected(redirect)       => onRedirect(node, redirect, command, redirectsLeft, complete, lease, cacheCtx)
       case Fault.Lost(false)                => onUnreachable(command, redirectsLeft, complete, lease, cacheCtx)
       case Fault.TryAgain                   => onTryAgain(command, error, redirectsLeft, complete, lease, cacheCtx)
+      case Fault.TemporarilyUnavailable     => onTryAgain(command, error, redirectsLeft, complete, lease, cacheCtx)
       case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error))
       case Fault.Fatal                      => Events.attributeNode(complete, node); complete(Failure(error))
     }
@@ -610,7 +638,7 @@ final private[client] class ClusterLive(
     // a MOVED proves `from` lost the slot; retire its cache even if the retry budget is now exhausted
     if (redirect.kind == RedirectKind.Moved) flushNode(from)
     if (redirectsLeft <= 0)
-      complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
+      complete(Failure(redirectFailure(redirect)))
     else {
       val target = resolve(redirect.target, from)
       redirect.kind match {
@@ -618,6 +646,14 @@ final private[client] class ClusterLive(
         case RedirectKind.Ask   => sendTo(target, command, asking = true, redirectsLeft - 1, complete, lease, cacheCtx)
       }
     }
+  }
+
+  private def redirectFailure(redirect: Redirect): ServerError = {
+    val code = redirect.kind match {
+      case RedirectKind.Moved => "MOVED"
+      case RedirectKind.Ask   => "ASK"
+    }
+    ServerError(code, s"${redirect.slot.value} ${redirect.target.host}:${redirect.target.port}")
   }
 
   // the command provably never executed: refresh to adopt the promoted master, then re-route. Jittered backoff paces retries so an in-progress
@@ -758,6 +794,7 @@ final private[client] class ClusterLive(
   // the read candidates for `master`'s shard under the policy, advancing its round-robin cursor once
   private def readCandidates(master: Node): Vector[Node] = {
     val replicas = topologyRef.get().shards.collectFirst { case s if s.master == master => s.replicas }.getOrElse(Vector.empty)
+    if (readFrom == ReadFrom.ReplicaPreferred && replicas.isEmpty) triggerRefresh()
     val cursor   = replicaCursors.computeIfAbsent(master, _ => new java.util.concurrent.atomic.AtomicInteger())
     ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement())
   }
@@ -841,13 +878,14 @@ final private[client] class ClusterLive(
             case Fault.Redirected(redirect)       =>
               redirect.kind match {
                 // strict Replica must not follow ASK onto the importing master (mirrors the single-read path at onReadFailure)
-                case RedirectKind.Ask if useReplica && readFrom == ReadFrom.Replica => settle(index, Failure(NotConnected()))
+                case RedirectKind.Ask if useReplica && readFrom == ReadFrom.Replica => settle(index, result)
                 case RedirectKind.Ask                                               =>
                   onRedirect(target, redirect, p.commands(index), cluster.maxRedirects, emits(index))
                 case RedirectKind.Moved                                             => reroute(index)
               }
             case Fault.Lost(false)                => reroute(index)
             case Fault.TryAgain                   => onTryAgain(p.commands(index), error, cluster.maxRedirects, emits(index))
+            case Fault.TemporarilyUnavailable     => onTryAgain(p.commands(index), error, cluster.maxRedirects, emits(index))
             case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); settle(index, result)
             case Fault.Fatal                      => settle(index, result)
           }
@@ -1133,19 +1171,16 @@ final private[client] class ClusterLive(
     candidates.iterator.flatMap(trySlots).nextOption()
 
   private def trySlots(node: Node): Option[(Node, Vector[Shard])] =
-    try querySlotsVia(getOrEstablish(node)).map(node -> _)
+    try querySlotsVia(getOrEstablish(node)).toOption.filter(_.nonEmpty).map(node -> _)
     catch { case NonFatal(_) => None }
 
-  private def querySlotsVia(nc: NodeClient): Option[Vector[Shard]] = {
+  private def querySlotsVia(nc: NodeClient): Either[Throwable, Vector[Shard]] = {
     val latch   = new CountDownLatch(1)
     val outcome = new AtomicReference[Try[Vector[Shard]]]()
     nc.submit[Vector[Shard]](Cluster.slots, asking = false, result => { outcome.set(result); latch.countDown() })
-    if (!latch.await(connectTimeout.toMillis, TimeUnit.MILLISECONDS)) None
-    else
-      outcome.get() match {
-        case Success(shards) => Some(shards)
-        case Failure(_)      => None
-      }
+    if (!latch.await(connectTimeout.toMillis, TimeUnit.MILLISECONDS))
+      Left(ClusterUnavailable(s"CLUSTER SLOTS timed out after ${connectTimeout.toMillis}ms"))
+    else outcome.get().toEither
   }
 
   // prunes bundles for masters it no longer lists, so a vanished node's reconnect loop cannot leak; an empty announce-IP from CLUSTER SLOTS

--- a/sage-client/shared/src/main/scala/sage/client/internal/Fault.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Fault.scala
@@ -11,12 +11,13 @@ private[client] enum Fault {
   case Demoted
   case Lost(mayHaveExecuted: Boolean)
   case TryAgain
+  case TemporarilyUnavailable
   case Fatal
 
-  // an ownership or connection change the topology must adopt; a data error or a transient mid-migration TryAgain leaves the mapping valid
+  // an ownership or connection change the topology must adopt; transient server refusals leave the mapping valid
   def refreshesTopology: Boolean = this match {
-    case Fatal | TryAgain => false
-    case _                => true
+    case Fatal | TryAgain | TemporarilyUnavailable => false
+    case _                                         => true
   }
 }
 
@@ -26,10 +27,12 @@ private[client] object Fault {
     error match {
       case e: ServerError           =>
         Redirect.parse(e.getMessage) match {
-          case Some(redirect)               => Fault.Redirected(redirect)
-          case None if e.code == "READONLY" => Fault.Demoted
-          case None if e.code == "TRYAGAIN" => Fault.TryAgain
-          case None                         => Fault.Fatal
+          case Some(redirect)                                                                   => Fault.Redirected(redirect)
+          case None if e.code == "READONLY"                                                     => Fault.Demoted
+          case None if e.code == "TRYAGAIN"                                                     => Fault.TryAgain
+          case None if e.code == "CLUSTERDOWN" || e.code == "LOADING" || e.code == "MASTERDOWN" =>
+            Fault.TemporarilyUnavailable
+          case None                                                                             => Fault.Fatal
         }
       case NotConnected()           => Fault.Lost(mayHaveExecuted = false)
       case ConnectionLost(executed) => Fault.Lost(executed)

--- a/sage-client/shared/src/test/scala/sage/client/internal/FaultSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/FaultSpec.scala
@@ -27,6 +27,12 @@ class FaultSpec extends munit.FunSuite {
     assertEquals(Fault.categorize(ServerError("TRYAGAIN", "Multiple keys request during rehashing of slot")), Fault.TryAgain)
   }
 
+  List("CLUSTERDOWN", "LOADING", "MASTERDOWN").foreach { code =>
+    test(s"a $code reply categorizes as TemporarilyUnavailable") {
+      assertEquals(Fault.categorize(ServerError(code, "temporarily unavailable")), Fault.TemporarilyUnavailable)
+    }
+  }
+
   test("any other ServerError categorizes as Fatal") {
     assertEquals(Fault.categorize(ServerError("WRONGTYPE", "Operation against a key holding the wrong kind of value")), Fault.Fatal)
     assertEquals(Fault.categorize(ServerError("ERR", "foo bar")), Fault.Fatal)

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration.*
 import kyo.compat.*
 
 import sage.Bytes
-import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, InvalidArgument, NotConnected, ServerError}
+import sage.SageException.{ClusterUnavailable, ConnectionLost, CrossSlot, DecodeError, InvalidArgument, NotConnected, ServerError}
 import sage.client.internal.{ClusterLive, CountingScheduler, FakeTransport, MultiplexedConnection, Scheduler}
 import sage.cluster.{Node, Slot}
 import sage.commands.{BroadcastReduce, Command, Connection, Json, JsonPath, Keys, Scripting, Server, Strings}
@@ -53,7 +53,9 @@ class ClusterClientSpec extends munit.FunSuite {
     readFrom: ReadFrom = ReadFrom.Master,
     connectGate: (Node, Int) => Unit = (_, _) => (), // blocks a node's nth transport creation, to park an establish mid-flight
     scheduler: Scheduler = Scheduler.real,
-    caching: Boolean = false
+    caching: Boolean = false,
+    clusterConfig: ClusterConfig = ClusterConfig(),
+    autoBootstrap: Boolean = true
   ) {
 
     // accumulate every transport per node (a node has both a Multiplexed and, once a transaction pins, a Dedicated connection) so a refresh
@@ -93,7 +95,7 @@ class ClusterClientSpec extends munit.FunSuite {
         1.second,
         Duration.Zero,
         DedicatedPoolConfig(),
-        ClusterConfig(),
+        clusterConfig,
         1024,
         seeds,
         readFrom,
@@ -101,7 +103,7 @@ class ClusterClientSpec extends munit.FunSuite {
         cacheMaxBytes = if (caching) 1L << 20 else 0L
       )
 
-    live.bootstrapTopology()
+    if (autoBootstrap) live.bootstrapTopology()
 
     def written(node: Node): Vector[String] = transportsOf(node).flatMap(_.written.map(_.asUtf8String))
 
@@ -126,6 +128,44 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   private def wholeClusterOn(node: Node): Frame = slotsFrame((node, 0, Slot.Count - 1))
+
+  test("bootstrap rejects an empty CLUSTER SLOTS topology with a cluster-specific error") {
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(Frame.Array(Vector.empty)) else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA), autoBootstrap = false)
+
+    val error = intercept[ClusterUnavailable](fixture.live.bootstrapTopology())
+    assert(error.getMessage.contains("no slot owners"), s"unexpected message: ${error.getMessage}")
+  }
+
+  test("bootstrap preserves a CLUSTER SLOTS server error instead of replacing it with NotConnected") {
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(Frame.SimpleError("ERR This instance has cluster support disabled"))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA), autoBootstrap = false)
+
+    val error = intercept[ServerError](fixture.live.bootstrapTopology())
+    assertEquals(error.code, "ERR")
+    assert(error.detail.contains("cluster support disabled"), s"unexpected detail: ${error.detail}")
+  }
+
+  test("a later unreachable seed does not erase an earlier empty-topology diagnostic") {
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(Frame.Array(Vector.empty)) else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA, nodeB), unreachable = Set(nodeB), autoBootstrap = false)
+
+    val error = intercept[ClusterUnavailable](fixture.live.bootstrapTopology())
+    assert(error.getMessage.contains(nodeA.host), s"unexpected message: ${error.getMessage}")
+  }
+
+  test("a later unreachable seed does not erase an earlier CLUSTER SLOTS server error") {
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(Frame.SimpleError("ERR This instance has cluster support disabled"))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA, nodeB), unreachable = Set(nodeB), autoBootstrap = false)
+
+    val error = intercept[ServerError](fixture.live.bootstrapTopology())
+    assertEquals(error.code, "ERR")
+    assert(error.detail.contains("cluster support disabled"), s"unexpected detail: ${error.detail}")
+  }
 
   test("routes a single-key command to the slot's owner") {
     // nodeA owns the lower half, nodeB the upper half
@@ -350,6 +390,26 @@ class ClusterClientSpec extends munit.FunSuite {
     }
   }
 
+  test("an unsent broadcast failure triggers topology refresh without replaying successful masters") {
+    val mid          = Slot.Count / 2
+    val clusterCalls = new java.util.concurrent.atomic.AtomicInteger()
+    val behaviour    = (_: Node, text: String) =>
+      if (text.contains("CLUSTER"))
+        if (clusterCalls.getAndIncrement() == 0) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+        else Seq(wholeClusterOn(nodeA))
+      else if (text.contains("DBSIZE")) Seq(Frame.Integer(1L))
+      else Seq(Frame.Null)
+    val fixture      = new Fixture(behaviour, Vector(nodeA), unreachable = Set(nodeB))
+
+    fixture.live.run(Server.dbSize).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[NotConnected], s"expected the original broadcast failure, got $error")
+      val deadline = System.nanoTime() + 2000000000L
+      while (clusterCalls.get() < 2 && System.nanoTime() < deadline) Thread.sleep(5)
+      assert(clusterCalls.get() >= 2, "an unsent broadcast failure did not refresh the stale master roster")
+      assertEquals(fixture.written(nodeA).count(_.contains("DBSIZE")), 1, "the successful shard must not be replayed automatically")
+    }
+  }
+
   test("a broadcast fold that throws on a reply arriving after dispatch fails the command rather than hanging the caller") {
     val mid       = Slot.Count / 2
     val behaviour =
@@ -492,6 +552,29 @@ class ClusterClientSpec extends munit.FunSuite {
     }
   }
 
+  test("ReplicaPreferred refreshes an empty replica roster so a newly added replica becomes eligible") {
+    val nodeR        = Node("r", 6379)
+    val clusterCalls = new java.util.concurrent.atomic.AtomicInteger()
+    def withReplica  =
+      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+    val behaviour    = (node: Node, text: String) =>
+      if (text.contains("CLUSTER"))
+        if (clusterCalls.getAndIncrement() == 0) Seq(wholeClusterOn(nodeA)) else Seq(withReplica)
+      else if (text.contains("READONLY")) Seq(Frame.SimpleString("OK"))
+      else Seq(Frame.BulkString(Bytes.utf8(if (node == nodeR) "from-replica" else "from-master")))
+    val fixture      = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.ReplicaPreferred)
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.flatMap { first =>
+      assertEquals(first, Some("from-master"))
+      val deadline = System.nanoTime() + 2000000000L
+      while (clusterCalls.get() < 2 && System.nanoTime() < deadline) Thread.sleep(5)
+      assert(clusterCalls.get() >= 2, "falling back with no known replica did not trigger a topology refresh")
+      fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { second =>
+        assertEquals(second, Some("from-replica"))
+      }
+    }
+  }
+
   test("follows a MOVED redirect to the named node and refreshes") {
     // topology says nodeA owns everything, but nodeA reports the slot has MOVED to nodeB
     val behaviour = (node: Node, text: String) =>
@@ -503,6 +586,21 @@ class ClusterClientSpec extends munit.FunSuite {
     fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
       assertEquals(result, Some("from-b"))
       assert(fixture.written(nodeB).exists(_.contains("GET")), "redirect target did not receive GET")
+    }
+  }
+
+  test("an exhausted redirect budget preserves the original MOVED error") {
+    val slot      = Slot.of(Bytes.utf8("foo")).value
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (node == nodeA) Seq(Frame.SimpleError(s"MOVED $slot ${nodeB.host}:${nodeB.port}"))
+      else Seq(Frame.BulkString(Bytes.utf8("unexpected")))
+    val fixture   = new Fixture(behaviour, Vector(nodeA), clusterConfig = ClusterConfig(maxRedirects = 0))
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[ServerError], s"expected the original MOVED ServerError, got $error")
+      assertEquals(error.asInstanceOf[ServerError].code, "MOVED")
+      assert(!fixture.written(nodeB).exists(_.contains("GET")), "the client followed a redirect after exhausting its budget")
     }
   }
 
@@ -533,6 +631,59 @@ class ClusterClientSpec extends munit.FunSuite {
     fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
       assertEquals(result, Some("value"))
       assert(attempts.get() >= 2, s"TRYAGAIN was not retried: ${attempts.get()} attempts")
+    }
+  }
+
+  List("CLUSTERDOWN", "LOADING").foreach { code =>
+    test(s"a transient $code reply is retried and eventually succeeds") {
+      val attempts  = new java.util.concurrent.atomic.AtomicInteger(0)
+      val behaviour = (_: Node, text: String) =>
+        if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+        else if (text.contains("GET") && attempts.getAndIncrement() == 0) Seq(Frame.SimpleError(s"$code temporarily unavailable"))
+        else Seq(Frame.BulkString(Bytes.utf8("value")))
+      val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+      fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
+        assertEquals(result, Some("value"))
+        assert(attempts.get() >= 2, s"$code was not retried: ${attempts.get()} attempts")
+      }
+    }
+  }
+
+  test("ReplicaPreferred falls through to the master when a replica replies MASTERDOWN") {
+    val nodeR     = Node("r", 6379)
+    def slots     =
+      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slots)
+      else if (text.contains("READONLY")) Seq(Frame.SimpleString("OK"))
+      else if (node == nodeR) Seq(Frame.SimpleError("MASTERDOWN Link with MASTER is down"))
+      else Seq(Frame.BulkString(Bytes.utf8("from-master")))
+    val fixture   = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.ReplicaPreferred)
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
+      assertEquals(result, Some("from-master"))
+      assert(fixture.written(nodeR).exists(_.contains("GET")), "replica did not receive the first attempt")
+      assert(fixture.written(nodeA).exists(_.contains("GET")), "master did not receive the fallback")
+    }
+  }
+
+  test("strict Replica preserves ASK when it cannot follow the redirect onto an importing master") {
+    val nodeR     = Node("r", 6379)
+    val slot      = Slot.of(Bytes.utf8("foo")).value
+    def slots     =
+      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slots)
+      else if (text.contains("READONLY")) Seq(Frame.SimpleString("OK"))
+      else if (node == nodeR && text.contains("GET")) Seq(Frame.SimpleError(s"ASK $slot b:6379"))
+      else Seq(Frame.BulkString(Bytes.utf8("unexpected")))
+    val fixture   = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.Replica)
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[ServerError], s"expected the original ASK ServerError, got $error")
+      assertEquals(error.asInstanceOf[ServerError].code, "ASK")
+      assert(!fixture.written(nodeB).exists(_.contains("GET")), "strict Replica must not follow ASK onto the importing master")
     }
   }
 

--- a/sage-core/src/main/scala/sage/SageException.scala
+++ b/sage-core/src/main/scala/sage/SageException.scala
@@ -66,6 +66,12 @@ object SageException {
   final case class NotConnected() extends SageException("not connected")
 
   /**
+    * A cluster endpoint was reachable, but no usable slot topology was available. Unlike [[NotConnected]], this says the transport itself
+    * worked; the cluster is still forming, has no assigned slots, or otherwise cannot currently route keyed commands.
+    */
+  final case class ClusterUnavailable(message: String) extends SageException(message)
+
+  /**
     * The server rejected `HELLO 3`: it predates RESP3 (Redis < 6.0) or is a RESP2-only proxy.
     */
   final case class UnsupportedServer(message: String) extends SageException(message)


### PR DESCRIPTION
## What changed

- Preserve actionable `CLUSTER SLOTS` failures during bootstrap and reject empty slot-owner topologies with `ClusterUnavailable`.
- Retry bounded transient cluster refusals (`TRYAGAIN`, `CLUSTERDOWN`, `LOADING`, and replica `MASTERDOWN`) only where the request is known not to have executed.
- Refresh stale replica and broadcast topology without replaying successful broadcast shards.
- Preserve original `MOVED`/`ASK` errors when redirect handling cannot continue.
- Document the new failure, transaction retry behavior, and per-master dedicated-pool limit.

## Why

The cluster runtime previously collapsed some reachable-server discovery failures into generic connection errors, could keep stale replica/master rosters, and sometimes replaced useful redirect diagnostics with synthetic errors. Those behaviors make failover and bootstrap failures harder to diagnose and recover from safely.

## Impact

Cluster callers receive more precise failures and safer bounded recovery during bootstrap, failover, redirects, and replica fallback. Ambiguous in-flight connection losses remain non-retried.

## Validation

- `sbt testUnit`
- `sbt check`
- `git diff --check main...codex/cluster-recovery`