### PR TITLE
Throttle the topology refresh a transaction fires on ASK

### DIFF
--- a/docs/pipelines-transactions.md
+++ b/docs/pipelines-transactions.md
@@ -124,6 +124,7 @@ A few rules follow from how Redis transactions work:
 - **A queueing-phase rejection discards the whole transaction**, so nothing runs.
 - **An execution-phase error leaves the other commands committed.** Redis does not roll back, so those errors surface per position, like a pipeline.
 - **In a cluster, every key in the transaction must hash to one slot** (use a [hash tag](/configuration#hash-tags) to force that). A pipeline has no such restriction for commands with documented cross-slot support.
+- **In a cluster, bound your retries.** A transaction never follows a redirect, because that would break atomicity, so the whole block is retried by the caller, exactly as a `WATCH` abort already requires. While a slot is migrating, a key that has already moved keeps answering `ASK` until the migration finalizes, and no retry can commit until then. Retry with backoff and a ceiling rather than in a tight loop.
 
 ## Which to use
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -687,8 +687,7 @@ final private[client] class ClusterLive(
   private def malformedKeys(name: String): InvalidArgument =
     InvalidArgument(s"$name: declared key positions fall outside its arguments")
 
-  // a transaction never follows a redirect, so the caller's retry depends on the topology actually refreshing — bypass the throttle window
-  // (single-flight still collapses concurrent refreshes); ordinary commands re-route, so they use the throttled triggerRefresh
+  // a transaction never follows a redirect, so an ownership move must be adopted before the caller can retry: bypass the throttle window
   private def forceRefresh(): Unit = offload(refresh(force = true))
 
   // --- pipelines (split per node, batch each, merge in submission order) ----------------------------------------------------------------
@@ -917,8 +916,14 @@ final private[client] class ClusterLive(
 
     // a transaction never follows a redirect (that would break MULTI/EXEC atomicity), but on any ownership/connection fault it refreshes in the
     // background so the caller's retry re-pins to the new owner instead of looping on the stale node; a data error refreshes nothing
-    private def refreshOnFault(error: Throwable): Unit =
-      if (Fault.categorize(error).refreshesTopology) forceRefresh()
+    private def refreshOnFault(error: Throwable): Unit = refreshFor(Vector(Fault.categorize(error)))
+
+    private def refreshFor(faults: Vector[Fault]): Unit =
+      faults.iterator.map(_.refreshPolicy).maxByOption(_.ordinal) match {
+        case Some(RefreshPolicy.Forced)    => forceRefresh()
+        case Some(RefreshPolicy.Throttled) => triggerRefresh()
+        case _                             => ()
+      }
 
     private def faulting[A](complete: Try[A] => Unit): Try[A] => Unit = {
       case failure @ Failure(error) => refreshOnFault(error); complete(failure)
@@ -929,8 +934,7 @@ final private[client] class ClusterLive(
     // level and the EXEC array and refresh on any non-terminal one so the caller's retry re-pins
     private def refreshOnExecFault(frames: Vector[Frame]): Unit = {
       val nested = frames.lastOption match { case Some(Frame.Array(elems)) => elems.iterator; case _ => Iterator.empty[Frame] }
-      val fault  = (frames.iterator ++ nested).flatMap(TxSupport.errorOf).exists(m => Fault.categorize(ServerError.of(m)).refreshesTopology)
-      if (fault) forceRefresh()
+      refreshFor((frames.iterator ++ nested).flatMap(TxSupport.errorOf).map(m => Fault.categorize(ServerError.of(m))).toVector)
     }
 
     private[sage] def exec[Out, R](p: Pipeline[Out, R]): CIO[Option[Out]] =

--- a/sage-client/shared/src/main/scala/sage/client/internal/Fault.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Fault.scala
@@ -1,7 +1,7 @@
 package sage.client.internal
 
 import sage.SageException.{ConnectionLost, NotConnected, ServerError}
-import sage.cluster.Redirect
+import sage.cluster.{Redirect, RedirectKind}
 
 /**
   * The shared categorization of a failed command: both runtimes read a [[Throwable]] the same way, so they cannot drift on what a fault is.
@@ -13,11 +13,19 @@ private[client] enum Fault {
   case TryAgain
   case Fatal
 
-  // an ownership or connection change the topology must adopt; a data error or a transient mid-migration TryAgain leaves the mapping valid
-  def refreshesTopology: Boolean = this match {
-    case Fatal | TryAgain => false
-    case _                => true
+  def refreshPolicy: RefreshPolicy = this match {
+    case Fatal | TryAgain                                          => RefreshPolicy.Skip
+    // ASK moves no ownership: discovery has nothing to adopt until the migration finalizes
+    case Redirected(redirect) if redirect.kind == RedirectKind.Ask => RefreshPolicy.Throttled
+    case Redirected(_) | Demoted | Lost(_)                         => RefreshPolicy.Forced
   }
+}
+
+/**
+  * What a [[Fault]] asks of topology discovery, weakest first: no refresh, one inside the `minRefreshInterval` window, or one that bypasses it.
+  */
+private[client] enum RefreshPolicy {
+  case Skip, Throttled, Forced
 }
 
 private[client] object Fault {

--- a/sage-client/shared/src/test/scala/sage/client/internal/FaultSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/FaultSpec.scala
@@ -47,4 +47,27 @@ class FaultSpec extends munit.FunSuite {
   test("an unrelated throwable categorizes as Fatal") {
     assertEquals(Fault.categorize(new RuntimeException("boom")), Fault.Fatal)
   }
+
+  test("an ownership or connection change forces a refresh past the throttle window") {
+    val moved = Fault.Redirected(Redirect(RedirectKind.Moved, Slot.at(1).get, Node("a", 6379)))
+    assertEquals(moved.refreshPolicy, RefreshPolicy.Forced)
+    assertEquals(Fault.Demoted.refreshPolicy, RefreshPolicy.Forced)
+    assertEquals(Fault.Lost(mayHaveExecuted = false).refreshPolicy, RefreshPolicy.Forced)
+    assertEquals(Fault.Lost(mayHaveExecuted = true).refreshPolicy, RefreshPolicy.Forced)
+  }
+
+  test("an ASK refreshes throttled: it leaves slot ownership unchanged") {
+    val ask = Fault.Redirected(Redirect(RedirectKind.Ask, Slot.at(1).get, Node("a", 6379)))
+    assertEquals(ask.refreshPolicy, RefreshPolicy.Throttled)
+  }
+
+  test("a data error and a TryAgain refresh nothing: the slot mapping stays valid") {
+    assertEquals(Fault.TryAgain.refreshPolicy, RefreshPolicy.Skip)
+    assertEquals(Fault.Fatal.refreshPolicy, RefreshPolicy.Skip)
+  }
+
+  test("the policies order weakest to strongest, so mixed faults can take the strongest") {
+    assert(RefreshPolicy.Skip.ordinal < RefreshPolicy.Throttled.ordinal)
+    assert(RefreshPolicy.Throttled.ordinal < RefreshPolicy.Forced.ordinal)
+  }
 }

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -1060,6 +1060,27 @@ class ClusterClientSpec extends munit.FunSuite {
     }
   }
 
+  test("an ASK during a transaction refreshes only within the throttle window") {
+    val slot      = Slot.of(Bytes.utf8("{a}1")).value
+    val behaviour = (_: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+      else if (text.contains("MULTI"))
+        Seq(Frame.SimpleString("OK"), Frame.SimpleError(s"ASK $slot b:6379"), Frame.SimpleError("EXECABORT discarded"))
+      else Seq(Frame.SimpleString("OK"))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
+
+    val tx = fixture.live.transaction(_.exec(Vector(Strings.get[String, String]("{a}1"))))
+    for {
+      _ <- tx.unsafeRun.failed
+      _  = Thread.sleep(150)
+      _ <- tx.unsafeRun.failed
+    } yield {
+      Thread.sleep(150)
+      val clusterCalls = fixture.written(nodeA).count(_.contains("CLUSTER"))
+      assertEquals(clusterCalls, 2, s"an ASK must not force a refresh past the throttle; CLUSTER calls: $clusterCalls")
+    }
+  }
+
   test("a cross-slot MGET remains forbidden inside a transaction") {
     val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(splitOn(slotB)) else Seq(Frame.SimpleString("OK"))
     val fixture   = new Fixture(behaviour, Vector(nodeA))


### PR DESCRIPTION
A cluster transaction never follows a redirect, since that would break MULTI/EXEC atomicity. Instead, any ownership fault force-refreshes the topology past the `minRefreshInterval` window so the caller's retry re-pins to the new owner.

An ASK is the one refreshing fault where that is wasted work. The migrating slot still belongs to the source until `SETSLOT NODE`, so `CLUSTER SLOTS` reports nothing new and the refresh cannot unstick the retry. A caller looping on its block was firing one `CLUSTER SLOTS` per attempt at a cluster that is already resharding, which is the worst moment for extra discovery traffic.

## Change

`Fault.refreshPolicy` names the three outcomes discovery can be asked for, weakest first: `Skip`, `Throttled`, `Forced`. An ASK is `Throttled`; MOVED, READONLY, and connection loss stay `Forced`. `ClusterTxScope.refreshFor` applies it on both transaction fault paths, taking the strongest policy when an EXEC batch reports several faults. This matches what the dispatch path already does, where MOVED triggers a refresh and ASK does not.

## What this does not change

The liveness gap itself. A key that has already migrated to the importing node answers ASK until the reshard finalizes, and since a transaction cannot follow it, no retry can commit until then. Following ASK inside a transaction is not viable, because the `WATCH` state and the lease live on the source connection. So bounded retries are the caller's job, and the cluster transaction rules in the docs now say so.

## Tests

- `FaultSpec`: pins the policy for every variant and its weakest-first ordering. The old `refreshesTopology` had no direct coverage.
- `ClusterClientSpec`: an ASK in EXEC retried twice inside the throttle window must produce exactly two `CLUSTER` calls, bootstrap plus one throttled refresh. Confirmed failing (3 calls) against the previous behavior. The existing MOVED tests still assert a forced refresh, so the two paths are separated by tests.

`scalafmtCheckAll` clean, 758 unit tests pass.
