### PR TITLE
Add an opt-in background topology refresh

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,6 +69,27 @@ A cluster replicates no script or function cache, and no node sees the whole key
 are folded into one. One master failing fails the whole call, with no partial result. A master that is only reconnecting is retried on the
 `maxRedirects` budget; a retried `waitReplicas` or `waitAof` waits again on that node.
 
+### Topology refresh
+
+Sage re-reads the slot map whenever a command shows it is out of date: a `MOVED` or `ASK` redirect, a slot no known node covers, a node that is
+unreachable or no longer a master. Reshardings and failovers therefore need no configuration.
+
+Adding a replica breaks nothing, so nothing tells sage to look again, and reads under `ReadFrom.Replica` or `ReadFrom.ReplicaPreferred` keep
+using the replicas already known. Set `topologyRefreshInterval` to check for new ones on a timer:
+
+```scala
+val config = SageConfig(
+  topology = Topology.Cluster(
+    Vector(Endpoint("localhost", 7000)),
+    ClusterConfig(topologyRefreshInterval = Some(30.seconds))
+  ),
+  readFrom = ReadFrom.Replica
+)
+```
+
+There is no timer unless you set one. Each tick costs one `CLUSTER SLOTS`, and no refresh ever runs more often than `minRefreshInterval`.
+`MasterReplicaConfig` has the same setting.
+
 ## Master-replica
 
 Select `Topology.MasterReplica` with seed endpoints. Sage discovers the nodes' roles, sends writes to the master, and routes reads per the read policy:
@@ -95,7 +116,8 @@ again when an existing reconnect or routing failure triggers a later role refres
 omitted until a later event-driven refresh sees its own `ROLE` state become `connected`.
 
 With `ReplicaPreferred`, a read that falls back to the master while no replica is known also schedules this throttled refresh. This lets an
