### PR TITLE
Share the read-candidate walk between the topology runtimes

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -58,7 +58,7 @@ final private[client] class ClusterLive(
 
   // READONLY at setup, so a replica serves reads for its master's slots instead of answering MOVED; separate from the master registry, which
   // drives redirects
-  private val replicaPool    = new NodePool(
+  private val replicaPool   = new NodePool(
     nodeFactory,
     scheduler,
     bootstrap :+ Connection.readonly,
@@ -69,9 +69,7 @@ final private[client] class ClusterLive(
     dedicatedPool,
     events = events
   )
-  // per-master round-robin cursor over its shard's replicas
-  private val replicaCursors = new java.util.concurrent.ConcurrentHashMap[Node, java.util.concurrent.atomic.AtomicInteger]()
-  private val keylessCursor  = new java.util.concurrent.atomic.AtomicInteger()
+  private val keylessCursor = new java.util.concurrent.atomic.AtomicInteger()
 
   private val subscriptions = new ClusterSubscriptions(
     nodeFactory,
@@ -100,6 +98,7 @@ final private[client] class ClusterLive(
     events = events,
     dedicatedBootstrap = Some(bootstrap)
   )
+  private val reads            = new ReadRouting(masterPool, replicaPool, scheduler, readFrom, () => triggerRefresh())
   // set once by close; routing refuses afterwards, so close is terminal like the standalone client's
   @volatile private var closed = false
 
@@ -354,12 +353,9 @@ final private[client] class ClusterLive(
     command.args.size > suffixArgs &&
       command.keyIndices == Vector.tabulate(command.args.size - suffixArgs)(identity)
 
-  // walk the policy's ordered candidates, falling through on connection loss; strict Replica with no live replica exhausts to NotConnected
   private def sendRead[A](command: Command[A], master: Node, slot: Slot, redirectsLeft: Int, complete: Try[A] => Unit): Unit = {
     val replicas = topologyRef.get().shardForSlot(slot).map(_.replicas).getOrElse(Vector.empty)
-    val cursor   = replicaCursors.computeIfAbsent(master, _ => new java.util.concurrent.atomic.AtomicInteger())
-    refreshIfNoReplica(replicas)
-    tryReadCandidates(command, ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement()), master, redirectsLeft, complete)
+    walkRead(command, reads.candidatesFor(master, replicas), master, redirectsLeft, complete)
   }
 
   // a keyless eligible read (RANDOMKEY): round-robin over every replica, falling back per policy, so strict Replica never hits a master
@@ -367,57 +363,13 @@ final private[client] class ClusterLive(
     pickNode(topology) match {
       case Some(master) =>
         val replicas = topology.shards.iterator.flatMap(_.replicas).toVector.distinct
-        refreshIfNoReplica(replicas)
-        tryReadCandidates(
-          command,
-          ReadRouting.candidates(readFrom, master, replicas, keylessCursor.getAndIncrement()),
-          master,
-          redirectsLeft,
-          complete
-        )
+        walkRead(command, reads.candidatesFor(master, replicas, keylessCursor.getAndIncrement()), master, redirectsLeft, complete)
       case None         => complete(Failure(NotConnected()))
     }
 
-  private def tryReadCandidates[A](command: Command[A], candidates: Vector[Node], master: Node, redirectsLeft: Int, complete: Try[A] => Unit): Unit =
-    candidates match {
-      case node +: rest =>
-        val pool     = if (node == master) masterPool else replicaPool
-        val existing = pool.existing(node)
-        if (existing != null)
-          if (existing.isLive) submitRead(existing, node, command, rest, master, redirectsLeft, complete)
-          else tryReadCandidates(command, rest, master, redirectsLeft, complete)
-        else
-          offload {
-            val nc =
-              try pool.getOrEstablish(node)
-              catch { case NonFatal(_) => null }
-            if (nc == null || !nc.isLive) tryReadCandidates(command, rest, master, redirectsLeft, complete)
-            else submitRead(nc, node, command, rest, master, redirectsLeft, complete)
-          }
-      // strict Replica, all candidates unreachable: refresh so the next read sees the new roster
-      case _            =>
-        triggerRefresh()
-        complete(Failure(NotConnected()))
-    }
-
-  private def submitRead[A](
-    nc: NodeClient,
-    node: Node,
-    command: Command[A],
-    rest: Vector[Node],
-    master: Node,
-    redirectsLeft: Int,
-    complete: Try[A] => Unit
-  ): Unit =
-    nc.submit[A](
-      command,
-      asking = false,
-      {
-        case Success(value) =>
-          Events.attributeNode(complete, node)
-          complete(Success(value))
-        case Failure(error) => offload(onReadFailure(node, command, error, rest, master, redirectsLeft, complete))
-      }
+  private def walkRead[A](command: Command[A], candidates: Vector[Node], master: Node, redirectsLeft: Int, complete: Try[A] => Unit): Unit =
+    reads.walk(command, candidates, master, complete)((node, error, rest) =>
+      onReadFailure(node, command, error, rest, master, redirectsLeft, complete)
     )
 
   private def onReadFailure[A](
@@ -430,7 +382,7 @@ final private[client] class ClusterLive(
     complete: Try[A] => Unit
   ): Unit =
     Fault.categorize(error) match {
-      case Fault.Redirected(redirect)       =>
+      case Fault.Redirected(redirect)     =>
         redirect.kind match {
           // strict Replica must not follow ASK onto the importing master (the migrating key is on no replica); MOVED refreshes and re-dispatches
           case RedirectKind.Ask                         =>
@@ -443,17 +395,23 @@ final private[client] class ClusterLive(
             refresh(force = true)
             offload(dispatch(command, redirectsLeft - 1, complete))
         }
-      case Fault.Lost(false)                =>
-        if (rest.nonEmpty) tryReadCandidates(command, rest, master, redirectsLeft, complete) else onUnreachable(command, redirectsLeft, complete)
-      case Fault.Unavailable(clusterWide)   =>
-        if (rest.nonEmpty) tryReadCandidates(command, rest, master, redirectsLeft, complete)
+      // only a loss that provably never ran may re-dispatch, per onUnreachable's contract
+      case Fault.Lost(executed)           =>
+        if (rest.nonEmpty) walkRead(command, rest, master, redirectsLeft, complete)
+        else if (executed) {
+          triggerRefresh()
+          Events.attributeNode(complete, node)
+          complete(Failure(error))
+        } else onUnreachable(command, redirectsLeft, complete)
+      case Fault.Unavailable(clusterWide) =>
+        if (rest.nonEmpty) walkRead(command, rest, master, redirectsLeft, complete)
         else onRetryable(command, error, clusterWide, redirectsLeft, complete)
-      case Fault.TryAgain                   => onRetryable(command, error, refreshFirst = false, redirectsLeft, complete)
-      case Fault.Demoted | Fault.Lost(true) =>
+      case Fault.TryAgain                 => onRetryable(command, error, refreshFirst = false, redirectsLeft, complete)
+      case Fault.Demoted                  =>
         triggerRefresh()
         Events.attributeNode(complete, node)
         complete(Failure(error))
-      case Fault.Fatal                      =>
+      case Fault.Fatal                    =>
         Events.attributeNode(complete, node)
         complete(Failure(error))
     }
@@ -847,46 +805,6 @@ final private[client] class ClusterLive(
     }
   }
 
-  // the read candidates for `master`'s shard under the policy, advancing its round-robin cursor once
-  private def readCandidates(master: Node): Vector[Node] = {
-    val replicas = topologyRef.get().shards.collectFirst { case s if s.master == master => s.replicas }.getOrElse(Vector.empty)
-    val cursor   = replicaCursors.computeIfAbsent(master, _ => new java.util.concurrent.atomic.AtomicInteger())
-    refreshIfNoReplica(replicas)
-    ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement())
-  }
-
-  // strict Replica refreshes by exhausting its candidates instead; replica-preferred falls back silently and would never look again
-  private def refreshIfNoReplica(replicas: Vector[Node]): Unit =
-    if (readFrom == ReadFrom.ReplicaPreferred && replicas.isEmpty) triggerRefresh()
-
-  // lock-free walk: the first live established candidate, Some((master, null)) when all are established but none live, and None when an
-  // unestablished candidate is met first — only then must the caller offload to establish
-  private def liveEstablished(candidates: Vector[Node], master: Node): Option[(Node, NodeClient)] = {
-    val it = candidates.iterator
-    while (it.hasNext) {
-      val node = it.next()
-      val pool = if (node == master) masterPool else replicaPool
-      val nc   = pool.existing(node)
-      if (nc == null) return None
-      if (nc.isLive) return Some((node, nc))
-    }
-    Some((master, null))
-  }
-
-  // first live read candidate, establishing as needed, with the node it landed on; (master, null) when none
-  private def establishRead(candidates: Vector[Node], master: Node): (Node, NodeClient) = {
-    val it = candidates.iterator
-    while (it.hasNext) {
-      val node = it.next()
-      val pool = if (node == master) masterPool else replicaPool
-      val nc   =
-        try pool.getOrEstablish(node)
-        catch { case NonFatal(_) => null }
-      if (nc != null && nc.isLive) return (node, nc)
-    }
-    (master, null)
-  }
-
   private def sendBatch[Out, R](
     node: Node,
     indices: Vector[Int],
@@ -897,14 +815,10 @@ final private[client] class ClusterLive(
   ): Unit =
     // the batch attributes to the node it lands on (a replica when useReplica)
     if (useReplica) {
-      val candidates = readCandidates(node)
-      liveEstablished(candidates, node) match {
+      val replicas = topologyRef.get().shards.collectFirst { case s if s.master == node => s.replicas }.getOrElse(Vector.empty)
+      reads.pickOne(reads.candidatesFor(node, replicas), node) {
         case Some((target, nc)) => submitBatch(target, nc, indices, p, emits, reroute, useReplica)
-        case None               =>
-          offload {
-            val (target, nc) = establishRead(candidates, node)
-            submitBatch(target, nc, indices, p, emits, reroute, useReplica)
-          }
+        case None               => indices.foreach(reroute)
       }
     } else {
       val existing = masterPool.existing(node)
@@ -1337,7 +1251,7 @@ final private[client] class ClusterLive(
     // prune replica connections and their cursors for replicas the new topology no longer lists, mirroring the master prune
     val replicaNodes = resolved.iterator.flatMap(_.replicas).toSet
     replicaPool.retain(replicaNodes.contains)
-    replicaCursors.keySet.removeIf(node => !masters.contains(node))
+    reads.retain(masters.contains)
     // re-home shard subscriptions only when slot ownership changed; else a forced refresh mid-failover loops (refresh -> adopt -> reconcile ->
     // refresh) at RTT. A classic subscription follows the cluster bus, so it re-homes only when its pinned master's socket drops, never here.
     if (!newTopology.sameOwnership(oldTopology)) subscriptions.onTopologyChanged()

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -1,7 +1,7 @@
 package sage.client.internal
 
 import java.util.concurrent.{CountDownLatch, TimeUnit}
-import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.concurrent.duration.*
@@ -67,7 +67,7 @@ final private[client] class MasterReplicaLive(
 
   private val masterNodeRef    = new AtomicReference[Node](null)
   private val replicasRef      = new AtomicReference[Vector[Node]](Vector.empty)
-  private val cursor           = new AtomicInteger()
+  private val reads            = new ReadRouting(masterPool, replicaPool, scheduler, readFrom, () => triggerRefresh())
   @volatile private var closed = false
 
   private val subLock                                         = new ReentrantLock()
@@ -211,6 +211,7 @@ final private[client] class MasterReplicaLive(
     replicasRef.set(topology.replicas)
     replicaPool.retain(topology.replicas.toSet.contains)
     masterPool.retain(_ == topology.master)
+    reads.retain(_ == topology.master)
   }
 
   // --- routing -------------------------------------------------------------------------------------------------------------------------
@@ -297,58 +298,13 @@ final private[client] class MasterReplicaLive(
       complete(Failure(NotConnected()))
       return
     }
-    val master     = masterNodeRef.get()
-    val candidates = readCandidates(master)
-    tryRead(command, candidates, master, complete)
+    val master = masterNodeRef.get()
+    walkRead(command, reads.candidatesFor(master, replicasRef.get()), master, complete)
   }
 
-  private def readCandidates(master: Node): Vector[Node] = {
-    val replicas = replicasRef.get()
-    if (readFrom == ReadFrom.ReplicaPreferred && replicas.isEmpty) triggerRefresh()
-    ReadRouting.candidates(readFrom, master, replicas, cursor.getAndIncrement())
-  }
-
-  private def tryRead[A](command: Command[A], candidates: Vector[Node], master: Node, complete: Try[A] => Unit): Unit =
-    candidates match {
-      case node +: rest =>
-        val isMaster = node == master
-        val pool     = if (isMaster) masterPool else replicaPool
-        val existing = pool.existing(node)
-        if (existing != null)
-          if (existing.isLive) submitRead(existing, node, isMaster, command, rest, master, complete)
-          else tryRead(command, rest, master, complete)
-        else
-          offload {
-            val nc =
-              try pool.getOrEstablish(node)
-              catch { case NonFatal(_) => null }
-            if (nc == null || !nc.isLive) tryRead(command, rest, master, complete)
-            else submitRead(nc, node, isMaster, command, rest, master, complete)
-          }
-      // nothing reached the wire, so no fault event fires: re-discover here or a strict-Replica read stays stuck on a stale replica set
-      case _            =>
-        triggerRefresh()
-        complete(Failure(NotConnected()))
-    }
-
-  private def submitRead[A](
-    nc: NodeClient,
-    node: Node,
-    isMaster: Boolean,
-    command: Command[A],
-    rest: Vector[Node],
-    master: Node,
-    complete: Try[A] => Unit
-  ): Unit =
-    nc.submit[A](
-      command,
-      asking = false,
-      {
-        case s @ Success(_) =>
-          Events.attributeNode(complete, node)
-          complete(s)
-        case Failure(error) => offload(onReadFault(node, isMaster, error, command, rest, master, complete))
-      }
+  private def walkRead[A](command: Command[A], candidates: Vector[Node], master: Node, complete: Try[A] => Unit): Unit =
+    reads.walk(command, candidates, master, complete)((node, error, rest) =>
+      onReadFault(node, node == master, error, command, rest, master, complete)
     )
 
   private def onReadFault[A](
@@ -366,7 +322,7 @@ final private[client] class MasterReplicaLive(
       complete(Failure(error))
     }
     if (servesNoRead(error))
-      if (rest.nonEmpty) tryRead(command, rest, master, complete)
+      if (rest.nonEmpty) walkRead(command, rest, master, complete)
       else {
         triggerRefresh()
         fail()
@@ -396,68 +352,32 @@ final private[client] class MasterReplicaLive(
       CIO.fail(InvalidArgument("a Pipeline cannot carry blocking commands; run them individually on the client"))
     else
       CIO.async { complete =>
-        val spans                                      = Events.startSpans(events, p.commands)
+        val spans                                              = Events.startSpans(events, p.commands)
         // all-or-nothing: a fully replica-eligible pipeline batches on a replica, else the master, never split
-        val useReplica                                 = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
-        def submitOn(node: Node, nc: NodeClient): Unit = {
+        val useReplica                                         = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
+        def submitOn(picked: Option[(Node, NodeClient)]): Unit = {
           // no reachable node fires no wire fault, so re-discover here or a stale replica set / down master strands the pipeline forever
-          if (nc == null) triggerRefresh()
-          val submit     = if (nc == null) (_: Vector[Command[?]], _: Vector[Try[Any] => Unit]) => false else nc.submitAll
-          // None when nothing reached the wire, so the batch is not attributed to a node it never landed on
-          val attributed = if (nc == null) None else Some(node)
-          Client.submitBatchOnOne(events, p.commands, spans, submit, complete, attributed)
-        }
-        val master                                     = masterNodeRef.get()
-        if (useReplica) {
-          val candidates = readCandidates(master)
-          liveEstablished(candidates, master) match {
-            case Some((node, nc)) => submitOn(node, nc)
-            case None             =>
-              offload {
-                val (node, nc) = establishRead(candidates, master)
-                submitOn(node, nc)
-              }
+          if (picked.isEmpty) triggerRefresh()
+          val submit = picked match {
+            case Some((_, nc)) => nc.submitAll
+            case None          => (_: Vector[Command[?]], _: Vector[Try[Any] => Unit]) => false
           }
-        } else {
+          Client.submitBatchOnOne(events, p.commands, spans, submit, complete, picked.map(_._1))
+        }
+        val master                                             = masterNodeRef.get()
+        if (useReplica) reads.pickOne(reads.candidatesFor(master, replicasRef.get()), master)(submitOn)
+        else {
           val existing = masterPool.existing(master)
-          if (existing != null) submitOn(master, existing)
+          if (existing != null) submitOn(Some((master, existing)))
           else
             offload {
               val nc =
                 try masterPool.getOrEstablish(master)
                 catch { case NonFatal(_) => null }
-              submitOn(master, nc)
+              submitOn(Option(nc).map(master -> _))
             }
         }
       }
-
-  // lock-free walk: the first live established candidate, Some((null, null)) when all are established but none live, and None when an
-  // unestablished candidate is met first — only then must the caller offload to establish
-  private def liveEstablished(candidates: Vector[Node], master: Node): Option[(Node, NodeClient)] = {
-    val it = candidates.iterator
-    while (it.hasNext) {
-      val node = it.next()
-      val pool = if (node == master) masterPool else replicaPool
-      val nc   = pool.existing(node)
-      if (nc == null) return None
-      if (nc.isLive) return Some((node, nc))
-    }
-    Some((null, null))
-  }
-
-  // the first live read candidate, establishing as needed, with the node it landed on; (null, null) when none
-  private def establishRead(candidates: Vector[Node], master: Node): (Node, NodeClient) = {
-    val it = candidates.iterator
-    while (it.hasNext) {
-      val node = it.next()
-      val pool = if (node == master) masterPool else replicaPool
-      val nc   =
-        try pool.getOrEstablish(node)
-        catch { case NonFatal(_) => null }
-      if (nc != null && nc.isLive) return (node, nc)
-    }
-    (null, null)
-  }
 
   // --- transactions (always on the master) ---------------------------------------------------------------------------------------------
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/ReadRouting.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ReadRouting.scala
@@ -1,13 +1,20 @@
 package sage.client.internal
 
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.duration.Duration
+import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
+
+import sage.SageException.NotConnected
 import sage.client.ReadFrom
 import sage.cluster.Node
 import sage.commands.Command
 
 /**
-  * The shared read-routing policy, used by both the cluster and master-replica runtimes. It decides nothing about connection liveness — it
-  * only turns a [[ReadFrom]] policy plus a master and its replicas into the ordered list of candidate Nodes to try; the runtime walks that
-  * list, skipping nodes it cannot establish, and falls back exactly as the order dictates.
+  * The read policy's pure half, shared by the cluster and master-replica runtimes: which Nodes may serve a read, and in what order. It
+  * decides nothing about connection liveness; the class below walks the order it produces.
   */
 private[client] object ReadRouting {
 
@@ -30,4 +37,123 @@ private[client] object ReadRouting {
       case ReadFrom.ReplicaPreferred => rotated :+ master
     }
   }
+}
+
+/**
+  * Walks the read policy's ordered candidates, shared by the cluster and master-replica runtimes: it picks each candidate's pool, skips
+  * what cannot serve the read, establishes off the caller's thread when it must, and reports a fault back with the candidates left so the
+  * runtime can apply its own disposition. Exhausting the order refreshes discovery and fails with [[NotConnected]], since nothing reached
+  * the wire and so no fault event will fire.
+  *
+  * It also owns the per-master round-robin cursors, pruned through [[retain]] as the pools are.
+  */
+final private[client] class ReadRouting(
+  masterPool: NodePool,
+  replicaPool: NodePool,
+  scheduler: Scheduler,
+  readFrom: ReadFrom,
+  triggerRefresh: () => Unit
+) {
+
+  private val cursors = new ConcurrentHashMap[Node, AtomicInteger]()
+
+  /**
+    * The candidates for `master`'s replicas under the policy, advancing that master's cursor once.
+    */
+  def candidatesFor(master: Node, replicas: Vector[Node]): Vector[Node] =
+    candidatesFor(master, replicas, cursors.computeIfAbsent(master, _ => new AtomicInteger()).getAndIncrement())
+
+  /**
+    * As [[candidatesFor]], but rotated by a cursor the caller owns, for a read whose rotation belongs to no single master's shard. A
+    * replica-preferred read that finds no replica schedules a refresh either way: it falls back to the master silently and would never look
+    * again, where strict Replica refreshes by exhausting its candidates instead.
+    */
+  def candidatesFor(master: Node, replicas: Vector[Node], rr: Int): Vector[Node] = {
+    if (readFrom == ReadFrom.ReplicaPreferred && replicas.isEmpty) triggerRefresh()
+    ReadRouting.candidates(readFrom, master, replicas, rr)
+  }
+
+  /**
+    * Drops the cursors of masters the topology no longer lists, alongside the pools' own `retain`.
+    */
+  def retain(keep: Node => Boolean): Unit = cursors.keySet.removeIf(node => !keep(node)): Unit
+
+  /**
+    * Submits `command` to the first candidate that can serve it, attributing the Node on success. `onFault` receives the failing Node, its
+    * error, and the candidates left, and runs off the reply thread. An empty `candidates` completes on the caller's thread; anything else
+    * completes on whichever thread answers the submit.
+    */
+  def walk[A](command: Command[A], candidates: Vector[Node], master: Node, complete: Try[A] => Unit)(
+    onFault: (Node, Throwable, Vector[Node]) => Unit
+  ): Unit =
+    candidates match {
+      case node +: rest =>
+        val pool     = poolFor(node, master)
+        val existing = pool.existing(node)
+        if (existing != null)
+          if (existing.isLive) submit(existing, node, command, rest, complete)(onFault)
+          else walk(command, rest, master, complete)(onFault)
+        else
+          offload {
+            val nc = establishOrNull(pool, node)
+            if (nc == null || !nc.isLive) walk(command, rest, master, complete)(onFault)
+            else submit(nc, node, command, rest, complete)(onFault)
+          }
+      case _            =>
+        triggerRefresh()
+        complete(Failure(NotConnected()))
+    }
+
+  /**
+    * The one Node a batch of reads should land on with its connection, established if need be, or `None` when no candidate can serve the
+    * read. `onPick` runs on the caller's thread while a live candidate is already established, and off it otherwise.
+    */
+  def pickOne(candidates: Vector[Node], master: Node)(onPick: Option[(Node, NodeClient)] => Unit): Unit = {
+    val it = candidates.iterator
+    while (it.hasNext) {
+      val node = it.next()
+      val nc   = poolFor(node, master).existing(node)
+      if (nc == null) {
+        offload(onPick(establishOne(candidates, master)))
+        return
+      }
+      if (nc.isLive) {
+        onPick(Some((node, nc)))
+        return
+      }
+    }
+    onPick(None)
+  }
+
+  private def submit[A](nc: NodeClient, node: Node, command: Command[A], rest: Vector[Node], complete: Try[A] => Unit)(
+    onFault: (Node, Throwable, Vector[Node]) => Unit
+  ): Unit =
+    nc.submit[A](
+      command,
+      asking = false,
+      {
+        case success @ Success(_) =>
+          Events.attributeNode(complete, node)
+          complete(success)
+        case Failure(error)       => offload(onFault(node, error, rest))
+      }
+    )
+
+  private def establishOne(candidates: Vector[Node], master: Node): Option[(Node, NodeClient)] = {
+    val it = candidates.iterator
+    while (it.hasNext) {
+      val node = it.next()
+      val nc   = establishOrNull(poolFor(node, master), node)
+      if (nc != null && nc.isLive) return Some((node, nc))
+    }
+    None
+  }
+
+  private def establishOrNull(pool: NodePool, node: Node): NodeClient =
+    try pool.getOrEstablish(node)
+    catch { case NonFatal(_) => null }
+
+  private def poolFor(node: Node, master: Node): NodePool = if (node == master) masterPool else replicaPool
+
+  private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/ReadRoutingSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ReadRoutingSpec.scala
@@ -1,8 +1,18 @@
 package sage.client.internal
 
-import sage.client.ReadFrom
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+
+import scala.concurrent.duration.*
+import scala.util.{Success, Try}
+
+import sage.Bytes
+import sage.SageException.NotConnected
+import sage.client.{BackoffConfig, DedicatedPoolConfig, ReadFrom, WatchdogConfig}
 import sage.cluster.Node
-import sage.commands.{Command, Execution}
+import sage.commands.{Command, Connection, Execution}
+import sage.protocol.Frame
 
 class ReadRoutingSpec extends munit.FunSuite {
 
@@ -54,5 +64,169 @@ class ReadRoutingSpec extends munit.FunSuite {
     assert(!ReadRouting.replicaEligible(cmd("XREAD", Execution.Blocking, isReadOnly = true)))
     // a SCAN cursor is only valid on its issuing node, so it must never round-robin across replicas
     assert(!ReadRouting.replicaEligible(cmd("HSCAN", isReadOnly = true, cursorBound = true)))
+  }
+
+  private val helloReply: Frame =
+    Frame.Map(
+      Vector(
+        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
+        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
+        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
+        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
+      )
+    )
+
+  private val ping = Connection.ping(None)
+
+  final private class Fixture(readFrom: ReadFrom = ReadFrom.Replica, unreachable: Set[Node] = Set.empty, refusing: Set[Node] = Set.empty) {
+    val scheduler                                                       = new ManualScheduler
+    val refreshes                                                       = new AtomicInteger()
+    private val transports                                              = new ConcurrentHashMap[Node, FakeTransport]()
+    private def respond(node: Node)(payload: Bytes): Seq[Frame]         =
+      if (payload.asUtf8String.contains("HELLO")) Seq(helloReply)
+      else if (refusing(node)) Seq(Frame.SimpleError("LOADING the dataset is loading"))
+      else Seq(Frame.SimpleString("PONG"))
+    private val factory: Node => MultiplexedConnection.TransportFactory = node =>
+      (onFrame, onClosed) =>
+        if (unreachable(node)) throw new IOException(s"unreachable $node")
+        else {
+          val transport = new FakeTransport(onFrame, onClosed, respond(node))
+          transports.put(node, transport)
+          transport
+        }
+    private def newPool(): NodePool                                     =
+      new NodePool(
+        factory,
+        scheduler,
+        Vector(Connection.hello(None)),
+        BackoffConfig(),
+        WatchdogConfig(enabled = false),
+        1.second,
+        Duration.Zero,
+        DedicatedPoolConfig()
+      )
+    val masterPool                                                      = newPool()
+    val replicaPool                                                     = newPool()
+    val reads                                                           =
+      new ReadRouting(masterPool, replicaPool, scheduler, readFrom, () => refreshes.incrementAndGet(): Unit)
+    def establish(node: Node): Unit                                     = replicaPool.getOrEstablish(node): Unit
+    def kill(node: Node): Unit                                          = transports.get(node).close()
+    def wrote(node: Node): Boolean                                      = transports.get(node).written.exists(_.asUtf8String.contains("PING"))
+    def close(): Unit                                                   = {
+      masterPool.close()
+      replicaPool.close()
+    }
+  }
+
+  private def collector(): (AtomicReference[Try[String]], Try[String] => Unit) = {
+    val result = new AtomicReference[Try[String]]()
+    (result, result.set)
+  }
+
+  test("walk with no candidate left refreshes, then fails with NotConnected") {
+    val fixture            = new Fixture()
+    val (result, complete) = collector()
+    fixture.reads.walk(ping, Vector.empty, m, complete)((_, _, _) => fail("no candidate should be tried"))
+    assertEquals(fixture.refreshes.get(), 1)
+    assert(result.get().failed.get.isInstanceOf[NotConnected])
+    fixture.close()
+  }
+
+  test("walk skips an established-but-dead candidate and submits to the next") {
+    val fixture            = new Fixture()
+    fixture.establish(r1)
+    fixture.establish(r2)
+    fixture.kill(r1)
+    val (result, complete) = collector()
+    fixture.reads.walk(ping, Vector(r1, r2), m, complete)((_, _, _) => fail("a live candidate should have answered"))
+    assertEquals(result.get(), Success("PONG"))
+    assert(!fixture.wrote(r1), "the dead candidate must not be written to")
+    assert(fixture.wrote(r2))
+    fixture.close()
+  }
+
+  test("walk offloads to establish an unseen candidate") {
+    val fixture            = new Fixture()
+    val (result, complete) = collector()
+    fixture.reads.walk(ping, Vector(r1), m, complete)((_, _, _) => fail("the candidate should have answered"))
+    assertEquals(result.get(), null, "establishing must not run on the caller's thread")
+    fixture.scheduler.advance(Duration.Zero)
+    assertEquals(result.get(), Success("PONG"))
+    fixture.close()
+  }
+
+  test("walk falls through a candidate it cannot establish") {
+    val fixture            = new Fixture(unreachable = Set(r1))
+    val (result, complete) = collector()
+    fixture.reads.walk(ping, Vector(r1, r2), m, complete)((_, _, _) => fail("r2 should have answered"))
+    fixture.scheduler.advance(Duration.Zero)
+    assertEquals(result.get(), Success("PONG"))
+    assert(fixture.wrote(r2))
+    fixture.close()
+  }
+
+  test("walk reports a fault with the node that failed and the candidates left") {
+    val fixture = new Fixture(refusing = Set(r1))
+    fixture.establish(r1)
+    val seen    = new AtomicReference[(Node, Vector[Node])]()
+    fixture.reads.walk(ping, Vector(r1, r2), m, _ => fail("the fault must not complete the command"))((node, _, rest) => seen.set((node, rest)))
+    fixture.scheduler.advance(Duration.Zero)
+    assertEquals(seen.get(), (r1, Vector(r2)))
+    fixture.close()
+  }
+
+  test("pickOne answers the first live candidate, without offloading") {
+    val fixture = new Fixture()
+    fixture.establish(r1)
+    val picked  = new AtomicReference[Option[(Node, NodeClient)]]()
+    fixture.reads.pickOne(Vector(r1), m)(picked.set)
+    assertEquals(picked.get(), Some((r1, fixture.replicaPool.existing(r1))))
+    fixture.close()
+  }
+
+  test("pickOne answers None when every candidate is established but dead") {
+    val fixture = new Fixture()
+    fixture.establish(r1)
+    fixture.kill(r1)
+    val picked  = new AtomicReference[Option[(Node, NodeClient)]]()
+    fixture.reads.pickOne(Vector(r1), m)(picked.set)
+    assertEquals(picked.get(), None)
+    fixture.close()
+  }
+
+  test("pickOne offloads to establish, then answers None when no candidate can be reached") {
+    val fixture = new Fixture(unreachable = Set(r1, r2))
+    val picked  = new AtomicReference[Option[(Node, NodeClient)]]()
+    fixture.reads.pickOne(Vector(r1, r2), m)(picked.set)
+    assertEquals(picked.get(), null, "establishing must not run on the caller's thread")
+    fixture.scheduler.advance(Duration.Zero)
+    assertEquals(picked.get(), None)
+    fixture.close()
+  }
+
+  test("candidatesFor advances its master's round-robin cursor once per call") {
+    val fixture = new Fixture()
+    assertEquals(fixture.reads.candidatesFor(m, Vector(r1, r2)), Vector(r1, r2))
+    assertEquals(fixture.reads.candidatesFor(m, Vector(r1, r2)), Vector(r2, r1))
+    fixture.close()
+  }
+
+  test("candidatesFor refreshes when a replica-preferred read finds no replica") {
+    val preferred = new Fixture(ReadFrom.ReplicaPreferred)
+    assertEquals(preferred.reads.candidatesFor(m, Vector.empty), Vector(m))
+    assertEquals(preferred.refreshes.get(), 1)
+    val strict    = new Fixture()
+    assertEquals(strict.reads.candidatesFor(m, Vector.empty), Vector.empty)
+    assertEquals(strict.refreshes.get(), 0)
+    preferred.close()
+    strict.close()
+  }
+
+  test("retain drops the cursors of departed masters") {
+    val fixture = new Fixture()
+    assertEquals(fixture.reads.candidatesFor(m, Vector(r1, r2)), Vector(r1, r2))
+    fixture.reads.retain(_ => false)
+    assertEquals(fixture.reads.candidatesFor(m, Vector(r1, r2)), Vector(r1, r2))
+    fixture.close()
   }
 }

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -636,20 +636,28 @@ class ClusterClientSpec extends munit.FunSuite {
     }
   }
 
-  test("under ReplicaPreferred a read whose connection dies mid-flight falls through to the master") {
-    val nodeR                   = Node("r", 6379)
-    def slotsWithReplica: Frame =
-      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
-    var fixture: Fixture        = null
-    val behaviour               = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsWithReplica)
+  /**
+    * A shard whose replica's socket dies with the read already written, so its reply fails as `ConnectionLost(mayHaveExecuted = true)`.
+    */
+  private def replicaDiesMidRead(readFrom: ReadFrom, replica: Node): Fixture = {
+    val slots            =
+      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(replica)))))
+    var fixture: Fixture = null
+    val behaviour        = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slots)
       else if (text.contains("GET"))
-        if (node == nodeR) {
-          fixture.drop(nodeR)
+        if (node == replica) {
+          fixture.drop(replica)
           Seq.empty
         } else Seq(Frame.BulkString(Bytes.utf8("from-master")))
       else Seq(Frame.SimpleString("OK"))
-    fixture = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.ReplicaPreferred)
+    fixture = new Fixture(behaviour, Vector(nodeA), readFrom = readFrom)
+    fixture
+  }
+
+  test("under ReplicaPreferred a read whose connection dies mid-flight falls through to the master") {
+    val nodeR   = Node("r", 6379)
+    val fixture = replicaDiesMidRead(ReadFrom.ReplicaPreferred, nodeR)
 
     fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
       assertEquals(result, Some("from-master"))
@@ -658,19 +666,8 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("a read whose connection dies mid-flight on its last candidate fails without re-running the command") {
-    val nodeR                   = Node("r", 6379)
-    def slotsWithReplica: Frame =
-      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
-    var fixture: Fixture        = null
-    val behaviour               = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsWithReplica)
-      else if (text.contains("GET"))
-        if (node == nodeR) {
-          fixture.drop(nodeR)
-          Seq.empty
-        } else Seq(Frame.BulkString(Bytes.utf8("from-master")))
-      else Seq(Frame.SimpleString("OK"))
-    fixture = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.Replica)
+    val nodeR   = Node("r", 6379)
+    val fixture = replicaDiesMidRead(ReadFrom.Replica, nodeR)
 
     fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[ConnectionLost], s"a command that may have executed must surface its loss, not a re-dispatch: $error")

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -636,6 +636,48 @@ class ClusterClientSpec extends munit.FunSuite {
     }
   }
 
+  test("under ReplicaPreferred a read whose connection dies mid-flight falls through to the master") {
+    val nodeR                   = Node("r", 6379)
+    def slotsWithReplica: Frame =
+      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+    var fixture: Fixture        = null
+    val behaviour               = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsWithReplica)
+      else if (text.contains("GET"))
+        if (node == nodeR) {
+          fixture.drop(nodeR)
+          Seq.empty
+        } else Seq(Frame.BulkString(Bytes.utf8("from-master")))
+      else Seq(Frame.SimpleString("OK"))
+    fixture = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.ReplicaPreferred)
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
+      assertEquals(result, Some("from-master"))
+      assert(fixture.written(nodeR).exists(_.contains("GET")), "the replica should have been tried before the master")
+    }
+  }
+
+  test("a read whose connection dies mid-flight on its last candidate fails without re-running the command") {
+    val nodeR                   = Node("r", 6379)
+    def slotsWithReplica: Frame =
+      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+    var fixture: Fixture        = null
+    val behaviour               = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(slotsWithReplica)
+      else if (text.contains("GET"))
+        if (node == nodeR) {
+          fixture.drop(nodeR)
+          Seq.empty
+        } else Seq(Frame.BulkString(Bytes.utf8("from-master")))
+      else Seq(Frame.SimpleString("OK"))
+    fixture = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.Replica)
+
+    fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[ConnectionLost], s"a command that may have executed must surface its loss, not a re-dispatch: $error")
+      assert(!fixture.written(nodeA).exists(_.contains("GET")), "a read that may have executed must not be re-dispatched to the master")
+    }
+  }
+
   test("under a strict Replica policy a replica answering MASTERDOWN fails the read rather than reaching the master") {
     val nodeR                   = Node("r", 6379)
     def slotsWithReplica: Frame =
@@ -719,6 +761,20 @@ class ClusterClientSpec extends munit.FunSuite {
       assertEquals(result, Some("from-master"))
       scheduler.advance(Duration.Zero)
       assertEquals(fixture.clusterSlotsCount(nodeA), before + 1, "the master fallback did not look for a replica")
+    }
+  }
+
+  test("a keyless replica-preferred read with no known replica schedules a topology refresh") {
+    val scheduler = new ManualScheduler
+    val behaviour =
+      (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.BulkString(Bytes.utf8("k")))
+    val fixture   = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.ReplicaPreferred, scheduler = scheduler)
+    val before    = fixture.clusterSlotsCount(nodeA)
+
+    fixture.live.run(Keys.randomKey[String]).unsafeRun.map { result =>
+      assertEquals(result, Some("k"))
+      scheduler.advance(Duration.Zero)
+      assertEquals(fixture.clusterSlotsCount(nodeA), before + 1, "the keyless master fallback did not look for a replica")
     }
   }
 

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -109,6 +109,7 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
 
     val roles                                                           = TrieMap.from(initialRoles)
     @volatile var writesFailReadonly                                    = false
+    @volatile var diesOnRead: Node                                      = null
     private val dials                                                   = new ConcurrentLinkedQueue[Node]()
     private val transports                                              = new ConcurrentLinkedQueue[(Node, FakeTransport)]()
     private val factory: Node => MultiplexedConnection.TransportFactory = node =>
@@ -120,7 +121,10 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
           val reads = text.sliding("ZSCORE".length).count(_ == "ZSCORE")
           if (text.contains("HELLO")) Seq(helloReply)
           else if (text.contains("ROLE")) roles.get(node).toSeq
-          else if (reads > 0) Seq.fill(reads)(Frame.Integer(1L))
+          else if (reads > 0 && node == diesOnRead) {
+            kill(node)
+            Nil
+          } else if (reads > 0) Seq.fill(reads)(Frame.Integer(1L))
           else if (text.contains("ZADD") && writesFailReadonly)
             Seq(Frame.SimpleError("READONLY You can't write against a read only replica."))
           else if (text.contains("ZADD")) Seq(Frame.Integer(1L))
@@ -142,6 +146,9 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     )
 
     def dialled: Vector[Node] = dials.asScala.toVector
