### PR TITLE
Retry a broadcast's node instead of failing the command

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,16 @@ did not run, so sage retries it. The retry shares the same `maxRedirects` budget
 immediately, a `-TRYAGAIN` retry is paced by a short jittered delay. If the migration outlasts that budget, the original `-TRYAGAIN` surfaces as
 a `ServerError`.
 
+### Commands that run on every master
+
+A cluster replicates no script or function cache and no single node sees the whole keyspace, so `scriptLoad`, `scriptExists`, `scriptFlush`,
+the `function*` mutations, `flushAll`, `flushDb`, `keys`, `dbSize`, `waitReplicas`, and `waitAof` run on every slot-owning master and their replies are
+folded into one. The call is all or nothing: one master answering with an error fails it, and no partial result is reported. A master that is
+merely reconnecting does not fail it, because the command provably never ran there: sage refreshes the topology and retries that one node,
+within the same `maxRedirects` budget and paced by the same jittered delay, leaving the masters that already answered untouched. A `waitReplicas`
+or `waitAof` retried this way serves its timeout again on the retried node. If the refreshed topology no longer lists the node as a slot-owning
+master, the call fails rather than chasing it, and the adopted topology makes the next call the correct one.
+
 ## Master-replica
 
 Select `Topology.MasterReplica` with seed endpoints. Sage discovers the nodes' roles, sends writes to the master, and routes reads per the read policy:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,13 +64,11 @@ a `ServerError`.
 
 ### Commands that run on every master
 
-A cluster replicates no script or function cache and no single node sees the whole keyspace, so `scriptLoad`, `scriptExists`, `scriptFlush`,
-the `function*` mutations, `flushAll`, `flushDb`, `keys`, `dbSize`, `waitReplicas`, and `waitAof` run on every slot-owning master and their replies are
-folded into one. The call is all or nothing: one master answering with an error fails it, and no partial result is reported. A master that is
-merely reconnecting does not fail it, because the command provably never ran there: sage refreshes the topology and retries that one node,
-within the same `maxRedirects` budget and paced by the same jittered delay, leaving the masters that already answered untouched. A `waitReplicas`
-or `waitAof` retried this way serves its timeout again on the retried node. If the refreshed topology no longer lists the node as a slot-owning
-master, the call fails rather than chasing it, and the adopted topology makes the next call the correct one.
+A cluster replicates no script or function cache and no single node sees the whole keyspace, so `scriptLoad`, `scriptExists`, `scriptFlush`, the
+`function*` mutations, `flushAll`, `flushDb`, `keys`, `dbSize`, `waitReplicas`, and `waitAof` run on every slot-owning master and their replies
+are folded into one. The call is all or nothing: one master answering with an error fails it, with no partial result. A master that is only
+reconnecting does not fail it, since the command never ran there: sage refreshes the topology and retries that one node on the `maxRedirects`
+budget. A retried `waitReplicas` or `waitAof` serves its timeout again on that node.
 
 ## Master-replica
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,11 +64,10 @@ a `ServerError`.
 
 ### Commands that run on every master
 
-A cluster replicates no script or function cache and no single node sees the whole keyspace, so `scriptLoad`, `scriptExists`, `scriptFlush`, the
-`function*` mutations, `flushAll`, `flushDb`, `keys`, `dbSize`, `waitReplicas`, and `waitAof` run on every slot-owning master and their replies
-are folded into one. The call is all or nothing: one master answering with an error fails it, with no partial result. A master that is only
-reconnecting does not fail it, since the command never ran there: sage refreshes the topology and retries that one node on the `maxRedirects`
-budget. A retried `waitReplicas` or `waitAof` serves its timeout again on that node.
+A cluster replicates no script or function cache, and no node sees the whole keyspace. So `scriptLoad`, `scriptExists`, `scriptFlush`, the
+`function*` mutations, `flushAll`, `flushDb`, `keys`, `dbSize`, `waitReplicas`, and `waitAof` run on every slot-owning master, and their replies
+are folded into one. One master failing fails the whole call, with no partial result. A master that is only reconnecting is retried on the
+`maxRedirects` budget; a retried `waitReplicas` or `waitAof` waits again on that node.
 
 ## Master-replica
 

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -2,7 +2,7 @@
 
 A **rate limiter** caps how often something may happen: so many requests per second for an API key, a budget of login attempts per account, a fair-use quota per tenant. Sage ships one built in, so every client has it with no extra dependency.
 
-The limiter is **distributed**. Its state lives on the server, not in process memory, so the limit holds across every process pointed at the same server (they share the keyspace, not a connection). Each check runs its whole decide-and-consume cycle atomically on the server; in steady state that is a single round trip. The script is cached on the server, so a check pays one extra round trip, sending the script body, only when the server has not cached it yet (a cold server, or after `SCRIPT FLUSH`), not per connection. In a cluster that recovery stays on the node owning the subject's key, so one other node being briefly unreachable cannot fail a check.
+The limiter is **distributed**. Its state lives on the server, not in process memory, so the limit holds across every process pointed at the same server (they share the keyspace, not a connection). Each check runs its whole decide-and-consume cycle atomically on the server; in steady state that is a single round trip. The script is cached on the server, so a check pays one extra round trip, resending the script body, only when the server has not cached it yet (a cold server, or after `SCRIPT FLUSH`), not per connection. In a cluster that stays on the node owning the subject's key.
 
 `rateLimiter` binds a policy to the client. Each `tryAcquire` consumes tokens for a subject and returns a `Decision`.
 

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -2,7 +2,7 @@
 
 A **rate limiter** caps how often something may happen: so many requests per second for an API key, a budget of login attempts per account, a fair-use quota per tenant. Sage ships one built in, so every client has it with no extra dependency.
 
