### PR TITLE
Reject an empty CLUSTER SLOTS reply

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -13,7 +13,7 @@ import scala.util.control.NonFatal
 import kyo.compat.*
 
 import sage.{Bytes, CommandSpan, Message, PatternMessage, SageEvent, SageException}
-import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, InvalidArgument, NotConnected, ServerError}
+import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, InvalidArgument, NotConnected, ServerError, TimedOut, UnsupportedServer}
 import sage.client.{BackoffConfig, ClusterConfig, DedicatedPoolConfig, ReadFrom, SageConfig, WatchdogConfig}
 import sage.cluster.{ClusterTopology, Node, NodeGroup, Redirect, RedirectKind, Rejected, Route, Shard, Slot, SplitPlan}
 import sage.codec.{KeyCodec, ValueCodec}
@@ -109,9 +109,9 @@ final private[client] class ClusterLive(
     while (candidates.hasNext) {
       val node = candidates.next()
       try
-        querySlotsVia(getOrEstablish(node)) match {
-          case Some(shards) => adopt(node, shards); return
-          case None         => ()
+        querySlotsVia(node, getOrEstablish(node)) match {
+          case Right(shards) => adopt(node, shards); return
+          case Left(error)   => lastError = error
         }
       catch { case NonFatal(error) => lastError = error }
     }
@@ -1133,18 +1133,26 @@ final private[client] class ClusterLive(
     candidates.iterator.flatMap(trySlots).nextOption()
 
   private def trySlots(node: Node): Option[(Node, Vector[Shard])] =
-    try querySlotsVia(getOrEstablish(node)).map(node -> _)
+    try querySlotsVia(node, getOrEstablish(node)).toOption.map(node -> _)
     catch { case NonFatal(_) => None }
 
-  private def querySlotsVia(nc: NodeClient): Option[Vector[Shard]] = {
+  // a node outside a formed cluster answers CLUSTER SLOTS with an empty array: a non-answer, not a topology owning no slots
+  private def querySlotsVia(node: Node, nc: NodeClient): Either[Throwable, Vector[Shard]] = {
     val latch   = new CountDownLatch(1)
     val outcome = new AtomicReference[Try[Vector[Shard]]]()
     nc.submit[Vector[Shard]](Cluster.slots, asking = false, result => { outcome.set(result); latch.countDown() })
-    if (!latch.await(connectTimeout.toMillis, TimeUnit.MILLISECONDS)) None
+    if (!latch.await(connectTimeout.toMillis, TimeUnit.MILLISECONDS))
+      Left(TimedOut(s"CLUSTER SLOTS on ${node.host}:${node.port} timed out after ${connectTimeout.toMillis}ms"))
     else
       outcome.get() match {
-        case Success(shards) => Some(shards)
-        case Failure(_)      => None
+        case Success(shards) if shards.nonEmpty =>
+          Right(shards)
+        case Success(_)                         =>
+          Left(UnsupportedServer(s"${node.host}:${node.port} owns no slots: it is not part of a formed cluster"))
+        case Failure(error: ServerError)        =>
+          Left(UnsupportedServer(s"${node.host}:${node.port} rejected CLUSTER SLOTS: ${error.getMessage}"))
+        case Failure(error)                     =>
+          Left(error)
       }
   }
 

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -143,12 +143,13 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("a refresh whose candidate owns no slots keeps the working topology instead of closing every master") {
-    val reset     = new java.util.concurrent.atomic.AtomicBoolean(false)
-    val behaviour = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) if (reset.get) Seq(Frame.Array(Vector.empty)) else Seq(wholeClusterOn(nodeA))
-      else if (node == nodeA && reset.compareAndSet(false, true)) Seq(Frame.SimpleError(s"MOVED ${Slot.of(Bytes.utf8("foo")).value} a:6379"))
+    val emptySlotsAfterRedirect = new java.util.concurrent.atomic.AtomicBoolean(false)
+    val behaviour               = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) if (emptySlotsAfterRedirect.get) Seq(Frame.Array(Vector.empty)) else Seq(wholeClusterOn(nodeA))
+      else if (node == nodeA && emptySlotsAfterRedirect.compareAndSet(false, true))
+        Seq(Frame.SimpleError(s"MOVED ${Slot.of(Bytes.utf8("foo")).value} a:6379"))
       else Seq(Frame.BulkString(Bytes.utf8(node.host)))
-    val fixture   = new Fixture(behaviour, Vector(nodeA))
+    val fixture                 = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.flatMap { result =>
       assertEquals(result, Some(nodeA.host))

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration.*
 import kyo.compat.*
 
 import sage.Bytes
-import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, InvalidArgument, NotConnected, ServerError}
+import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, InvalidArgument, NotConnected, ServerError, UnsupportedServer}
 import sage.client.internal.{ClusterLive, CountingScheduler, FakeTransport, MultiplexedConnection, Scheduler}
 import sage.cluster.{Node, Slot}
 import sage.commands.{BroadcastReduce, Command, Connection, Json, JsonPath, Keys, Scripting, Server, Strings}
@@ -126,6 +126,35 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   private def wholeClusterOn(node: Node): Frame = slotsFrame((node, 0, Slot.Count - 1))
+
+  test("a seed that owns no slots fails the bootstrap rather than adopting an empty topology") {
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(Frame.Array(Vector.empty)) else Seq(Frame.Null)
+
+    val error = intercept[UnsupportedServer](new Fixture(behaviour, Vector(nodeA)))
+    assert(error.getMessage.contains("not part of a formed cluster"), error.getMessage)
+  }
+
+  test("a seed with cluster support disabled fails the bootstrap with the server's own reply, not NotConnected") {
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(Frame.SimpleError("ERR This instance has cluster support disabled")) else Seq(Frame.Null)
+
+    val error = intercept[UnsupportedServer](new Fixture(behaviour, Vector(nodeA)))
+    assert(error.getMessage.contains("cluster support disabled"), error.getMessage)
+  }
+
+  test("a refresh whose candidate owns no slots keeps the working topology instead of closing every master") {
+    val reset     = new java.util.concurrent.atomic.AtomicBoolean(false)
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) if (reset.get) Seq(Frame.Array(Vector.empty)) else Seq(wholeClusterOn(nodeA))
+      else if (node == nodeA && reset.compareAndSet(false, true)) Seq(Frame.SimpleError(s"MOVED ${Slot.of(Bytes.utf8("foo")).value} a:6379"))
+      else Seq(Frame.BulkString(Bytes.utf8(node.host)))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.flatMap { result =>
+      assertEquals(result, Some(nodeA.host))
+      fixture.live.run(Strings.get[String, String]("bar")).unsafeRun.map(assertEquals(_, Some(nodeA.host)))
+    }
+  }
 
   test("routes a single-key command to the slot's owner") {
     // nodeA owns the lower half, nodeB the upper half

--- a/sage-core/src/main/scala/sage/SageException.scala
+++ b/sage-core/src/main/scala/sage/SageException.scala
@@ -66,7 +66,8 @@ object SageException {
   final case class NotConnected() extends SageException("not connected")
 
   /**
-    * The server rejected `HELLO 3`: it predates RESP3 (Redis < 6.0) or is a RESP2-only proxy.
+    * The server cannot serve what this client requires: it rejected `HELLO 3` (predates RESP3, or is a RESP2-only proxy), or a cluster
+    * client was pointed at a server that is not part of a formed cluster.
     */
   final case class UnsupportedServer(message: String) extends SageException(message)
 

--- a/sage-core/src/main/scala/sage/SageException.scala
+++ b/sage-core/src/main/scala/sage/SageException.scala
@@ -85,7 +85,8 @@ object SageException {
   final case class CrossSlot(message: String) extends SageException(message)
 
   /**
-    * A blocking command or transaction waited past `dedicatedPool.acquireTimeout` for a free pooled connection. Not a per-command timeout.
+    * A wait ran past its budget: a blocking command or transaction past `dedicatedPool.acquireTimeout` for a free pooled connection, or a
+    * topology probe (`ROLE`, `CLUSTER SLOTS`) past `connectTimeout`. Not a per-command timeout.
     */
   final case class TimedOut(message: String) extends SageException(message)
 


### PR DESCRIPTION
A node outside a formed cluster answers `CLUSTER SLOTS` with an empty array. That decoded to a successful empty topology, which the client then adopted.

At bootstrap, `adopt` published a topology with no owners and `masterPool.retain` closed the seed connection that had just been opened. Connect therefore "succeeded" and every keyed command routed `Route.Unowned` -> `sendToAny` -> `pickNode` returning `None` -> a bare `NotConnected` with nothing to diagnose from. It self-heals once slots are assigned, since the seeds survive the pool prune, but the window is opaque.

The refresh path was worse. `querySlots` takes the first candidate that answers, and a node reset out of an otherwise healthy cluster answers empty *successfully*, so a single confused node could replace a working routing table with an empty one and close every master connection.

Failures were being discarded too: `querySlotsVia` mapped them all to `None` and `bootstrapTopology` only recorded thrown exceptions, so pointing a cluster client at a standalone server reported `NotConnected` rather than the server's `ERR This instance has cluster support disabled`.

## Change

`querySlotsVia` returns `Either[Throwable, Vector[Shard]]` and treats an empty reply as a non-answer:

- empty array -> `UnsupportedServer("... owns no slots: it is not part of a formed cluster")`
- server error -> `UnsupportedServer` carrying the server's own text
- timeout -> `TimedOut` naming the node and the elapsed budget
- anything else -> the original error, untouched

Both callers then do what they already did with a non-answer: bootstrap records it and tries the next seed, and a refresh skips the candidate and keeps the current topology. Thrown connect/TLS errors still propagate unwrapped, preserving the existing behaviour of surfacing a handshake error the way a standalone connect does.

`UnsupportedServer`'s Scaladoc is widened, having previously described only the `HELLO 3` rejection.

## Tests

Three added to `ClusterClientSpec`. Confirmed failing without the guard, reproducing both symptoms:

```
==> X ...a seed that owns no slots fails the bootstrap...
      expected exception of type 'UnsupportedServer' but body evaluated successfully
==> X ...a refresh whose candidate owns no slots keeps the working topology...
      sage.SageException$NotConnected: not connected
```

758 core + 314 clientZio unit tests pass, scalafmt clean, and the cluster integration suites pass on both backends (7 tests each, Redis and Valkey).

## Note

A non-cluster server never produced the empty array. `clusterCommand` rejects outright when `cluster_enabled == 0`, verified against valkey 9.1.1:

```
$ valkey-cli cluster slots
ERR This instance has cluster support disabled
```

That case always failed at connect rather than yielding a live-but-broken client; its only bug was the discarded diagnostic, which this fixes as well. The empty-array scenario is real only for cluster-enabled nodes with no slots assigned.