+
+    private def kill(node: Node): Unit =
+      transports.asScala.toVector.collect { case (`node`, transport) => transport }.foreach(_.close())
 
     def readsServedBy(node: Node): Int =
       transports.asScala.toVector.collect { case (`node`, transport) =>
@@ -185,6 +192,20 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     fixture.close()
 
     assert(!dialled.contains(advertisedReplica), s"advertised address must not be dialled: $dialled")
+  }
+
+  test("a read whose connection dies mid-flight falls through to the next candidate") {
+    val fixture = new Fixture(
+      seeds = Vector(primary),
+      initialRoles = Map(primary -> masterRole(advertisedReplica), advertisedReplica -> replicaRole(primary))
+    )
+    fixture.live.bootstrapRoles()
+    fixture.diesOnRead = advertisedReplica
+
+    assertEquals(fixture.read(), 1L)
+    assertEquals(fixture.readsServedBy(advertisedReplica), 1)
+    assertEquals(fixture.readsServedBy(primary), 1, "the master should serve the read the replica's dead socket could not")
+    fixture.close()
   }
 
   test("a single seed retains advertised-replica discovery") {


### PR DESCRIPTION
The cluster and master-replica runtimes each carried their own copy of the walk over the Read Policy's ordered candidates. A `diff` of `ClusterLive.tryReadCandidates` against `MasterReplicaLive.tryRead` differed only in the threaded parameter (`redirectsLeft` vs `isMaster`) and the method names, and `liveEstablished`/`establishRead` were identical apart from returning `Some((master, null))` on one side and `Some((null, null))` on the other, with each caller reading that `null` differently.

The copies had drifted. #220 ported the "a replica-preferred read that finds no replica schedules a refresh" rule to cluster months after master-replica already had it, #217 changed one fall-through rule in two places at once, and 7 of the previous 60 commits had to edit both runtimes in lockstep.

`ReadRouting` now owns the walk, the exhaustion refresh, the round-robin cursors, and the pipeline node-pick. Its pure half (`replicaEligible`, `candidates`) is untouched, so its existing tests stand unchanged. What stays mode-specific is what to do with a fault: cluster keeps its redirect budget and re-dispatch, master-replica its role re-discovery.

`ClusterLive` 1400 → 1319 lines, `MasterReplicaLive` 589 → 508, `ReadRouting` 33 → 132. Production code net −45.

## Behavior changes

**A read whose connection dies mid-flight now falls through to the next candidate in cluster mode**, matching master-replica. Only read-only, non-blocking, non-cursor-bound commands reach this walk (`ReadRouting.replicaEligible`), so re-sending one cannot double-apply anything or resume a node-local cursor somewhere it does not belong. Previously a cluster read failed where a live replica could have served it.

`Demoted` stays terminal on both sides: a `READONLY` reply says the master moved, so the shard's replicas may be on the losing side of a failover.

**On the last candidate the two losses split.** Only `Lost(false)` may reach `onUnreachable`, whose contract is that the command provably never executed and which therefore re-dispatches; `onUnreachable` is shared with the write paths, where that invariant is load-bearing. A `Lost(true)` with nothing left refreshes and fails, as master-replica already did.

## The null sentinels are gone

`pickOne` answers `Option[(Node, NodeClient)]` and absorbs the "no candidate is established yet, so establish off the caller's thread" decision that both call sites previously spelled out. No call site sees a null `NodeClient`.

## Tests

11 new cases in `ReadRoutingSpec` drive the walk directly with real `NodePool`s over `FakeTransport` and a `ManualScheduler` that holds every offload, so the slow path is observable rather than raced. No new seam or fake was introduced. Three runtime-level tests cover the behavior change and the keyless refresh rule. Nothing was deleted.

Note: the keyless (`RANDOMKEY`) path calls the shared rule with its own cursor, so a keyless rotation does not share an offset with a master's slot reads. An earlier revision of this branch dropped that refresh entirely and every existing test still passed, so `a keyless replica-preferred read with no known replica schedules a topology refresh` was added and verified to fail without the fix.

## Not in scope

Unifying the fall-through predicate (cluster's `Fault` match vs master-replica's `servesNoRead`), and the two meanings `triggerRefresh` still carries: cluster blocks on an in-flight refresh via `refreshThrottle(force)`, master-replica claims-or-skips via `refreshThrottle.trigger`. Both belong to a follow-up that makes the fault disposition a pure table.