-The limiter is **distributed**. Its state lives on the server, not in process memory, so the limit holds across every process pointed at the same server (they share the keyspace, not a connection). Each check runs its whole decide-and-consume cycle atomically on the server; in steady state that is a single round trip. The script is cached on the server, so a check pays a one-time load-and-retry only when the server has not cached it yet (a cold server, or after `SCRIPT FLUSH`), not per connection.
+The limiter is **distributed**. Its state lives on the server, not in process memory, so the limit holds across every process pointed at the same server (they share the keyspace, not a connection). Each check runs its whole decide-and-consume cycle atomically on the server; in steady state that is a single round trip. The script is cached on the server, so a check pays one extra round trip, sending the script body, only when the server has not cached it yet (a cold server, or after `SCRIPT FLUSH`), not per connection. In a cluster that recovery stays on the node owning the subject's key, so one other node being briefly unreachable cannot fail a check.
 
 `rateLimiter` binds a policy to the client. Each `tryAcquire` consumes tokens for a subject and returns a `Decision`.
 

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -2,7 +2,7 @@
 
 A **rate limiter** caps how often something may happen: so many requests per second for an API key, a budget of login attempts per account, a fair-use quota per tenant. Sage ships one built in, so every client has it with no extra dependency.
 
-The limiter is **distributed**. Its state lives on the server, not in process memory, so the limit holds across every process pointed at the same server (they share the keyspace, not a connection). Each check runs its whole decide-and-consume cycle atomically on the server; in steady state that is a single round trip. The script is cached on the server, so a check pays one extra round trip, resending the script body, only when the server has not cached it yet (a cold server, or after `SCRIPT FLUSH`), not per connection. In a cluster that stays on the node owning the subject's key.
+The limiter is **distributed**. Its state lives on the server, not in process memory, so the limit holds across every process pointed at the same server (they share the keyspace, not a connection). Each check runs its whole decide-and-consume cycle atomically on the server; in steady state that is a single round trip. The script is cached on the server, so only a cold server (or one after `SCRIPT FLUSH`) costs a second round trip to resend the script body. In a cluster that resend goes to the node owning the subject's key, like the check itself.
 
 `rateLimiter` binds a policy to the client. Each `tryAcquire` consumes tokens for a subject and returns a `Decision`.
 

--- a/integration-tests/shared/src/test/scala/sage/integration/ratelimit/RateLimiterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/ratelimit/RateLimiterSuite.scala
@@ -110,7 +110,7 @@ abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
     }
   }
 
