### PR TITLE
Improve code readability

### DIFF
--- a/benchmarks/ox/src/main/scala/sage/benchmarks/Clients.scala
+++ b/benchmarks/ox/src/main/scala/sage/benchmarks/Clients.scala
@@ -126,14 +126,14 @@ final class LettuceBench(host: String, port: Int) extends BenchClient {
     def fireNext(): Unit = {
       val i = nextIndex.getAndIncrement()
       if (i < n) {
-        try {
+        try
           submit(keys(i)).whenComplete { (v, t) =>
-            if (t != null) failure.compareAndSet(null, t)
-            else if (v != null) total.addAndGet(score(v))
+            if (t != null) { failure.compareAndSet(null, t): Unit }
+            else if (v != null) { total.addAndGet(score(v)): Unit }
             remaining.countDown()
             fireNext()
-          }
-        } catch {
+          }: Unit
+        catch {
           case t: Throwable =>
             failure.compareAndSet(null, t)
             remaining.countDown()
@@ -237,7 +237,7 @@ final class RediscalaBench(host: String, port: Int) extends BenchClient {
 
   def close(): Unit = {
     client.stop()
-    Await.result(system.terminate(), 30.seconds)
+    Await.result(system.terminate(), 30.seconds): Unit
   }
 }
 

--- a/benchmarks/ox/src/main/scala/sage/benchmarks/Clients.scala
+++ b/benchmarks/ox/src/main/scala/sage/benchmarks/Clients.scala
@@ -55,10 +55,10 @@ final class SageOxBench(host: String, port: Int) extends BenchClient {
 
   def seed(prefix: String, count: Int, value: String, hashKey: String, fields: Int): Unit = supervised {
     (0 until count).foreach { i =>
-      val _ = client.set(s"$prefix:$i", value)
+      client.set(s"$prefix:$i", value)
     }
     (0 until fields).foreach { i =>
-      val _ = client.hSet(hashKey, (s"f$i", value))
+      client.hSet(hashKey, (s"f$i", value))
     }
   }
 
@@ -77,7 +77,8 @@ final class SageOxBench(host: String, port: Int) extends BenchClient {
       .toList
       .map(g =>
         fork(g.foldLeft(0L) { (n, k) =>
-          val _ = client.set(k, value); n + 1
+          client.set(k, value)
+          n + 1
         })
       )
       .map(_.join())
@@ -109,7 +110,7 @@ final class LettuceBench(host: String, port: Int) extends BenchClient {
   def seed(prefix: String, count: Int, value: String, hashKey: String, fields: Int): Unit = {
     val writes = (0 until count).map(i => async.set(s"$prefix:$i", value)) ++ (0 until fields).map(i => async.hset(hashKey, s"f$i", value))
     writes.foreach { f =>
-      val _ = f.get()
+      f.get()
     }
   }
 
@@ -126,22 +127,25 @@ final class LettuceBench(host: String, port: Int) extends BenchClient {
       val i = nextIndex.getAndIncrement()
       if (i < n) {
         try {
-          val _ = submit(keys(i)).whenComplete { (v, t) =>
-            if (t != null) { val _ = failure.compareAndSet(null, t) }
-            else if (v != null) { val _ = total.addAndGet(score(v)) }
+          submit(keys(i)).whenComplete { (v, t) =>
+            if (t != null) failure.compareAndSet(null, t)
+            else if (v != null) total.addAndGet(score(v))
             remaining.countDown()
             fireNext()
           }
         } catch {
           case t: Throwable =>
-            val _ = failure.compareAndSet(null, t)
+            failure.compareAndSet(null, t)
             remaining.countDown()
             fireNext()
         }
       }
     }
     var k                = 0
-    while (k < width) { fireNext(); k += 1 }
+    while (k < width) {
+      fireNext()
+      k += 1
+    }
     remaining.await()
     val t                = failure.get()
     if (t != null) throw t // never publish numbers for a run where commands failed
@@ -152,7 +156,7 @@ final class LettuceBench(host: String, port: Int) extends BenchClient {
     slidingWindow(keys, concurrency)(async.get)(v => v.length.toLong)
 
   def setAll(keys: Array[String], value: String, concurrency: Int): Long = {
-    val _ = slidingWindow(keys, concurrency)(k => async.set(k, value))(_ => 0L)
+    slidingWindow(keys, concurrency)(k => async.set(k, value))(_ => 0L)
     keys.length.toLong
   }
 
@@ -184,7 +188,7 @@ final class RediscalaBench(host: String, port: Int) extends BenchClient {
   def seed(prefix: String, count: Int, value: String, hashKey: String, fields: Int): Unit = {
     val writes = (0 until count).map(i => client.set(s"$prefix:$i", value)) ++ (0 until fields).map(i => client.hset(hashKey, s"f$i", value))
     writes.foreach { f =>
-      val _ = await(f)
+      await(f)
     }
   }
 
@@ -201,15 +205,18 @@ final class RediscalaBench(host: String, port: Int) extends BenchClient {
       if (i < n)
         submit(keys(i)).onComplete { result =>
           result match {
-            case Success(v) => val _ = total.addAndGet(score(v))
-            case Failure(t) => val _ = failure.compareAndSet(null, t)
+            case Success(v) => total.addAndGet(score(v))
+            case Failure(t) => failure.compareAndSet(null, t)
           }
           remaining.countDown()
           fireNext()
         }
     }
     var k                = 0
-    while (k < width) { fireNext(); k += 1 }
+    while (k < width) {
+      fireNext()
+      k += 1
+    }
     remaining.await()
     val t                = failure.get()
     if (t != null) throw t // never publish numbers for a run where commands failed
@@ -220,7 +227,7 @@ final class RediscalaBench(host: String, port: Int) extends BenchClient {
     slidingWindow(keys, concurrency)(k => client.get[String](k))(_.fold(0L)(_.length.toLong))
 
   def setAll(keys: Array[String], value: String, concurrency: Int): Long = {
-    val _ = slidingWindow(keys, concurrency)(k => client.set(k, value))(_ => 0L)
+    slidingWindow(keys, concurrency)(k => client.set(k, value))(_ => 0L)
     keys.length.toLong
   }
 
@@ -230,7 +237,7 @@ final class RediscalaBench(host: String, port: Int) extends BenchClient {
 
   def close(): Unit = {
     client.stop()
-    val _ = Await.result(system.terminate(), 30.seconds)
+    Await.result(system.terminate(), 30.seconds)
   }
 }
 
@@ -257,10 +264,10 @@ final class JedisBench(host: String, port: Int) extends BenchClient {
     try {
       val p = j.pipelined()
       (0 until count).foreach { i =>
-        val _ = p.set(s"$prefix:$i", value)
+        p.set(s"$prefix:$i", value)
       }
       (0 until fields).foreach { i =>
-        val _ = p.hset(hashKey, s"f$i", value)
+        p.hset(hashKey, s"f$i", value)
       }
       p.sync()
     } finally j.close()
@@ -284,9 +291,9 @@ final class JedisBench(host: String, port: Int) extends BenchClient {
     lanes(keys, concurrency)((j, g) => g.foldLeft(0L)((t, k) => t + Option(j.get(k)).fold(0L)(_.length.toLong)))
 
   def setAll(keys: Array[String], value: String, concurrency: Int): Long = {
-    val _ = lanes(keys, concurrency) { (j, g) =>
+    lanes(keys, concurrency) { (j, g) =>
       g.foreach { k =>
-        val _ = j.set(k, value)
+        j.set(k, value)
       }
       g.length.toLong
     }

--- a/benchmarks/pekko/src/main/scala/sage/benchmarks/Clients.scala
+++ b/benchmarks/pekko/src/main/scala/sage/benchmarks/Clients.scala
@@ -72,6 +72,6 @@ final class SagePekkoBench(host: String, port: Int) extends BenchClient {
   def close(): Unit = {
     Await.result(client.close, 30.seconds)
     system.terminate()
-    Await.ready(system.whenTerminated, 10.seconds)
+    Await.ready(system.whenTerminated, 10.seconds): Unit
   }
 }

--- a/benchmarks/pekko/src/main/scala/sage/benchmarks/Clients.scala
+++ b/benchmarks/pekko/src/main/scala/sage/benchmarks/Clients.scala
@@ -44,7 +44,7 @@ final class SagePekkoBench(host: String, port: Int) extends BenchClient {
       case h :: t => client.hSet(hashKey, h, t*).map(_ => ())
       case Nil    => Future.unit
     }
-    val _    = Await.result(sets.flatMap(_ => hash), 120.seconds)
+    Await.result(sets.flatMap(_ => hash), 120.seconds)
   }
 
   def getAll(keys: Array[String], concurrency: Int): Long =
@@ -70,8 +70,8 @@ final class SagePekkoBench(host: String, port: Int) extends BenchClient {
     Await.result(client.hGetAll[String, String](key).map(_.size.toLong), 120.seconds)
 
   def close(): Unit = {
-    val _ = Await.result(client.close, 30.seconds)
+    Await.result(client.close, 30.seconds)
     system.terminate()
-    val _ = Await.ready(system.whenTerminated, 10.seconds)
+    Await.ready(system.whenTerminated, 10.seconds)
   }
 }

--- a/benchmarks/shared/src/main/scala/sage/benchmarks/ClusterFormation.scala
+++ b/benchmarks/shared/src/main/scala/sage/benchmarks/ClusterFormation.scala
@@ -25,7 +25,7 @@ object ClusterFormation {
 
       command("CONFIG", "SET", "cluster-announce-ip", host)
       command("CONFIG", "SET", "cluster-announce-port", port.toString)
-      if (!clusterOk) command("CLUSTER", "ADDSLOTSRANGE", "0", "16383")
+      if (!clusterOk) { command("CLUSTER", "ADDSLOTSRANGE", "0", "16383"): Unit }
       var attempts = 100
       var ok       = clusterOk
       while (!ok && attempts > 0) {

--- a/benchmarks/shared/src/main/scala/sage/benchmarks/ClusterFormation.scala
+++ b/benchmarks/shared/src/main/scala/sage/benchmarks/ClusterFormation.scala
@@ -23,9 +23,9 @@ object ClusterFormation {
       }
       def clusterOk: Boolean             = command("CLUSTER", "INFO").contains("cluster_state:ok")
 
-      val _        = command("CONFIG", "SET", "cluster-announce-ip", host)
-      val _        = command("CONFIG", "SET", "cluster-announce-port", port.toString)
-      if (!clusterOk) { val _ = command("CLUSTER", "ADDSLOTSRANGE", "0", "16383") }
+      command("CONFIG", "SET", "cluster-announce-ip", host)
+      command("CONFIG", "SET", "cluster-announce-port", port.toString)
+      if (!clusterOk) command("CLUSTER", "ADDSLOTSRANGE", "0", "16383")
       var attempts = 100
       var ok       = clusterOk
       while (!ok && attempts > 0) {

--- a/examples/ox/src/main/scala/sage/examples/ox/CachedReadsExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/CachedReadsExample.scala
@@ -14,7 +14,7 @@ import sage.backend.*
 object CachedReadsExample {
 
   def run(client: SageClient)(using Ox): Unit = {
-    val _      = client.set("cached:key", "v1")
+    client.set("cached:key", "v1")
     val first  = client.cached(Commands.get[String, String]("cached:key"), 1.minute) // fetch + cache
     val second = client.cached(Commands.get[String, String]("cached:key"), 1.minute) // local hit
     println(s"first=$first second=$second")

--- a/examples/ox/src/main/scala/sage/examples/ox/CommandsExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/CommandsExample.scala
@@ -15,21 +15,21 @@ object CommandsExample {
 
   def run(client: SageClient)(using Ox): Unit = {
     // strings, numbers, and a conditional write with a TTL
-    val _        = client.set("greeting", "hello")
+    client.set("greeting", "hello")
     val greeting = client.get[String]("greeting")
-    val _        = client.incrBy("counter", 10)
-    val _        = client.set("session", "token", expiry = SetExpiry.In(1.minute), condition = SetCondition.IfNotExists)
+    client.incrBy("counter", 10)
+    client.set("session", "token", expiry = SetExpiry.In(1.minute), condition = SetCondition.IfNotExists)
     // hashes
-    val _        = client.hSet("user:1", ("name", "Ada"), ("age", "36"))
+    client.hSet("user:1", ("name", "Ada"), ("age", "36"))
     val profile  = client.hGetAll[String, String]("user:1")
     // lists: a blocking pop off a Dedicated Connection (data is pushed first, so it returns at once)
-    val _        = client.rPush("queue", "a", "b", "c")
+    client.rPush("queue", "a", "b", "c")
     val head     = client.blPop[String]("queue")(BlockTimeout.Forever)
     // sets and sorted sets
-    val _        = client.sAdd("tags", "scala", "redis")
-    val _        = client.zAdd("scores")(("ada", 36.0))
+    client.sAdd("tags", "scala", "redis")
+    client.zAdd("scores")(("ada", 36.0))
     // a custom-codec round-trip: User rides on the given ValueCodec from the shared module
-    val _        = client.set("user:ada", User("Ada", 36))
+    client.set("user:ada", User("Ada", 36))
     val ada      = client.get[User]("user:ada")
     // a raw Lua eval yields a Frame; decode it with the strict helpers
     val sum      = client.eval("return 1 + 1")

--- a/examples/ox/src/main/scala/sage/examples/ox/MasterReplicaExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/MasterReplicaExample.scala
@@ -20,8 +20,8 @@ object MasterReplicaExample {
 
   def run(using Ox): Unit = {
     val client = SageClient.scoped(config)
-    val _      = client.set("k", "v")    // writes always go to the master
-    val value  = client.get[String]("k") // reads may be served by a replica, per the policy
+    client.set("k", "v") // writes always go to the master
+    val value = client.get[String]("k") // reads may be served by a replica, per the policy
     println(s"value=$value")
   }
 }

--- a/examples/ox/src/main/scala/sage/examples/ox/PipelinesExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/PipelinesExample.scala
@@ -12,10 +12,10 @@ import sage.backend.*
 object PipelinesExample {
 
   def run(client: SageClient)(using Ox): Unit = {
-    val _       = client.set("pipe:a", "x")
-    val _       = client.set("pipe:n", 10)
+    client.set("pipe:a", "x")
+    client.set("pipe:n", 10)
     val tuple   = client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy("pipe:n", 5)))
-    val _       = client.set("pipe:str", "hello")
+    client.set("pipe:str", "hello")
     // INCR on a non-numeric string fails only at its own position; the GET still succeeds
     val attempt = client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr("pipe:str")))
     println(s"tuple=$tuple attempt=$attempt")

--- a/examples/ox/src/main/scala/sage/examples/ox/PubSubExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/PubSubExample.scala
@@ -15,7 +15,7 @@ object PubSubExample {
     // subscribeScoped confirms before returning, so the publishes below can't outrun the registration
     val news     = client.subscribeScoped[String]("news")
     (1 to 3).foreach { i =>
-      val _ = client.publish("news", s"item-$i")
+      client.publish("news", s"item-$i")
     }
     val messages = news.take(3).runToList()
     println(s"received=${messages.map(_.payload)}")

--- a/examples/ox/src/main/scala/sage/examples/ox/StreamsExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/StreamsExample.scala
@@ -12,18 +12,18 @@ import sage.backend.*
 object StreamsExample {
 
   def run(client: SageClient)(using Ox): Unit = {
-    val _   = client.del("stream:orders")
-    val _   = client.xAdd("stream:orders")(("item", "book"), ("qty", "2"))
-    val _   = client.xAdd("stream:orders")(("item", "pen"), ("qty", "5"))
+    client.del("stream:orders")
+    client.xAdd("stream:orders")(("item", "book"), ("qty", "2"))
+    client.xAdd("stream:orders")(("item", "pen"), ("qty", "5"))
     val len = client.xLen("stream:orders")
 
     val entries = client.xRange[String, String]("stream:orders")
 
     // a Consumer Group reading from the start of the stream
-    val _       = client.xGroupCreate("stream:orders", "workers", id = GroupStartId.At(StreamId.Zero))
+    client.xGroupCreate("stream:orders", "workers", id = GroupStartId.At(StreamId.Zero))
     val batches = client.xReadGroup[String, String]("workers", "w1")(("stream:orders", GroupReadId.New))()
     val ids     = batches.flatMap(_._2).map(_.id)
-    val _       = client.xAck("stream:orders", "workers")(ids.head, ids.tail*)
+    client.xAck("stream:orders", "workers")(ids.head, ids.tail*)
 
     println(s"len=$len read=${entries.size} acked=${ids.size}")
   }

--- a/examples/ox/src/main/scala/sage/examples/ox/TransactionsExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/TransactionsExample.scala
@@ -12,10 +12,10 @@ import sage.backend.*
 object TransactionsExample {
 
   def run(client: SageClient)(using Ox): Unit = {
-    val _      = client.set("tx:n", 1)
+    client.set("tx:n", 1)
     val result = client.transaction { tx =>
-      val _ = tx.watch("tx:n")
-      val _ = tx.get[Int]("tx:n")
+      tx.watch("tx:n")
+      tx.get[Int]("tx:n")
       tx.exec((Commands.incr("tx:n"), Commands.incrBy("tx:n", 4)))
     }
     println(s"transaction result=$result")

--- a/examples/pekko/src/main/scala/sage/examples/pekko/Tour.scala
+++ b/examples/pekko/src/main/scala/sage/examples/pekko/Tour.scala
@@ -38,7 +38,7 @@ object Tour {
     try Await.result(program, 60.seconds)
     finally {
       system.terminate()
-      val _ = Await.ready(system.whenTerminated, 10.seconds)
+      Await.ready(system.whenTerminated, 10.seconds): Unit
     }
   }
 }

--- a/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
+++ b/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
@@ -18,7 +18,7 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
         val values = (1 to 50).toList
           .map(i =>
             fork {
-              val _ = client.set(s"key-$i", s"value-$i")
+              client.set(s"key-$i", s"value-$i")
               client.get[String](s"key-$i")
             }
           )
@@ -32,11 +32,11 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
     withContainers { server =>
       supervised {
         val client  = SageClient.scoped(configOf(server))
-        val _       = client.set("pipe:a", "x")
-        val _       = client.set("pipe:n", 10)
+        client.set("pipe:a", "x")
+        client.set("pipe:n", 10)
         val out     = client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)))
         assertEquals(out, (Some("x"), 15L))
-        val _       = client.set("pipe:str", "hello")
+        client.set("pipe:str", "hello")
         val attempt = client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")))
         assert(attempt._1 == Right(Some("hello")), attempt._1)
         assert(attempt._2.isLeft, attempt._2)
@@ -48,10 +48,10 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
     withContainers { server =>
       supervised {
         val client = SageClient.scoped(configOf(server))
-        val _      = client.set("tx:n", 1)
+        client.set("tx:n", 1)
         val out    = client.transaction { tx =>
-          val _ = tx.watch("tx:n")
-          val _ = tx.get[Int]("tx:n")
+          tx.watch("tx:n")
+          tx.get[Int]("tx:n")
           tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)))
         }
         assertEquals(out, Some((2L, 6L)))
@@ -64,7 +64,7 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
       supervised {
         val client = SageClient.scoped(configOf(server))
         (1 to 50).foreach { i =>
-          val _ = client.set(s"scan-$i", "v")
+          client.set(s"scan-$i", "v")
         }
         val keys   = client.scanAll(pattern = Some("scan-*"), count = Some(10L)).runToList()
         assertEquals(keys.toSet, (1 to 50).map(i => s"scan-$i").toSet)
@@ -78,7 +78,7 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
         val client   = SageClient.scoped(configOf(server))
         val stream   = client.subscribeScoped[String]("smoke")
         (1 to 3).foreach { i =>
-          val _ = client.publish("smoke", s"m$i")
+          client.publish("smoke", s"m$i")
         }
         val messages = stream.take(3).runToList()
         assertEquals(messages.map(_.channel).toSet, Set("smoke"))
@@ -92,9 +92,9 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
       supervised {
         val client = SageClient.scoped(configOf(server))
         val stream = client.subscribeScoped[String]("scoped-live")
-        val _      = client.publish("scoped-live", "a")
+        client.publish("scoped-live", "a")
         val first  = stream.take(1).runToList()
-        val _      = client.publish("scoped-live", "b")
+        client.publish("scoped-live", "b")
         val second = stream.take(1).runToList()
         assertEquals(first.map(_.payload), List("a"))
         assertEquals(second.map(_.payload), List("b"))
@@ -111,7 +111,7 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
         val running   = new java.util.concurrent.atomic.AtomicBoolean(true)
         val publisher = fork {
           while (running.get()) {
-            val _ = client.publish("rerun", "tick")
+            client.publish("rerun", "tick")
             Thread.sleep(50)
           }
         }
@@ -133,7 +133,7 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
       supervised {
         val client = SageClient.scoped(configOf(server))
         (1 to 50).foreach { i =>
-          val _ = client.hSet("hscan", (s"f$i", s"v$i"))
+          client.hSet("hscan", (s"f$i", s"v$i"))
         }
         val pairs  = client.hScanAll[String, String]("hscan", count = Some(10L)).runToList()
         assertEquals(pairs.toMap, (1 to 50).map(i => s"f$i" -> s"v$i").toMap)
@@ -146,7 +146,7 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
       supervised {
         val client  = SageClient.scoped(configOf(server))
         (1 to 50).foreach { i =>
-          val _ = client.sAdd("sscan", s"m$i")
+          client.sAdd("sscan", s"m$i")
         }
         val members = client.sScanAll[String]("sscan", count = Some(10L)).runToList()
         assertEquals(members.toSet, (1 to 50).map(i => s"m$i").toSet)
@@ -159,7 +159,7 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
       supervised {
         val client = SageClient.scoped(configOf(server))
         (1 to 50).foreach { i =>
-          val _ = client.zAdd("zscan")((s"m$i", i.toDouble))
+          client.zAdd("zscan")((s"m$i", i.toDouble))
         }
         val pairs  = client.zScanAll[String]("zscan", count = Some(10L)).runToList()
         assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)

--- a/integration-tests/pekko/src/test/scala/sage/integration/PekkoSmokeSuite.scala
+++ b/integration-tests/pekko/src/test/scala/sage/integration/PekkoSmokeSuite.scala
@@ -27,7 +27,7 @@ class PekkoSmokeSuite extends ServerSuite(Images.redis) {
       )
     finally {
       system.terminate()
-      val _ = Await.ready(system.whenTerminated, 10.seconds)
+      Await.ready(system.whenTerminated, 10.seconds): Unit
     }
   }
 

--- a/sage-client/ox/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/backend/SageClient.scala
@@ -216,7 +216,7 @@ extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]
     val sub                 = open
     val closed              = new AtomicBoolean(false)
     def unsubscribe(): Unit = if (closed.compareAndSet(false, true)) sub.close
-    val _                   = useInScope(sub)(_ => unsubscribe())
+    useInScope(sub)(_ => unsubscribe())
     Flow.usingEmit { emit =>
       var continue = true
       while (continue)

--- a/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
@@ -206,8 +206,8 @@ extension [K](client: Client[Future, K])(using @unused ev: KeyCodec[K]) {
             () => {
               val opened = open
               opened.onComplete {
-                case Success(_) => val _ = confirmed.trySuccess(Done)
-                case Failure(e) => val _ = confirmed.tryFailure(e)
+                case Success(_) => confirmed.trySuccess(Done)
+                case Failure(e) => confirmed.tryFailure(e)
               }(ExecutionContext.parasitic)
               opened
             },

--- a/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
+++ b/sage-client/shared/src/main/scala/sage/client/SageConfig.scala
@@ -231,7 +231,10 @@ object SageConfig {
       case -1 => uri
       case at =>
         val prefix    = uri.substring(0, at)
-        val schemeEnd = prefix.indexOf("://") match { case -1 => 0; case i => i + 3 }
+        val schemeEnd = prefix.indexOf("://") match {
+          case -1 => 0
+          case i  => i + 3
+        }
         val userinfo  = prefix.substring(schemeEnd)
         val redacted  = userinfo.indexOf(':') match {
           case -1 => "<redacted>"
@@ -262,10 +265,15 @@ object SageConfig {
       while (i < component.length && !fail)
         component.charAt(i) match {
           case '%' if i + 2 < component.length && isHex(component.charAt(i + 1)) && isHex(component.charAt(i + 2)) =>
-            out.write(Integer.parseInt(component.substring(i + 1, i + 3), 16)); i += 3
+            out.write(Integer.parseInt(component.substring(i + 1, i + 3), 16))
+            i += 3
           case '%'                                                                                                 => fail = true
-          case c if c < 128                                                                                        => out.write(c.toInt); i += 1
-          case c                                                                                                   => out.write(c.toString.getBytes(StandardCharsets.UTF_8)); i += 1
+          case c if c < 128                                                                                        =>
+            out.write(c.toInt)
+            i += 1
+          case c                                                                                                   =>
+            out.write(c.toString.getBytes(StandardCharsets.UTF_8))
+            i += 1
         }
       if (fail) Left(s"invalid redis URI '$uri': malformed percent-encoding in $label")
       else Right(new String(out.toByteArray, StandardCharsets.UTF_8))

--- a/sage-client/shared/src/main/scala/sage/client/internal/Bootstrap.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Bootstrap.scala
@@ -43,14 +43,22 @@ private[client] object Bootstrap {
     commands.foreach { command =>
       val latch   = new CountDownLatch(1)
       val outcome = new AtomicReference[Try[Any]]()
-      submit(command, result => { outcome.set(result); latch.countDown() })
+      submit(
+        command,
+        result => {
+          outcome.set(result)
+          latch.countDown()
+        }
+      )
       if (!latch.await(connectTimeoutMillis, TimeUnit.MILLISECONDS)) {
         close()
         throw ConnectionLost(mayHaveExecuted = false)
       }
       outcome.get() match {
         case Failure(_: ServerError) if bestEffort(command) => onTolerated(command)
-        case Failure(error)                                 => close(); throw error
+        case Failure(error)                                 =>
+          close()
+          throw error
         case Success(_)                                     => ()
       }
     }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2302,7 +2302,10 @@ object Client {
 
   // attributes the node at the completion site, so a batch that never reaches the wire (a false submit) leaves its callbacks unattributed
   private def attributeOnComplete(cb: Try[Any] => Unit, node: Node): Try[Any] => Unit =
-    result => { Events.attributeNode(cb, node); cb(result) }
+    result => {
+      Events.attributeNode(cb, node)
+      cb(result)
+    }
 
   // a pipeline batched onto a single connection: scatter each reply into its submission-order slot, and on a disconnect report a failed
   // completion per position before failing the effect once. Shared by standalone/master-replica; the cluster runtime splits per node instead.
@@ -2465,7 +2468,10 @@ object Client {
         )
         new Live(connection, pool, subscriptions, cachingEnabled, events)
       }
-      .mapError { error => events.close(); translateHandshake(error) }
+      .mapError { error =>
+        events.close()
+        translateHandshake(error)
+      }
   }
 
   // pre-6.0 Redis answers HELLO with an unknown-command error; newer servers reject an unsupported protocol version with NOPROTO. A
@@ -2566,7 +2572,12 @@ object Client {
     def subscribeShardChannels[V: ValueCodec](channel: String, rest: String*): CIO[Subscription[CIO, Message[V]]] =
       CIO.blocking(channelMessages(subscriptions.subscribeShard(channel +: rest.toVector)))
 
-    def close: CIO[Unit] = CIO.blocking { subscriptions.close(); pool.close(); connection.close(); events.close() }
+    def close: CIO[Unit] = CIO.blocking {
+      subscriptions.close()
+      pool.close()
+      connection.close()
+      events.close()
+    }
   }
 
   // wrap a raw subscription as the effect-typed interface each backend lowers into its native stream; `build` returns None to end the stream
@@ -2578,7 +2589,11 @@ object Client {
       def next: CIO[Option[M]] = {
         // deregister the parked waiter if this next is interrupted, else a stale waiter trips the single-consumer guard
         val registered = new AtomicReference[Option[SubscriptionConnection.Delivery] => Unit]()
-        CIO.ensure(CIO.defer { val cb = registered.getAndSet(null); if (cb ne null) raw.cancelNext(cb) }) {
+        val deregister = CIO.defer {
+          val cb = registered.getAndSet(null)
+          if (cb ne null) raw.cancelNext(cb)
+        }
+        CIO.ensure(deregister) {
           CIO.async { complete =>
             val cb: Option[SubscriptionConnection.Delivery] => Unit = {
               case Some(delivery) => complete(Try(build(delivery)))
@@ -2624,13 +2639,18 @@ object Client {
     val armed = new AtomicBoolean(false)
 
     private def faulting[A](complete: Try[A] => Unit): Try[A] => Unit = {
-      case failure @ Failure(error) => onFault(error); complete(failure)
+      case failure @ Failure(error) =>
+        onFault(error)
+        complete(failure)
       case success                  => complete(success)
     }
 
     // an EXEC fault arrives as an error *frame* in a Success, invisible to `faulting`, so scan the top level and the EXEC array
     private def refreshOnExecFault(frames: Vector[Frame]): Unit = {
-      val nested = frames.lastOption match { case Some(Frame.Array(elems)) => elems.iterator; case _ => Iterator.empty[Frame] }
+      val nested = frames.lastOption match {
+        case Some(Frame.Array(elems)) => elems.iterator
+        case _                        => Iterator.empty[Frame]
+      }
       (frames.iterator ++ nested).flatMap(TxSupport.errorOf).foreach(message => onFault(ServerError.of(message)))
     }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClientCache.scala
@@ -96,8 +96,10 @@ final private[client] class ClientCache(maxBytes: Long) {
 
   def flush(): Unit = {
     lock.lock()
-    try { clearEntries(); epoch = epoch.next }
-    finally lock.unlock()
+    try {
+      clearEntries()
+      epoch = epoch.next
+    } finally lock.unlock()
   }
 
   def flushForReroute(): Unit = {
@@ -150,7 +152,7 @@ final private[client] class ClientCache(maxBytes: Long) {
     entry.keys.foreach { k =>
       reverse.get(k).foreach { set =>
         set -= key
-        if (set.isEmpty) { val _ = reverse.remove(k) }
+        if (set.isEmpty) { reverse.remove(k): Unit }
       }
     }
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -113,7 +113,10 @@ final private[client] class ClusterLive(
       val node = candidates.next()
       try
         querySlotsVia(node, getOrEstablish(node)) match {
-          case Right(shards) => adopt(node, shards); startRefreshPoll(); return
+          case Right(shards) =>
+            adopt(node, shards)
+            startRefreshPoll()
+            return
           case Left(error)   => lastError = error
         }
       catch { case NonFatal(error) => lastError = error }
@@ -392,7 +395,9 @@ final private[client] class ClusterLive(
             else submitRead(nc, node, command, rest, master, redirectsLeft, complete)
           }
       // strict Replica, all candidates unreachable: refresh so the next read sees the new roster
-      case _            => triggerRefresh(); complete(Failure(NotConnected()))
+      case _            =>
+        triggerRefresh()
+        complete(Failure(NotConnected()))
     }
 
   private def submitRead[A](
@@ -408,7 +413,9 @@ final private[client] class ClusterLive(
       command,
       asking = false,
       {
-        case Success(value) => Events.attributeNode(complete, node); complete(Success(value))
+        case Success(value) =>
+          Events.attributeNode(complete, node)
+          complete(Success(value))
         case Failure(error) => offload(onReadFailure(node, command, error, rest, master, redirectsLeft, complete))
       }
     )
@@ -432,7 +439,9 @@ final private[client] class ClusterLive(
           case RedirectKind.Moved if redirectsLeft <= 0 =>
             refreshBeforeFailing()
             complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
-          case RedirectKind.Moved                       => refresh(force = true); offload(dispatch(command, redirectsLeft - 1, complete))
+          case RedirectKind.Moved                       =>
+            refresh(force = true)
+            offload(dispatch(command, redirectsLeft - 1, complete))
         }
       case Fault.Lost(false)                =>
         if (rest.nonEmpty) tryReadCandidates(command, rest, master, redirectsLeft, complete) else onUnreachable(command, redirectsLeft, complete)
@@ -440,8 +449,13 @@ final private[client] class ClusterLive(
         if (rest.nonEmpty) tryReadCandidates(command, rest, master, redirectsLeft, complete)
         else onRetryable(command, error, clusterWide, redirectsLeft, complete)
       case Fault.TryAgain                   => onRetryable(command, error, refreshFirst = false, redirectsLeft, complete)
-      case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error))
-      case Fault.Fatal                      => Events.attributeNode(complete, node); complete(Failure(error))
+      case Fault.Demoted | Fault.Lost(true) =>
+        triggerRefresh()
+        Events.attributeNode(complete, node)
+        complete(Failure(error))
+      case Fault.Fatal                      =>
+        Events.attributeNode(complete, node)
+        complete(Failure(error))
     }
 
   private def broadcast[A](
@@ -540,7 +554,9 @@ final private[client] class ClusterLive(
       case Fault.Lost(false)                         => retryBroadcast(node, command, error, refreshFirst = true, attemptsLeft, settle)
       case Fault.TryAgain | Fault.Unavailable(false) => retryBroadcast(node, command, error, refreshFirst = false, attemptsLeft, settle)
       // a cluster-wide refusal may have moved the masters this fan-out captured, so it is not chased
-      case Fault.Unavailable(true)                   => refreshBeforeFailing(); settle(Failure(error))
+      case Fault.Unavailable(true)                   =>
+        refreshBeforeFailing()
+        settle(Failure(error))
       case fault                                     =>
         if (fault.refreshPolicy != RefreshPolicy.Skip) triggerRefresh()
         settle(Failure(error))
@@ -555,8 +571,10 @@ final private[client] class ClusterLive(
     attemptsLeft: Int,
     settle: Try[B] => Unit
   ): Unit =
-    if (attemptsLeft <= 0) { if (refreshFirst) refreshBeforeFailing(); settle(Failure(error)) }
-    else
+    if (attemptsLeft <= 0) {
+      if (refreshFirst) refreshBeforeFailing()
+      settle(Failure(error))
+    } else
       afterBackoff(attemptsLeft) {
         if (refreshFirst) refresh(force = true)
         if (closed || !slotOwningMasters(topologyRef.get()).contains(node)) settle(Failure(error))
@@ -566,7 +584,10 @@ final private[client] class ClusterLive(
   private def collectFrames(frames: java.util.concurrent.atomic.AtomicReferenceArray[Frame], size: Int): Vector[Frame] = {
     val out = Vector.newBuilder[Frame]
     var i   = 0
-    while (i < size) { out += frames.get(i); i += 1 }
+    while (i < size) {
+      out += frames.get(i)
+      i += 1
+    }
     out.result()
   }
 
@@ -624,7 +645,9 @@ final private[client] class ClusterLive(
     cacheCtx: Cached
   ): Unit = {
     val onReply: Try[A] => Unit = {
-      case Success(value) => Events.attributeNode(complete, node); complete(Success(value))
+      case Success(value) =>
+        Events.attributeNode(complete, node)
+        complete(Success(value))
       case Failure(error) => offload(onFailure(node, command, error, redirectsLeft, complete, lease, cacheCtx))
     }
     if (cacheCtx != null && !asking) nc.cachedSubmit[A](command, cacheCtx.ttlMillis, onReply, cacheCtx.deferred)
@@ -645,8 +668,13 @@ final private[client] class ClusterLive(
       case Fault.Lost(false)                => onUnreachable(command, redirectsLeft, complete, lease, cacheCtx)
       case Fault.TryAgain                   => onRetryable(command, error, refreshFirst = false, redirectsLeft, complete, lease, cacheCtx)
       case Fault.Unavailable(clusterWide)   => onRetryable(command, error, clusterWide, redirectsLeft, complete, lease, cacheCtx)
-      case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); Events.attributeNode(complete, node); complete(Failure(error))
-      case Fault.Fatal                      => Events.attributeNode(complete, node); complete(Failure(error))
+      case Fault.Demoted | Fault.Lost(true) =>
+        triggerRefresh()
+        Events.attributeNode(complete, node)
+        complete(Failure(error))
+      case Fault.Fatal                      =>
+        Events.attributeNode(complete, node)
+        complete(Failure(error))
     }
 
   private def onRedirect[A](
@@ -666,7 +694,9 @@ final private[client] class ClusterLive(
     } else {
       val target = resolve(redirect.target, from)
       redirect.kind match {
-        case RedirectKind.Moved => triggerRefresh(); sendTo(target, command, asking = false, redirectsLeft - 1, complete, lease, cacheCtx)
+        case RedirectKind.Moved =>
+          triggerRefresh()
+          sendTo(target, command, asking = false, redirectsLeft - 1, complete, lease, cacheCtx)
         case RedirectKind.Ask   => sendTo(target, command, asking = true, redirectsLeft - 1, complete, lease, cacheCtx)
       }
     }
@@ -681,8 +711,10 @@ final private[client] class ClusterLive(
     lease: DedicatedPool.Lease = null,
     cacheCtx: Cached = null
   ): Unit =
-    if (redirectsLeft <= 0) { refreshBeforeFailing(); complete(Failure(NotConnected())) }
-    else {
+    if (redirectsLeft <= 0) {
+      refreshBeforeFailing()
+      complete(Failure(NotConnected()))
+    } else {
       refresh(force = true)
       afterBackoff(redirectsLeft)(
         dispatch(command, redirectsLeft - 1, complete, allowReplica = replicaAllowed(cacheCtx), lease = lease, cacheCtx = cacheCtx)
@@ -699,8 +731,10 @@ final private[client] class ClusterLive(
     lease: DedicatedPool.Lease = null,
     cacheCtx: Cached = null
   ): Unit =
-    if (redirectsLeft <= 0) { if (refreshFirst) refreshBeforeFailing(); complete(Failure(error)) }
-    else {
+    if (redirectsLeft <= 0) {
+      if (refreshFirst) refreshBeforeFailing()
+      complete(Failure(error))
+    } else {
       if (refreshFirst) refresh(force = true)
       afterBackoff(redirectsLeft)(
         dispatch(command, redirectsLeft - 1, complete, allowReplica = replicaAllowed(cacheCtx), lease = lease, cacheCtx = cacheCtx)
@@ -893,7 +927,10 @@ final private[client] class ClusterLive(
     reroute: Int => Unit,
     useReplica: Boolean
   ): Unit = {
-    def settle(index: Int, result: Try[Any]): Unit = { Events.attributeNode(emits(index), target); emits(index)(result) }
+    def settle(index: Int, result: Try[Any]): Unit = {
+      Events.attributeNode(emits(index), target)
+      emits(index)(result)
+    }
     val callbacks: Vector[Try[Any] => Unit]        = indices.map { index => (result: Try[Any]) =>
       result match {
         case Success(_)     => settle(index, result)
@@ -914,7 +951,9 @@ final private[client] class ClusterLive(
               case Fault.Lost(false)                => reroute(index)
               case Fault.TryAgain                   => onRetryable(p.commands(index), error, refreshFirst = false, cluster.maxRedirects, emits(index))
               case Fault.Unavailable(clusterWide)   => onRetryable(p.commands(index), error, clusterWide, cluster.maxRedirects, emits(index))
-              case Fault.Demoted | Fault.Lost(true) => triggerRefresh(); settle(index, result)
+              case Fault.Demoted | Fault.Lost(true) =>
+                triggerRefresh()
+                settle(index, result)
               case Fault.Fatal                      => settle(index, result)
             }
           }
@@ -951,7 +990,10 @@ final private[client] class ClusterLive(
       val command = Connection.watch(key, rest*)
       CIO.async[Unit] { complete =>
         val tracked = Events.trackSpan(events, command, complete)
-        offload(withConn(command, tracked) { c => armed.set(true); c.submit(command, faulting(tracked)) })
+        offload(withConn(command, tracked) { c =>
+          armed.set(true)
+          c.submit(command, faulting(tracked))
+        })
       }
     }
 
@@ -977,7 +1019,11 @@ final private[client] class ClusterLive(
           try
             if (released) complete(Failure(TxSupport.scopeReleasedError))
             else if (conn == null) complete(Success(())) // nothing leased, nothing watched
-            else Client.completing(complete) { armed.set(false); conn.submit(Connection.unwatch, faulting(complete)) }
+            else
+              Client.completing(complete) {
+                armed.set(false)
+                conn.submit(Connection.unwatch, faulting(complete))
+              }
           finally lock.unlock()
         }
       }
@@ -994,14 +1040,19 @@ final private[client] class ClusterLive(
       }
 
     private def faulting[A](complete: Try[A] => Unit): Try[A] => Unit = {
-      case failure @ Failure(error) => refreshOnFault(error); complete(failure)
+      case failure @ Failure(error) =>
+        refreshOnFault(error)
+        complete(failure)
       case success                  => complete(success)
     }
 
     // EXEC replies arrive as a Success carrying raw frames, so an ownership fault is an error *frame*, invisible to `faulting`; scan the top
     // level and the EXEC array and refresh on any non-terminal one so the caller's retry re-pins
     private def refreshOnExecFault(frames: Vector[Frame]): Unit = {
-      val nested = frames.lastOption match { case Some(Frame.Array(elems)) => elems.iterator; case _ => Iterator.empty[Frame] }
+      val nested = frames.lastOption match {
+        case Some(Frame.Array(elems)) => elems.iterator
+        case _                        => Iterator.empty[Frame]
+      }
       refreshFor((frames.iterator ++ nested).flatMap(TxSupport.errorOf).map(m => Fault.categorize(ServerError.of(m))).toVector)
     }
 
@@ -1059,12 +1110,18 @@ final private[client] class ClusterLive(
           if (released) complete(Failure(TxSupport.scopeReleasedError))
           else
             slotResult match {
-              case Left(error) => fault = error; complete(Failure(error))
+              case Left(error) =>
+                fault = error
+                complete(Failure(error))
               case Right(s)    =>
-                if (conn == null) { acquire = true; slot = s }
-                else
+                if (conn == null) {
+                  acquire = true
+                  slot = s
+                } else
                   checkPin(s) match {
-                    case Left(error) => fault = error; complete(Failure(error))
+                    case Left(error) =>
+                      fault = error
+                      complete(Failure(error))
                     case Right(())   => Client.completing(complete)(use(conn))
                   }
             }
@@ -1072,14 +1129,22 @@ final private[client] class ClusterLive(
         if (fault != null) refreshOnFault(fault)
         else if (acquire)
           acquireConn(slot) match {
-            case Left(error)               => refreshOnFault(error); complete(Failure(error))
+            case Left(error)               =>
+              refreshOnFault(error)
+              complete(Failure(error))
             case Right((nc, c, node, pin)) =>
               var giveBack = false
               lock.lock()
               try
-                if (released) { giveBack = true; complete(Failure(TxSupport.scopeReleasedError)) }
-                else if (conn != null) { giveBack = true; retry = true } // lost the acquire race; re-validate against the winner's pin
-                else {
+                if (released) {
+                  giveBack = true
+                  complete(Failure(TxSupport.scopeReleasedError))
+                }
+                // lost the acquire race; re-validate against the winner's pin
+                else if (conn != null) {
+                  giveBack = true
+                  retry = true
+                } else {
                   nodeClient = nc
                   conn = c
                   pinnedNode = node
@@ -1102,8 +1167,10 @@ final private[client] class ClusterLive(
             case Some(ps)            =>
               Left(CrossSlot(s"transaction touches slot ${s.value} but is pinned to slot ${ps.value}; MULTI/EXEC requires a single slot"))
             case None                =>
-              if (topologyRef.get().nodeForSlot(s).contains(pinnedNode)) { pinnedSlot = Some(s); Right(()) }
-              else Left(CrossSlot(s"transaction touches slot ${s.value} on a node other than its pinned one; MULTI/EXEC requires a single slot"))
+              if (topologyRef.get().nodeForSlot(s).contains(pinnedNode)) {
+                pinnedSlot = Some(s)
+                Right(())
+              } else Left(CrossSlot(s"transaction touches slot ${s.value} on a node other than its pinned one; MULTI/EXEC requires a single slot"))
           }
       }
 
@@ -1127,7 +1194,10 @@ final private[client] class ClusterLive(
     }
 
     private def nodeForSlotRefreshing(slot: Slot): Option[Node] =
-      topologyRef.get().nodeForSlot(slot).orElse { refresh(force = true); topologyRef.get().nodeForSlot(slot) }
+      topologyRef.get().nodeForSlot(slot).orElse {
+        refresh(force = true)
+        topologyRef.get().nodeForSlot(slot)
+      }
 
     private def commandSlot(command: Command[?]): Either[Throwable, Option[Slot]] =
       if (command.hasMalformedKeys)
@@ -1175,8 +1245,10 @@ final private[client] class ClusterLive(
     private[internal] def release(): Unit = {
       lock.lock()
       val (nc, c, reusable) =
-        try { released = true; (nodeClient, conn, conn != null && conn.isHealthy && conn.isQuiescent && !armed.get) }
-        finally lock.unlock()
+        try {
+          released = true
+          (nodeClient, conn, conn != null && conn.isHealthy && conn.isQuiescent && !armed.get)
+        } finally lock.unlock()
       if (nc != null) nc.releaseTransaction(c, reusable)
     }
   }
@@ -1188,7 +1260,10 @@ final private[client] class ClusterLive(
     catch { case NonFatal(_) => null }
 
   private def flushNode(node: Node): Unit =
-    if (cachingEnabled) { val nc = masterPool.existing(node); if (nc != null) nc.flushCache() }
+    if (cachingEnabled) {
+      val nc = masterPool.existing(node)
+      if (nc != null) nc.flushCache()
+    }
 
   // --- topology refresh (single-flight, throttled) -------------------------------------------------------------------------------------
 
@@ -1219,7 +1294,14 @@ final private[client] class ClusterLive(
   private def querySlotsVia(node: Node, nc: NodeClient): Either[Throwable, Vector[Shard]] = {
     val latch   = new CountDownLatch(1)
     val outcome = new AtomicReference[Try[Vector[Shard]]]()
-    nc.submit[Vector[Shard]](Cluster.slots, asking = false, result => { outcome.set(result); latch.countDown() })
+    nc.submit[Vector[Shard]](
+      Cluster.slots,
+      asking = false,
+      result => {
+        outcome.set(result)
+        latch.countDown()
+      }
+    )
     if (!latch.await(connectTimeout.toMillis, TimeUnit.MILLISECONDS))
       Left(TimedOut(s"CLUSTER SLOTS on ${node.host}:${node.port} timed out after ${connectTimeout.toMillis}ms"))
     else
@@ -1306,7 +1388,13 @@ private[client] object ClusterLive {
       )
       // translate discovery's handshake/TLS failures here rather than via mapError, which the per-backend CIO alias does not reconcile through
       // `Client`'s invariant type parameter
-      try { live.bootstrapTopology(); live }
-      catch { case NonFatal(error) => events.close(); throw translate(error) }
+      try {
+        live.bootstrapTopology()
+        live
+      } catch {
+        case NonFatal(error) =>
+          events.close()
+          throw translate(error)
+      }
     }
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
@@ -80,7 +80,10 @@ final private[client] class ClusterSubscriptions(
         }
       conn.attach(sink, names, kind)
     } catch {
-      case e: Throwable => locked(classicSubs -= sub); sink.terminate(); throw e
+      case e: Throwable =>
+        locked(classicSubs -= sub)
+        sink.terminate()
+        throw e
     }
     new RawSubscription(sink, () => closeClassic(sub))
   }
@@ -121,8 +124,13 @@ final private[client] class ClusterSubscriptions(
   private def scheduleRehomeClassic(): Unit = {
     val go = locked {
       if (closed) false
-      else if (rehomeRunning) { rehomeQueued = true; false }
-      else { rehomeRunning = true; true }
+      else if (rehomeRunning) {
+        rehomeQueued = true
+        false
+      } else {
+        rehomeRunning = true
+        true
+      }
     }
     if (go) offload(runRehomeClassicPass())
   }
@@ -130,9 +138,15 @@ final private[client] class ClusterSubscriptions(
   private def runRehomeClassicPass(): Unit = {
     refresh()
     rehomeClassic()
-    val again = locked(if (!closed && rehomeQueued) {
-      rehomeQueued = false; true
-    } else { rehomeRunning = false; false })
+    val again = locked {
+      if (!closed && rehomeQueued) {
+        rehomeQueued = false
+        true
+      } else {
+        rehomeRunning = false
+        false
+      }
+    }
     if (again) offload(runRehomeClassicPass())
   }
 
@@ -155,7 +169,7 @@ final private[client] class ClusterSubscriptions(
           try {
             conn.attach(sub.sink, sub.names, sub.kind)
             // closed during attach: closeClassic couldn't detach a not-yet-attached sub, so detach here or its channels leak on `conn`
-            if (!locked(classicSubs.contains(sub))) { val _ = conn.detach(sub.sink, sub.names, sub.kind) }
+            if (!locked(classicSubs.contains(sub))) { conn.detach(sub.sink, sub.names, sub.kind): Unit }
           } catch { case NonFatal(_) => failed = true }
         }
         if (failed) {
@@ -188,7 +202,11 @@ final private[client] class ClusterSubscriptions(
     }
     // roll back partial placements on failure: closeShard detaches whatever landed (no orphaned SSUBSCRIBE) and terminates the sink
     try place(sub)
-    catch { case e: Throwable => closeShard(sub); throw e }
+    catch {
+      case e: Throwable =>
+        closeShard(sub)
+        throw e
+    }
     new RawSubscription(sink, () => closeShard(sub))
   }
 
@@ -225,7 +243,10 @@ final private[client] class ClusterSubscriptions(
     locked(shardConns.remove(node))
     // a drop may mean the slot migrated (server sends sunsubscribe then disconnects); force a refresh — stale topology still names the dead
     // owner, which planFor would not see as unowned — then reconcile onto the current owner
-    offload { refresh(); scheduleReconcile() }
+    offload {
+      refresh()
+      scheduleReconcile()
+    }
   }
 
   def onTopologyChanged(): Unit = scheduleReconcile()
@@ -234,17 +255,28 @@ final private[client] class ClusterSubscriptions(
   private def scheduleReconcile(): Unit = {
     val go = locked {
       if (closed) false
-      else if (reconcileRunning) { reconcileQueued = true; false }
-      else { reconcileRunning = true; true }
+      else if (reconcileRunning) {
+        reconcileQueued = true
+        false
+      } else {
+        reconcileRunning = true
+        true
+      }
     }
     if (go) offload(runReconcilePass())
   }
 
   private def runReconcilePass(): Unit = {
     reconcileShard()
-    val again = locked(if (!closed && reconcileQueued) {
-      reconcileQueued = false; true
-    } else { reconcileRunning = false; false })
+    val again = locked {
+      if (!closed && reconcileQueued) {
+        reconcileQueued = false
+        true
+      } else {
+        reconcileRunning = false
+        false
+      }
+    }
     if (again) offload(runReconcilePass())
   }
 
@@ -257,7 +289,7 @@ final private[client] class ClusterSubscriptions(
       subs.foreach { sub =>
         val failed = sub.placement.reconcile(planFor(sub.channels), conns)
         // closed during this pass: a racing closeShard may have detached before we re-attached, so reconcile back to empty
-        if (!locked(shardSubs.contains(sub))) { val _ = sub.placement.reconcile(Map.empty, conns) }
+        if (!locked(shardSubs.contains(sub))) { sub.placement.reconcile(Map.empty, conns): Unit }
         // an unowned slot is dropped from the plan, so reconcile reports no failure though the sub isn't placed; retry until fullyPlaced
         else if (failed || !sub.placement.fullyPlaced) incomplete = true
       }

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedConnection.scala
@@ -106,10 +106,15 @@ final private[client] class DedicatedConnection private (
 
     override def clearPayload(): Unit = payload = Bytes.empty
 
-    def writeAttempted(): Unit = { val _ = pending.add(this) }
+    def writeAttempted(): Unit =
+      pending.add(this): Unit
 
     // dropped fires only during teardown, ahead of onClosed; mark dead first so the pool can't recycle this connection mid-close
-    def dropped(): Unit = { dead = true; inFlight.decrementAndGet(); callback(Failure(ConnectionLost(mayHaveExecuted = false))) }
+    def dropped(): Unit = {
+      dead = true
+      inFlight.decrementAndGet()
+      callback(Failure(ConnectionLost(mayHaveExecuted = false)))
+    }
 
     def complete(frame: Frame): Unit = {
       val result = Reply.decode(command, frame)
@@ -117,7 +122,10 @@ final private[client] class DedicatedConnection private (
       callback(result)
     }
 
-    def fail(error: SageException): Unit = { inFlight.decrementAndGet(); callback(Failure(error)) }
+    def fail(error: SageException): Unit = {
+      inFlight.decrementAndGet()
+      callback(Failure(error))
+    }
   }
 
   // One write, N waiters: the batch is written (or dropped) atomically, and each reply frame fills its slot. The shared collector fires the
@@ -135,10 +143,16 @@ final private[client] class DedicatedConnection private (
 
     def writeAttempted(): Unit = {
       var i = 0
-      while (i < n) { val _ = pending.add(new Slot(i)); i += 1 }
+      while (i < n) {
+        pending.add(new Slot(i))
+        i += 1
+      }
     }
 
-    def dropped(): Unit = { dead = true; finish(Failure(ConnectionLost(mayHaveExecuted = false))) }
+    def dropped(): Unit = {
+      dead = true
+      finish(Failure(ConnectionLost(mayHaveExecuted = false)))
+    }
 
     private def finish(result: Try[Vector[Frame]]): Unit =
       if (done.compareAndSet(false, true)) {

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -84,7 +84,14 @@ final private[client] class DedicatedPool(
             val onInterrupt = () => callback(scala.util.Failure(ConnectionLost(mayHaveExecuted = true)))
             if (lease.attach(this, conn, onInterrupt)) {
               if (asking) conn.submit[Unit](Connection.asking, _ => ())
-              conn.submit(command, result => if (lease.finish(conn)) { release(conn); callback(result) })
+              conn.submit(
+                command,
+                result =>
+                  if (lease.finish(conn)) {
+                    release(conn)
+                    callback(result)
+                  }
+              )
             } else onInterrupt()
         }
       }
@@ -140,7 +147,7 @@ final private[client] class DedicatedPool(
         }
         val remaining = deadlineNanos - System.nanoTime()
         if (remaining <= 0L) throw acquireTimedOut
-        val _         = available.awaitNanos(remaining)
+        available.awaitNanos(remaining): Unit
       }
       throw new IllegalStateException("unreachable")
     }
@@ -155,7 +162,11 @@ final private[client] class DedicatedPool(
     try connection.establish(bootstrap)
     catch {
       case e: Throwable =>
-        locked { establishing -= connection; reserved -= 1; available.signal() }
+        locked {
+          establishing -= connection
+          reserved -= 1
+          available.signal()
+        }
         lock.lock() // re-take so acquire()'s `locked` block unlocks exactly once on exit
         throw e
     }
@@ -205,7 +216,7 @@ final private[client] class DedicatedPool(
       val due     = Vector.newBuilder[DedicatedConnection]
       idle.filterInPlace { entry =>
         val keep = reusable(entry)
-        if (!keep) { val _ = due += entry.connection }
+        if (!keep) due += entry.connection
         keep
       }
       val expired = due.result()
@@ -279,7 +290,10 @@ private[client] object DedicatedPool {
 
     private[internal] def attach(pool: DedicatedPool, conn: DedicatedConnection, onInterrupt: () => Unit): Boolean =
       if (state.compareAndSet(null, Held(pool, conn, onInterrupt))) true
-      else { pool.releaseTransaction(conn, reusable = false); false }
+      else {
+        pool.releaseTransaction(conn, reusable = false)
+        false
+      }
 
     private[internal] def finish(conn: DedicatedConnection): Boolean =
       state.get() match {
@@ -288,7 +302,9 @@ private[client] object DedicatedPool {
       }
 
     def cancel(): Unit = state.getAndSet(Cancelled) match {
-      case h: Held => h.pool.releaseTransaction(h.conn, reusable = false); h.onInterrupt()
+      case h: Held =>
+        h.pool.releaseTransaction(h.conn, reusable = false)
+        h.onInterrupt()
       case _       => ()
     }
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Events.scala
@@ -72,15 +72,18 @@ private[client] object Events {
       if (queue != null)
         event match {
           case failure @ SageEvent.Connection.ConnectFailed(Some(node), _) =>
-            if (failedConnections.add(node) && !queue.offer(failure)) { val _ = failedConnections.remove(node) }
+            if (failedConnections.add(node) && !queue.offer(failure)) { failedConnections.remove(node): Unit }
           case connected @ SageEvent.Connection.Connected(Some(node))      =>
-            val _ = failedConnections.remove(node)
-            val _ = queue.offer(connected)
+            failedConnections.remove(node)
+            queue.offer(connected): Unit
           case _                                                           =>
-            val _ = queue.offer(event)
+            queue.offer(event): Unit
         }
 
-    def close(): Unit = if (worker != null) { running = false; worker.interrupt() }
+    def close(): Unit = if (worker != null) {
+      running = false
+      worker.interrupt()
+    }
 
     private def drain(): Unit = {
       // keep serving while running: a listener may leave the interrupt flag set, and shutdown clears running first, so only it ends the loop
@@ -89,7 +92,10 @@ private[client] object Events {
         catch { case _: InterruptedException => () }
       // best-effort: deliver what is already queued before exiting
       var event = queue.poll()
-      while (event != null) { dispatch(event); event = queue.poll() }
+      while (event != null) {
+        dispatch(event)
+        event = queue.poll()
+      }
     }
 
     private def dispatch(event: SageEvent): Unit = {
@@ -192,7 +198,10 @@ private[client] object Events {
 
     @volatile private var node: Option[Node] = None
 
-    def at(n: Node): Unit = { node = Some(n); routeSpan(span, n) }
+    def at(n: Node): Unit = {
+      node = Some(n)
+      routeSpan(span, n)
+    }
 
     def abandon(error: Throwable): Unit = settleSpan(span, Outcome.Failed(error))
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -85,8 +85,12 @@ final private[client] class MasterReplicaLive(
 
   private[client] def bootstrapRoles(): Unit =
     resolveTopology(seeds) match {
-      case Right(topology) => installTopology(topology); startRefreshPoll()
-      case Left(error)     => closeAll(); throw error
+      case Right(topology) =>
+        installTopology(topology)
+        startRefreshPoll()
+      case Left(error)     =>
+        closeAll()
+        throw error
     }
 
   private def resolveTopology(discoveredCandidates: => Vector[Node]): Either[Throwable, MasterReplicaLive.ResolvedTopology] =
@@ -166,7 +170,14 @@ final private[client] class MasterReplicaLive(
     try {
       val latch   = new CountDownLatch(1)
       val outcome = new AtomicReference[Try[Role]]()
-      nc.submit[Role](Server.role, asking = false, result => { outcome.set(result); latch.countDown() })
+      nc.submit[Role](
+        Server.role,
+        asking = false,
+        result => {
+          outcome.set(result)
+          latch.countDown()
+        }
+      )
       if (!latch.await(config.connectTimeout.toMillis, TimeUnit.MILLISECONDS)) {
         val error = TimedOut(s"ROLE timed out after ${config.connectTimeout.toMillis}ms")
         reportProbeFailure(node, error)
@@ -245,7 +256,11 @@ final private[client] class MasterReplicaLive(
   // run `submit` on the master, completing with node attribution; an ownership fault (a demoted master) kicks a re-discovery.
   // `onDown` fires on any short-circuit that never reaches `submit`.
   private def onMaster[A](complete: Try[A] => Unit, onDown: () => Unit = () => ())(submit: (NodeClient, Node, Try[A] => Unit) => Unit): Unit = {
-    if (closed) { onDown(); complete(Failure(NotConnected())); return }
+    if (closed) {
+      onDown()
+      complete(Failure(NotConnected()))
+      return
+    }
     val node     = masterNodeRef.get()
     val existing = masterPool.existing(node)
     if (existing != null) submitMaster(existing, node, complete, submit)
@@ -254,8 +269,11 @@ final private[client] class MasterReplicaLive(
         val nc =
           try masterPool.getOrEstablish(node)
           catch { case NonFatal(_) => null }
-        if (nc == null) { triggerRefresh(); onDown(); complete(Failure(NotConnected())) }
-        else submitMaster(nc, node, complete, submit)
+        if (nc == null) {
+          triggerRefresh()
+          onDown()
+          complete(Failure(NotConnected()))
+        } else submitMaster(nc, node, complete, submit)
       }
   }
 
@@ -264,13 +282,21 @@ final private[client] class MasterReplicaLive(
       nc,
       node,
       {
-        case s @ Success(_) => Events.attributeNode(complete, node); complete(s)
-        case f @ Failure(e) => if (isOwnershipFault(e)) triggerRefresh(); Events.attributeNode(complete, node); complete(f)
+        case s @ Success(_) =>
+          Events.attributeNode(complete, node)
+          complete(s)
+        case f @ Failure(e) =>
+          if (isOwnershipFault(e)) triggerRefresh()
+          Events.attributeNode(complete, node)
+          complete(f)
       }
     )
 
   private def sendRead[A](command: Command[A], complete: Try[A] => Unit): Unit = {
-    if (closed) { complete(Failure(NotConnected())); return }
+    if (closed) {
+      complete(Failure(NotConnected()))
+      return
+    }
     val master     = masterNodeRef.get()
     val candidates = readCandidates(master)
     tryRead(command, candidates, master, complete)
@@ -300,7 +326,9 @@ final private[client] class MasterReplicaLive(
             else submitRead(nc, node, isMaster, command, rest, master, complete)
           }
       // nothing reached the wire, so no fault event fires: re-discover here or a strict-Replica read stays stuck on a stale replica set
-      case _            => triggerRefresh(); complete(Failure(NotConnected()))
+      case _            =>
+        triggerRefresh()
+        complete(Failure(NotConnected()))
     }
 
   private def submitRead[A](
@@ -316,7 +344,9 @@ final private[client] class MasterReplicaLive(
       command,
       asking = false,
       {
-        case s @ Success(_) => Events.attributeNode(complete, node); complete(s)
+        case s @ Success(_) =>
+          Events.attributeNode(complete, node)
+          complete(s)
         case Failure(error) => offload(onReadFault(node, isMaster, error, command, rest, master, complete))
       }
     )
@@ -331,10 +361,16 @@ final private[client] class MasterReplicaLive(
     complete: Try[A] => Unit
   ): Unit = {
     if (isMaster && isOwnershipFault(error)) triggerRefresh()
-    def fail(): Unit = { Events.attributeNode(complete, node); complete(Failure(error)) }
+    def fail(): Unit = {
+      Events.attributeNode(complete, node)
+      complete(Failure(error))
+    }
     if (servesNoRead(error))
       if (rest.nonEmpty) tryRead(command, rest, master, complete)
-      else { triggerRefresh(); fail() }
+      else {
+        triggerRefresh()
+        fail()
+      }
     else fail()
   }
 
@@ -376,7 +412,11 @@ final private[client] class MasterReplicaLive(
           val candidates = readCandidates(master)
           liveEstablished(candidates, master) match {
             case Some((node, nc)) => submitOn(node, nc)
-            case None             => offload { val (node, nc) = establishRead(candidates, master); submitOn(node, nc) }
+            case None             =>
+              offload {
+                val (node, nc) = establishRead(candidates, master)
+                submitOn(node, nc)
+              }
           }
         } else {
           val existing = masterPool.existing(master)
@@ -431,14 +471,22 @@ final private[client] class MasterReplicaLive(
       val nc =
         try masterPool.getOrEstablish(masterNodeRef.get())
         catch {
-          case e: SageException => triggerRefresh(); throw e
-          case NonFatal(_)      => triggerRefresh(); throw ConnectionLost(mayHaveExecuted = false)
+          case e: SageException =>
+            triggerRefresh()
+            throw e
+          case NonFatal(_)      =>
+            triggerRefresh()
+            throw ConnectionLost(mayHaveExecuted = false)
         }
       try new MasterReplicaLive.TxLease(new Client.TxScope(nc.acquireForTransaction(), refreshOnTxFault, events), nc)
       catch {
         case e: TimedOut      => throw e
-        case e: SageException => triggerRefresh(); throw e
-        case NonFatal(_)      => triggerRefresh(); throw ConnectionLost(mayHaveExecuted = false)
+        case e: SageException =>
+          triggerRefresh()
+          throw e
+        case NonFatal(_)      =>
+          triggerRefresh()
+          throw ConnectionLost(mayHaveExecuted = false)
       }
     }
 
@@ -529,7 +577,13 @@ private[client] object MasterReplicaLive {
       val events                                                  = Events(config.listeners, config.tracer)
       val live                                                    =
         new MasterReplicaLive(factory, scheduler, bootstrap, config, seeds, masterReplica, events)
-      try { live.bootstrapRoles(); live }
-      catch { case NonFatal(error) => events.close(); throw translate(error) }
+      try {
+        live.bootstrapRoles()
+        live
+      } catch {
+        case NonFatal(error) =>
+          events.close()
+          throw translate(error)
+      }
     }
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -78,7 +78,8 @@ final private[client] class MultiplexedConnection private (
   // Reserves n drain slots against the live connection under the same lock that admits the command, so close() can never sample
   // inFlight == 0 for a command that already passed the Live gate but hasn't reached Conn.submit yet (#95). null => not Live.
   private def reserved(n: Int): Conn = locked(if (state == State.Live) {
-    current.reserve(n); current
+    current.reserve(n)
+    current
   } else null)
 
   def submit[A](command: Command[A], callback: Try[A] => Unit): Unit = {
@@ -134,7 +135,7 @@ final private[client] class MultiplexedConnection private (
     }
     if (aborting != null) aborting.close()
     if (draining != null) {
-      val _ = draining.beginDrain().await(closeTimeout.toMillis, TimeUnit.MILLISECONDS)
+      draining.beginDrain().await(closeTimeout.toMillis, TimeUnit.MILLISECONDS)
       locked(stopWatchdog())
       draining.close()
     }
@@ -162,8 +163,10 @@ final private[client] class MultiplexedConnection private (
     val teardown = locked {
       // a close() during establish() wins: tear down rather than publish Live
       if (state == State.Closed) conn
-      else if (conn.isTerminated) { scheduleReconnect(0); null }
-      else {
+      else if (conn.isTerminated) {
+        scheduleReconnect(0)
+        null
+      } else {
         current = conn
         generation = generation.next
         transition(State.Live)
@@ -177,7 +180,10 @@ final private[client] class MultiplexedConnection private (
 
   private def establish(): Conn = {
     val conn = new Conn
-    locked { establishing = conn; if (state == State.Closed) conn.close() }
+    locked {
+      establishing = conn
+      if (state == State.Closed) conn.close()
+    }
     try {
       conn.start()
       var tracking = true
@@ -186,7 +192,10 @@ final private[client] class MultiplexedConnection private (
       Bootstrap.run(
         bootstrap,
         connectTimeout.toMillis,
-        (c, cb) => { conn.reserve(1); conn.submit(c, cb) },
+        (c, cb) => {
+          conn.reserve(1)
+          conn.submit(c, cb)
+        },
         () => conn.close(),
         onTolerated = c => if (Connection.isClientTracking(c)) tracking = false
       )
@@ -195,7 +204,10 @@ final private[client] class MultiplexedConnection private (
     } finally locked { if (establishing eq conn) establishing = null }
   }
 
-  private[internal] def flushCache(): Unit = { val c = locked(current); if (c != null) c.flushCache() }
+  private[internal] def flushCache(): Unit = {
+    val c = locked(current)
+    if (c != null) c.flushCache()
+  }
 
   private def scheduleReconnect(attempt: Int): Unit = {
     reconnectAttempt = attempt
@@ -230,7 +242,10 @@ final private[client] class MultiplexedConnection private (
         }
       } catch {
         case NonFatal(error) =>
-          locked(if (state == State.Reconnecting) { events.emit(SageEvent.Connection.ReconnectFailed(node, error)); scheduleReconnect(attempt + 1) })
+          locked(if (state == State.Reconnecting) {
+            events.emit(SageEvent.Connection.ReconnectFailed(node, error))
+            scheduleReconnect(attempt + 1)
+          })
       }
   }
 
@@ -242,9 +257,17 @@ final private[client] class MultiplexedConnection private (
       if (conn eq current)
         state match {
           case State.Live         =>
-            transition(State.Reconnecting); scheduleReconnect(nextReconnectAttempt()); events.emit(SageEvent.Connection.Disconnected(node)); true
-          case State.Reconnecting => scheduleReconnect(0); false
-          case State.Draining     => transition(State.Closed); stopWatchdog(); false
+            transition(State.Reconnecting)
+            scheduleReconnect(nextReconnectAttempt())
+            events.emit(SageEvent.Connection.Disconnected(node))
+            true
+          case State.Reconnecting =>
+            scheduleReconnect(0)
+            false
+          case State.Draining     =>
+            transition(State.Closed)
+            stopWatchdog()
+            false
           case State.Closed       => false
         }
       else false
@@ -306,13 +329,18 @@ final private[client] class MultiplexedConnection private (
     }
 
     // Reserves drain slots; the matching retire() (per completed entry) or release() (per unsent reservation) balances them.
-    def reserve(n: Int): Unit = { val _ = inFlight.addAndGet(n) }
+    def reserve(n: Int): Unit =
+      inFlight.addAndGet(n): Unit
 
     // OPTIN tracking: a cached read writes [CLIENT CACHING YES, <read>] adjacently so only this read is tracked. The read is submitted with
     // an identity decoder so the raw reply Frame reaches the cache; each waiter decodes it with its own command's decoder.
     def cachedSubmit[A](command: Command[A], ttlMillis: Long, callback: Try[A] => Unit, deferred: () => CommandSpan): Unit = {
       // tracking off: run uncached, releasing one of the two slots reserved for the (now unsent) caching prefix
-      if (!trackingActive) { release(1); uncached(command, callback, deferred); return }
+      if (!trackingActive) {
+        release(1)
+        uncached(command, callback, deferred)
+        return
+      }
       val commandBytes                = command.encode
       val keys                        = command.keys
       def deliver(frame: Frame): Unit = callback(decodeFrame(command, frame))
@@ -325,11 +353,19 @@ final private[client] class MultiplexedConnection private (
           // a Hit serves locally; a Wait coalesces onto an in-flight fetch — both avoid a server round trip, so both are reported as a hit
           // and release the two slots reserved for the (now unsent) fetch
           case ClientCache.Acquire.Hit(frame, epoch) =>
-            if (cache.isCurrent(epoch)) { release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name)); deliver(frame) }
+            if (cache.isCurrent(epoch)) {
+              release(2)
+              if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name))
+              deliver(frame)
+            }
             // reroute a hit retired by a topology change or a dead connection; refetch here one retired by a server flush (ownership unchanged)
-            else if (terminated || cache.rerouteRetired(epoch)) { release(2); callback(Failure(ConnectionLost(mayHaveExecuted = false))) }
-            else attempt()
-          case ClientCache.Acquire.Wait              => release(2); if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name))
+            else if (terminated || cache.rerouteRetired(epoch)) {
+              release(2)
+              callback(Failure(ConnectionLost(mayHaveExecuted = false)))
+            } else attempt()
+          case ClientCache.Acquire.Wait              =>
+            release(2)
+            if (events.emitsEvents) events.emit(SageEvent.Cache.Hit(command.name))
           case ClientCache.Acquire.Fetch             =>
             if (events.emitsEvents) events.emit(SageEvent.Cache.Miss(command.name))
             traced(command, deferred) { settle =>
@@ -345,7 +381,9 @@ final private[client] class MultiplexedConnection private (
               try submitAll(Vector(Connection.clientCachingYes, raw), Vector(_ => (), onReply.asInstanceOf[Try[Any] => Unit]))
               catch {
                 // nothing was sent: release the slots the entries won't retire, and fail the fetch as a reply failure would
-                case NonFatal(error) => release(2); onReply(Failure(error))
+                case NonFatal(error) =>
+                  release(2)
+                  onReply(Failure(error))
               }
             }
         }
@@ -353,7 +391,15 @@ final private[client] class MultiplexedConnection private (
     }
 
     private def uncached[A](command: Command[A], callback: Try[A] => Unit, deferred: () => CommandSpan): Unit =
-      traced(command, deferred)(settle => submit(command, (result: Try[A]) => { settle(Outcome.of(result)); callback(result) }))
+      traced(command, deferred)(settle =>
+        submit(
+          command,
+          (result: Try[A]) => {
+            settle(Outcome.of(result))
+            callback(result)
+          }
+        )
+      )
 
     // span and CommandCompleted bookkeeping around a server-bound submit; `send` is handed a settle hook to call with the outcome
     private def traced(command: Command[?], deferred: () => CommandSpan)(send: ((=> Outcome) => Unit) => Unit): Unit = {
@@ -398,7 +444,10 @@ final private[client] class MultiplexedConnection private (
       if (head != null) {
         // offload: close() blocks joining I/O threads, and the watchdog tick runs on the shared timer thread, which must not block
         if (now - head.sentAtMillis >= timeoutMillis) scheduler.after(Duration.Zero)(close())
-      } else if (now - lastReplyAtMillis >= intervalMillis) { reserve(1); submit(Connection.ping(None), _ => ()) }
+      } else if (now - lastReplyAtMillis >= intervalMillis) {
+        reserve(1)
+        submit(Connection.ping(None), _ => ())
+      }
     }
 
     // Out-of-band frames never consume a pending entry. A READONLY reply fails its command, then poisons the connection: an in-place
@@ -443,15 +492,24 @@ final private[client] class MultiplexedConnection private (
 
       def writeAttempted(): Unit = {
         sentAtMillis = scheduler.nowMillis
-        val _ = pending.add(this)
+        pending.add(this): Unit
       }
 
-      def dropped(): Unit = { callback(Failure(ConnectionLost(mayHaveExecuted = false))); retire() }
+      def dropped(): Unit = {
+        callback(Failure(ConnectionLost(mayHaveExecuted = false)))
+        retire()
+      }
 
       // decodeFrame guards against throwing user decoders: an escaped exception would otherwise lose the callback and hang the awaiting fiber
-      def complete(frame: Frame): Unit = { callback(decodeFrame(command, frame)); retire() }
+      def complete(frame: Frame): Unit = {
+        callback(decodeFrame(command, frame))
+        retire()
+      }
 
-      def fail(error: SageException): Unit = { callback(Failure(error)); retire() }
+      def fail(error: SageException): Unit = {
+        callback(Failure(error))
+        retire()
+      }
     }
 
     // A pipeline as one write unit: its payload is the entries concatenated, and its write/drop hooks fan out to every entry so each is

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -78,7 +78,9 @@ final private[client] class NodePool(
       if (existing == null)
         pendingEstablish.get(node) match {
           case Some(p) => waitOn = p
-          case None    => mine = new NodePool.Establish; val _ = pendingEstablish.put(node, mine)
+          case None    =>
+            mine = new NodePool.Establish
+            pendingEstablish.put(node, mine): Unit
         }
     }
     if (existing != null) existing
@@ -100,14 +102,21 @@ final private[client] class NodePool(
             Some(node),
             events,
             dedicatedBootstrap,
-            onConstructed = conn => { connRef.set(conn); if (locked { establishing += conn; closed }) conn.close() }
+            onConstructed = conn => {
+              connRef.set(conn)
+              val poolClosed = locked {
+                establishing += conn
+                closed
+              }
+              if (poolClosed) conn.close()
+            }
           )
         catch {
           case error: Throwable =>
             locked {
               val conn = connRef.get()
-              if (conn != null) { val _ = establishing -= conn }
-              if (pendingEstablish.get(node).exists(_ eq mine)) { val _ = pendingEstablish.remove(node) }
+              if (conn != null) establishing -= conn
+              if (pendingEstablish.get(node).exists(_ eq mine)) { pendingEstablish.remove(node): Unit }
             }
             mine.fail(error)
             if (!closed) events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
@@ -116,14 +125,22 @@ final private[client] class NodePool(
       // publish only if our token is still current: a retain, close, or newer attempt supersedes us, and the new client is discarded not leaked
       val publish = locked {
         val conn    = connRef.get()
-        if (conn != null) { val _ = establishing -= conn }
+        if (conn != null) establishing -= conn
         val current = pendingEstablish.get(node).exists(_ eq mine)
-        if (current) { val _ = pendingEstablish.remove(node) }
-        if (current && !closed) { established.put(node, nc); true }
-        else false
+        if (current) { pendingEstablish.remove(node): Unit }
+        if (current && !closed) {
+          established.put(node, nc)
+          true
+        } else false
       }
-      if (publish) { mine.succeed(nc); nc }
-      else { nc.close(); mine.fail(NotConnected()); throw NotConnected() }
+      if (publish) {
+        mine.succeed(nc)
+        nc
+      } else {
+        nc.close()
+        mine.fail(NotConnected())
+        throw NotConnected()
+      }
     }
   }
 
@@ -169,7 +186,10 @@ private[client] object NodePool {
     def fail(error: Throwable): Unit  = settle(Left(error))
 
     private def settle(outcome: Either[Throwable, NodeClient]): Unit =
-      if (settled.compareAndSet(false, true)) { result = outcome; latch.countDown() }
+      if (settled.compareAndSet(false, true)) {
+        result = outcome
+        latch.countDown()
+      }
 
     def get(): NodeClient = {
       latch.await()

--- a/sage-client/shared/src/main/scala/sage/client/internal/Placement.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Placement.scala
@@ -63,8 +63,10 @@ final private[internal] class Placement(sink: Sink, requested: Vector[String]) {
           case None       => incomplete = true
           case Some(conn) =>
             groups.foreach { group =>
-              try { conn.attach(sink, group, Kind.Shard); actual.update(node, actual.getOrElse(node, Set.empty) ++ group) }
-              catch { case NonFatal(_) => incomplete = true }
+              try {
+                conn.attach(sink, group, Kind.Shard)
+                actual.update(node, actual.getOrElse(node, Set.empty) ++ group)
+              } catch { case NonFatal(_) => incomplete = true }
             }
         }
       }

--- a/sage-client/shared/src/main/scala/sage/client/internal/ReadRouting.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ReadRouting.scala
@@ -19,7 +19,10 @@ private[client] object ReadRouting {
   def candidates(readFrom: ReadFrom, master: Node, replicas: Vector[Node], rr: Int): Vector[Node] = {
     val rotated =
       if (replicas.isEmpty) Vector.empty
-      else { val k = ((rr % replicas.length) + replicas.length) % replicas.length; replicas.drop(k) ++ replicas.take(k) }
+      else {
+        val k = ((rr % replicas.length) + replicas.length) % replicas.length
+        replicas.drop(k) ++ replicas.take(k)
+      }
     readFrom match {
       case ReadFrom.Master           => Vector(master)
       case ReadFrom.MasterPreferred  => master +: rotated

--- a/sage-client/shared/src/main/scala/sage/client/internal/RefreshThrottle.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/RefreshThrottle.scala
@@ -43,7 +43,12 @@ final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: 
       val handle = scheduler.every(period)(tick)
       lock.lock()
       val keep   =
-        try if (stopped) false else { ticker = handle; true }
+        try
+          if (stopped) false
+          else {
+            ticker = handle
+            true
+          }
         finally lock.unlock()
       if (!keep) handle.cancel()
     }
@@ -51,17 +56,26 @@ final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: 
   def stopPolling(): Unit = {
     lock.lock()
     val handle =
-      try { stopped = true; val current = ticker; ticker = null; current }
-      finally lock.unlock()
+      try {
+        stopped = true
+        val current = ticker
+        ticker = null
+        current
+      } finally lock.unlock()
     if (handle != null) handle.cancel()
   }
 
   private def claim(force: Boolean, wait: Boolean): Boolean = {
     lock.lock()
     try
-      if (refreshing && wait) { while (refreshing) done.awaitUninterruptibly(); false }
-      else if (refreshing || (!force && scheduler.nowMillis - lastRefreshMs < minRefreshMs)) false
-      else { refreshing = true; true }
+      if (refreshing && wait) {
+        while (refreshing) done.awaitUninterruptibly()
+        false
+      } else if (refreshing || (!force && scheduler.nowMillis - lastRefreshMs < minRefreshMs)) false
+      else {
+        refreshing = true
+        true
+      }
     finally lock.unlock()
   }
 
@@ -71,7 +85,10 @@ final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: 
 
   private def finish(): Unit = {
     lock.lock()
-    try { refreshing = false; lastRefreshMs = scheduler.nowMillis; done.signalAll() }
-    finally lock.unlock()
+    try {
+      refreshing = false
+      lastRefreshMs = scheduler.nowMillis
+      done.signalAll()
+    } finally lock.unlock()
   }
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Scheduler.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Scheduler.scala
@@ -48,13 +48,10 @@ private[client] object Scheduler {
 
     def after(delay: FiniteDuration)(task: => Unit): Unit =
       // zero-delay offloads must not queue behind watchdog/reconnect timing on the timer thread
-      if (delay <= Duration.Zero) { val _ = Thread.ofVirtual().name("sage-offload").start(() => task) }
+      if (delay <= Duration.Zero) { Thread.ofVirtual().name("sage-offload").start(() => task): Unit }
       else {
-        val _ = timer.schedule(
-          (() => { val _ = Thread.ofVirtual().name("sage-reconnect").start(() => task) }): Runnable,
-          delay.toMillis,
-          TimeUnit.MILLISECONDS
-        )
+        val fire: Runnable = () => Thread.ofVirtual().name("sage-reconnect").start(() => task): Unit
+        timer.schedule(fire, delay.toMillis, TimeUnit.MILLISECONDS): Unit
       }
 
     def every(interval: FiniteDuration)(task: => Unit): Cancelable = {
@@ -63,7 +60,7 @@ private[client] object Scheduler {
         try task
         catch { case NonFatal(_) => () }
       val future: ScheduledFuture[?] = timer.scheduleAtFixedRate(guarded, interval.toMillis, interval.toMillis, TimeUnit.MILLISECONDS)
-      () => { val _ = future.cancel(false) }
+      () => future.cancel(false): Unit
     }
   }
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
@@ -182,7 +182,10 @@ final private[client] class SocketTransport private (
         if (Thread.currentThread() ne writer) writer.join()
         // fence the reader before onClosed, else an in-flight reply races the consumer's pending drain (#94); interrupt frees a reader
         // parked on backpressure so the join cannot hang
-        if (Thread.currentThread() ne reader) { reader.interrupt(); reader.join() }
+        if (Thread.currentThread() ne reader) {
+          reader.interrupt()
+          reader.join()
+        }
       }
       drainQueue()
       onClosed()

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -95,7 +95,11 @@ final private[client] class SubscriptionConnection(
     // closeOwned, not bare terminate: if attach registered the sink but awaitActive then threw, fully unwind it so no phantom channel is
     // resubscribed on the next reconnect
     try attachInternal(sink, names, kind, failIfUnconfirmed = true)
-    catch { case e: Throwable => closeOwned(sink); throw e }
+    catch {
+      case e: Throwable =>
+        closeOwned(sink)
+        throw e
+    }
     new RawSubscription(sink, () => closeOwned(sink))
   }
 
@@ -122,8 +126,10 @@ final private[client] class SubscriptionConnection(
           case State.Live         =>
             val fresh = register(sink, names, kind)
             // nothing sent (names already subscribed): target the confirmed count, not subscribeSent, so we don't wait on an unrelated pending ack
-            if (fresh.nonEmpty) { sendSubscribe(current, kind, fresh); confirmTarget = subscribeSent }
-            else confirmTarget = subscribeConfirmed
+            if (fresh.nonEmpty) {
+              sendSubscribe(current, kind, fresh)
+              confirmTarget = subscribeSent
+            } else confirmTarget = subscribeConfirmed
             settled = true
           case State.Reconnecting =>
             register(sink, names, kind) // the next successful reconnect resubscribes everything currently registered
@@ -142,7 +148,11 @@ final private[client] class SubscriptionConnection(
       catch {
         case e: Throwable =>
           // drop the phantom sink, but only if a concurrent close/goLive hasn't already moved us off Establishing
-          locked(if (state == State.Establishing) { deregister(sink, names, kind); state = State.Idle; established.signalAll() })
+          locked(if (state == State.Establishing) {
+            deregister(sink, names, kind)
+            state = State.Idle
+            established.signalAll()
+          })
           throw e
       }
     awaitActive(failIfUnconfirmed, confirmTarget)
@@ -179,8 +189,15 @@ final private[client] class SubscriptionConnection(
     locked {
       if (state != State.Establishing && state != State.Reconnecting) teardown = conn
       else if (conn.isTerminated) {
-        if (cluster) { stopWatchdog(); current = null; state = State.Closed; notify = true }
-        else { state = State.Reconnecting; reconnect = true }
+        if (cluster) {
+          stopWatchdog()
+          current = null
+          state = State.Closed
+          notify = true
+        } else {
+          state = State.Reconnecting
+          reconnect = true
+        }
         established.signalAll()
         confirmed.signalAll()
       } else {
@@ -198,7 +215,10 @@ final private[client] class SubscriptionConnection(
           if (shards.nonEmpty) sendSubscribe(conn, Kind.Shard, shards)
         } catch {
           // resubscribe write failed: drop this socket and clear current so a superseded generation can't keep dispatching, then rethrow
-          case e: Throwable => current = null; teardown = conn; failure = e
+          case e: Throwable =>
+            current = null
+            teardown = conn
+            failure = e
         }
         if (failure == null)
           if (channels.isEmpty && patterns.isEmpty && shards.isEmpty) {
@@ -240,8 +260,10 @@ final private[client] class SubscriptionConnection(
           case State.Closed => settled = true
           case State.Live   =>
             if (target < 0) target = liveTarget
-            if (subscribeConfirmed >= target) { active = true; settled = true }
-            else if (awaitOrTimeout(deadline)) settled = true
+            if (subscribeConfirmed >= target) {
+              active = true
+              settled = true
+            } else if (awaitOrTimeout(deadline)) settled = true
           case _            =>
             target = -1L // a reconnect reset the counters: re-arm to liveTarget
             if (awaitOrTimeout(deadline)) settled = true
@@ -254,12 +276,18 @@ final private[client] class SubscriptionConnection(
   private def awaitOrTimeout(deadline: Long): Boolean = {
     val remaining = deadline - scheduler.nowMillis
     if (remaining <= 0) true
-    else { val _ = confirmed.await(remaining, TimeUnit.MILLISECONDS); false }
+    else {
+      confirmed.await(remaining, TimeUnit.MILLISECONDS)
+      false
+    }
   }
 
   private def establish(): Conn = {
     val conn = new Conn
-    locked { establishing += conn; if (state == State.Closed) conn.close() }
+    locked {
+      establishing += conn
+      if (state == State.Closed) conn.close()
+    }
     try {
       try conn.start()
       catch {
@@ -271,7 +299,7 @@ final private[client] class SubscriptionConnection(
       }
       runBootstrap(conn)
       conn
-    } finally locked { val _ = establishing -= conn }
+    } finally locked(establishing -= conn): Unit
   }
 
   // per-conn waiter (two establishes can bootstrap concurrently and must not cross-complete); the finally clears it so a later PONG isn't misrouted
@@ -282,7 +310,7 @@ final private[client] class SubscriptionConnection(
         connectTimeoutMillis,
         (command, cb) => {
           conn.armBootstrap(result => cb(result.flatMap(frame => Reply.decode(command, frame))))
-          if (conn.isTerminated) { val _ = conn.completeBootstrap(Failure(ConnectionLost(mayHaveExecuted = false))) }
+          if (conn.isTerminated) { conn.completeBootstrap(Failure(ConnectionLost(mayHaveExecuted = false))): Unit }
           else conn.send(command.encode)
         },
         () => conn.close()
@@ -299,7 +327,10 @@ final private[client] class SubscriptionConnection(
       try goLive(establish())
       catch {
         case NonFatal(error) =>
-          locked(if (state == State.Reconnecting) { events.emit(SageEvent.Connection.ReconnectFailed(node, error)); scheduleReconnect(attempt + 1) })
+          locked(if (state == State.Reconnecting) {
+            events.emit(SageEvent.Connection.ReconnectFailed(node, error))
+            scheduleReconnect(attempt + 1)
+          })
       }
     }
   }
@@ -313,7 +344,12 @@ final private[client] class SubscriptionConnection(
         else
           state match {
             case State.Live | State.Establishing =>
-              stopWatchdog(); current = null; state = State.Closed; established.signalAll(); confirmed.signalAll(); true
+              stopWatchdog()
+              current = null
+              state = State.Closed
+              established.signalAll()
+              confirmed.signalAll()
+              true
             case _                               => false
           }
       }
@@ -323,7 +359,10 @@ final private[client] class SubscriptionConnection(
         if (conn ne current) false
         else
           state match {
-            case State.Live | State.Reconnecting => state = State.Reconnecting; confirmed.signalAll(); true
+            case State.Live | State.Reconnecting =>
+              state = State.Reconnecting
+              confirmed.signalAll()
+              true
             case _                               => false
           }
       }
@@ -340,7 +379,10 @@ final private[client] class SubscriptionConnection(
           case Some(Pubsub.Event.PatternMessage(pattern, ch, payload)) => dispatch(patternSinks, pattern, Delivery.Pattern(pattern, ch, payload))
           case Some(_: Pubsub.Event.Subscribed)                        =>
             // conn eq current: a late ack from a superseded generation must not advance this generation's count
-            locked(if (conn eq current) { subscribeConfirmed += 1; confirmed.signalAll() })
+            locked(if (conn eq current) {
+              subscribeConfirmed += 1
+              confirmed.signalAll()
+            })
           case _                                                       => () // an Unsubscribed ack is informational; re-homing is disconnect-driven
         }
       case reply                => // non-push reply: bootstrap HELLO, watchdog PONG, or an unexpected error
@@ -403,7 +445,10 @@ final private[client] class SubscriptionConnection(
     var toClose: Vector[Conn] = Vector.empty
     val closing               = locked {
       if (!isEmptyUnlocked) false
-      else { toClose = markClosed(); true }
+      else {
+        toClose = markClosed()
+        true
+      }
     }
     toClose.foreach(_.close())
     closing
@@ -454,7 +499,10 @@ final private[client] class SubscriptionConnection(
     names.foreach { name =>
       map.get(name).foreach { set =>
         set -= sink
-        if (set.isEmpty) { map -= name; emptied += name }
+        if (set.isEmpty) {
+          map -= name
+          emptied += name
+        }
       }
     }
     emptied.result()
@@ -504,7 +552,7 @@ final private[client] class SubscriptionConnection(
 
     private def onTerminated(): Unit = {
       terminated = true
-      val _ = completeBootstrap(Failure(ConnectionLost(mayHaveExecuted = false)))
+      completeBootstrap(Failure(ConnectionLost(mayHaveExecuted = false)))
       onConnClosed(this)
     }
 
@@ -513,8 +561,10 @@ final private[client] class SubscriptionConnection(
 
     def completeBootstrap(result: Try[Frame]): Boolean = {
       val waiter = bootstrapWaiter.getAndSet(null)
-      if (waiter != null) { waiter(result); true }
-      else false
+      if (waiter != null) {
+        waiter(result)
+        true
+      } else false
     }
 
     def send(payload: Bytes): Unit = {
@@ -593,8 +643,10 @@ private[client] object SubscriptionConnection {
         // an existing waiter means a concurrent consumer; fail loud rather than silently evict it
         if (waiter != null) throw new IllegalStateException("a subscription is single-consumer; concurrent next is not supported")
         val head = backlog.poll()
-        if (head != null) { notFull.signal(); ready = Some(head) }
-        else if (closed) ready = None
+        if (head != null) {
+          notFull.signal()
+          ready = Some(head)
+        } else if (closed) ready = None
         else waiter = callback
       } finally lock.unlock()
       if (ready != null) callback(ready)
@@ -614,9 +666,18 @@ private[client] object SubscriptionConnection {
         var settled = false
         while (!settled)
           if (closed) settled = true
-          else if (waiter != null) { hungry = waiter; waiter = null; settled = true }
-          else if (backlog.size < cap) { backlog.add(delivery); settled = true }
-          else { blocked = true; notFull.await() } // backlog full, no consumer: backpressure the reader
+          else if (waiter != null) {
+            hungry = waiter
+            waiter = null
+            settled = true
+          } else if (backlog.size < cap) {
+            backlog.add(delivery)
+            settled = true
+          } else {
+            // backlog full, no consumer: backpressure the reader
+            blocked = true
+            notFull.await()
+          }
       } finally lock.unlock()
       if (hungry != null) hungry(Some(delivery))
       blocked

--- a/sage-client/shared/src/test/scala/sage/client/internal/ConnectFailureRecorder.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ConnectFailureRecorder.scala
@@ -16,7 +16,9 @@ final private[sage] class ConnectFailureRecorder {
     Vector(
       new SageListener {
         def onEvent(event: SageEvent): Unit = event match {
-          case failure: SageEvent.Connection.ConnectFailed => val _ = seen.add(failure); delivered.countDown()
+          case failure: SageEvent.Connection.ConnectFailed =>
+            seen.add(failure)
+            delivered.countDown()
           case _                                           => ()
         }
       }

--- a/sage-client/shared/src/test/scala/sage/client/internal/ConnectingTransport.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ConnectingTransport.scala
@@ -12,12 +12,26 @@ final class ConnectingTransport(onClosed: () => Unit) extends Transport {
   private val closed                   = new AtomicBoolean(false)
   private val queued                   = new ConcurrentLinkedQueue[Transport.Item]()
   def wasClosed: Boolean               = closed.get()
-  def start(): Unit                    = { reached.countDown(); gate.await(); throw new java.io.IOException("connect aborted") }
-  def send(item: Transport.Item): Unit = { val _ = queued.add(item); if (closed.get()) drainQueue() }
-  def close(): Unit                    = if (closed.compareAndSet(false, true)) { gate.countDown(); drainQueue(); onClosed() }
+  def start(): Unit                    = {
+    reached.countDown()
+    gate.await()
+    throw new java.io.IOException("connect aborted")
+  }
+  def send(item: Transport.Item): Unit = {
+    queued.add(item)
+    if (closed.get()) drainQueue()
+  }
+  def close(): Unit                    = if (closed.compareAndSet(false, true)) {
+    gate.countDown()
+    drainQueue()
+    onClosed()
+  }
 
   private def drainQueue(): Unit = {
     var item = queued.poll()
-    while (item != null) { item.dropped(); item = queued.poll() }
+    while (item != null) {
+      item.dropped()
+      item = queued.poll()
+    }
   }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/CountingScheduler.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/CountingScheduler.scala
@@ -16,7 +16,7 @@ final class CountingScheduler extends Scheduler {
   def jitterMillis(boundExclusive: Long): Long = Scheduler.real.jitterMillis(boundExclusive)
 
   def after(delay: FiniteDuration)(task: => Unit): Unit = {
-    if (delay <= Duration.Zero) { val _ = zeroDelays.incrementAndGet() }
+    if (delay <= Duration.Zero) { zeroDelays.incrementAndGet(): Unit }
     Scheduler.real.after(delay)(task)
   }
 

--- a/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
@@ -131,7 +131,9 @@ class DedicatedPoolSpec extends munit.FunSuite {
   test("a dropped queued command marks the connection dead before failing the work, so the pool cannot recycle it") {
     val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
     val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
-      val t = new FakeTransport(onFrame, onClosed, replyWith(Nil)); transports += t; t
+      val t = new FakeTransport(onFrame, onClosed, replyWith(Nil))
+      transports += t
+      t
     }
     val conn                                            = DedicatedConnection.create(factory, 1000L)
     conn.establish(Vector(Connection.hello()))
@@ -187,7 +189,10 @@ class DedicatedPoolSpec extends munit.FunSuite {
     // the multiplexed connection reconnects (generation bumps) while the first dedicated connection is running its HELLO bootstrap
     val respond: Bytes => Seq[Frame]                  = payload =>
       if (payload.asUtf8String.contains("HELLO")) {
-        if (!bumped) { bumped = true; live = Some(MultiplexedConnection.Generation.initial.next) }
+        if (!bumped) {
+          bumped = true
+          live = Some(MultiplexedConnection.Generation.initial.next)
+        }
         Seq(helloReply)
       } else Seq(popReply)
     val (pool, scheduler, transports)                 = make(respond, liveGeneration = () => live)
@@ -282,7 +287,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
     scheduler.advance(Duration.Zero)
     assertEquals(transports.head.closeCount, 1)
 
-    val _ = pool.acquireForTransaction()
+    pool.acquireForTransaction()
     assertEquals(transports.size, 2)
   }
 
@@ -296,7 +301,9 @@ class DedicatedPoolSpec extends munit.FunSuite {
     val scheduler                                       = new ManualScheduler
     val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
     val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
-      val t = new FakeTransport(onFrame, onClosed, replyWith(Nil)); transports += t; t
+      val t = new FakeTransport(onFrame, onClosed, replyWith(Nil))
+      transports += t
+      t
     }
     val connection                                      = MultiplexedConnection.connect(
       factory,

--- a/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
@@ -24,14 +24,17 @@ class EventsSpec extends munit.FunSuite {
     private val buf                  = mutable.ArrayBuffer.empty[SageEvent]
     def enabled: Boolean             = true
     def emitsEvents: Boolean         = true
-    def emit(event: SageEvent): Unit = synchronized { val _ = buf += event }
+    def emit(event: SageEvent): Unit = synchronized(buf += event: Unit)
     def close(): Unit                = ()
     def events: Vector[SageEvent]    = synchronized(buf.toVector)
   }
 
   final private class Capturing(latch: CountDownLatch) extends SageListener {
     val received                        = new ConcurrentLinkedQueue[SageEvent]()
-    def onEvent(event: SageEvent): Unit = { received.add(event); latch.countDown() }
+    def onEvent(event: SageEvent): Unit = {
+      received.add(event)
+      latch.countDown()
+    }
   }
 
   private def connect(
@@ -88,13 +91,19 @@ class EventsSpec extends munit.FunSuite {
     val seen     = new java.util.concurrent.atomic.AtomicInteger(0)
     // blocks on the first event so the queue fills behind it
     val blocking = new SageListener {
-      def onEvent(event: SageEvent): Unit = { seen.incrementAndGet(); release.await() }
+      def onEvent(event: SageEvent): Unit = {
+        seen.incrementAndGet()
+        release.await()
+      }
     }
     val bus      = Events(Vector(blocking))
     try {
       val started = System.nanoTime()
       var i       = 0
-      while (i < 5000) { bus.emit(SageEvent.Cache.Miss("GET")); i += 1 }
+      while (i < 5000) {
+        bus.emit(SageEvent.Cache.Miss("GET"))
+        i += 1
+      }
       val elapsed = (System.nanoTime() - started).nanos
       assert(elapsed < 2.seconds, s"emit blocked: took $elapsed for 5000 events")
     } finally {
@@ -131,13 +140,18 @@ class EventsSpec extends munit.FunSuite {
     val calls        = new java.util.concurrent.atomic.AtomicInteger(0)
     val interrupting = new SageListener {
       def onEvent(event: SageEvent): Unit =
-        if (calls.getAndIncrement() == 0) { started.countDown(); block.await() }
-        else throw new InterruptedException("interrupted again during the drain")
+        if (calls.getAndIncrement() == 0) {
+          started.countDown()
+          block.await()
+        } else throw new InterruptedException("interrupted again during the drain")
     }
     val peer         = new ConcurrentLinkedQueue[SageEvent]()
     val delivered    = new CountDownLatch(2)
     val healthy      = new SageListener {
-      def onEvent(event: SageEvent): Unit = { peer.add(event); delivered.countDown() }
+      def onEvent(event: SageEvent): Unit = {
+        peer.add(event)
+        delivered.countDown()
+      }
     }
     val bus          = Events(Vector(interrupting, healthy))
     try {
@@ -156,7 +170,10 @@ class EventsSpec extends munit.FunSuite {
     val worker           = new java.util.concurrent.atomic.AtomicReference[Thread]()
     val first            = new java.util.concurrent.atomic.AtomicBoolean(true)
     val selfInterrupting = new SageListener {
-      def onEvent(event: SageEvent): Unit = if (first.getAndSet(false)) { worker.set(Thread.currentThread()); Thread.currentThread().interrupt() }
+      def onEvent(event: SageEvent): Unit = if (first.getAndSet(false)) {
+        worker.set(Thread.currentThread())
+        Thread.currentThread().interrupt()
+      }
     }
     val healthy          = new SageListener {
       def onEvent(event: SageEvent): Unit = event match {
@@ -216,7 +233,10 @@ class EventsSpec extends munit.FunSuite {
       rec,
       commands,
       Events.startSpans(rec, commands),
-      (_, cbs) => { cbs.foreach(_(Success("PONG"))); true },
+      (_, cbs) => {
+        cbs.foreach(_(Success("PONG")))
+        true
+      },
       _ => (),
       Some(node)
     )
@@ -257,7 +277,10 @@ class EventsSpec extends munit.FunSuite {
     assertEquals(tracer.log.toVector, Vector("start:PING"))
     tracked(Success("PONG"))
     assertEquals(tracer.log.toVector, Vector("start:PING", "settled:Succeeded"))
-    assert(rec.events.exists { case _: SageEvent.CommandCompleted => true; case _ => false })
+    assert(rec.events.exists {
+      case _: SageEvent.CommandCompleted => true
+      case _                             => false
+    })
   }
 
   test("startSpan routes to a fixed serverNode when set (standalone), without a node ever being attributed") {
@@ -336,16 +359,17 @@ class EventsSpec extends munit.FunSuite {
       transports += t
       t
     }
-    val connection                                      =
-      MultiplexedConnection
-        .connect(factory, scheduler, Vector(Connection.ping()), fixedBackoff, noWatchdog, 1.second, Duration.Zero, 1L << 20, node, rec)
-    val _                                               = connection
+    MultiplexedConnection
+      .connect(factory, scheduler, Vector(Connection.ping()), fixedBackoff, noWatchdog, 1.second, Duration.Zero, 1L << 20, node, rec): Unit
 
     healthy = false
     transports.head.close()
     scheduler.advance(1.milli)
     assert(
-      rec.events.exists { case SageEvent.Connection.ReconnectFailed(`node`, _: sage.SageException.ServerError) => true; case _ => false },
+      rec.events.exists {
+        case SageEvent.Connection.ReconnectFailed(`node`, _: sage.SageException.ServerError) => true
+        case _                                                                               => false
+      },
       rec.events
     )
   }
@@ -359,10 +383,16 @@ class EventsSpec extends munit.FunSuite {
     val first                                           = new java.util.concurrent.atomic.AtomicReference[FakeTransport]()
     val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
       attempt += 1
-      if (attempt == 1) { val t = new FakeTransport(onFrame, onClosed, _ => Seq(Frame.SimpleString("PONG"))); first.set(t); t }
-      else
+      if (attempt == 1) {
+        val t = new FakeTransport(onFrame, onClosed, _ => Seq(Frame.SimpleString("PONG")))
+        first.set(t)
+        t
+      } else
         new Transport {
-          def start(): Unit                    = { connection.close(); throw new RuntimeException("aborted by close") }
+          def start(): Unit                    = {
+            connection.close()
+            throw new RuntimeException("aborted by close")
+          }
           def send(item: Transport.Item): Unit = ()
           def close(): Unit                    = ()
         }
@@ -372,7 +402,13 @@ class EventsSpec extends munit.FunSuite {
 
     first.get().close()
     scheduler.advance(1.milli)
-    assert(!rec.events.exists { case _: SageEvent.Connection.ReconnectFailed => true; case _ => false }, rec.events)
+    assert(
+      !rec.events.exists {
+        case _: SageEvent.Connection.ReconnectFailed => true
+        case _                                       => false
+      },
+      rec.events
+    )
   }
 
   // --- cache -----------------------------------------------------------------------------------------------------------------------------

--- a/sage-client/shared/src/test/scala/sage/client/internal/FakeTransport.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/FakeTransport.scala
@@ -28,9 +28,11 @@ final class FakeTransport(
 
   def send(item: Transport.Item): Unit = {
     val shouldDrain = synchronized {
-      val _ = queued += item
-      if (autoWrite && !draining) { draining = true; true }
-      else false
+      queued += item
+      if (autoWrite && !draining) {
+        draining = true
+        true
+      } else false
     }
     if (shouldDrain) drain()
   }
@@ -45,8 +47,11 @@ final class FakeTransport(
   def close(): Unit = {
     val (first, dropped) = synchronized {
       closeCount += 1
-      if (closeCount == 1) { val pending = queued.toVector; queued.clear(); true -> pending }
-      else false -> Vector.empty
+      if (closeCount == 1) {
+        val pending = queued.toVector
+        queued.clear()
+        true -> pending
+      } else false -> Vector.empty
     }
     if (first) {
       dropped.foreach(_.dropped())
@@ -70,12 +75,15 @@ final class FakeTransport(
   private def next(): Transport.Item =
     synchronized {
       if (queued.nonEmpty) queued.remove(0)
-      else { draining = false; null }
+      else {
+        draining = false
+        null
+      }
     }
 
   private def write(item: Transport.Item): Unit = {
     item.writeAttempted()
-    synchronized { val _ = writes += item.payload }
+    synchronized(writes += item.payload)
     respond(item.payload).foreach(onFrame)
   }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/ManualScheduler.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ManualScheduler.scala
@@ -17,9 +17,8 @@ final class ManualScheduler extends Scheduler {
 
   def jitterMillis(boundExclusive: Long): Long = if (boundExclusive <= 0) 0L else boundExclusive - 1
 
-  def after(delay: FiniteDuration)(task: => Unit): Unit = {
-    val _ = oneShots += ((clockMillis + delay.toMillis, () => task))
-  }
+  def after(delay: FiniteDuration)(task: => Unit): Unit =
+    oneShots += ((clockMillis + delay.toMillis, () => task))
 
   def every(interval: FiniteDuration)(task: => Unit): Scheduler.Cancelable = {
     val periodic = new ManualScheduler.Periodic(interval.toMillis, clockMillis + interval.toMillis, () => task)

--- a/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
@@ -175,7 +175,7 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
   test("a batch's single write concatenates every command's encoding") {
     val (connection, _, transports) = make(autoWrite = false)
     val commands                    = Vector(Connection.ping(Some("a")), Connection.ping(Some("b")))
-    val _                           = connection.submitAll(commands, Vector.fill(2)((_: Try[Any]) => ()))
+    connection.submitAll(commands, Vector.fill(2)((_: Try[Any]) => ()))
     transports.head.writeNext()
     val expected                    = Bytes.concat(commands.map(_.encode))
     assertEquals(transports.head.written.length, 1)
@@ -194,7 +194,7 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     val commands                    = Vector(Connection.ping(Some("a")), Connection.ping(Some("b")), Connection.ping(Some("c")))
     val results                     = new Array[Try[Any]](3)
     val callbacks                   = Vector.tabulate(3)(i => (r: Try[Any]) => results(i) = r)
-    val _                           = connection.submitAll(commands, callbacks)
+    connection.submitAll(commands, callbacks)
     transports.head.writeNext() // the whole batch is one write
     transports.head.emit(Frame.SimpleString("a"))
     connection.close()
@@ -207,7 +207,7 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     val (connection, _, _) = make(autoWrite = false)
     val results            = new Array[Try[Any]](3)
     val callbacks          = Vector.tabulate(3)(i => (r: Try[Any]) => results(i) = r)
-    val _                  = connection.submitAll(Vector.fill(3)(Connection.ping()), callbacks)
+    connection.submitAll(Vector.fill(3)(Connection.ping()), callbacks)
     connection.close()
     assertEquals(results.toVector, Vector.fill[Try[Any]](3)(Failure(ConnectionLost(mayHaveExecuted = false))))
   }
@@ -334,8 +334,10 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     var first                                           = true
     val scheduler                                       = new ManualScheduler
     val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) =>
-      if (first) { first = false; new DyingAfterBootstrap(onFrame, onClosed) }
-      else {
+      if (first) {
+        first = false
+        new DyingAfterBootstrap(onFrame, onClosed)
+      } else {
         val t = new FakeTransport(onFrame, onClosed, _ => Seq(Frame.SimpleString("PONG")))
         healthy += t
         t

--- a/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
@@ -79,7 +79,7 @@ class NodePoolSpec extends munit.FunSuite {
     val pool  = newPool(gated.factory)
     assertEquals(pool.existing(node), null)
 
-    val establishing = new Thread(() => { val _ = Try(pool.getOrEstablish(node)) }, "establisher")
+    val establishing = new Thread(() => Try(pool.getOrEstablish(node)): Unit, "establisher")
     establishing.start()
     gated.awaitReached(0)
     assertEquals(pool.existing(node), null)
@@ -235,7 +235,7 @@ class NodePoolSpec extends munit.FunSuite {
       assertEquals(recorder.failures.size, 1, "the same establishment outage should be reported only once")
 
       failing.set(false)
-      val _                = pool.getOrEstablish(node)
+      pool.getOrEstablish(node)
       pool.retain(_ => false)
       failing.set(true)
       intercept[IOException](pool.getOrEstablish(node))

--- a/sage-client/shared/src/test/scala/sage/client/internal/RateLimitFallbackSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/RateLimitFallbackSpec.scala
@@ -21,7 +21,9 @@ class RateLimitFallbackSpec extends munit.FunSuite {
     var evalShas = 0
     val runner   = new CommandRunner[CIO, String] {
       def run[A](command: Command[A]): CIO[A] = command.name match {
-        case "EVALSHA" => evalShas += 1; CIO.fail(ServerError("NOSCRIPT", ""))
+        case "EVALSHA" =>
+          evalShas += 1
+          CIO.fail(ServerError("NOSCRIPT", ""))
         case "EVAL"    =>
           evals += 1
           assertEquals(command.keyIndices, Vector(2))
@@ -80,7 +82,10 @@ class RateLimitFallbackSpec extends munit.FunSuite {
   test("a misconfigured policy fails through the effect without touching the runner") {
     var calls  = 0
     val runner = new CommandRunner[CIO, String] {
-      def run[A](command: Command[A]): CIO[A] = { calls += 1; CIO.fail(ServerError("ERR", "should not run")) }
+      def run[A](command: Command[A]): CIO[A] = {
+        calls += 1
+        CIO.fail(ServerError("ERR", "should not run"))
+      }
     }
     val bad    = new RateLimitExecutor[String](RateLimiter[String](RateLimit(0, 1, 1.second)))
     for {

--- a/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
@@ -20,7 +20,10 @@ class SocketTransportSpec extends munit.FunSuite {
     @volatile var clears: Int         = 0
     def writeAttempted(): Unit        = writeAttempts += 1
     def dropped(): Unit               = drops += 1
-    override def clearPayload(): Unit = { clears += 1; payload = Bytes.empty }
+    override def clearPayload(): Unit = {
+      clears += 1
+      payload = Bytes.empty
+    }
   }
 
   private def withTransport(
@@ -151,8 +154,14 @@ class SocketTransportSpec extends munit.FunSuite {
     val proceed                                 = new CountDownLatch(1)
     @volatile var transportRef: SocketTransport = null
     withTransport(
-      onClosed = () => { readerAliveAtClose.set(transportRef.reader.isAlive); proceed.countDown() },
-      onFrame = _ => { inOnFrame.countDown(); proceed.await() }
+      onClosed = () => {
+        readerAliveAtClose.set(transportRef.reader.isAlive)
+        proceed.countDown()
+      },
+      onFrame = _ => {
+        inOnFrame.countDown()
+        proceed.await()
+      }
     ) { (transport, peer) =>
       transportRef = transport
       peer.getOutputStream.write("+PONG\r\n".getBytes(StandardCharsets.UTF_8))

--- a/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
@@ -75,7 +75,10 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
   private def nextBlocking(sub: SubscriptionConnection.RawSubscription): Option[SubscriptionConnection.Delivery] = {
     val box   = new AtomicReference[Option[SubscriptionConnection.Delivery]]()
     val latch = new CountDownLatch(1)
-    sub.next { delivery => box.set(delivery); latch.countDown() }
+    sub.next { delivery =>
+      box.set(delivery)
+      latch.countDown()
+    }
     latch.await()
     box.get()
   }
@@ -83,7 +86,10 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
   private def nextBlocking(sink: SubscriptionConnection.Sink): Option[SubscriptionConnection.Delivery] = {
     val box   = new AtomicReference[Option[SubscriptionConnection.Delivery]]()
     val latch = new CountDownLatch(1)
-    sink.next { delivery => box.set(delivery); latch.countDown() }
+    sink.next { delivery =>
+      box.set(delivery)
+      latch.countDown()
+    }
     latch.await()
     box.get()
   }
@@ -91,7 +97,9 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
   // Bytes has no structural `==` (CONTEXT: compare with sameBytes), so destructure and compare the payload as text
   private def assertChannel(delivery: Option[SubscriptionConnection.Delivery], channel: String, payload: String)(using munit.Location): Unit =
     delivery match {
-      case Some(SubscriptionConnection.Delivery.Channel(ch, p)) => assertEquals(ch, channel); assertEquals(p.asUtf8String, payload)
+      case Some(SubscriptionConnection.Delivery.Channel(ch, p)) =>
+        assertEquals(ch, channel)
+        assertEquals(p.asUtf8String, payload)
       case other                                                => fail(s"expected a channel delivery, got $other")
     }
 
@@ -100,7 +108,9 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
   ): Unit =
     delivery match {
       case Some(SubscriptionConnection.Delivery.Pattern(pat, ch, p)) =>
-        assertEquals(pat, pattern); assertEquals(ch, channel); assertEquals(p.asUtf8String, payload)
+        assertEquals(pat, pattern)
+        assertEquals(ch, channel)
+        assertEquals(p.asUtf8String, payload)
       case other                                                     => fail(s"expected a pattern delivery, got $other")
     }
 
@@ -219,7 +229,7 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
     }
     val watchdog                            = WatchdogConfig(pingInterval = 100.millis, pingTimeout = 50.millis, enabled = true)
     val (connection, scheduler, transports) = make(watchdog = watchdog, respond = silentToPing, bootstrap = Vector(Connection.select(0)))
-    val _                                   = connection.subscribeChannels(Vector("news"))
+    connection.subscribeChannels(Vector("news"))
     assertEquals(transports.size, 1)
 
     var iteration = 0
@@ -250,7 +260,7 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
     assert(!connection.closeIfEmpty(), "a connection carrying a live sink must not be evicted")
     assertEquals(transports.head.closeCount, 0)
 
-    val _ = connection.detach(sink, Vector("orders"), SubscriptionConnection.Kind.Shard)
+    connection.detach(sink, Vector("orders"), SubscriptionConnection.Kind.Shard)
     assert(connection.closeIfEmpty(), "with its last sink gone the connection is empty and closes")
     assertEquals(transports.head.closeCount, 1)
 
@@ -277,7 +287,9 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
     val scheduler                                       = new ManualScheduler
     val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
     val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
-      val t = new FakeTransport(onFrame, onClosed, serverResponder); transports += t; t
+      val t = new FakeTransport(onFrame, onClosed, serverResponder)
+      transports += t
+      t
     }
     val connection                                      = new SubscriptionConnection(
       factory,
@@ -308,7 +320,10 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
       def send(item: Transport.Item): Unit = {
         item.writeAttempted()
         serverResponder(item.payload).foreach(onFrame)
-        if (!bootstrapped) { bootstrapped = true; onClosed() }
+        if (!bootstrapped) {
+          bootstrapped = true
+          onClosed()
+        }
       }
       def close(): Unit                    = ()
     }
@@ -349,7 +364,10 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
 
     val box   = new AtomicReference[Option[SubscriptionConnection.Delivery]]()
     val latch = new CountDownLatch(1)
-    sink.next { delivery => box.set(delivery); latch.countDown() }
+    sink.next { delivery =>
+      box.set(delivery)
+      latch.countDown()
+    }
     sink.offer(SubscriptionConnection.Delivery.Channel("news", Bytes.utf8("hello")))
     latch.await()
     assertChannel(box.get(), "news", "hello")
@@ -372,11 +390,16 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
         item.writeAttempted()
         serverResponder(item.payload).foreach(onFrame)
       }
-      def close(): Unit                    = { closeCount += 1; onClosed() }
+      def close(): Unit                    = {
+        closeCount += 1
+        onClosed()
+      }
     }
     val transports = mutable.ArrayBuffer.empty[FailingSubscribe]
     val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
-      val t = new FailingSubscribe(onFrame, onClosed); transports += t; t
+      val t = new FailingSubscribe(onFrame, onClosed)
+      transports += t
+      t
     }
     val connection                                      =
       new SubscriptionConnection(factory, Vector(Connection.ping()), new ManualScheduler, fixedBackoff, noWatchdog, 1000L, 16, () => true)
@@ -395,11 +418,16 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
         item.writeAttempted()
         serverResponder(item.payload).foreach(onFrame)
       }
-      def close(): Unit                    = { closeCount += 1; onClosed() }
+      def close(): Unit                    = {
+        closeCount += 1
+        onClosed()
+      }
     }
     val transports = mutable.ArrayBuffer.empty[FailingUnsubscribe]
     val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
-      val t = new FailingUnsubscribe(onFrame, onClosed); transports += t; t
+      val t = new FailingUnsubscribe(onFrame, onClosed)
+      transports += t
+      t
     }
     val connection                                      =
       new SubscriptionConnection(factory, Vector(Connection.ping()), new ManualScheduler, fixedBackoff, noWatchdog, 1000L, 16, () => true)
@@ -407,7 +435,10 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
     val sub   = connection.subscribeChannels(Vector("news"))
     val box   = new AtomicReference[Option[SubscriptionConnection.Delivery]]()
     val latch = new CountDownLatch(1)
-    sub.next { delivery => box.set(delivery); latch.countDown() }
+    sub.next { delivery =>
+      box.set(delivery)
+      latch.countDown()
+    }
 
     intercept[RuntimeException](sub.close())
     assert(latch.await(1, java.util.concurrent.TimeUnit.SECONDS), "the parked consumer must be woken, not left hanging")
@@ -435,7 +466,7 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
       def emitsEvents: Boolean                  = true
       def tracer: Option[sage.CommandTracer]    = None
       def serverNode: Option[sage.cluster.Node] = None
-      def emit(event: sage.SageEvent): Unit     = { val _ = recorded.add(event) }
+      def emit(event: sage.SageEvent): Unit     = recorded.add(event): Unit
       def close(): Unit                         = ()
     }
     var healthy                                         = true
@@ -444,7 +475,9 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
       else serverResponder(payload)
     val transports                                      = mutable.ArrayBuffer.empty[FakeTransport]
     val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
-      val t = new FakeTransport(onFrame, onClosed, respond); transports += t; t
+      val t = new FakeTransport(onFrame, onClosed, respond)
+      transports += t
+      t
     }
     val scheduler                                       = new ManualScheduler
     val connection                                      =
@@ -503,7 +536,7 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
       new SubscriptionConnection(factory, Vector(Connection.ping()), new ManualScheduler, fixedBackoff, noWatchdog, 1000L, 16, () => true)
 
     val subscribing = new Thread(() =>
-      try { val _ = connection.subscribeChannels(Vector("news")) }
+      try connection.subscribeChannels(Vector("news")): Unit
       catch { case _: Throwable => () }
     )
     subscribing.start() // blocks in the connect
@@ -523,12 +556,20 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
   test("close unblocks a subscriber parked waiting for the bootstrap reply") {
     val pinged                                          = new CountDownLatch(1)
     val factory: MultiplexedConnection.TransportFactory =
-      (onFrame, onClosed) => new FakeTransport(onFrame, onClosed, payload => { if (payload.asUtf8String.contains("PING")) pinged.countDown(); Nil })
+      (onFrame, onClosed) =>
+        new FakeTransport(
+          onFrame,
+          onClosed,
+          payload => {
+            if (payload.asUtf8String.contains("PING")) pinged.countDown()
+            Nil
+          }
+        )
     val connection                                      =
       new SubscriptionConnection(factory, Vector(Connection.ping()), new ManualScheduler, fixedBackoff, noWatchdog, 60000L, 16, () => true)
 
     val subscribing = new Thread(() =>
-      try { val _ = connection.subscribeChannels(Vector("news")) }
+      try connection.subscribeChannels(Vector("news")): Unit
       catch { case _: Throwable => () }
     )
     subscribing.start()
@@ -547,8 +588,14 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
     val connecting                                      = new java.util.concurrent.CopyOnWriteArrayList[ConnectingTransport]()
     var fake: FakeTransport                             = null
     val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) =>
-      if (attempt.getAndIncrement() == 0) { fake = new FakeTransport(onFrame, onClosed, serverResponder); fake }
-      else { val t = new ConnectingTransport(onClosed); connecting.add(t); t }
+      if (attempt.getAndIncrement() == 0) {
+        fake = new FakeTransport(onFrame, onClosed, serverResponder)
+        fake
+      } else {
+        val t = new ConnectingTransport(onClosed)
+        connecting.add(t)
+        t
+      }
     val connection                                      =
       new SubscriptionConnection(factory, Vector(Connection.ping()), scheduler, fixedBackoff, noWatchdog, 5000L, 16, () => true)
 
@@ -571,7 +618,7 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
     sub.close() // Reconnecting -> Idle, leaving conn1 still establishing
 
     val attaching = new Thread(() =>
-      try { val _ = connection.subscribeChannels(Vector("b")) }
+      try connection.subscribeChannels(Vector("b")): Unit
       catch { case _: Throwable => () }
     )
     attaching.start() // blocks in the attach's connect

--- a/sage-client/shared/src/test/scala/sage/client/internal/TlsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/TlsSpec.scala
@@ -69,17 +69,23 @@ class TlsSpec extends munit.FunSuite {
       .asInstanceOf[SSLServerSocket]
     socket.setSoTimeout(10000)
     val accept = Thread.ofVirtual().start { () =>
-      try { val s = socket.accept(); s.getInputStream.read(); s.close() }
-      catch { case _: Throwable => () }
+      try {
+        val s = socket.accept()
+        s.getInputStream.read()
+        s.close()
+      } catch { case _: Throwable => () }
     }
     try body(socket.getLocalPort)
-    finally { socket.close(); accept.join() }
+    finally {
+      socket.close()
+      accept.join()
+    }
   }
 
   private def upgrade(host: String, port: Int): Unit = {
     val plain = new Socket()
     plain.connect(new InetSocketAddress("127.0.0.1", port), 5000)
-    try { val _ = Tls.buildUpgrade(Some(TlsConfig(TrustSource.Custom(material._2))), host, port)(plain) }
+    try Tls.buildUpgrade(Some(TlsConfig(TrustSource.Custom(material._2))), host, port)(plain): Unit
     finally plain.close()
   }
 

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -80,7 +80,7 @@ class ClusterClientSpec extends munit.FunSuite {
           else behaviour(node, text)
         }
         val transport                    = new FakeTransport(onFrame, onClosed, respond)
-        transports.synchronized { val _ = transports.getOrElseUpdate(node, mutable.ArrayBuffer.empty) += transport }
+        transports.synchronized(transports.getOrElseUpdate(node, mutable.ArrayBuffer.empty) += transport)
         transport
       }
 
@@ -600,8 +600,10 @@ class ClusterClientSpec extends munit.FunSuite {
     val mid          = Slot.Count / 2
     val clusterCalls = new java.util.concurrent.atomic.AtomicInteger(0)
     val behaviour    = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) { clusterCalls.incrementAndGet(); Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1))) }
-      else if (text.contains("SCRIPT"))
+      if (text.contains("CLUSTER")) {
+        clusterCalls.incrementAndGet()
+        Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      } else if (text.contains("SCRIPT"))
         Seq(if (node == nodeB) Frame.SimpleError("CLUSTERDOWN The cluster is down") else Frame.BulkString(Bytes.utf8("sha1")))
       else Seq(Frame.SimpleString("OK"))
     val fixture      = new Fixture(behaviour, Vector(nodeA))
@@ -796,8 +798,10 @@ class ClusterClientSpec extends munit.FunSuite {
     val clusterCalls = new java.util.concurrent.atomic.AtomicInteger(0)
     val attempts     = new java.util.concurrent.atomic.AtomicInteger(0)
     val behaviour    = (_: Node, text: String) =>
-      if (text.contains("CLUSTER")) { clusterCalls.incrementAndGet(); Seq(wholeClusterOn(nodeA)) }
-      else if (text.contains("GET"))
+      if (text.contains("CLUSTER")) {
+        clusterCalls.incrementAndGet()
+        Seq(wholeClusterOn(nodeA))
+      } else if (text.contains("GET"))
         if (attempts.getAndIncrement() == 0) Seq(Frame.SimpleError("LOADING Redis is loading the dataset in memory"))
         else Seq(Frame.BulkString(Bytes.utf8("value")))
       else Seq(Frame.SimpleString("OK"))

--- a/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
@@ -50,7 +50,12 @@ class ConnectSpec extends munit.FunSuite {
   }
 
   test("a refused connection surfaces as a recoverable ConnectionFailed carrying the cause") {
-    val deadPort = { val s = new java.net.ServerSocket(0); val p = s.getLocalPort; s.close(); p } // a port nothing listens on
+    val deadPort = {
+      val s = new java.net.ServerSocket(0)
+      val p = s.getLocalPort
+      s.close()
+      p
+    } // a port nothing listens on
     val config   = SageConfig(topology = Topology.Standalone(Endpoint("127.0.0.1", deadPort)), connectTimeout = 1.second)
     Client.connect(config).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[ConnectionFailed], s"expected ConnectionFailed, got $error")
@@ -187,7 +192,9 @@ class ConnectSpec extends munit.FunSuite {
     val latch                = new CountDownLatch(2)
     val listener             = new SageListener {
       def onEvent(event: SageEvent): Unit = event match {
-        case c: SageEvent.CommandCompleted => completions.add(c); latch.countDown()
+        case c: SageEvent.CommandCompleted =>
+          completions.add(c)
+          latch.countDown()
         case _                             => ()
       }
     }

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
@@ -64,7 +64,10 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
   private def occurrences(haystack: String, needle: String): Int = {
     var count = 0
     var from  = haystack.indexOf(needle)
-    while (from >= 0) { count += 1; from = haystack.indexOf(needle, from + needle.length) }
+    while (from >= 0) {
+      count += 1
+      from = haystack.indexOf(needle, from + needle.length)
+    }
     count
   }
 
@@ -72,7 +75,7 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
     val routed                                      = new ConcurrentLinkedQueue[(String, Node)]()
     def onCommand(command: Command[?]): CommandSpan =
       new CommandSpan {
-        def routedTo(node: Node): Unit      = { val _ = routed.add(command.name -> node) }
+        def routedTo(node: Node): Unit      = routed.add(command.name -> node): Unit
         def settled(outcome: Outcome): Unit = ()
       }
   }
@@ -92,7 +95,9 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
     val latch                                                   = new CountDownLatch(2)
     val listener                                                = new SageListener {
       def onEvent(event: SageEvent): Unit = event match {
-        case c: SageEvent.CommandCompleted if c.name == "PREAD" || c.name == "PWRITE" => completions.add(c); latch.countDown()
+        case c: SageEvent.CommandCompleted if c.name == "PREAD" || c.name == "PWRITE" =>
+          completions.add(c)
+          latch.countDown()
         case _                                                                        => ()
       }
     }
@@ -121,7 +126,7 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
       f.live.run(writeCmd).unsafeRun.flatMap { _ =>
         f.live.pipeline(Seq(writeCmd, readCmd)).unsafeRun.map { _ =>
           assertEquals(counting.zeroDelays.get(), before, "an established-master dispatch must not offload")
-          val _ = f.live.close.unsafeRun
+          f.live.close.unsafeRun
         }
       }
     }
@@ -134,7 +139,7 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
       val before = counting.zeroDelays.get()
       f.live.pipeline(Seq(readCmd, readCmd)).unsafeRun.map { _ =>
         assertEquals(counting.zeroDelays.get(), before, "a warmed replica pipeline must not offload")
-        val _ = f.live.close.unsafeRun
+        f.live.close.unsafeRun
       }
     }
   }
@@ -150,7 +155,7 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
         assertEquals(nodes, Vector(Some(replica), Some(replica)), s"pipeline commands should attribute to the replica, got $nodes")
         val routed = f.tracer.routed.asScala.toVector.filter(_._1 == "PREAD")
         assertEquals(routed, Vector("PREAD" -> replica, "PREAD" -> replica), s"tracer should route both reads to the replica, got $routed")
-        val _      = f.live.close.unsafeRun
+        f.live.close.unsafeRun
       }
   }
 
@@ -165,7 +170,7 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
         assertEquals(nodes, Vector(Some(master), Some(master)), s"a write forces the whole batch to the master, got $nodes")
         val routed = f.tracer.routed.asScala.toVector.filter(p => p._1 == "PWRITE" || p._1 == "PREAD")
         assertEquals(routed, Vector("PWRITE" -> master, "PREAD" -> master), s"tracer should route both commands to the master, got $routed")
-        val _      = f.live.close.unsafeRun
+        f.live.close.unsafeRun
       }
   }
 }

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -80,12 +80,12 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     def nowMillis: Long                          = 0L
     def jitterMillis(boundExclusive: Long): Long = 0L
 
-    def after(delay: FiniteDuration)(task: => Unit): Unit = { val _ = queued += (() => task) }
+    def after(delay: FiniteDuration)(task: => Unit): Unit = queued += (() => task)
 
     def every(interval: FiniteDuration)(task: => Unit): Scheduler.Cancelable = {
       val tick = () => task
       ticks += tick
-      () => { val _ = ticks -= tick }
+      () => ticks -= tick
     }
 
     def tick(): Unit = ticks.toVector.foreach(_())
@@ -113,7 +113,7 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     private val transports                                              = new ConcurrentLinkedQueue[(Node, FakeTransport)]()
     private val factory: Node => MultiplexedConnection.TransportFactory = node =>
       (onFrame, onClosed) => {
-        val _                            = dials.add(node)
+        dials.add(node)
         if (unreachable(node)) throw new IOException(s"cannot reach $node")
         val respond: Bytes => Seq[Frame] = payload => {
           val text  = payload.asUtf8String
@@ -127,7 +127,7 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
           else Seq(Frame.SimpleString("OK"))
         }
         val transport                    = new FakeTransport(onFrame, onClosed, respond)
-        val _                            = transports.add(node -> transport)
+        transports.add(node -> transport)
         transport
       }
 
@@ -154,9 +154,8 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     def write(): Try[Long] =
       Try(scala.concurrent.Await.result(live.run(writeCommand).unsafeRun, 10.seconds))
 
-    def readPipeline(): Unit = {
-      val _ = scala.concurrent.Await.result(live.pipeline(Seq(readCommand, readCommand)).unsafeRun, 10.seconds)
-    }
+    def readPipeline(): Unit =
+      scala.concurrent.Await.result(live.pipeline(Seq(readCommand, readCommand)).unsafeRun, 10.seconds): Unit
 
     def awaitTrue(condition: => Boolean, clue: String, timeout: FiniteDuration = 5.seconds): Unit = {
       val deadline = System.nanoTime() + timeout.toNanos
@@ -209,7 +208,7 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
       def serverNode                   = None
       def close(): Unit                = ()
       def emit(event: SageEvent): Unit = event match {
-        case event: SageEvent.Connection.Connected => val _ = connected.add(event)
+        case event: SageEvent.Connection.Connected => connected.add(event): Unit
         case _                                     => ()
       }
     }
@@ -277,7 +276,7 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     down -= reader
     fixture.awaitTrue(
       {
-        val _ = fixture.read()
+        fixture.read()
         fixture.readsServedBy(reader) > 0
       },
       "replica-preferred reads did not reconsider the recovered endpoint",
@@ -343,7 +342,7 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
 
     fixture.awaitTrue(
       {
-        val _ = fixture.read()
+        fixture.read()
         fixture.readsServedBy(reader) > 0
       },
       "replica-preferred reads did not reconsider the connected replica",
@@ -371,7 +370,7 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     fixture.roles.update(advertisedReplica, replicaRole(primary))
     fixture.awaitTrue(
       {
-        val _ = fixture.read()
+        fixture.read()
         fixture.readsServedBy(advertisedReplica) > 0
       },
       "the background poll did not adopt the new replica",
@@ -450,7 +449,7 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     val before  = fixture.readsServedBy(primary)
     fixture.awaitTrue(
       {
-        val _ = fixture.read()
+        fixture.read()
         fixture.readsServedBy(primary) > before
       },
       "the refresh did not move reads to the demoted endpoint"

--- a/sage-core/src/main/scala/sage/codec/Primitives.scala
+++ b/sage-core/src/main/scala/sage/codec/Primitives.scala
@@ -23,7 +23,10 @@ private[codec] object Primitives {
       val negative  = value < 0
       var counter   = value
       var digits    = 0
-      while (counter != 0L) { counter /= 10; digits += 1 }
+      while (counter != 0L) {
+        counter /= 10
+        digits += 1
+      }
       val start     = if (negative) 1 else 0
       val out       = new Array[Byte](start + digits)
       var i         = out.length - 1

--- a/sage-core/src/main/scala/sage/commands/StreamInfo.scala
+++ b/sage-core/src/main/scala/sage/commands/StreamInfo.scala
@@ -249,7 +249,10 @@ private[sage] object StreamInfo {
           val pairs = Vector.newBuilder[(Frame, Frame)]
           pairs.sizeHint(elements.length / 2)
           var i     = 0
-          while (i < elements.length) { pairs += (elements(i) -> elements(i + 1)); i += 2 }
+          while (i < elements.length) {
+            pairs += (elements(i) -> elements(i + 1))
+            i += 2
+          }
           build(pairs.result())
         case other => Left(DecodeError("introspection map", Frame.describe(other)))
       }

--- a/sage-core/src/main/scala/sage/commands/Streams.scala
+++ b/sage-core/src/main/scala/sage/commands/Streams.scala
@@ -16,7 +16,8 @@ import sage.protocol.Frame
   */
 final case class StreamId(ms: Long, seq: Long) extends Ordered[StreamId] {
   def compare(that: StreamId): Int  = {
-    val c = java.lang.Long.compareUnsigned(ms, that.ms); if (c != 0) c else java.lang.Long.compareUnsigned(seq, that.seq)
+    val c = java.lang.Long.compareUnsigned(ms, that.ms)
+    if (c != 0) c else java.lang.Long.compareUnsigned(seq, that.seq)
   }
   private[commands] def wire: Bytes = Bytes.utf8(s"$ms-$seq")
 }
@@ -483,10 +484,12 @@ private[sage] object Streams {
     }
 
   private def thresholdKeyword(threshold: TrimThreshold): Bytes = threshold match {
-    case _: TrimThreshold.MaxLen => MaxLenWord; case _: TrimThreshold.MinId => MinIdWord
+    case _: TrimThreshold.MaxLen => MaxLenWord
+    case _: TrimThreshold.MinId  => MinIdWord
   }
   private def thresholdValue(threshold: TrimThreshold): Bytes   = threshold match {
-    case TrimThreshold.MaxLen(c) => Bytes.utf8(c.toString); case TrimThreshold.MinId(id) => id.wire
+    case TrimThreshold.MaxLen(c) => Bytes.utf8(c.toString)
+    case TrimThreshold.MinId(id) => id.wire
   }
 
   private def policyArgs(policy: StreamDeletionPolicy): Vector[Bytes] =

--- a/sage-core/src/main/scala/sage/protocol/RespParser.scala
+++ b/sage-core/src/main/scala/sage/protocol/RespParser.scala
@@ -130,8 +130,10 @@ final private[sage] class RespParser {
           if (top.kind == Attr) closing = false // an attribute yields no value; the value it prefixes is produced next, for the same slot
           else {
             val value = build(top)
-            if (stackDepth == 0) { onFrame(value); closing = false }
-            else addChild(stack(stackDepth - 1), value) // re-check: the parent may now be complete too
+            if (stackDepth == 0) {
+              onFrame(value)
+              closing = false
+            } else addChild(stack(stackDepth - 1), value) // re-check: the parent may now be complete too
           }
         } else closing = false
 
@@ -304,7 +306,10 @@ final private[sage] class RespParser {
     else {
       readPos = cursor
       val agg = new Agg(kind, count)
-      if (kind == Map) { agg.pairs = Vector.newBuilder[(Frame, Frame)]; agg.pairs.sizeHint(count) }
+      if (kind == Map) {
+        agg.pairs = Vector.newBuilder[(Frame, Frame)]
+        agg.pairs.sizeHint(count)
+      }
       push(agg)
     }
   }

--- a/sage-core/src/main/scala/sage/protocol/RespWriter.scala
+++ b/sage-core/src/main/scala/sage/protocol/RespWriter.scala
@@ -25,7 +25,10 @@ private[sage] object RespWriter {
       val count     = wordBytes.length.toLong + args.length
       var bodySize  = 0
       var s         = 0
-      while (s < wordBytes.length) { bodySize += bulkSize(wordBytes(s).length); s += 1 }
+      while (s < wordBytes.length) {
+        bodySize += bulkSize(wordBytes(s).length)
+        s += 1
+      }
       val sink      = new Sink(headerSize(count) + bodySize + argsSize(args))
       sink.writeByte('*')
       sink.writeLong(count)

--- a/sage-opentelemetry/src/main/scala/sage/opentelemetry/OpenTelemetryCommandTracer.scala
+++ b/sage-opentelemetry/src/main/scala/sage/opentelemetry/OpenTelemetryCommandTracer.scala
@@ -82,8 +82,8 @@ object OpenTelemetryCommandTracer {
     private val ended = new AtomicBoolean(false)
 
     def routedTo(node: Node): Unit = {
-      val _ = span.setAttribute(ServerAddress, node.host)
-      val _ = span.setAttribute(ServerPort, node.port.toLong)
+      span.setAttribute(ServerAddress, node.host)
+      span.setAttribute(ServerPort, node.port.toLong): Unit
     }
 
     def settled(outcome: Outcome): Unit =
@@ -91,8 +91,8 @@ object OpenTelemetryCommandTracer {
         outcome match {
           case Outcome.Succeeded   => ()
           case Outcome.Failed(err) =>
-            val _ = span.setStatus(StatusCode.ERROR, Option(err.getMessage).getOrElse(err.getClass.getName))
-            val _ = span.recordException(err)
+            span.setStatus(StatusCode.ERROR, Option(err.getMessage).getOrElse(err.getClass.getName))
+            span.recordException(err)
         }
         span.end()
       }


### PR DESCRIPTION
`-Wvalue-discard` was being satisfied with `val _ = expr` at 133 sites, and another 207 lines packed several statements onto one line with `;`. Neither reads like ordinary Scala.

Every `val _ =` was deleted first, then the compiler was asked which sites actually needed a silencer. 103 needed nothing: Scala 3 does not warn when the discarded value is the receiver itself (`buf += x`, `set -= conn`), and non-final statements in a block are only caught by `-Wnonunit-statement`, which is not enabled. The remaining 30 use `: Unit`, the form the compiler's own diagnostic recommends. `-Wvalue-discard` stays on.

Statement separators became newlines. Semicolons in comments, prose, and the embedded Lua in `RateLimiter` are untouched.

```scala
client.set("greeting", "hello")
val greeting = client.get[String]("greeting")
client.incrBy("counter", 10)
```

No behaviour change: every edit is a deleted binding, an added ascription, or a line break. `Test/compile` is clean with `-Xfatal-warnings` across all 10 matrix cells on both 3.3.8 and 3.8.4; unit tests and `scalafmtCheckAll` pass.