### PR TITLE
Restore the broadcast refresh after the RefreshPolicy rename

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -531,7 +531,7 @@ final private[client] class ClusterLive(
     Fault.categorize(error) match {
       case Fault.Lost(false) => retryBroadcast(node, command, error, attemptsLeft, settle)
       case fault             =>
-        if (fault.refreshesTopology) triggerRefresh()
+        if (fault.refreshPolicy != RefreshPolicy.Skip) triggerRefresh()
         settle(Failure(error))
     }
 


### PR DESCRIPTION
main does not compile:

```
ClusterLive.scala:534:18
534 |        if (fault.refreshesTopology) triggerRefresh()
    |            value refreshesTopology is not a member of sage.client.internal.Fault
```

#221 replaced `Fault.refreshesTopology` with `refreshPolicy: RefreshPolicy` and updated every call site that existed on its base. #218 merged a minute later and added a new one in `onBroadcastFailure`. Neither PR touched the other's lines, so the merge was clean and both were green on their own branches, but the result does not build.

The non-`Skip` policies cover exactly the faults `refreshesTopology` reported (`Redirected | Demoted | Lost`, and not `Fatal | TryAgain`), so this is a rename fix, not a behavior change. The throttled `triggerRefresh()` matches what the sibling paths in this file already do.

Verified locally: `sbt check` and `sbt testUnit` both pass.