### PR TITLE
Retry self-clearing server refusals

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,14 +60,17 @@ one slot.
 While a slot is being migrated, the server answers a multi-key command whose keys briefly straddle the moving slot with `-TRYAGAIN`. The command
 did not run, so sage retries it. The retry shares the same `maxRedirects` budget as `MOVED`/`ASK` follows, but where those are resent
 immediately, a `-TRYAGAIN` retry is paced by a short jittered delay. If the migration outlasts that budget, the original `-TRYAGAIN` surfaces as
-a `ServerError`.
+a `ServerError`. `-CLUSTERDOWN`, `-LOADING`, and `-MASTERDOWN` are retried much the same way, with one exception for all-master commands; see
+[Refusals sage retries for you](/error-handling#refusals-sage-retries-for-you).
 
 ### Commands that run on every master
 
 A cluster replicates no script or function cache, and no node sees the whole keyspace. So `scriptLoad`, `scriptExists`, `scriptFlush`, the
 `function*` mutations, `flushAll`, `flushDb`, `keys`, `dbSize`, `waitReplicas`, and `waitAof` run on every slot-owning master, and their replies
-are folded into one. One master failing fails the whole call, with no partial result. A master that is only reconnecting is retried on the
-`maxRedirects` budget; a retried `waitReplicas` or `waitAof` waits again on that node.
+are folded into one. One master failing fails the whole call, with no partial result. A master that is only reconnecting, or that refuses for its own
+reasons (`-LOADING`, `-TRYAGAIN`), is retried on the `maxRedirects` budget; a retried `waitReplicas` or `waitAof` waits again on that node. A
+`-CLUSTERDOWN` is not retried here, since it may have moved the very masters the call fanned out to; see
+[Refusals sage retries for you](/error-handling#refusals-sage-retries-for-you).
 
 ## Master-replica
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,17 +60,16 @@ one slot.
 While a slot is being migrated, the server answers a multi-key command whose keys briefly straddle the moving slot with `-TRYAGAIN`. The command
 did not run, so sage retries it. The retry shares the same `maxRedirects` budget as `MOVED`/`ASK` follows, but where those are resent
 immediately, a `-TRYAGAIN` retry is paced by a short jittered delay. If the migration outlasts that budget, the original `-TRYAGAIN` surfaces as
-a `ServerError`. `-CLUSTERDOWN`, `-LOADING`, and `-MASTERDOWN` are retried much the same way, with one exception for all-master commands; see
+a `ServerError`. `-CLUSTERDOWN`, `-LOADING`, and `-MASTERDOWN` are retried the same way, with one exception; see
 [Refusals sage retries for you](/error-handling#refusals-sage-retries-for-you).
 
 ### Commands that run on every master
 
 A cluster replicates no script or function cache, and no node sees the whole keyspace. So `scriptLoad`, `scriptExists`, `scriptFlush`, the
 `function*` mutations, `flushAll`, `flushDb`, `keys`, `dbSize`, `waitReplicas`, and `waitAof` run on every slot-owning master, and their replies
-are folded into one. One master failing fails the whole call, with no partial result. A master that is only reconnecting, or that refuses for its own
-reasons (`-LOADING`, `-TRYAGAIN`), is retried on the `maxRedirects` budget; a retried `waitReplicas` or `waitAof` waits again on that node. A
-`-CLUSTERDOWN` is not retried here, since it may have moved the very masters the call fanned out to; see
-[Refusals sage retries for you](/error-handling#refusals-sage-retries-for-you).
+are folded into one. One master failing fails the whole call, with no partial result. A master that is only reconnecting, or refusing with `-LOADING`
+or `-TRYAGAIN`, is retried on the `maxRedirects` budget; a retried `waitReplicas` or `waitAof` waits again there. A `-CLUSTERDOWN` is not retried,
+since it may have moved the masters the call fanned out to.
 
 ### Topology refresh
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -53,8 +53,8 @@ When `mayHaveExecuted` is `true`, do not blindly retry a non-idempotent command:
 
 ## Refusals sage retries for you
 
-Some replies mean the server turned the command down *before* running it, for a reason that goes away on its own. Sage retries those for you. It is
-safe: nothing ran, so nothing can run twice.
+Some replies mean the server turned the command down *before* running it, for a reason that goes away on its own. Sage retries those for you; nothing
+ran, so nothing can run twice.
 
 | Reply | What it means |
 | --- | --- |
@@ -63,21 +63,14 @@ safe: nothing ran, so nothing can run twice.
 | `-LOADING` | The node is still loading its dataset. |
 | `-MASTERDOWN` | A replica cut off from its master, running with `replica-serve-stale-data no`. |
 
-Retries are bounded and spaced out by a short random delay, sharing the cluster's `maxRedirects` budget. If the condition lasts longer than that, the
-original reply reaches you as a `ServerError`, code intact.
+Retries are bounded and spaced by a short random delay, sharing the cluster's `maxRedirects` budget. If the condition outlasts it, the original reply
+reaches you as a `ServerError`, code intact. A read tries its next [`ReadFrom`](/configuration#read-routing) candidate first, so a refusing replica
+costs one hop when the master or another replica can serve it.
 
-Reads try the next node first. Under a [`ReadFrom`](/configuration#read-routing) policy, a replica answering `-MASTERDOWN` or `-LOADING` costs one hop
-when the master or another replica can serve the read instead.
-
-One exception. Commands that run on every master (`SCRIPT LOAD`, `FUNCTION LOAD`, `KEYS`, `WAIT`) do not retry a `-CLUSTERDOWN`: a failover may have
-moved the very masters they fan out to, so the reply reaches you and you retry the command yourself. `-LOADING` and `-MASTERDOWN` are still retried,
-since those leave the master list intact.
-
-Here the "nothing ran" guarantee does not apply, because the fan-out is not atomic. Masters that answered before the refusal have already run the
-command, and your retry runs them again. That is harmless for the read-only ones and for `SCRIPT LOAD` and the `FLUSH` family, which are idempotent.
-The `function*` mutations are not, unless you ask for one that tolerates what the first pass left behind: a second `FUNCTION LOAD` answers `already
-exists` and `FUNCTION DELETE` answers `not found`, while `FUNCTION RESTORE` answers `already exists` under its default `APPEND` policy. Pass
-`replace = true` to `functionLoad`, or `RestorePolicy.Replace` or `RestorePolicy.Flush` to `functionRestore`, and the retry is repeatable.
+Commands that run on every master are the exception: a `-CLUSTERDOWN` there reaches you, because the failover may have moved the masters the call
+fanned out to. Retry it yourself, remembering that the fan-out is not atomic, so masters that already ran it run it again. Harmless for the read-only
+ones, `SCRIPT LOAD`, and the `FLUSH` family. `FUNCTION LOAD`, `FUNCTION DELETE`, and `FUNCTION RESTORE` answer `already exists` or `not found` unless
+you pass `replace = true`, or `RestorePolicy.Replace` or `RestorePolicy.Flush`.
 
 ## How failures surface per backend
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -75,8 +75,9 @@ since those leave the master list intact.
 
 Here the "nothing ran" guarantee does not apply, because the fan-out is not atomic. Masters that answered before the refusal have already run the
 command, and your retry runs them again. That is harmless for the read-only ones and for `SCRIPT LOAD` and the `FLUSH` family, which are idempotent.
-`FUNCTION LOAD`, `FUNCTION DELETE`, and `FUNCTION RESTORE` are not: a second pass reports an error on the masters that already applied it, `already
-exists` or `not found`. Pass `replace = true` to make `functionLoad` repeatable.
+The `function*` mutations are not, unless you ask for one that tolerates what the first pass left behind: a second `FUNCTION LOAD` answers `already
+exists` and `FUNCTION DELETE` answers `not found`, while `FUNCTION RESTORE` answers `already exists` under its default `APPEND` policy. Pass
+`replace = true` to `functionLoad`, or `RestorePolicy.Replace` or `RestorePolicy.Flush` to `functionRestore`, and the retry is repeatable.
 
 ## How failures surface per backend
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -45,11 +45,38 @@ def classify(e: SageException): String = e match {
 - `false` means the command was never sent, so retrying is always safe.
 - `true` means it was already in flight when the connection dropped, so the server may or may not have applied it. A non-idempotent command (an `INCR`, an `LPUSH`) is then not safe to blindly retry; an idempotent one (a `SET` to a fixed value) is.
 
-Sage does not retry for you, and it does not queue commands while disconnected (see [What happens when the connection drops?](/faq#what-happens-when-the-connection-drops)). This flag gives you what you need to decide.
+Sage does not retry a lost command for you, and it does not queue commands while disconnected (see [What happens when the connection drops?](/faq#what-happens-when-the-connection-drops)). This flag gives you what you need to decide.
 
 ::: warning
 When `mayHaveExecuted` is `true`, do not blindly retry a non-idempotent command: it may already have run. Retry only when the command is idempotent, or make it so first.
 :::
+
+## Refusals sage retries for you
+
+Some replies mean the server turned the command down *before* running it, for a reason that goes away on its own. Sage retries those for you. It is
+safe: nothing ran, so nothing can run twice.
+
+| Reply | What it means |
+| --- | --- |
+| `-TRYAGAIN` | A multi-key command whose keys straddle a slot being migrated. |
+| `-CLUSTERDOWN` | The cluster is mid-failover, or the slot is not served right now. |
+| `-LOADING` | The node is still loading its dataset. |
+| `-MASTERDOWN` | A replica cut off from its master, running with `replica-serve-stale-data no`. |
+
+Retries are bounded and spaced out by a short random delay, sharing the cluster's `maxRedirects` budget. If the condition lasts longer than that, the
+original reply reaches you as a `ServerError`, code intact.
+
+Reads try the next node first. Under a [`ReadFrom`](/configuration#read-routing) policy, a replica answering `-MASTERDOWN` or `-LOADING` costs one hop
+when the master or another replica can serve the read instead.
+
+One exception. Commands that run on every master (`SCRIPT LOAD`, `FUNCTION LOAD`, `KEYS`, `WAIT`) do not retry a `-CLUSTERDOWN`: a failover may have
+moved the very masters they fan out to, so the reply reaches you and you retry the command yourself. `-LOADING` and `-MASTERDOWN` are still retried,
+since those leave the master list intact.
+
+Here the "nothing ran" guarantee does not apply, because the fan-out is not atomic. Masters that answered before the refusal have already run the
+command, and your retry runs them again. That is harmless for the read-only ones and for `SCRIPT LOAD` and the `FLUSH` family, which are idempotent.
+`FUNCTION LOAD`, `FUNCTION DELETE`, and `FUNCTION RESTORE` are not: a second pass reports an error on the masters that already applied it, `already
+exists` or `not found`. Pass `replace = true` to make `functionLoad` repeatable.
 
 ## How failures surface per backend
 

--- a/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
@@ -313,6 +313,61 @@ abstract class MasterReplicaReplicaDownSuite(image: String, serverBinary: String
   }
 }
 
+/**
+  * A replica that refuses to serve stale data. With `replica-serve-stale-data no` set, breaking its replication link makes it answer reads with
+  * `-MASTERDOWN` while staying perfectly reachable, so the policy's fallback cannot be reached by connection loss: `ReplicaPreferred` must fall
+  * through to the master on the server's refusal, and strict `Replica` has nowhere left to go and fails. Both clients connect before the link
+  * breaks, so the stale replica really is the candidate they try first. `sd:k` is written after the link broke, so only the master can hold it.
+  */
+abstract class MasterReplicaStaleReplicaSuite(image: String, serverBinary: String) extends MasterReplicaSuiteBase(image, serverBinary) {
+
+  // 6399 is a port nothing listens on: the link stays down while the replica itself keeps answering
+  private def refuseStaleReads(replica: Client[CIO, String]): CIO[Unit] =
+    for {
+      _ <- replica.run(admin("CONFIG", "SET", "replica-serve-stale-data", "no"))
+      _ <- replica.run(admin("REPLICAOF", "127.0.0.1", "6399"))
+      _ <- awaitLinkDown(replica, 100)
+    } yield ()
+
+  private def awaitLinkDown(replica: Client[CIO, String], attempts: Int): CIO[Unit] =
+    replica.run(infoReplication).flatMap { info =>
+      if (info.contains("master_link_status:down")) CIO.value(())
+      else if (attempts <= 0) CIO.fail(new RuntimeException(s"replica link never went down: $info"))
+      else CIO.sleep(100.millis).flatMap(_ => awaitLinkDown(replica, attempts - 1))
+    }
+
+  test("a replica answering MASTERDOWN falls through to the master under ReplicaPreferred, and fails a strict Replica read") {
+    withContainers { server =>
+      val host       = server.host
+      val pm         = server.mappedPort(masterPort)
+      val pr         = server.mappedPort(replicaPort)
+      val replicaCfg = standalone(host, pr)
+
+      val program =
+        connectAndUse(replicaCfg)(ensureReplicating(_, host, pr)).flatMap { _ =>
+          connectAndUse(masterReplica(host, pm, ReadFrom.Replica)) { strict =>
+            connectAndUse(masterReplica(host, pm, ReadFrom.ReplicaPreferred)) { preferred =>
+              for {
+                warmStrict    <- strict.get[String](marker)
+                warmPreferred <- preferred.get[String](marker)
+                _             <- connectAndUse(replicaCfg)(refuseStaleReads)
+                _             <- preferred.set("sd:k", "v")
+                fallback      <- preferred.get[String]("sd:k")
+                strictFailed  <- strict.get[String]("sd:k").fold(_ => CIO.value(false), _ => CIO.value(true))
+              } yield {
+                assertEquals(warmStrict, Some("from-replica"))
+                assertEquals(warmPreferred, Some("from-replica"))
+                assertEquals(fallback, Some("v"))
+                assert(strictFailed, "strict Replica read should fail when the only replica refuses to serve stale data")
+              }
+            }
+          }
+        }
+      program.unsafeRun
+    }
+  }
+}
+
 class RedisMasterReplicaSuite extends MasterReplicaSuite(Images.redis, "redis-server")
 
 class ValkeyMasterReplicaSuite extends MasterReplicaSuite(Images.valkey, "valkey-server")
@@ -328,3 +383,7 @@ class ValkeyMasterReplicaConnectionLossFailoverSuite extends MasterReplicaConnec
 class RedisMasterReplicaReplicaDownSuite extends MasterReplicaReplicaDownSuite(Images.redis, "redis-server")
 
 class ValkeyMasterReplicaReplicaDownSuite extends MasterReplicaReplicaDownSuite(Images.valkey, "valkey-server")
+
+class RedisMasterReplicaStaleReplicaSuite extends MasterReplicaStaleReplicaSuite(Images.redis, "redis-server")
+
+class ValkeyMasterReplicaStaleReplicaSuite extends MasterReplicaStaleReplicaSuite(Images.valkey, "valkey-server")

--- a/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
@@ -314,14 +314,12 @@ abstract class MasterReplicaReplicaDownSuite(image: String, serverBinary: String
 }
 
 /**
-  * A replica that refuses to serve stale data. With `replica-serve-stale-data no` set, breaking its replication link makes it answer reads with
-  * `-MASTERDOWN` while staying perfectly reachable, so the policy's fallback cannot be reached by connection loss: `ReplicaPreferred` must fall
-  * through to the master on the server's refusal, and strict `Replica` has nowhere left to go and fails. Both clients connect before the link
-  * breaks, so the stale replica really is the candidate they try first. `sd:k` is written after the link broke, so only the master can hold it.
+  * A replica that refuses to serve stale data: with `replica-serve-stale-data no` and its link broken, it answers reads `-MASTERDOWN` while staying
+  * reachable, so only a fall-through on the refusal itself saves the read. Both clients connect first, so the stale replica is the candidate they try.
   */
 abstract class MasterReplicaStaleReplicaSuite(image: String, serverBinary: String) extends MasterReplicaSuiteBase(image, serverBinary) {
 
-  // 6399 is a port nothing listens on: the link stays down while the replica itself keeps answering
+  // 6399 listens to nothing, so the link stays down while the replica keeps answering
   private def refuseStaleReads(replica: Client[CIO, String]): CIO[Unit] =
     for {
       _ <- replica.run(admin("CONFIG", "SET", "replica-serve-stale-data", "no"))

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -431,7 +431,10 @@ final private[client] class ClusterLive(
         }
       case Fault.Lost(false)                =>
         if (rest.nonEmpty) tryReadCandidates(command, rest, master, redirectsLeft, complete) else onUnreachable(command, redirectsLeft, complete)
-      case Fault.TryAgain                   => onTryAgain(command, error, redirectsLeft, complete)
+      case Fault.Unavailable(clusterWide)   =>
+        if (rest.nonEmpty) tryReadCandidates(command, rest, master, redirectsLeft, complete)
+        else onRetryable(command, error, clusterWide, redirectsLeft, complete)
+      case Fault.TryAgain                   => onRetryable(command, error, refreshFirst = false, redirectsLeft, complete)
       case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error))
       case Fault.Fatal                      => Events.attributeNode(complete, node); complete(Failure(error))
     }
@@ -514,7 +517,7 @@ final private[client] class ClusterLive(
   private def submitBroadcast[B](node: Node, command: Command[B], resolve: Node => NodeClient, attemptsLeft: Int, settle: Try[B] => Unit): Unit = {
     val nc = resolve(node)
     // the dispatch fast path resolves inline on the caller, which the retry's refresh would block
-    if (nc == null) offload(retryBroadcast(node, command, NotConnected(), attemptsLeft, settle))
+    if (nc == null) offload(retryBroadcast(node, command, NotConnected(), refreshFirst = true, attemptsLeft, settle))
     else
       nc.submit[B](
         command,
@@ -526,21 +529,31 @@ final private[client] class ClusterLive(
       )
   }
 
-  // only the node that lost its connection is retried; a command carrying its own timeout (WAIT) re-serves it there
+  // only a node that lost its connection, or refused for its own reasons, is retried; a command carrying its own timeout (WAIT) re-serves it there
   private def onBroadcastFailure[B](node: Node, command: Command[B], error: Throwable, attemptsLeft: Int, settle: Try[B] => Unit): Unit =
     Fault.categorize(error) match {
-      case Fault.Lost(false) => retryBroadcast(node, command, error, attemptsLeft, settle)
-      case fault             =>
+      case Fault.Lost(false)                         => retryBroadcast(node, command, error, refreshFirst = true, attemptsLeft, settle)
+      case Fault.TryAgain | Fault.Unavailable(false) => retryBroadcast(node, command, error, refreshFirst = false, attemptsLeft, settle)
+      // a cluster-wide refusal may have moved the masters this fan-out captured, so the caller re-broadcasts against an adopted topology
+      case Fault.Unavailable(true)                   => refreshBeforeFailing(); settle(Failure(error))
+      case fault                                     =>
         if (fault.refreshPolicy != RefreshPolicy.Skip) triggerRefresh()
         settle(Failure(error))
     }
 
   // a node the refreshed topology no longer lists as a slot-owning master makes this broadcast's target set stale, so it fails unchased
-  private def retryBroadcast[B](node: Node, command: Command[B], error: Throwable, attemptsLeft: Int, settle: Try[B] => Unit): Unit =
+  private def retryBroadcast[B](
+    node: Node,
+    command: Command[B],
+    error: Throwable,
+    refreshFirst: Boolean,
+    attemptsLeft: Int,
+    settle: Try[B] => Unit
+  ): Unit =
     if (attemptsLeft <= 0) { refreshBeforeFailing(); settle(Failure(error)) }
     else
       afterBackoff(attemptsLeft) {
-        refresh(force = true)
+        if (refreshFirst) refresh(force = true)
         if (closed || !slotOwningMasters(topologyRef.get()).contains(node)) settle(Failure(error))
         else submitBroadcast(node, command, establishOrNull, attemptsLeft - 1, settle)
       }
@@ -625,7 +638,8 @@ final private[client] class ClusterLive(
     Fault.categorize(error) match {
       case Fault.Redirected(redirect)       => onRedirect(node, redirect, command, redirectsLeft, complete, lease, cacheCtx)
       case Fault.Lost(false)                => onUnreachable(command, redirectsLeft, complete, lease, cacheCtx)
-      case Fault.TryAgain                   => onTryAgain(command, error, redirectsLeft, complete, lease, cacheCtx)
+      case Fault.TryAgain                   => onRetryable(command, error, refreshFirst = false, redirectsLeft, complete, lease, cacheCtx)
+      case Fault.Unavailable(clusterWide)   => onRetryable(command, error, clusterWide, redirectsLeft, complete, lease, cacheCtx)
       case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error))
       case Fault.Fatal                      => Events.attributeNode(complete, node); complete(Failure(error))
     }
@@ -670,20 +684,23 @@ final private[client] class ClusterLive(
       )
     }
 
-  // -TRYAGAIN is a transient mid-migration refusal: the slot mapping is still valid, so retry (bounded, jittered) without refreshing the topology.
-  private def onTryAgain[A](
+  // a self-clearing refusal (-TRYAGAIN, -LOADING, -MASTERDOWN, -CLUSTERDOWN): retry bounded and jittered, then surface the original error
+  private def onRetryable[A](
     command: Command[A],
     error: Throwable,
+    refreshFirst: Boolean,
     redirectsLeft: Int,
     complete: Try[A] => Unit,
     lease: DedicatedPool.Lease = null,
     cacheCtx: Cached = null
   ): Unit =
-    if (redirectsLeft <= 0) complete(Failure(error))
-    else
+    if (redirectsLeft <= 0) { if (refreshFirst) refreshBeforeFailing(); complete(Failure(error)) }
+    else {
+      if (refreshFirst) refresh(force = true)
       afterBackoff(redirectsLeft)(
         dispatch(command, redirectsLeft - 1, complete, allowReplica = replicaAllowed(cacheCtx), lease = lease, cacheCtx = cacheCtx)
       )
+    }
 
   // paces a retry, growing with the attempts already spent, so an in-progress failover or migration is not hammered
   private def afterBackoff(attemptsLeft: Int)(retry: => Unit): Unit =
@@ -883,7 +900,8 @@ final private[client] class ClusterLive(
                 case RedirectKind.Moved                                             => reroute(index)
               }
             case Fault.Lost(false)                => reroute(index)
-            case Fault.TryAgain                   => onTryAgain(p.commands(index), error, cluster.maxRedirects, emits(index))
+            case Fault.TryAgain                   => onRetryable(p.commands(index), error, refreshFirst = false, cluster.maxRedirects, emits(index))
+            case Fault.Unavailable(clusterWide)   => onRetryable(p.commands(index), error, clusterWide, cluster.maxRedirects, emits(index))
             case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); settle(index, result)
             case Fault.Fatal                      => settle(index, result)
           }

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -555,7 +555,7 @@ final private[client] class ClusterLive(
     attemptsLeft: Int,
     settle: Try[B] => Unit
   ): Unit =
-    if (attemptsLeft <= 0) { refreshBeforeFailing(); settle(Failure(error)) }
+    if (attemptsLeft <= 0) { if (refreshFirst) refreshBeforeFailing(); settle(Failure(error)) }
     else
       afterBackoff(attemptsLeft) {
         if (refreshFirst) refresh(force = true)
@@ -897,23 +897,26 @@ final private[client] class ClusterLive(
     val callbacks: Vector[Try[Any] => Unit]        = indices.map { index => (result: Try[Any]) =>
       result match {
         case Success(_)     => settle(index, result)
+        // a fault's disposition can block on CLUSTER SLOTS, whose reply needs the very reader thread this callback runs on
         case Failure(error) =>
-          Fault.categorize(error) match {
-            // ASK keeps the slot's owner, so re-routing by topology bounces off the exporting node and burns a redirect; follow it straight
-            // to the importing node with ASKING. MOVED and connection loss re-route normally.
-            case Fault.Redirected(redirect)       =>
-              redirect.kind match {
-                // strict Replica must not follow ASK onto the importing master (mirrors the single-read path at onReadFailure)
-                case RedirectKind.Ask if useReplica && readFrom == ReadFrom.Replica => settle(index, Failure(NotConnected()))
-                case RedirectKind.Ask                                               =>
-                  onRedirect(target, redirect, p.commands(index), cluster.maxRedirects, emits(index))
-                case RedirectKind.Moved                                             => reroute(index)
-              }
-            case Fault.Lost(false)                => reroute(index)
-            case Fault.TryAgain                   => onRetryable(p.commands(index), error, refreshFirst = false, cluster.maxRedirects, emits(index))
-            case Fault.Unavailable(clusterWide)   => onRetryable(p.commands(index), error, clusterWide, cluster.maxRedirects, emits(index))
-            case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); settle(index, result)
-            case Fault.Fatal                      => settle(index, result)
+          offload {
+            Fault.categorize(error) match {
+              // ASK keeps the slot's owner, so re-routing by topology bounces off the exporting node and burns a redirect; follow it straight
+              // to the importing node with ASKING. MOVED and connection loss re-route normally.
+              case Fault.Redirected(redirect)       =>
+                redirect.kind match {
+                  // strict Replica must not follow ASK onto the importing master (mirrors the single-read path at onReadFailure)
+                  case RedirectKind.Ask if useReplica && readFrom == ReadFrom.Replica => settle(index, Failure(NotConnected()))
+                  case RedirectKind.Ask                                               =>
+                    onRedirect(target, redirect, p.commands(index), cluster.maxRedirects, emits(index))
+                  case RedirectKind.Moved                                             => reroute(index)
+                }
+              case Fault.Lost(false)                => reroute(index)
+              case Fault.TryAgain                   => onRetryable(p.commands(index), error, refreshFirst = false, cluster.maxRedirects, emits(index))
+              case Fault.Unavailable(clusterWide)   => onRetryable(p.commands(index), error, clusterWide, cluster.maxRedirects, emits(index))
+              case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); settle(index, result)
+              case Fault.Fatal                      => settle(index, result)
+            }
           }
       }
     }

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -534,12 +534,12 @@ final private[client] class ClusterLive(
       )
   }
 
-  // only a node that lost its connection, or refused for its own reasons, is retried; a command carrying its own timeout (WAIT) re-serves it there
+  // only the node that lost its connection or refused for its own reasons is retried; a WAIT re-serves its own timeout there
   private def onBroadcastFailure[B](node: Node, command: Command[B], error: Throwable, attemptsLeft: Int, settle: Try[B] => Unit): Unit =
     Fault.categorize(error) match {
       case Fault.Lost(false)                         => retryBroadcast(node, command, error, refreshFirst = true, attemptsLeft, settle)
       case Fault.TryAgain | Fault.Unavailable(false) => retryBroadcast(node, command, error, refreshFirst = false, attemptsLeft, settle)
-      // a cluster-wide refusal may have moved the masters this fan-out captured, so the caller re-broadcasts against an adopted topology
+      // a cluster-wide refusal may have moved the masters this fan-out captured, so it is not chased
       case Fault.Unavailable(true)                   => refreshBeforeFailing(); settle(Failure(error))
       case fault                                     =>
         if (fault.refreshPolicy != RefreshPolicy.Skip) triggerRefresh()
@@ -689,7 +689,7 @@ final private[client] class ClusterLive(
       )
     }
 
-  // a self-clearing refusal (-TRYAGAIN, -LOADING, -MASTERDOWN, -CLUSTERDOWN): retry bounded and jittered, then surface the original error
+  // a self-clearing refusal (-TRYAGAIN, -LOADING, -MASTERDOWN, -CLUSTERDOWN): retry bounded and jittered
   private def onRetryable[A](
     command: Command[A],
     error: Throwable,
@@ -897,7 +897,7 @@ final private[client] class ClusterLive(
     val callbacks: Vector[Try[Any] => Unit]        = indices.map { index => (result: Try[Any]) =>
       result match {
         case Success(_)     => settle(index, result)
-        // a fault's disposition can block on CLUSTER SLOTS, whose reply needs the very reader thread this callback runs on
+        // a fault's disposition can block on CLUSTER SLOTS, whose reply needs this very reader thread
         case Failure(error) =>
           offload {
             Fault.categorize(error) match {

--- a/sage-client/shared/src/main/scala/sage/client/internal/Fault.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Fault.scala
@@ -16,14 +16,14 @@ private[client] enum Fault {
 
   def refreshPolicy: RefreshPolicy = this match {
     case Fatal | TryAgain                                          => RefreshPolicy.Skip
-    // only a cluster-wide refusal implies the slot mapping moved; a node-local one leaves it valid
+    // only a cluster-wide refusal implies the mapping moved
     case Unavailable(clusterWide)                                  => if (clusterWide) RefreshPolicy.Forced else RefreshPolicy.Skip
     // ASK moves no ownership: discovery has nothing to adopt until the migration finalizes
     case Redirected(redirect) if redirect.kind == RedirectKind.Ask => RefreshPolicy.Throttled
     case Redirected(_) | Demoted | Lost(_)                         => RefreshPolicy.Forced
   }
 
-  // the server refused before running the command, for a reason that clears on its own, so the same command is safe to send again
+  // refused before running, for a reason that clears on its own: the same command is safe to send again
   def selfClearing: Boolean = this match {
     case TryAgain | Unavailable(_) => true
     case _                         => false
@@ -46,7 +46,6 @@ private[client] object Fault {
           case Some(redirect)                                        => Fault.Redirected(redirect)
           case None if e.code == "READONLY"                          => Fault.Demoted
           case None if e.code == "TRYAGAIN"                          => Fault.TryAgain
-          // the server refused before running the command and the refusal clears on its own; only CLUSTERDOWN implies the slot map moved
           case None if e.code == "CLUSTERDOWN"                       => Fault.Unavailable(clusterWide = true)
           case None if e.code == "LOADING" || e.code == "MASTERDOWN" => Fault.Unavailable(clusterWide = false)
           case None                                                  => Fault.Fatal

--- a/sage-client/shared/src/main/scala/sage/client/internal/Fault.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Fault.scala
@@ -11,13 +11,22 @@ private[client] enum Fault {
   case Demoted
   case Lost(mayHaveExecuted: Boolean)
   case TryAgain
+  case Unavailable(clusterWide: Boolean)
   case Fatal
 
   def refreshPolicy: RefreshPolicy = this match {
     case Fatal | TryAgain                                          => RefreshPolicy.Skip
+    // only a cluster-wide refusal implies the slot mapping moved; a node-local one leaves it valid
+    case Unavailable(clusterWide)                                  => if (clusterWide) RefreshPolicy.Forced else RefreshPolicy.Skip
     // ASK moves no ownership: discovery has nothing to adopt until the migration finalizes
     case Redirected(redirect) if redirect.kind == RedirectKind.Ask => RefreshPolicy.Throttled
     case Redirected(_) | Demoted | Lost(_)                         => RefreshPolicy.Forced
+  }
+
+  // the server refused before running the command, for a reason that clears on its own, so the same command is safe to send again
+  def selfClearing: Boolean = this match {
+    case TryAgain | Unavailable(_) => true
+    case _                         => false
   }
 }
 
@@ -34,10 +43,13 @@ private[client] object Fault {
     error match {
       case e: ServerError           =>
         Redirect.parse(e.getMessage) match {
-          case Some(redirect)               => Fault.Redirected(redirect)
-          case None if e.code == "READONLY" => Fault.Demoted
-          case None if e.code == "TRYAGAIN" => Fault.TryAgain
-          case None                         => Fault.Fatal
+          case Some(redirect)                                        => Fault.Redirected(redirect)
+          case None if e.code == "READONLY"                          => Fault.Demoted
+          case None if e.code == "TRYAGAIN"                          => Fault.TryAgain
+          // the server refused before running the command and the refusal clears on its own; only CLUSTERDOWN implies the slot map moved
+          case None if e.code == "CLUSTERDOWN"                       => Fault.Unavailable(clusterWide = true)
+          case None if e.code == "LOADING" || e.code == "MASTERDOWN" => Fault.Unavailable(clusterWide = false)
+          case None                                                  => Fault.Fatal
         }
       case NotConnected()           => Fault.Lost(mayHaveExecuted = false)
       case ConnectionLost(executed) => Fault.Lost(executed)

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -328,10 +328,11 @@ final private[client] class MasterReplicaLive(
     complete: Try[A] => Unit
   ): Unit = {
     if (isMaster && isOwnershipFault(error)) triggerRefresh()
-    if (isConnLoss(error)) {
+    def fail(): Unit = { Events.attributeNode(complete, node); complete(Failure(error)) }
+    if (servesNoRead(error))
       if (rest.nonEmpty) tryRead(command, rest, master, complete)
-      else { triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error)) }
-    } else { Events.attributeNode(complete, node); complete(Failure(error)) }
+      else { triggerRefresh(); fail() }
+    else fail()
   }
 
   private def isOwnershipFault(error: Throwable): Boolean = Fault.categorize(error) match {
@@ -339,9 +340,10 @@ final private[client] class MasterReplicaLive(
     case _                             => false
   }
 
-  private def isConnLoss(error: Throwable): Boolean = Fault.categorize(error) match {
+  // a lost connection or a self-clearing refusal (`-MASTERDOWN`, `-LOADING`) means this node cannot answer the read, not that the read must fail
+  private def servesNoRead(error: Throwable): Boolean = Fault.categorize(error) match {
     case Fault.Lost(_) => true
-    case _             => false
+    case fault         => fault.selfClearing
   }
 
   // --- pipelines -----------------------------------------------------------------------------------------------------------------------

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -343,7 +343,7 @@ final private[client] class MasterReplicaLive(
     case _                             => false
   }
 
-  // a lost connection or a self-clearing refusal (`-MASTERDOWN`, `-LOADING`) means this node cannot answer the read, not that the read must fail
+  // this node cannot answer the read, which says nothing about the read itself
   private def servesNoRead(error: Throwable): Boolean = Fault.categorize(error) match {
     case Fault.Lost(_) => true
     case fault         => fault.selfClearing

--- a/sage-client/shared/src/test/scala/sage/client/internal/FaultSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/FaultSpec.scala
@@ -27,6 +27,21 @@ class FaultSpec extends munit.FunSuite {
     assertEquals(Fault.categorize(ServerError("TRYAGAIN", "Multiple keys request during rehashing of slot")), Fault.TryAgain)
   }
 
+  test("a CLUSTERDOWN reply categorizes as a cluster-wide unavailability, whose mapping must be re-read past the throttle") {
+    val fault = Fault.categorize(ServerError("CLUSTERDOWN", "The cluster is down"))
+    assertEquals(fault, Fault.Unavailable(clusterWide = true))
+    assertEquals(fault.refreshPolicy, RefreshPolicy.Forced)
+  }
+
+  test("LOADING and MASTERDOWN categorize as node-local unavailabilities, which leave the topology alone") {
+    val loading    = Fault.categorize(ServerError("LOADING", "Redis is loading the dataset in memory"))
+    val masterDown = Fault.categorize(ServerError("MASTERDOWN", "Link with MASTER is down and replica-serve-stale-data is set to 'no'"))
+    assertEquals(loading, Fault.Unavailable(clusterWide = false))
+    assertEquals(masterDown, Fault.Unavailable(clusterWide = false))
+    assertEquals(loading.refreshPolicy, RefreshPolicy.Skip)
+    assertEquals(masterDown.refreshPolicy, RefreshPolicy.Skip)
+  }
+
   test("any other ServerError categorizes as Fatal") {
     assertEquals(Fault.categorize(ServerError("WRONGTYPE", "Operation against a key holding the wrong kind of value")), Fault.Fatal)
     assertEquals(Fault.categorize(ServerError("ERR", "foo bar")), Fault.Fatal)

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -134,6 +134,12 @@ class ClusterClientSpec extends munit.FunSuite {
     await(s"expected a second CLUSTER SLOTS, saw $slotsCalls")(slotsCalls >= 2)
   }
 
+  private def awaitAtLeast(counter: java.util.concurrent.atomic.AtomicInteger, target: Int, clue: String): Unit = {
+    val deadline = System.nanoTime() + 2000000000L
+    while (counter.get() < target && System.nanoTime() < deadline) Thread.sleep(5)
+    assert(counter.get() >= target, s"$clue (saw ${counter.get()}, wanted $target)")
+  }
+
   private def wholeClusterOn(node: Node): Frame = slotsFrame((node, 0, Slot.Count - 1))
 
   test("a seed that owns no slots fails the bootstrap rather than adopting an empty topology") {
@@ -574,6 +580,79 @@ class ClusterClientSpec extends munit.FunSuite {
     }
   }
 
+  test("a broadcast leg retries a LOADING master on its own node, so one loading node does not fail the command") {
+    val mid       = Slot.Count / 2
+    val attempts  = new java.util.concurrent.atomic.AtomicInteger(0)
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else if (text.contains("SCRIPT"))
+        if (node == nodeB && attempts.getAndIncrement() == 0) Seq(Frame.SimpleError("LOADING Redis is loading the dataset in memory"))
+        else Seq(Frame.BulkString(Bytes.utf8("sha1")))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Scripting.scriptLoad("return 1")).unsafeRun.map { sha =>
+      assertEquals(sha, "sha1")
+      assert(attempts.get() >= 2, s"the loading leg was not retried: ${attempts.get()} attempts")
+    }
+  }
+
+  test("a broadcast leg surfaces a CLUSTERDOWN instead of retrying the node that may no longer be a master") {
+    val mid          = Slot.Count / 2
+    val clusterCalls = new java.util.concurrent.atomic.AtomicInteger(0)
+    val behaviour    = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) { clusterCalls.incrementAndGet(); Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1))) }
+      else if (text.contains("SCRIPT"))
+        Seq(if (node == nodeB) Frame.SimpleError("CLUSTERDOWN The cluster is down") else Frame.BulkString(Bytes.utf8("sha1")))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture      = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Scripting.scriptLoad("return 1")).unsafeRun.failed.map { error =>
+      assert(
+        error.isInstanceOf[ServerError] && error.asInstanceOf[ServerError].code == "CLUSTERDOWN",
+        s"the refusal must reach the caller intact, not as a NotConnected from a retry: $error"
+      )
+      assertEquals(fixture.written(nodeB).count(_.contains("SCRIPT")), 1, "a cluster-wide refusal must not be retried on the node that gave it")
+      awaitAtLeast(clusterCalls, 2, "a cluster-wide refusal must refresh the topology")
+    }
+  }
+
+  test("under ReplicaPreferred a replica answering MASTERDOWN falls through to the master") {
+    val nodeR                   = Node("r", 6379)
+    def slotsWithReplica: Frame =
+      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+    val behaviour               = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsWithReplica)
+      else if (text.contains("GET"))
+        if (node == nodeR) Seq(Frame.SimpleError("MASTERDOWN Link with MASTER is down and replica-serve-stale-data is set to 'no'"))
+        else Seq(Frame.BulkString(Bytes.utf8("from-master")))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture                 = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.ReplicaPreferred)
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
+      assertEquals(result, Some("from-master"))
+      assert(fixture.written(nodeR).exists(_.contains("GET")), "the replica should have been tried before the master")
+    }
+  }
+
+  test("under a strict Replica policy a replica answering MASTERDOWN fails the read rather than reaching the master") {
+    val nodeR                   = Node("r", 6379)
+    def slotsWithReplica: Frame =
+      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+    val behaviour               = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsWithReplica)
+      else if (text.contains("GET"))
+        if (node == nodeR) Seq(Frame.SimpleError("MASTERDOWN Link with MASTER is down and replica-serve-stale-data is set to 'no'"))
+        else Seq(Frame.BulkString(Bytes.utf8("from-master")))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture                 = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.Replica)
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[ServerError] && error.asInstanceOf[ServerError].code == "MASTERDOWN", s"unexpected error: $error")
+      assert(!fixture.written(nodeA).exists(_.contains("GET")), "a strict Replica read must not fall back to the master")
+    }
+  }
+
   test("under a Replica policy an eligible read routes to the shard's replica, which gets READONLY at setup") {
     val nodeR                   = Node("r", 6379)
     // CLUSTER SLOTS lists nodeR as nodeA's replica for the whole keyspace
@@ -669,6 +748,43 @@ class ClusterClientSpec extends munit.FunSuite {
     fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
       assertEquals(result, Some("value"))
       assert(attempts.get() >= 2, s"TRYAGAIN was not retried: ${attempts.get()} attempts")
+    }
+  }
+
+  test("a LOADING reply is retried, without refreshing the topology") {
+    val clusterCalls = new java.util.concurrent.atomic.AtomicInteger(0)
+    val attempts     = new java.util.concurrent.atomic.AtomicInteger(0)
+    val behaviour    = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) { clusterCalls.incrementAndGet(); Seq(wholeClusterOn(nodeA)) }
+      else if (text.contains("GET"))
+        if (attempts.getAndIncrement() == 0) Seq(Frame.SimpleError("LOADING Redis is loading the dataset in memory"))
+        else Seq(Frame.BulkString(Bytes.utf8("value")))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture      = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
+      assertEquals(result, Some("value"))
+      assert(attempts.get() >= 2, s"LOADING was not retried: ${attempts.get()} attempts")
+      assertEquals(clusterCalls.get(), 1, "a node-local refusal must not trigger a topology refresh")
+    }
+  }
+
+  test("a CLUSTERDOWN retry re-dispatches on the mapping the refresh adopted, not the one that refused") {
+    val clusterCalls = new java.util.concurrent.atomic.AtomicInteger(0)
+    val behaviour    = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) {
+        val call = clusterCalls.incrementAndGet()
+        // a slow topology query: a retry that merely fires the refresh alongside itself re-dispatches on the mapping that just refused
+        if (call > 1) Thread.sleep(300)
+        Seq(if (call == 1) wholeClusterOn(nodeA) else wholeClusterOn(nodeB))
+      } else if (text.contains("GET"))
+        Seq(if (node == nodeA) Frame.SimpleError("CLUSTERDOWN The cluster is down") else Frame.BulkString(Bytes.utf8("from-b")))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture      = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
+      assertEquals(result, Some("from-b"))
+      assertEquals(fixture.written(nodeA).count(_.contains("GET")), 1, "the retry must not go back to the master that refused")
     }
   }
 

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -136,11 +136,8 @@ class ClusterClientSpec extends munit.FunSuite {
     await(s"expected a second CLUSTER SLOTS, saw $slotsCalls")(slotsCalls >= 2)
   }
 
-  private def awaitAtLeast(counter: java.util.concurrent.atomic.AtomicInteger, target: Int, clue: String): Unit = {
-    val deadline = System.nanoTime() + 2000000000L
-    while (counter.get() < target && System.nanoTime() < deadline) Thread.sleep(5)
-    assert(counter.get() >= target, s"$clue (saw ${counter.get()}, wanted $target)")
-  }
+  private def awaitAtLeast(counter: java.util.concurrent.atomic.AtomicInteger, target: Int, clue: String): Unit =
+    await(s"$clue (saw ${counter.get()}, wanted $target)")(counter.get() >= target)
 
   private def wholeClusterOn(node: Node): Frame = slotsFrame((node, 0, Slot.Count - 1))
 
@@ -810,6 +807,22 @@ class ClusterClientSpec extends munit.FunSuite {
       assertEquals(result, Some("value"))
       assert(attempts.get() >= 2, s"LOADING was not retried: ${attempts.get()} attempts")
       assertEquals(clusterCalls.get(), 1, "a node-local refusal must not trigger a topology refresh")
+    }
+  }
+
+  test("a pipeline position refused with CLUSTERDOWN retries on the adopted mapping, off the reader thread") {
+    val clusterCalls = new java.util.concurrent.atomic.AtomicInteger(0)
+    val behaviour    = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(if (clusterCalls.incrementAndGet() == 1) wholeClusterOn(nodeA) else wholeClusterOn(nodeB))
+      // the batch carries both positions, so nodeA answers both; the retries reach nodeB one command at a time
+      else if (text.contains("GET"))
+        if (node == nodeA) Seq.fill(2)(Frame.SimpleError("CLUSTERDOWN The cluster is down")) else Seq(Frame.BulkString(Bytes.utf8("from-b")))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture      = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.pipeline((Strings.get[String, String]("{x}1"), Strings.get[String, String]("{x}2"))).unsafeRun.map { result =>
+      assertEquals(result, (Some("from-b"), Some("from-b")))
+      assertEquals(fixture.written(nodeA).count(_.contains("GET")), 1, "the refused master must see the batch once, never a retry")
     }
   }
 

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -814,7 +814,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val clusterCalls = new java.util.concurrent.atomic.AtomicInteger(0)
     val behaviour    = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(if (clusterCalls.incrementAndGet() == 1) wholeClusterOn(nodeA) else wholeClusterOn(nodeB))
-      // the batch carries both positions, so nodeA answers both; the retries reach nodeB one command at a time
+      // the batch carries both positions; the retries reach nodeB one at a time
       else if (text.contains("GET"))
         if (node == nodeA) Seq.fill(2)(Frame.SimpleError("CLUSTERDOWN The cluster is down")) else Seq(Frame.BulkString(Bytes.utf8("from-b")))
       else Seq(Frame.SimpleString("OK"))
@@ -831,7 +831,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val behaviour    = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) {
         val call = clusterCalls.incrementAndGet()
-        // a slow topology query: a retry that merely fires the refresh alongside itself re-dispatches on the mapping that just refused
+        // slow on purpose: a refresh merely fired alongside the retry would leave it on the stale mapping
         if (call > 1) Thread.sleep(300)
         Seq(if (call == 1) wholeClusterOn(nodeA) else wholeClusterOn(nodeB))
       } else if (text.contains("GET"))


### PR DESCRIPTION
`CLUSTERDOWN`, `LOADING`, and `MASTERDOWN` were classified `Fatal`: surfaced to the caller with no refresh and no retry. All three mean the server declined the command *before* running it, for a reason that clears on its own, so retrying is as safe as it already is for `TRYAGAIN` and a provably-unexecuted connection loss. The gap was visible in our own suite: `ClusterFailoverSuite` hand-rolls a 150-attempt retry loop around a write, commented "as a real application would", purely to survive a cluster warm-up.

`MASTERDOWN` also defeated the read policy. Both read ladders fell through to the next candidate only on connection loss, so a `ReplicaPreferred` read that met a *reachable* replica refusing to serve stale data failed instead of falling back to the master, which is the case the policy exists for.

### Changes

`Fault` gains `Unavailable(clusterWide)`. The flag carries the one axis the three codes differ on: `CLUSTERDOWN` implies the slot mapping may have moved and refreshes first, while `LOADING` and `MASTERDOWN` are node-local and leave the topology alone. That distinction reaches past the retry, since `refreshesTopology` also drives the transaction reply scan.

Both read ladders exhaust their candidates before retrying, since a sibling replica or the master usually can answer now. In the cluster runtime the retry reuses the `TRYAGAIN` mechanism (`onTryAgain` generalized to `onRetryable`): bounded by `maxRedirects`, paced by the shared jittered backoff, and surfacing the original reply once the budget runs out, so `CLUSTERDOWN` stays a matchable `ServerError` rather than a synthetic `NotConnected`. At defaults that adds at most ~1.5s before a genuinely stuck condition surfaces. The master-replica runtime has no retry budget to borrow, so it gets the fall-through only, keeping its existing "no candidate left" disposition of a re-discovery then the server's own error.

Everything else stays `Fatal`, including `BUSY`: it means a script is monopolizing the server, where a client that retries is part of the problem.

### Tests

`MasterReplicaStaleReplicaSuite` induces the condition for real (`replica-serve-stale-data no`, then repoint the replica at a dead port) and asserts `ReplicaPreferred` falls back while strict `Replica` still fails. Verified it fails without the fix, with exactly `MASTERDOWN Link with MASTER is down and replica-serve-stale-data is set to 'no'`. `ClusterClientSpec` covers every branch against the fake cluster, each verified to fail without its fix: `LOADING` retried, retried without a refresh, a `CLUSTERDOWN` retry landing on the adopted mapping, a broadcast leg retrying its own node, a broadcast leg surfacing `CLUSTERDOWN` unchased, a pipeline position refused off the reader thread, and a `MASTERDOWN` replica falling through to the master. No integration test induces `CLUSTERDOWN` or `LOADING`: doing so deterministically needs a failover race or a large dataset load, and a test waiting on one would be flaky rather than thorough.

`testUnit` green; cluster and master-replica integration suites green on both Redis and Valkey.
