### PR TITLE
Scope the minRefreshInterval scaladoc to unforced refreshes

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
+++ b/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
@@ -98,7 +98,8 @@ final case class Endpoint(host: String = "localhost", port: Int = 6379)
 
 /**
   * Cluster tuning. `maxRedirects` bounds how many `MOVED`/`ASK` hops a single command follows before failing (the same default as
-  * lettuce); `minRefreshInterval` throttles topology refreshes so a redirect storm triggers at most one `CLUSTER SLOTS` per window.
+  * lettuce); `minRefreshInterval` limits how often a `MOVED` or an unowned slot triggers `CLUSTER SLOTS`: once per window. A retry that
+  * must see the new topology first, as after a failover, refreshes regardless of the window and is bounded by `maxRedirects` instead.
   */
 final case class ClusterConfig(
   maxRedirects: Int = 5,


### PR DESCRIPTION
`minRefreshInterval` bounds only the refreshes no command is waiting on. The forcing call sites in `ClusterLive` (failover recovery, a pre-retry refresh, the cluster transaction path) skip the window by design, since the retry cannot route until it reads the new mapping.

Doc fix only.