-omitted reader return to service under otherwise healthy master-only traffic without adding background polling.
+omitted reader return to service under otherwise healthy master-only traffic without any polling. Once one replica is known, a second one is
+only picked up by `topologyRefreshInterval`; see [Topology refresh](#topology-refresh).
 
 ## Read routing
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,9 +87,9 @@ val config = SageConfig(
 )
 ```
 
-There is no timer unless you set one. Each tick costs one `CLUSTER SLOTS`, and a tick landing inside the `minRefreshInterval` window is skipped,
-so a short interval cannot outpace it. The first tick is the exception: discovery at connect opens no window, so it always runs.
-`MasterReplicaConfig` has the same setting.
+There is no timer unless you set one. Each admitted tick costs one `CLUSTER SLOTS`, and a tick landing inside the `minRefreshInterval` window is
+skipped, so a short interval cannot outpace it. The first tick is initially eligible, since discovery at connect opens no window, though an
+event-driven refresh before it can still throttle it. `MasterReplicaConfig` has the same setting.
 
 ## Master-replica
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,8 +87,8 @@ val config = SageConfig(
 )
 ```
 
-There is no timer unless you set one. Each tick costs one `CLUSTER SLOTS`, and no refresh ever runs more often than `minRefreshInterval`.
-`MasterReplicaConfig` has the same setting.
+There is no timer unless you set one. Each tick costs one `CLUSTER SLOTS`, and a tick landing inside the `minRefreshInterval` window is skipped,
+so a short interval cannot outpace it. `MasterReplicaConfig` has the same setting.
 
 ## Master-replica
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,7 +88,8 @@ val config = SageConfig(
 ```
 
 There is no timer unless you set one. Each tick costs one `CLUSTER SLOTS`, and a tick landing inside the `minRefreshInterval` window is skipped,
-so a short interval cannot outpace it. `MasterReplicaConfig` has the same setting.
+so a short interval cannot outpace it. The first tick is the exception: discovery at connect opens no window, so it always runs.
+`MasterReplicaConfig` has the same setting.
 
 ## Master-replica
 

--- a/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
+++ b/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
@@ -100,18 +100,24 @@ final case class Endpoint(host: String = "localhost", port: Int = 6379)
   * Cluster tuning. `maxRedirects` bounds how many `MOVED`/`ASK` hops a single command follows before failing (the same default as
   * lettuce); `minRefreshInterval` limits how often a `MOVED` or an unowned slot triggers `CLUSTER SLOTS`: once per window. A retry that
   * must see the new topology first, as after a failover, refreshes regardless of the window and is bounded by `maxRedirects` instead.
+  *
+  * `topologyRefreshInterval` polls `CLUSTER SLOTS` on a timer, off by default. Redirects and faults already cover everything a command can
+  * notice; the poll is for what none can, namely a replica added to a shard that is serving reads normally.
   */
 final case class ClusterConfig(
   maxRedirects: Int = 5,
-  minRefreshInterval: FiniteDuration = 5.seconds
+  minRefreshInterval: FiniteDuration = 5.seconds,
+  topologyRefreshInterval: Option[FiniteDuration] = None
 )
 
 /**
   * Master-replica tuning. `minRefreshInterval` throttles role re-discovery (`ROLE`/`INFO replication`) so a burst of `READONLY`s, reconnects,
-  * or replica-preferred reads with no known replica triggers at most one discovery per window. There is no periodic poll.
+  * or replica-preferred reads with no known replica triggers at most one discovery per window. `topologyRefreshInterval` re-discovers on a
+  * timer as well, off by default, for what no command reveals: a replica added while the known nodes stay healthy.
   */
 final case class MasterReplicaConfig(
-  minRefreshInterval: FiniteDuration = 5.seconds
+  minRefreshInterval: FiniteDuration = 5.seconds,
+  topologyRefreshInterval: Option[FiniteDuration] = None
 )
 
 /**

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2375,12 +2375,14 @@ object Client {
         Vector(
           cond(seeds.nonEmpty, "cluster topology requires at least one seed"),
           cond(cluster.maxRedirects >= 0, "cluster.maxRedirects must be >= 0"),
-          atLeastOneMilli(cluster.minRefreshInterval, "cluster.minRefreshInterval")
+          atLeastOneMilli(cluster.minRefreshInterval, "cluster.minRefreshInterval"),
+          cluster.topologyRefreshInterval.flatMap(atLeastOneMilli(_, "cluster.topologyRefreshInterval"))
         ) ++ seeds.map(s => port(s.port, s"seed ${s.host}:${s.port} port"))
       case Topology.MasterReplica(seeds, masterReplica) =>
         Vector(
           cond(seeds.nonEmpty, "master-replica topology requires at least one seed"),
-          atLeastOneMilli(masterReplica.minRefreshInterval, "masterReplica.minRefreshInterval")
+          atLeastOneMilli(masterReplica.minRefreshInterval, "masterReplica.minRefreshInterval"),
+          masterReplica.topologyRefreshInterval.flatMap(atLeastOneMilli(_, "masterReplica.topologyRefreshInterval"))
         ) ++ seeds.map(s => port(s.port, s"seed ${s.host}:${s.port} port"))
       // a Standalone has no replicas, so the strict Replica policy could never serve a read; the *Preferred policies harmlessly degrade to
       // the one node, so they stay valid (a readFrom can then be shared across environments)

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -105,8 +105,6 @@ final private[client] class ClusterLive(
 
   private val refreshThrottle = new RefreshThrottle(scheduler, cluster.minRefreshInterval.toMillis)
 
-  @volatile private var refreshTicker: Scheduler.Cancelable = null
-
   // if no seed answers, throws the last failure so the first connect surfaces a handshake/TLS error like a standalone connect, not None
   private[client] def bootstrapTopology(): Unit = {
     var lastError: Throwable = NotConnected()
@@ -115,7 +113,7 @@ final private[client] class ClusterLive(
       val node = candidates.next()
       try
         querySlotsVia(node, getOrEstablish(node)) match {
-          case Right(shards) => adopt(node, shards); startRefreshTicker(); return
+          case Right(shards) => adopt(node, shards); startRefreshPoll(); return
           case Left(error)   => lastError = error
         }
       catch { case NonFatal(error) => lastError = error }
@@ -1175,13 +1173,11 @@ final private[client] class ClusterLive(
 
   private def triggerRefresh(): Unit = offload(refresh(force = false))
 
-  private def startRefreshTicker(): Unit =
-    cluster.topologyRefreshInterval.foreach { interval =>
-      refreshTicker = scheduler.every(interval)(if (!closed) triggerRefresh())
-    }
+  private def startRefreshPoll(): Unit = refreshThrottle.startPolling(cluster.topologyRefreshInterval)(triggerRefresh())
 
+  // a refresh queued before close must not re-establish what the close tore down
   private def refresh(force: Boolean): Unit =
-    refreshThrottle(force) {
+    if (!closed) refreshThrottle(force) {
       querySlots(refreshCandidates()) match {
         case Some((from, shards)) => adopt(from, shards)
         // no candidate answered CLUSTER SLOTS: ownership is unknowable, so retire every cache
@@ -1246,8 +1242,7 @@ final private[client] class ClusterLive(
 
   private def closeAll(): Unit = {
     closed = true
-    val ticker = refreshTicker
-    if (ticker != null) { ticker.cancel(); refreshTicker = null }
+    refreshThrottle.stopPolling()
     masterPool.close()
     subscriptions.close()
     replicaPool.close()

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -33,7 +33,7 @@ import sage.ratelimit.Decision
   * where the submit fails fast. Only the paths that may establish a connection or refresh the topology hop to an offloaded virtual thread,
   * and a submit's reply callback re-offloads before any blocking continuation (never on the reply thread).
   *
-  * The topology refreshes on events — a redirect, an ownership or connection fault, an unowned slot, a subscription drop — throttled by
+  * The topology refreshes on events (a redirect, an ownership or connection fault, an unowned slot, a subscription drop), throttled by
   * `minRefreshInterval`; a timer only comes into it when `topologyRefreshInterval` opts into the background poll.
   */
 final private[client] class ClusterLive(

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -32,6 +32,9 @@ import sage.ratelimit.Decision
   * Dispatch to an already-established node runs inline on the caller: the registry lookup and the submit never block, even mid-reconnect,
   * where the submit fails fast. Only the paths that may establish a connection or refresh the topology hop to an offloaded virtual thread,
   * and a submit's reply callback re-offloads before any blocking continuation (never on the reply thread).
+  *
+  * The topology refreshes on events — a redirect, an ownership or connection fault, an unowned slot, a subscription drop — throttled by
+  * `minRefreshInterval`; a timer only comes into it when `topologyRefreshInterval` opts into the background poll.
   */
 final private[client] class ClusterLive(
   nodeFactory: Node => MultiplexedConnection.TransportFactory,
@@ -102,6 +105,8 @@ final private[client] class ClusterLive(
 
   private val refreshThrottle = new RefreshThrottle(scheduler, cluster.minRefreshInterval.toMillis)
 
+  @volatile private var refreshTicker: Scheduler.Cancelable = null
+
   // if no seed answers, throws the last failure so the first connect surfaces a handshake/TLS error like a standalone connect, not None
   private[client] def bootstrapTopology(): Unit = {
     var lastError: Throwable = NotConnected()
@@ -110,7 +115,7 @@ final private[client] class ClusterLive(
       val node = candidates.next()
       try
         querySlotsVia(node, getOrEstablish(node)) match {
-          case Right(shards) => adopt(node, shards); return
+          case Right(shards) => adopt(node, shards); startRefreshTicker(); return
           case Left(error)   => lastError = error
         }
       catch { case NonFatal(error) => lastError = error }
@@ -352,6 +357,7 @@ final private[client] class ClusterLive(
   private def sendRead[A](command: Command[A], master: Node, slot: Slot, redirectsLeft: Int, complete: Try[A] => Unit): Unit = {
     val replicas = topologyRef.get().shardForSlot(slot).map(_.replicas).getOrElse(Vector.empty)
     val cursor   = replicaCursors.computeIfAbsent(master, _ => new java.util.concurrent.atomic.AtomicInteger())
+    refreshIfNoReplica(replicas)
     tryReadCandidates(command, ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement()), master, redirectsLeft, complete)
   }
 
@@ -360,6 +366,7 @@ final private[client] class ClusterLive(
     pickNode(topology) match {
       case Some(master) =>
         val replicas = topology.shards.iterator.flatMap(_.replicas).toVector.distinct
+        refreshIfNoReplica(replicas)
         tryReadCandidates(
           command,
           ReadRouting.candidates(readFrom, master, replicas, keylessCursor.getAndIncrement()),
@@ -795,8 +802,13 @@ final private[client] class ClusterLive(
   private def readCandidates(master: Node): Vector[Node] = {
     val replicas = topologyRef.get().shards.collectFirst { case s if s.master == master => s.replicas }.getOrElse(Vector.empty)
     val cursor   = replicaCursors.computeIfAbsent(master, _ => new java.util.concurrent.atomic.AtomicInteger())
+    refreshIfNoReplica(replicas)
     ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement())
   }
+
+  // strict Replica refreshes by exhausting its candidates instead; replica-preferred falls back silently and would never look again
+  private def refreshIfNoReplica(replicas: Vector[Node]): Unit =
+    if (readFrom == ReadFrom.ReplicaPreferred && replicas.isEmpty) triggerRefresh()
 
   // lock-free walk: the first live established candidate, Some((master, null)) when all are established but none live, and None when an
   // unestablished candidate is met first — only then must the caller offload to establish
@@ -1163,6 +1175,11 @@ final private[client] class ClusterLive(
 
   private def triggerRefresh(): Unit = offload(refresh(force = false))
 
+  private def startRefreshTicker(): Unit =
+    cluster.topologyRefreshInterval.foreach { interval =>
+      refreshTicker = scheduler.every(interval)(if (!closed) triggerRefresh())
+    }
+
   private def refresh(force: Boolean): Unit =
     refreshThrottle(force) {
       querySlots(refreshCandidates()) match {
@@ -1229,6 +1246,8 @@ final private[client] class ClusterLive(
 
   private def closeAll(): Unit = {
     closed = true
+    val ticker = refreshTicker
+    if (ticker != null) { ticker.cancel(); refreshTicker = null }
     masterPool.close()
     subscriptions.close()
     replicaPool.close()

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -12,7 +12,7 @@ import kyo.compat.*
 
 import sage.{CommandSpan, Message, Outcome, PatternMessage, SageEvent, SageException}
 import sage.SageException.{ConnectionFailed, ConnectionLost, InvalidArgument, NotConnected, TimedOut}
-import sage.client.{ReadFrom, SageConfig}
+import sage.client.{MasterReplicaConfig, ReadFrom, SageConfig}
 import sage.cluster.Node
 import sage.codec.ValueCodec
 import sage.commands.{Command, Connection, Pipeline, Role, Server}
@@ -24,10 +24,10 @@ import sage.ratelimit.Decision
   * [[ReadFrom]] policy (round-robin, with the policy's fallback). The same `Client` type as standalone and cluster; only the topology selects
   * it.
   *
-  * Roles refresh only on events — a reconnect-driven command loss, a `READONLY` from the presumed master, a read that can reach no candidate,
-  * or a replica-preferred read/pipeline when no replica is known — throttled by `minRefreshInterval`, never on a timer. A write that meets a
-  * demoted master fails fast (kicking off a re-discovery) so the caller's retry lands on the freshly-discovered master, mirroring the cluster
-  * runtime's `READONLY` disposition.
+  * Roles refresh on events — a reconnect-driven command loss, a `READONLY` from the presumed master, a read that can reach no candidate, or a
+  * replica-preferred read/pipeline when no replica is known — throttled by `minRefreshInterval`; a timer only comes into it when
+  * `topologyRefreshInterval` opts into the background poll. A write that meets a demoted master fails fast (kicking off a re-discovery) so the
+  * caller's retry lands on the freshly-discovered master, mirroring the cluster runtime's `READONLY` disposition.
   */
 final private[client] class MasterReplicaLive(
   nodeFactory: Node => MultiplexedConnection.TransportFactory,
@@ -35,7 +35,7 @@ final private[client] class MasterReplicaLive(
   bootstrap: Vector[Command[?]],
   config: SageConfig,
   seeds: Vector[Node],
-  minRefreshInterval: FiniteDuration,
+  masterReplica: MasterReplicaConfig,
   events: Events = Events.disabled
 ) extends Client[CIO, String] {
 
@@ -73,7 +73,9 @@ final private[client] class MasterReplicaLive(
   private val subLock                                         = new ReentrantLock()
   @volatile private var subscriptions: SubscriptionConnection = null
 
-  private val refreshThrottle = new RefreshThrottle(scheduler, minRefreshInterval.toMillis)
+  private val refreshThrottle = new RefreshThrottle(scheduler, masterReplica.minRefreshInterval.toMillis)
+
+  @volatile private var refreshTicker: Scheduler.Cancelable = null
 
   private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
 
@@ -85,7 +87,7 @@ final private[client] class MasterReplicaLive(
 
   private[client] def bootstrapRoles(): Unit =
     resolveTopology(seeds) match {
-      case Right(topology) => installTopology(topology)
+      case Right(topology) => installTopology(topology); startRefreshTicker()
       case Left(error)     => closeAll(); throw error
     }
 
@@ -185,6 +187,11 @@ final private[client] class MasterReplicaLive(
     events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
 
   private def triggerRefresh(): Unit = refreshThrottle.trigger(rediscover())
+
+  private def startRefreshTicker(): Unit =
+    masterReplica.topologyRefreshInterval.foreach { interval =>
+      refreshTicker = scheduler.every(interval)(if (!closed) triggerRefresh())
+    }
 
   // forced, but single-flight may collapse this onto an in-flight refresh, so a stale masterNodeRef self-corrects on the next reconnect
   private def refreshRolesBeforeRehome(): Unit = refreshThrottle(force = true)(rediscover())
@@ -493,7 +500,9 @@ final private[client] class MasterReplicaLive(
 
   private def closeAll(): Unit = {
     closed = true
-    val s = subscriptions
+    val ticker = refreshTicker
+    if (ticker != null) { ticker.cancel(); refreshTicker = null }
+    val s      = subscriptions
     if (s != null) s.close()
     masterPool.close()
     replicaPool.close()
@@ -510,7 +519,7 @@ private[client] object MasterReplicaLive {
   def connect(
     config: SageConfig,
     seeds: Vector[Node],
-    masterReplica: sage.client.MasterReplicaConfig,
+    masterReplica: MasterReplicaConfig,
     scheduler: Scheduler,
     translate: Throwable => Throwable
   ): CIO[Client[CIO, String]] =
@@ -522,7 +531,7 @@ private[client] object MasterReplicaLive {
       }
       val events                                                  = Events(config.listeners, config.tracer)
       val live                                                    =
-        new MasterReplicaLive(factory, scheduler, bootstrap, config, seeds, masterReplica.minRefreshInterval, events)
+        new MasterReplicaLive(factory, scheduler, bootstrap, config, seeds, masterReplica, events)
       try { live.bootstrapRoles(); live }
       catch { case NonFatal(error) => events.close(); throw translate(error) }
     }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -75,8 +75,6 @@ final private[client] class MasterReplicaLive(
 
   private val refreshThrottle = new RefreshThrottle(scheduler, masterReplica.minRefreshInterval.toMillis)
 
-  @volatile private var refreshTicker: Scheduler.Cancelable = null
-
   private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
 
   // --- discovery -----------------------------------------------------------------------------------------------------------------------
@@ -87,7 +85,7 @@ final private[client] class MasterReplicaLive(
 
   private[client] def bootstrapRoles(): Unit =
     resolveTopology(seeds) match {
-      case Right(topology) => installTopology(topology); startRefreshTicker()
+      case Right(topology) => installTopology(topology); startRefreshPoll()
       case Left(error)     => closeAll(); throw error
     }
 
@@ -188,16 +186,14 @@ final private[client] class MasterReplicaLive(
 
   private def triggerRefresh(): Unit = refreshThrottle.trigger(rediscover())
 
-  private def startRefreshTicker(): Unit =
-    masterReplica.topologyRefreshInterval.foreach { interval =>
-      refreshTicker = scheduler.every(interval)(if (!closed) triggerRefresh())
-    }
+  private def startRefreshPoll(): Unit = refreshThrottle.startPolling(masterReplica.topologyRefreshInterval)(triggerRefresh())
 
   // forced, but single-flight may collapse this onto an in-flight refresh, so a stale masterNodeRef self-corrects on the next reconnect
   private def refreshRolesBeforeRehome(): Unit = refreshThrottle(force = true)(rediscover())
 
+  // a re-discovery queued before close must not probe ROLE on a connection the close cannot reach
   private def rediscover(): Unit =
-    resolveTopology((Option(masterNodeRef.get()).toVector ++ replicasRef.get() ++ seeds).distinct).foreach(installTopology)
+    if (!closed) resolveTopology((Option(masterNodeRef.get()).toVector ++ replicasRef.get() ++ seeds).distinct).foreach(installTopology)
 
   private def installTopology(topology: MasterReplicaLive.ResolvedTopology): Unit = {
     masterNodeRef.set(topology.master)
@@ -500,9 +496,8 @@ final private[client] class MasterReplicaLive(
 
   private def closeAll(): Unit = {
     closed = true
-    val ticker = refreshTicker
-    if (ticker != null) { ticker.cancel(); refreshTicker = null }
-    val s      = subscriptions
+    refreshThrottle.stopPolling()
+    val s = subscriptions
     if (s != null) s.close()
     masterPool.close()
     replicaPool.close()

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -24,8 +24,8 @@ import sage.ratelimit.Decision
   * [[ReadFrom]] policy (round-robin, with the policy's fallback). The same `Client` type as standalone and cluster; only the topology selects
   * it.
   *
-  * Roles refresh on events — a reconnect-driven command loss, a `READONLY` from the presumed master, a read that can reach no candidate, or a
-  * replica-preferred read/pipeline when no replica is known — throttled by `minRefreshInterval`; a timer only comes into it when
+  * Roles refresh on events (a reconnect-driven command loss, a `READONLY` from the presumed master, a read that can reach no candidate, or a
+  * replica-preferred read/pipeline when no replica is known), throttled by `minRefreshInterval`; a timer only comes into it when
   * `topologyRefreshInterval` opts into the background poll. A write that meets a demoted master fails fast (kicking off a re-discovery) so the
   * caller's retry lands on the freshly-discovered master, mirroring the cluster runtime's `READONLY` disposition.
   */

--- a/sage-client/shared/src/main/scala/sage/client/internal/RefreshThrottle.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/RefreshThrottle.scala
@@ -2,12 +2,14 @@ package sage.client.internal
 
 import java.util.concurrent.locks.ReentrantLock
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 /**
   * Single-flight, throttled discovery: collapses concurrent refreshes onto one in-flight run (others block until it finishes) and skips a
   * run that lands within `minRefreshMs` of the last, unless `force`. Shared by the cluster and master-replica runtimes, which differ only in
   * what `work` does. `lastRefresh` starts a full window in the past, so the first triggered refresh always runs.
+  *
+  * It also owns the optional background poll ([[startPolling]]/[[stopPolling]]), so both runtimes get one lifecycle for it.
   */
 final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: Long) {
 
@@ -15,6 +17,8 @@ final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: 
   private val done          = lock.newCondition()
   private var refreshing    = false
   private var lastRefreshMs = scheduler.nowMillis - minRefreshMs
+  private var ticker        = null: Scheduler.Cancelable
+  private var stopped       = false
 
   def apply(force: Boolean)(work: => Unit): Unit =
     if (claim(force, wait = true)) run(work)
@@ -30,6 +34,27 @@ final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: 
           finish()
           throw error
       }
+
+  /**
+    * Starts the background poll when an interval is configured; `tick` runs on the timer thread, so it must only queue work.
+    */
+  def startPolling(interval: Option[FiniteDuration])(tick: => Unit): Unit =
+    interval.foreach { period =>
+      val handle = scheduler.every(period)(tick)
+      lock.lock()
+      val keep   =
+        try if (stopped) false else { ticker = handle; true }
+        finally lock.unlock()
+      if (!keep) handle.cancel()
+    }
+
+  def stopPolling(): Unit = {
+    lock.lock()
+    val handle =
+      try { stopped = true; val current = ticker; ticker = null; current }
+      finally lock.unlock()
+    if (handle != null) handle.cancel()
+  }
 
   private def claim(force: Boolean, wait: Boolean): Boolean = {
     lock.lock()

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -8,7 +8,7 @@ import kyo.compat.*
 
 import sage.Bytes
 import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, InvalidArgument, NotConnected, ServerError, UnsupportedServer}
-import sage.client.internal.{ClusterLive, CountingScheduler, FakeTransport, MultiplexedConnection, Scheduler}
+import sage.client.internal.{ClusterLive, CountingScheduler, FakeTransport, ManualScheduler, MultiplexedConnection, Scheduler}
 import sage.cluster.{Node, Slot}
 import sage.commands.{BroadcastReduce, Command, Connection, Json, JsonPath, Keys, Scripting, Server, Strings}
 import sage.protocol.Frame
@@ -105,6 +105,8 @@ class ClusterClientSpec extends munit.FunSuite {
     live.bootstrapTopology()
 
     def written(node: Node): Vector[String] = transportsOf(node).flatMap(_.written.map(_.asUtf8String))
+
+    def clusterSlotsCount(node: Node): Int = written(node).count(_.contains("CLUSTER"))
 
     // simulate the server dropping a node's Sharded Subscription Connection (the post-migration disconnect): close the transport that
     // carried the SSUBSCRIBE so its onClosed fires and the manager re-homes
@@ -626,6 +628,48 @@ class ClusterClientSpec extends munit.FunSuite {
       assert(fixture.written(nodeA).exists(_.contains("SET")), "master did not receive the write")
       assert(!fixture.written(nodeR).exists(_.contains("SET")), "replica received a write")
     }
+  }
+
+  test("a replica-preferred read with no known replica schedules a topology refresh") {
+    val scheduler = new ManualScheduler
+    val behaviour =
+      (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.BulkString(Bytes.utf8("from-master")))
+    val fixture   = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.ReplicaPreferred, scheduler = scheduler)
+    val before    = fixture.clusterSlotsCount(nodeA)
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
+      assertEquals(result, Some("from-master"))
+      scheduler.advance(Duration.Zero)
+      assertEquals(fixture.clusterSlotsCount(nodeA), before + 1, "the master fallback did not look for a replica")
+    }
+  }
+
+  test("an opted-in topologyRefreshInterval polls CLUSTER SLOTS in the background") {
+    val scheduler = new ManualScheduler
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.Null)
+    val fixture   =
+      new Fixture(behaviour, Vector(nodeA), scheduler = scheduler, cluster = ClusterConfig(topologyRefreshInterval = Some(1.minute)))
+
+    assertEquals(fixture.clusterSlotsCount(nodeA), 1)
+    scheduler.advance(1.minute)
+    assertEquals(fixture.clusterSlotsCount(nodeA), 2)
+    scheduler.advance(1.minute)
+    assertEquals(fixture.clusterSlotsCount(nodeA), 3)
+
+    fixture.live.close.unsafeRun.map { _ =>
+      scheduler.advance(1.minute)
+      assertEquals(fixture.clusterSlotsCount(nodeA), 3, "the poll outlived the client")
+    }
+  }
+
+  test("no timer refreshes the topology unless topologyRefreshInterval opts in") {
+    val scheduler = new ManualScheduler
+    val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.Null)
+    val fixture   = new Fixture(behaviour, Vector(nodeA), scheduler = scheduler)
+
+    scheduler.advance(10.minutes)
+
+    assertEquals(fixture.clusterSlotsCount(nodeA), 1)
   }
 
   test("follows a MOVED redirect to the named node and refreshes") {

--- a/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
@@ -103,6 +103,20 @@ class ConnectSpec extends munit.FunSuite {
     }
   }
 
+  test("a topologyRefreshInterval under 1ms is rejected by validation, not thrown at the timer") {
+    val cluster       =
+      SageConfig(topology = Topology.Cluster(Vector(Endpoint("localhost", 7000)), ClusterConfig(topologyRefreshInterval = Some(Duration.Zero))))
+    val masterReplica = SageConfig(topology =
+      Topology.MasterReplica(Vector(Endpoint("localhost", 6379)), MasterReplicaConfig(topologyRefreshInterval = Some(500.micros)))
+    )
+    Client.connect(cluster).unsafeRun.failed.flatMap { clusterError =>
+      Client.connect(masterReplica).unsafeRun.failed.map { masterReplicaError =>
+        assert(clusterError.isInstanceOf[InvalidArgument], s"unexpected error: $clusterError")
+        assert(masterReplicaError.isInstanceOf[InvalidArgument], s"unexpected error: $masterReplicaError")
+      }
+    }
+  }
+
   test("readFrom = ReplicaPreferred on a Standalone topology passes validation (degrades to the one node)") {
     // it may connect (a local server) or fail to connect (none) — either way it must not be rejected by validation
     Client

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
@@ -106,7 +106,7 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
         Vector(Connection.hello(None)),
         SageConfig(readFrom = readFrom),
         Vector(master),
-        1.second,
+        MasterReplicaConfig(1.second),
         Events(Vector(listener), Some(tracer))
       )
     live.bootstrapRoles()

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -75,7 +75,8 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     initialRoles: Map[Node, Frame],
     unreachable: collection.Set[Node] = Set.empty,
     events: Events = Events.disabled,
-    minRefreshInterval: FiniteDuration = 50.millis
+    minRefreshInterval: FiniteDuration = 50.millis,
+    topologyRefreshInterval: Option[FiniteDuration] = None
   ) {
 
     val roles                                                           = TrieMap.from(initialRoles)
@@ -108,7 +109,7 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
       Vector(Connection.hello(None)),
       SageConfig(readFrom = ReadFrom.ReplicaPreferred, connectTimeout = 500.millis, closeTimeout = Duration.Zero),
       seeds,
-      minRefreshInterval,
+      MasterReplicaConfig(minRefreshInterval, topologyRefreshInterval),
       events
     )
 
@@ -319,6 +320,34 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
       },
       "replica-preferred reads did not reconsider the connected replica",
       timeout = 1.second
+    )
+    fixture.close()
+  }
+
+  test("an opted-in topologyRefreshInterval adopts a replica that no routing event would reveal") {
+    val fixture = new Fixture(
+      seeds = Vector(primary, reader, advertisedReplica),
+      initialRoles = Map(
+        primary           -> masterRole(),
+        reader            -> replicaRole(primary),
+        advertisedReplica -> replicaRole(primary, state = "sync")
+      ),
+      topologyRefreshInterval = Some(50.millis)
+    )
+    fixture.live.bootstrapRoles()
+
+    assertEquals(fixture.read(), 1L)
+    assertEquals(fixture.readsServedBy(reader), 1)
+    assertEquals(fixture.readsServedBy(advertisedReplica), 0)
+
+    fixture.roles.update(advertisedReplica, replicaRole(primary))
+    fixture.awaitTrue(
+      {
+        val _ = fixture.read()
+        fixture.readsServedBy(advertisedReplica) > 0
+      },
+      "the background poll did not adopt the new replica",
+      timeout = 2.seconds
     )
     fixture.close()
   }

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -70,13 +70,41 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
   private val writeCommand: Command[Long] =
     Command("ZADD", Command.NoKeys, Vector.empty, (_: Frame) => Right(1L), isReadOnly = false)
 
+  /**
+    * Holds the periodic tick and every zero-delay offload until the test runs them.
+    */
+  final private class DeferringScheduler extends Scheduler {
+    private val ticks  = mutable.ArrayBuffer.empty[() => Unit]
+    private val queued = mutable.ArrayBuffer.empty[() => Unit]
+
+    def nowMillis: Long                          = 0L
+    def jitterMillis(boundExclusive: Long): Long = 0L
+
+    def after(delay: FiniteDuration)(task: => Unit): Unit = { val _ = queued += (() => task) }
+
+    def every(interval: FiniteDuration)(task: => Unit): Scheduler.Cancelable = {
+      val tick = () => task
+      ticks += tick
+      () => { val _ = ticks -= tick }
+    }
+
+    def tick(): Unit = ticks.toVector.foreach(_())
+
+    def runQueued(): Unit = {
+      val pending = queued.toVector
+      queued.clear()
+      pending.foreach(_())
+    }
+  }
+
   final private class Fixture(
     seeds: Vector[Node],
     initialRoles: Map[Node, Frame],
     unreachable: collection.Set[Node] = Set.empty,
     events: Events = Events.disabled,
     minRefreshInterval: FiniteDuration = 50.millis,
-    topologyRefreshInterval: Option[FiniteDuration] = None
+    topologyRefreshInterval: Option[FiniteDuration] = None,
+    scheduler: Scheduler = Scheduler.real
   ) {
 
     val roles                                                           = TrieMap.from(initialRoles)
@@ -105,7 +133,7 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
 
     val live = new MasterReplicaLive(
       factory,
-      Scheduler.real,
+      scheduler,
       Vector(Connection.hello(None)),
       SageConfig(readFrom = ReadFrom.ReplicaPreferred, connectTimeout = 500.millis, closeTimeout = Duration.Zero),
       seeds,
@@ -350,6 +378,24 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
       timeout = 2.seconds
     )
     fixture.close()
+  }
+
+  test("a re-discovery the poll queued before close does not probe after it") {
+    val scheduler          = new DeferringScheduler
+    val fixture            = new Fixture(
+      seeds = Vector(primary, reader),
+      initialRoles = Map(primary -> masterRole(), reader -> replicaRole(primary)),
+      topologyRefreshInterval = Some(1.minute),
+      scheduler = scheduler
+    )
+    fixture.live.bootstrapRoles()
+    val dialledAtBootstrap = fixture.dialled.size
+
+    scheduler.tick()
+    fixture.close()
+    scheduler.runQueued()
+
+    assertEquals(fixture.dialled.size, dialledAtBootstrap, "the queued re-discovery dialled after close")
   }
 
   test("replica-preferred pipelines reconsider a supplied endpoint after its ROLE state becomes connected") {


### PR DESCRIPTION
Topology discovery is purely reactive today. Slot moves, failovers, and unreachable nodes all reveal themselves to a command, so those self-correct, but a replica added to an otherwise healthy shard reveals itself to nothing: under `ReadFrom.Replica` or `ReadFrom.ReplicaPreferred` the new reader stays unused, and no fault ever forces the client to look again.

`ClusterConfig` and `MasterReplicaConfig` gain `topologyRefreshInterval: Option[FiniteDuration]`, off by default, matching the default-off posture of other clients that offer a periodic refresh. When set, the runtime starts a ticker once the bootstrap adopts its topology and cancels it on close. The tick only queues the offloaded refresh, so it keeps `Scheduler`'s contract that a periodic task must not block, and it shares the throttle with the event-driven refreshes, so an interval below `minRefreshInterval` admits no extra discovery.

This also closes a smaller gap on the cluster read path: a replica-preferred read whose shard lists no replica fell back to the master silently, where the master-replica runtime already scheduled a throttled refresh for exactly that case. Strict `Replica` was unaffected, since exhausting its candidates already refreshes.

## Tests

Three new cases, each verified to fail without the change:

- a replica-preferred cluster read with no known replica schedules a refresh
- an opted-in interval polls `CLUSTER SLOTS` on the timer, and stops polling after `close`
- a master-replica poll adopts a replica that no routing event would reveal

A fourth pins the default: no timer refreshes the topology unless the interval opts in.