-  test("the native EVALSHA path recovers from NOSCRIPT by loading the script and retrying") {
+  test("the native EVALSHA path recovers from NOSCRIPT by re-running with the script body") {
     withClient { client =>
       val rl = client.rateLimiter[String](limit(2), namespace = "noscript")
       for {
@@ -118,8 +118,8 @@ abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
         first  <- rl.tryAcquire("cold")
         second <- rl.tryAcquire("cold")
       } yield {
-        assert(first.isAllowed && first.remainingTokens == 1L, "a cold server is recovered by one load-and-retry")
-        assert(second.isAllowed && second.remainingTokens == 0L, "the loaded script then serves EVALSHA directly")
+        assert(first.isAllowed && first.remainingTokens == 1L, "a cold server is recovered by one EVAL of the body")
+        assert(second.isAllowed && second.remainingTokens == 0L, "that EVAL caches the script, so EVALSHA then serves directly")
       }
     }
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -425,6 +425,7 @@ final private[client] class ClusterLive(
             if (readFrom == ReadFrom.Replica) complete(Failure(NotConnected()))
             else onRedirect(node, redirect, command, redirectsLeft, complete)
           case RedirectKind.Moved if redirectsLeft <= 0 =>
+            refreshBeforeFailing()
             complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
           case RedirectKind.Moved                       => refresh(force = true); offload(dispatch(command, redirectsLeft - 1, complete))
         }
@@ -512,7 +513,8 @@ final private[client] class ClusterLive(
 
   private def submitBroadcast[B](node: Node, command: Command[B], resolve: Node => NodeClient, attemptsLeft: Int, settle: Try[B] => Unit): Unit = {
     val nc = resolve(node)
-    if (nc == null) retryBroadcast(node, command, NotConnected(), attemptsLeft, settle)
+    // the dispatch fast path resolves inline on the caller, which the retry's refresh would block
+    if (nc == null) offload(retryBroadcast(node, command, NotConnected(), attemptsLeft, settle))
     else
       nc.submit[B](
         command,
@@ -535,7 +537,7 @@ final private[client] class ClusterLive(
 
   // a node the refreshed topology no longer lists as a slot-owning master makes this broadcast's target set stale, so it fails unchased
   private def retryBroadcast[B](node: Node, command: Command[B], error: Throwable, attemptsLeft: Int, settle: Try[B] => Unit): Unit =
-    if (attemptsLeft <= 0) { triggerRefresh(); settle(Failure(error)) }
+    if (attemptsLeft <= 0) { refreshBeforeFailing(); settle(Failure(error)) }
     else
       afterBackoff(attemptsLeft) {
         refresh(force = true)
@@ -637,14 +639,15 @@ final private[client] class ClusterLive(
     lease: DedicatedPool.Lease = null,
     cacheCtx: Cached = null
   ): Unit = {
-    // a MOVED proves `from` lost the slot; retire its cache and adopt the new ownership even if the retry budget is now exhausted
-    if (redirect.kind == RedirectKind.Moved) { flushNode(from); triggerRefresh() }
-    if (redirectsLeft <= 0)
+    // a MOVED proves `from` lost the slot; retire its cache even if the retry budget is now exhausted
+    if (redirect.kind == RedirectKind.Moved) flushNode(from)
+    if (redirectsLeft <= 0) {
+      if (redirect.kind == RedirectKind.Moved) refreshBeforeFailing()
       complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
-    else {
+    } else {
       val target = resolve(redirect.target, from)
       redirect.kind match {
-        case RedirectKind.Moved => sendTo(target, command, asking = false, redirectsLeft - 1, complete, lease, cacheCtx)
+        case RedirectKind.Moved => triggerRefresh(); sendTo(target, command, asking = false, redirectsLeft - 1, complete, lease, cacheCtx)
         case RedirectKind.Ask   => sendTo(target, command, asking = true, redirectsLeft - 1, complete, lease, cacheCtx)
       }
     }
@@ -659,8 +662,7 @@ final private[client] class ClusterLive(
     lease: DedicatedPool.Lease = null,
     cacheCtx: Cached = null
   ): Unit =
-    // a zero or exhausted budget must still adopt the new topology, or the next command repeats this loss
-    if (redirectsLeft <= 0) { triggerRefresh(); complete(Failure(NotConnected())) }
+    if (redirectsLeft <= 0) { refreshBeforeFailing(); complete(Failure(NotConnected())) }
     else {
       refresh(force = true)
       afterBackoff(redirectsLeft)(
@@ -684,8 +686,11 @@ final private[client] class ClusterLive(
       )
 
   // paces a retry, growing with the attempts already spent, so an in-progress failover or migration is not hammered
-  private def afterBackoff(redirectsLeft: Int)(retry: => Unit): Unit =
-    scheduler.after(Backoff.jitteredMillis(reconnect, (cluster.maxRedirects - redirectsLeft).max(0), scheduler).millis)(retry)
+  private def afterBackoff(attemptsLeft: Int)(retry: => Unit): Unit =
+    scheduler.after(Backoff.jitteredMillis(reconnect, (cluster.maxRedirects - attemptsLeft).max(0), scheduler).millis)(retry)
+
+  // a path that will not retry must adopt a topology, not schedule one a throttle could drop
+  private def refreshBeforeFailing(): Unit = refresh(force = true)
 
   private def onUnowned[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit, lease: DedicatedPool.Lease, cacheCtx: Cached): Unit = {
     refresh(force = false)

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -524,8 +524,7 @@ final private[client] class ClusterLive(
       )
   }
 
-  // a broadcast is all-or-nothing, so one master reconnecting must not fail it: that node provably never ran the command, so retry it alone,
-  // leaving the masters that already answered untouched. A command carrying its own timeout (WAIT) re-serves it on the retried node.
+  // only the node that lost its connection is retried; a command carrying its own timeout (WAIT) re-serves it there
   private def onBroadcastFailure[B](node: Node, command: Command[B], error: Throwable, attemptsLeft: Int, settle: Try[B] => Unit): Unit =
     Fault.categorize(error) match {
       case Fault.Lost(false) => retryBroadcast(node, command, error, attemptsLeft, settle)
@@ -534,18 +533,15 @@ final private[client] class ClusterLive(
         settle(Failure(error))
     }
 
-  // refresh first: a node the new topology no longer lists as a slot-owning master means the broadcast's target set is stale, so fail rather
-  // than chase a departed node — the adopted topology makes the caller's next broadcast the right one
+  // a node the refreshed topology no longer lists as a slot-owning master makes this broadcast's target set stale, so it fails unchased
   private def retryBroadcast[B](node: Node, command: Command[B], error: Throwable, attemptsLeft: Int, settle: Try[B] => Unit): Unit =
-    if (attemptsLeft <= 0) settle(Failure(error))
-    else {
-      val attempt = (cluster.maxRedirects - attemptsLeft).max(0)
-      scheduler.after(Backoff.jitteredMillis(reconnect, attempt, scheduler).millis) {
+    if (attemptsLeft <= 0) { triggerRefresh(); settle(Failure(error)) }
+    else
+      afterBackoff(attemptsLeft) {
         refresh(force = true)
         if (closed || !slotOwningMasters(topologyRef.get()).contains(node)) settle(Failure(error))
         else submitBroadcast(node, command, establishOrNull, attemptsLeft - 1, settle)
       }
-    }
 
   private def collectFrames(frames: java.util.concurrent.atomic.AtomicReferenceArray[Frame], size: Int): Vector[Frame] = {
     val out = Vector.newBuilder[Frame]
@@ -641,14 +637,14 @@ final private[client] class ClusterLive(
     lease: DedicatedPool.Lease = null,
     cacheCtx: Cached = null
   ): Unit = {
-    // a MOVED proves `from` lost the slot; retire its cache even if the retry budget is now exhausted
-    if (redirect.kind == RedirectKind.Moved) flushNode(from)
+    // a MOVED proves `from` lost the slot; retire its cache and adopt the new ownership even if the retry budget is now exhausted
+    if (redirect.kind == RedirectKind.Moved) { flushNode(from); triggerRefresh() }
     if (redirectsLeft <= 0)
       complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
     else {
       val target = resolve(redirect.target, from)
       redirect.kind match {
-        case RedirectKind.Moved => triggerRefresh(); sendTo(target, command, asking = false, redirectsLeft - 1, complete, lease, cacheCtx)
+        case RedirectKind.Moved => sendTo(target, command, asking = false, redirectsLeft - 1, complete, lease, cacheCtx)
         case RedirectKind.Ask   => sendTo(target, command, asking = true, redirectsLeft - 1, complete, lease, cacheCtx)
       }
     }
@@ -663,11 +659,11 @@ final private[client] class ClusterLive(
     lease: DedicatedPool.Lease = null,
     cacheCtx: Cached = null
   ): Unit =
-    if (redirectsLeft <= 0) complete(Failure(NotConnected()))
+    // a zero or exhausted budget must still adopt the new topology, or the next command repeats this loss
+    if (redirectsLeft <= 0) { triggerRefresh(); complete(Failure(NotConnected())) }
     else {
       refresh(force = true)
-      val attempt = (cluster.maxRedirects - redirectsLeft).max(0)
-      scheduler.after(Backoff.jitteredMillis(reconnect, attempt, scheduler).millis)(
+      afterBackoff(redirectsLeft)(
         dispatch(command, redirectsLeft - 1, complete, allowReplica = replicaAllowed(cacheCtx), lease = lease, cacheCtx = cacheCtx)
       )
     }
@@ -682,12 +678,14 @@ final private[client] class ClusterLive(
     cacheCtx: Cached = null
   ): Unit =
     if (redirectsLeft <= 0) complete(Failure(error))
-    else {
-      val attempt = (cluster.maxRedirects - redirectsLeft).max(0)
-      scheduler.after(Backoff.jitteredMillis(reconnect, attempt, scheduler).millis)(
+    else
+      afterBackoff(redirectsLeft)(
         dispatch(command, redirectsLeft - 1, complete, allowReplica = replicaAllowed(cacheCtx), lease = lease, cacheCtx = cacheCtx)
       )
-    }
+
+  // paces a retry, growing with the attempts already spent, so an in-progress failover or migration is not hammered
+  private def afterBackoff(redirectsLeft: Int)(retry: => Unit): Unit =
+    scheduler.after(Backoff.jitteredMillis(reconnect, (cluster.maxRedirects - redirectsLeft).max(0), scheduler).millis)(retry)
 
   private def onUnowned[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit, lease: DedicatedPool.Lease, cacheCtx: Cached): Unit = {
     refresh(force = false)
@@ -1145,7 +1143,6 @@ final private[client] class ClusterLive(
 
   private def getOrEstablish(node: Node): NodeClient = masterPool.getOrEstablish(node)
 
-  // blocking establish for a caller that treats a failure as the node being unreachable
   private def establishOrNull(node: Node): NodeClient =
     try getOrEstablish(node)
     catch { case NonFatal(_) => null }

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -216,18 +216,8 @@ final private[client] class ClusterLive(
       val topology = topologyRef.get()
       if (command.allMasters)
         if (slotOwningMasters(topology).forall(node => masterPool.existing(node) != null))
-          broadcast(topology, command, complete, masterPool.existing)
-        else
-          offload {
-            broadcast(
-              topology,
-              command,
-              complete,
-              node =>
-                try getOrEstablish(node)
-                catch { case NonFatal(_) => null }
-            )
-          }
+          broadcast(topology, command, redirectsLeft, complete, masterPool.existing)
+        else offload(broadcast(topology, command, redirectsLeft, complete, establishOrNull))
       else
         topology.route(command) match {
           case Route.ToNode(node, slot) =>
@@ -445,16 +435,28 @@ final private[client] class ClusterLive(
       case Fault.Fatal                      => Events.attributeNode(complete, node); complete(Failure(error))
     }
 
-  private def broadcast[A](topology: ClusterTopology, command: Command[A], complete: Try[A] => Unit, resolve: Node => NodeClient): Unit =
+  private def broadcast[A](
+    topology: ClusterTopology,
+    command: Command[A],
+    redirectsLeft: Int,
+    complete: Try[A] => Unit,
+    resolve: Node => NodeClient
+  ): Unit =
     command.broadcast match {
-      case BroadcastReduce.First      => sendToAllMasters(topology, command, complete, resolve)
-      case BroadcastReduce.Concat     => broadcastCombine(topology, command, concatFrames, complete, resolve)
-      case BroadcastReduce.Fold(fold) => broadcastCombine(topology, command, _.reduce(fold), complete, resolve)
+      case BroadcastReduce.First      => sendToAllMasters(topology, command, redirectsLeft, complete, resolve)
+      case BroadcastReduce.Concat     => broadcastCombine(topology, command, concatFrames, redirectsLeft, complete, resolve)
+      case BroadcastReduce.Fold(fold) => broadcastCombine(topology, command, _.reduce(fold), redirectsLeft, complete, resolve)
     }
 
   // a broadcast command (SCRIPT LOAD, FUNCTION LOAD, …) runs on every slot-owning master, since a cluster replicates no script/function
-  // cache; any node failing fails the command
-  private def sendToAllMasters[A](topology: ClusterTopology, command: Command[A], complete: Try[A] => Unit, resolve: Node => NodeClient): Unit = {
+  // cache; any node failing terminally fails the command
+  private def sendToAllMasters[A](
+    topology: ClusterTopology,
+    command: Command[A],
+    redirectsLeft: Int,
+    complete: Try[A] => Unit,
+    resolve: Node => NodeClient
+  ): Unit = {
     val masters = slotOwningMasters(topology)
     if (masters.isEmpty) sendToAny(topology, command, cluster.maxRedirects, complete)
     else {
@@ -469,21 +471,18 @@ final private[client] class ClusterLive(
         if (remaining.decrementAndGet() == 0)
           complete(Option(firstError.get()).map(Failure(_)).getOrElse(firstValue.get()))
       }
-      masters.foreach { node =>
-        val nc = resolve(node)
-        if (nc == null) settle(Failure(NotConnected()))
-        else nc.submit[A](command, asking = false, settle)
-      }
+      masters.foreach(node => submitBroadcast(node, command, resolve, redirectsLeft, settle))
     }
   }
 
   // an all-masters broadcast whose per-node replies fold into one: KEYS concatenates each node's node-local slice (no single node sees the
   // whole keyspace), WAIT/WAITAOF reduce to the weakest shard. Frames are collected raw and combined before a single decode; any node
-  // failing fails the command
+  // failing terminally fails the command
   private def broadcastCombine[A](
     topology: ClusterTopology,
     command: Command[A],
     combine: Vector[Frame] => Frame,
+    redirectsLeft: Int,
     complete: Try[A] => Unit,
     resolve: Node => NodeClient
   ): Unit = {
@@ -506,12 +505,47 @@ final private[client] class ClusterLive(
           }
       }
       masters.iterator.zipWithIndex.foreach { case (node, index) =>
-        val nc = resolve(node)
-        if (nc == null) settle(index, Failure(NotConnected()))
-        else nc.submit[Frame](raw, asking = false, result => settle(index, result))
+        submitBroadcast(node, raw, resolve, redirectsLeft, result => settle(index, result))
       }
     }
   }
+
+  private def submitBroadcast[B](node: Node, command: Command[B], resolve: Node => NodeClient, attemptsLeft: Int, settle: Try[B] => Unit): Unit = {
+    val nc = resolve(node)
+    if (nc == null) retryBroadcast(node, command, NotConnected(), attemptsLeft, settle)
+    else
+      nc.submit[B](
+        command,
+        asking = false,
+        {
+          case Success(value) => settle(Success(value))
+          case Failure(error) => offload(onBroadcastFailure(node, command, error, attemptsLeft, settle))
+        }
+      )
+  }
+
+  // a broadcast is all-or-nothing, so one master reconnecting must not fail it: that node provably never ran the command, so retry it alone,
+  // leaving the masters that already answered untouched. A command carrying its own timeout (WAIT) re-serves it on the retried node.
+  private def onBroadcastFailure[B](node: Node, command: Command[B], error: Throwable, attemptsLeft: Int, settle: Try[B] => Unit): Unit =
+    Fault.categorize(error) match {
+      case Fault.Lost(false) => retryBroadcast(node, command, error, attemptsLeft, settle)
+      case fault             =>
+        if (fault.refreshesTopology) triggerRefresh()
+        settle(Failure(error))
+    }
+
+  // refresh first: a node the new topology no longer lists as a slot-owning master means the broadcast's target set is stale, so fail rather
+  // than chase a departed node — the adopted topology makes the caller's next broadcast the right one
+  private def retryBroadcast[B](node: Node, command: Command[B], error: Throwable, attemptsLeft: Int, settle: Try[B] => Unit): Unit =
+    if (attemptsLeft <= 0) settle(Failure(error))
+    else {
+      val attempt = (cluster.maxRedirects - attemptsLeft).max(0)
+      scheduler.after(Backoff.jitteredMillis(reconnect, attempt, scheduler).millis) {
+        refresh(force = true)
+        if (closed || !slotOwningMasters(topologyRef.get()).contains(node)) settle(Failure(error))
+        else submitBroadcast(node, command, establishOrNull, attemptsLeft - 1, settle)
+      }
+    }
 
   private def collectFrames(frames: java.util.concurrent.atomic.AtomicReferenceArray[Frame], size: Int): Vector[Frame] = {
     val out = Vector.newBuilder[Frame]
@@ -1110,6 +1144,11 @@ final private[client] class ClusterLive(
   }
 
   private def getOrEstablish(node: Node): NodeClient = masterPool.getOrEstablish(node)
+
+  // blocking establish for a caller that treats a failure as the node being unreachable
+  private def establishOrNull(node: Node): NodeClient =
+    try getOrEstablish(node)
+    catch { case NonFatal(_) => null }
 
   private def flushNode(node: Node): Unit =
     if (cachingEnabled) { val nc = masterPool.existing(node); if (nc != null) nc.flushCache() }

--- a/sage-client/shared/src/main/scala/sage/client/internal/RateLimitExecutor.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/RateLimitExecutor.scala
@@ -7,7 +7,8 @@ import sage.commands.Command
 import sage.ratelimit.{Decision, RateLimiter}
 
 /**
-  * Runs one bound limiter: [[evalSha]] validates, runs by digest, and reloads the script once on a `NOSCRIPT`.
+  * Runs one bound limiter: [[evalSha]] validates, runs by digest, and falls back once to sending the script body on a `NOSCRIPT`. The
+  * fallback is keyed like the check itself, so in a cluster it routes to the one owning master and needs no all-masters `SCRIPT LOAD`.
   */
 final private[client] class RateLimitExecutor[K](definition: RateLimiter[K]) {
 
@@ -19,9 +20,8 @@ final private[client] class RateLimitExecutor[K](definition: RateLimiter[K]) {
     definition.validate(cost) match {
       case Some(problem) => CIO.fail(InvalidArgument(problem))
       case None          =>
-        val check = definition.evalSha(subject, cost, peek)
-        runner.run(check).recover {
-          case ServerError(code, _) if code == "NOSCRIPT" => runner.run(definition.loadCommand).flatMap(_ => runner.run(check))
+        runner.run(definition.evalSha(subject, cost, peek)).recover {
+          case ServerError(code, _) if code == "NOSCRIPT" => runner.run(definition.evalScript(subject, cost, peek))
           case other                                      => CIO.fail(other)
         }
     }

--- a/sage-client/shared/src/test/scala/sage/client/internal/RateLimitFallbackSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/RateLimitFallbackSpec.scala
@@ -16,16 +16,17 @@ class RateLimitFallbackSpec extends munit.FunSuite {
   private def executor(limit: RateLimit = RateLimit.perSecond(10)) =
     new RateLimitExecutor[String](RateLimiter[String](limit))
 
-  test("a NOSCRIPT loads the script once and retries the EVALSHA") {
-    var loads    = 0
+  test("a NOSCRIPT retries once with the script body, on the same key, and never broadcasts a SCRIPT LOAD") {
+    var evals    = 0
     var evalShas = 0
     val runner   = new CommandRunner[CIO, String] {
       def run[A](command: Command[A]): CIO[A] = command.name match {
-        case "EVALSHA" =>
-          evalShas += 1
-          if (loads == 0) CIO.fail(ServerError("NOSCRIPT", ""))
-          else CIO.value(Decision.Allowed(3, 1.second).asInstanceOf[A])
-        case "SCRIPT"  => loads += 1; CIO.value("sha".asInstanceOf[A])
+        case "EVALSHA" => evalShas += 1; CIO.fail(ServerError("NOSCRIPT", ""))
+        case "EVAL"    =>
+          evals += 1
+          assertEquals(command.keyIndices, Vector(2))
+          assert(!command.allMasters)
+          CIO.value(Decision.Allowed(3, 1.second).asInstanceOf[A])
         case other     => CIO.fail(ServerError("ERR", s"unexpected $other"))
       }
     }
@@ -33,17 +34,37 @@ class RateLimitFallbackSpec extends munit.FunSuite {
       result <- executor().evalSha(runner, "k", 1, peek = false).unsafeRun
     } yield {
       assertEquals(result, Decision.Allowed(3, 1.second))
-      assertEquals(loads, 1)
-      assertEquals(evalShas, 2)
+      assertEquals(evals, 1)
+      assertEquals(evalShas, 1)
     }
   }
 
-  test("a non-NOSCRIPT error propagates and never loads") {
-    var loads  = 0
+  test("a NOSCRIPT on the fallback itself propagates rather than looping") {
+    var evals  = 0
     val runner = new CommandRunner[CIO, String] {
-      def run[A](command: Command[A]): CIO[A] =
-        if (command.name == "SCRIPT") { loads += 1; CIO.value("sha".asInstanceOf[A]) }
-        else CIO.fail(ServerError("WRONGTYPE", "nope"))
+      def run[A](command: Command[A]): CIO[A] = {
+        if (command.name == "EVAL") evals += 1
+        CIO.fail(ServerError("NOSCRIPT", ""))
+      }
+    }
+    for {
+      failed <- executor().evalSha(runner, "k", 1, peek = false).unsafeRun.failed
+    } yield {
+      failed match {
+        case e: ServerError => assertEquals(e.code, "NOSCRIPT")
+        case other          => fail(s"expected ServerError, got $other")
+      }
+      assertEquals(evals, 1)
+    }
+  }
+
+  test("a non-NOSCRIPT error propagates and never falls back") {
+    var evals  = 0
+    val runner = new CommandRunner[CIO, String] {
+      def run[A](command: Command[A]): CIO[A] = {
+        if (command.name == "EVAL") evals += 1
+        CIO.fail(ServerError("WRONGTYPE", "nope"))
+      }
     }
     for {
       failed <- executor().evalSha(runner, "k", 1, peek = false).unsafeRun.failed
@@ -52,7 +73,7 @@ class RateLimitFallbackSpec extends munit.FunSuite {
         case e: ServerError => assertEquals(e.code, "WRONGTYPE")
         case other          => fail(s"expected ServerError, got $other")
       }
-      assertEquals(loads, 0)
+      assertEquals(evals, 0)
     }
   }
 

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -125,6 +125,12 @@ class ClusterClientSpec extends munit.FunSuite {
     assert(fixture.written(node).exists(_.contains(token)), s"$node never received $token")
   }
 
+  private def awaitCount(what: String, atLeast: Int)(count: => Int): Unit = {
+    val deadline = System.nanoTime() + 2000000000L
+    while (count < atLeast && System.nanoTime() < deadline) Thread.sleep(5)
+    assert(count >= atLeast, s"$what: expected at least $atLeast, got $count")
+  }
+
   private def wholeClusterOn(node: Node): Frame = slotsFrame((node, 0, Slot.Count - 1))
 
   test("a seed that owns no slots fails the bootstrap rather than adopting an empty topology") {
@@ -377,6 +383,55 @@ class ClusterClientSpec extends munit.FunSuite {
 
     fixture.live.run(Server.waitReplicas(1L, 100.millis)).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[NotConnected], s"expected NotConnected, got $error")
+    }
+  }
+
+  test("a broadcast retries a master whose establish failed transiently instead of failing the whole command") {
+    val mid       = Slot.Count / 2
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else if (text.contains("SCRIPT")) Seq(Frame.BulkString(Bytes.utf8("digest")))
+      else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.flakyHello += nodeB
+    fixture.live.run(Scripting.scriptLoad("return 1")).unsafeRun.map { result =>
+      assertEquals(result, "digest")
+      assert(fixture.written(nodeB).exists(_.contains("SCRIPT")), "nodeB never received the retried SCRIPT LOAD")
+    }
+  }
+
+  test("a broadcast fails fast rather than chasing a master a refresh no longer lists") {
+    val mid       = Slot.Count / 2
+    val owned     = new java.util.concurrent.atomic.AtomicBoolean(true)
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER"))
+        Seq(if (owned.get()) slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)) else wholeClusterOn(nodeA))
+      else if (text.contains("SCRIPT")) Seq(Frame.BulkString(Bytes.utf8("digest")))
+      else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA), unreachable = Set(nodeB))
+
+    owned.set(false) // nodeB has left the cluster: the retry's refresh drops it, so the stale broadcast fails instead of retrying it
+    fixture.live.run(Scripting.scriptLoad("return 1")).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[NotConnected], s"expected NotConnected, got $error")
+      assertEquals(fixture.written(nodeB).count(_.contains("HELLO")), 1, "the departed node was contacted more than once")
+      assert(fixture.written(nodeA).count(_.contains("CLUSTER")) >= 2, "the broadcast's loss did not refresh the topology")
+    }
+  }
+
+  test("a broadcast refreshes the topology when a master answers READONLY") {
+    val mid       = Slot.Count / 2
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else if (text.contains("FLUSHALL"))
+        Seq(if (node == nodeA) Frame.SimpleString("OK") else Frame.SimpleError("READONLY You can't write against a read only replica"))
+      else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    fixture.live.run(Server.flushAll()).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[ServerError], s"expected ServerError, got $error")
+      // the demoted node is not retried (the command may have run there), but its reply must still cost the topology its trust
+      awaitCount("CLUSTER SLOTS calls", 2)(fixture.written(nodeA).count(_.contains("CLUSTER")) + fixture.written(nodeB).count(_.contains("CLUSTER")))
     }
   }
 

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -437,18 +437,30 @@ class ClusterClientSpec extends munit.FunSuite {
     }
   }
 
-  test("maxRedirects = 0 refuses to retry a broadcast but still refreshes, so the next one is not stale") {
-    val mid       = Slot.Count / 2
-    val behaviour = (_: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+  test("maxRedirects = 0 refuses to retry a broadcast but still adopts a topology, so the next one succeeds") {
+    val mid        = Slot.Count / 2
+    val departed   = new java.util.concurrent.atomic.AtomicBoolean(false)
+    val behaviour  = (_: Node, text: String) =>
+      if (text.contains("CLUSTER"))
+        Seq(if (departed.get()) wholeClusterOn(nodeA) else slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
       else if (text.contains("SCRIPT")) Seq(Frame.BulkString(Bytes.utf8("digest")))
       else Seq(Frame.Null)
-    val fixture   = new Fixture(behaviour, Vector(nodeA), unreachable = Set(nodeB), cluster = ClusterConfig(maxRedirects = 0))
+    val fixture    = new Fixture(behaviour, Vector(nodeA), unreachable = Set(nodeB), cluster = ClusterConfig(maxRedirects = 0))
+    val scriptLoad = Scripting.scriptLoad("return 1")
+    def helloes    = fixture.written(nodeB).count(_.contains("HELLO"))
 
-    fixture.live.run(Scripting.scriptLoad("return 1")).unsafeRun.failed.map { error =>
-      assert(error.isInstanceOf[NotConnected], s"expected NotConnected, got $error")
-      assertEquals(fixture.written(nodeB).count(_.contains("HELLO")), 1, "a zero budget still retried the unreachable node")
-      awaitRefreshed(fixture, nodeA, nodeB)
+    // the first failure's refresh arms the minRefreshInterval throttle, so a throttled second refresh would be dropped
+    fixture.live.run(scriptLoad).unsafeRun.failed.flatMap { _ =>
+      assertEquals(helloes, 1, "a zero budget retried the unreachable node")
+      departed.set(true)
+      fixture.live.run(scriptLoad).unsafeRun.failed.flatMap { error =>
+        assert(error.isInstanceOf[NotConnected], s"expected NotConnected, got $error")
+        val contacted = helloes
+        fixture.live.run(scriptLoad).unsafeRun.map { digest =>
+          assertEquals(digest, "digest")
+          assertEquals(helloes, contacted, "the next broadcast still targeted the departed node")
+        }
+      }
     }
   }
 
@@ -578,6 +590,28 @@ class ClusterClientSpec extends munit.FunSuite {
       assert(fixture.written(nodeR).exists(_.contains("READONLY")), "replica connection did not issue READONLY at setup")
       assert(fixture.written(nodeR).exists(_.contains("GET")), "replica did not receive the read")
       assert(!fixture.written(nodeA).exists(_.contains("GET")), "master received a read it should not have")
+    }
+  }
+
+  test("a replica read's MOVED adopts a topology even with no budget to follow it") {
+    val nodeR     = Node("r", 6379)
+    val moved     = new java.util.concurrent.atomic.AtomicBoolean(true)
+    def slots     =
+      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slots)
+      else if (text.contains("READONLY")) Seq(Frame.SimpleString("OK"))
+      else if (node == nodeR && moved.get()) Seq(Frame.SimpleError(s"MOVED 12182 ${nodeB.host}:${nodeB.port}"))
+      else Seq(Frame.BulkString(Bytes.utf8("value")))
+    val fixture   =
+      new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.Replica, cluster = ClusterConfig(maxRedirects = 0))
+    val get       = Strings.get[String, String]("foo")
+
+    fixture.live.run(get).unsafeRun.failed.flatMap { error =>
+      assert(error.getMessage.contains("exceeded 0 cluster redirects"), error.getMessage)
+      assert(fixture.written(nodeA).count(_.contains("CLUSTER")) >= 2, "the exhausted MOVED did not refresh the topology")
+      moved.set(false)
+      fixture.live.run(get).unsafeRun.map(assertEquals(_, Some("value")))
     }
   }
 

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -53,7 +53,8 @@ class ClusterClientSpec extends munit.FunSuite {
     readFrom: ReadFrom = ReadFrom.Master,
     connectGate: (Node, Int) => Unit = (_, _) => (), // blocks a node's nth transport creation, to park an establish mid-flight
     scheduler: Scheduler = Scheduler.real,
-    caching: Boolean = false
+    caching: Boolean = false,
+    cluster: ClusterConfig = ClusterConfig()
   ) {
 
     // accumulate every transport per node (a node has both a Multiplexed and, once a transaction pins, a Dedicated connection) so a refresh
@@ -93,7 +94,7 @@ class ClusterClientSpec extends munit.FunSuite {
         1.second,
         Duration.Zero,
         DedicatedPoolConfig(),
-        ClusterConfig(),
+        cluster,
         1024,
         seeds,
         readFrom,
@@ -119,16 +120,18 @@ class ClusterClientSpec extends munit.FunSuite {
     def deliver(node: Node, frame: Frame): Unit = transportsOf(node).lastOption.foreach(_.emit(frame))
   }
 
-  private def awaitWritten(fixture: Fixture, node: Node, token: String): Unit = {
+  private def await(clue: => String)(condition: => Boolean): Unit = {
     val deadline = System.nanoTime() + 2000000000L
-    while (!fixture.written(node).exists(_.contains(token)) && System.nanoTime() < deadline) Thread.sleep(5)
-    assert(fixture.written(node).exists(_.contains(token)), s"$node never received $token")
+    while (!condition && System.nanoTime() < deadline) Thread.sleep(5)
+    assert(condition, clue)
   }
 
-  private def awaitCount(what: String, atLeast: Int)(count: => Int): Unit = {
-    val deadline = System.nanoTime() + 2000000000L
-    while (count < atLeast && System.nanoTime() < deadline) Thread.sleep(5)
-    assert(count >= atLeast, s"$what: expected at least $atLeast, got $count")
+  private def awaitWritten(fixture: Fixture, node: Node, token: String): Unit =
+    await(s"$node never received $token")(fixture.written(node).exists(_.contains(token)))
+
+  private def awaitRefreshed(fixture: Fixture, nodes: Node*): Unit = {
+    def slotsCalls = nodes.map(node => fixture.written(node).count(_.contains("CLUSTER"))).sum
+    await(s"expected a second CLUSTER SLOTS, saw $slotsCalls")(slotsCalls >= 2)
   }
 
   private def wholeClusterOn(node: Node): Frame = slotsFrame((node, 0, Slot.Count - 1))
@@ -411,7 +414,7 @@ class ClusterClientSpec extends munit.FunSuite {
       else Seq(Frame.Null)
     val fixture   = new Fixture(behaviour, Vector(nodeA), unreachable = Set(nodeB))
 
-    owned.set(false) // nodeB has left the cluster: the retry's refresh drops it, so the stale broadcast fails instead of retrying it
+    owned.set(false) // nodeB has left the cluster, so the retry's refresh drops it
     fixture.live.run(Scripting.scriptLoad("return 1")).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[NotConnected], s"expected NotConnected, got $error")
       assertEquals(fixture.written(nodeB).count(_.contains("HELLO")), 1, "the departed node was contacted more than once")
@@ -430,8 +433,22 @@ class ClusterClientSpec extends munit.FunSuite {
 
     fixture.live.run(Server.flushAll()).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[ServerError], s"expected ServerError, got $error")
-      // the demoted node is not retried (the command may have run there), but its reply must still cost the topology its trust
-      awaitCount("CLUSTER SLOTS calls", 2)(fixture.written(nodeA).count(_.contains("CLUSTER")) + fixture.written(nodeB).count(_.contains("CLUSTER")))
+      awaitRefreshed(fixture, nodeA, nodeB)
+    }
+  }
+
+  test("maxRedirects = 0 refuses to retry a broadcast but still refreshes, so the next one is not stale") {
+    val mid       = Slot.Count / 2
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      else if (text.contains("SCRIPT")) Seq(Frame.BulkString(Bytes.utf8("digest")))
+      else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA), unreachable = Set(nodeB), cluster = ClusterConfig(maxRedirects = 0))
+
+    fixture.live.run(Scripting.scriptLoad("return 1")).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[NotConnected], s"expected NotConnected, got $error")
+      assertEquals(fixture.written(nodeB).count(_.contains("HELLO")), 1, "a zero budget still retried the unreachable node")
+      awaitRefreshed(fixture, nodeA, nodeB)
     }
   }
 

--- a/sage-core/src/main/scala/sage/ratelimit/RateLimiter.scala
+++ b/sage-core/src/main/scala/sage/ratelimit/RateLimiter.scala
@@ -73,7 +73,9 @@ final case class RateLimiter[K](limit: RateLimit, namespace: String = RateLimite
   private[sage] def tryAcquireAt(subject: K, cost: Long, nowMicros: Long): Command[Decision] =
     eval(RateLimiter.Invocation.Eval, subject, cost, peek = false, Some(nowMicros))
 
-  private[sage] def loadCommand: Command[String] = Scripting.scriptLoad(RateLimiter.script)
+  // the NOSCRIPT recovery for evalSha: sending the body runs the check and caches it on that node, so no cluster-wide SCRIPT LOAD is needed
+  private[sage] def evalScript(subject: K, cost: Long, peek: Boolean): Command[Decision] =
+    eval(RateLimiter.Invocation.Eval, subject, cost, peek)
 
   // length-framing keeps namespace `a` + subject `b:c` distinct from namespace `a:b` + subject `c`
   private def keyBytes(subject: K): Bytes = Bytes.concat(Vector(keyPrefix, keyCodec.encode(subject)))

--- a/sage-core/src/test/scala/sage/ratelimit/RateLimiterSpec.scala
+++ b/sage-core/src/test/scala/sage/ratelimit/RateLimiterSpec.scala
@@ -72,8 +72,11 @@ class RateLimiterSpec extends munit.FunSuite {
     assertEquals(command.keyIndices, Vector(2))
   }
 
-  test("loadCommand is SCRIPT LOAD and sha is a 40-char hex digest") {
-    assertEquals(limiter.loadCommand.name, "SCRIPT")
+  test("evalScript is a keyed EVAL carrying the script body, and sha is a 40-char hex digest") {
+    val command = limiter.evalScript("u", 1, peek = false)
+    assertEquals(command.name, "EVAL")
+    assertEquals(command.args.head.asUtf8String, RateLimiter.script)
+    assertEquals(command.keyIndices, Vector(2))
     assertEquals(RateLimiter.sha.length, 40)
     assert(RateLimiter.sha.forall(c => c.isDigit || ('a' to 'f').contains(c)))
   }


### PR DESCRIPTION
An `allMasters` broadcast (`scriptLoad`, `functionLoad`, `flushAll`, `flushDb`, `keys`, `dbSize`, `waitReplicas`, `waitAof`, `script*`) threaded no retry budget and never refreshed the topology. Every other path (`onUnreachable`, `onReadFailure`, the pipeline's per-node settle) refreshes on a loss; the broadcast collector only recorded the first error. Two consequences:

- one master merely reconnecting failed the whole command, since a submit on a non-live connection fails fast with `NotConnected`
- a stale topology naming a departed master kept failing every broadcast until some other command's fault happened to refresh, as cluster refresh is fault-driven with no periodic poll

A never-executed loss on one node now refreshes and retries that node alone, within the same `maxRedirects` budget and jittered pacing the other paths use, leaving the masters that already answered untouched (so no re-execution of a non-idempotent `FUNCTION LOAD` on a healthy node). A node the refreshed topology no longer lists as a slot-owning master fails the command rather than being chased through the retry budget. Any other fault still fails the command, and a topology-changing one triggers a best-effort refresh: scheduled and throttled, like every other fault-driven refresh in the runtime. A `waitReplicas`/`waitAof` retried this way serves its timeout again on the retried node; that is the one latency-visible change, and it is documented.

All-or-nothing is unchanged: no partial result is ever reported.

### Retry-free paths

`maxRedirects = 0` is a valid setting, and it made every exhaustion path settle without refreshing at all: a broadcast to a departed master, a lost ordinary command, and a MOVED (including a replica read's MOVED, which never went through `onRedirect`, so it refreshed on no budget at all). Zero now means "do not retry", not "do not learn". Since those paths will not retry, the refresh is the only remedy left, so they complete a forced refresh before settling rather than scheduling a throttled one that the settle can beat or `minRefreshInterval` can drop.

That completed-refresh guarantee is specific to exhausted-budget paths. `Fault.Demoted` and `Fault.Lost(true)` stay best-effort, since those errors may follow execution and the command should fail without a blocking topology round trip.

MOVED with budget left is unchanged, and it already differed by path. `onRedirect` (ordinary and pipelined commands) schedules a throttled refresh and re-sends, so the hot redirect path never waits on one; that is why the refresh sits inside the branches rather than above the budget check. The replica read path instead forces a synchronous refresh before re-dispatching, since the read policy needs the new topology to locate the slot's replica, and it now does the same before failing on an exhausted budget.

### Rate limiter

The limiter no longer depends on the broadcast path at all. Its `NOSCRIPT` recovery ran a broadcast `SCRIPT LOAD`, and since every acquire goes through `EVALSHA`, the *first* acquire against a fresh cluster always took it, so one unrelated node being down could fail a rate-limit check at startup. It now re-runs the check with the script body (`Invocation.Eval`, which already existed): keyed, routed to the one owning master, cached there as a side effect, and one round trip cheaper than load-then-retry.

### Tests

Five new cluster cases, each verified to fail without the change: a transient establish failure is retried and the command succeeds; a departed master fails fast, contacted once, with the topology refreshed; a `READONLY` reply refreshes the topology; `maxRedirects = 0` refuses to retry yet the *next* broadcast lands on the adopted master set (the first failure arms the refresh throttle, so a throttled refresh would be dropped and the third call would fail); a replica read's exhausted MOVED refreshes. The rate-limiter fallback spec now asserts the retry is a keyed, non-broadcast `EVAL`.

`sbt check testUnit` green; `integrationTestsZio` cluster, failover, and rate-limiter suites green on both Redis and Valkey.
