### PR TITLE
Reduce client runtime duplication

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2300,7 +2300,8 @@ object Client {
     try submit
     catch { case NonFatal(error) => complete(Failure(error)) }
 
-  // acquire a fresh lease per execution: a lease is single-shot (cancel is terminal), so a captured one would make a re-run of this value hang
+  // acquire a fresh lease per execution so interruption can release the pool slot; a lease is single-shot (cancel is terminal), so a
+  // captured one would make a re-run of this value hang
   private[internal] def withLeaseIfBlocking[A](command: Command[?])(body: DedicatedPool.Lease => CIO[A]): CIO[A] =
     command.execution match {
       case Execution.Ordinary => body(null)

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2300,6 +2300,11 @@ object Client {
     try submit
     catch { case NonFatal(error) => complete(Failure(error)) }
 
+  // acquire a fresh lease per execution: a lease is single-shot (cancel is terminal), so a captured one would make a re-run of this value hang
+  private[internal] def withBlockingLease[A](command: Command[?])(body: DedicatedPool.Lease => CIO[A]): CIO[A] =
+    if (!command.isBlocking) body(null)
+    else CIO.acquireReleaseWith(CIO.defer(new DedicatedPool.Lease))(lease => CIO.blocking(lease.cancel()))(body)
+
   // attributes the node at the completion site, so a batch that never reaches the wire (a false submit) leaves its callbacks unattributed
   private def attributeOnComplete(cb: Try[Any] => Unit, node: Node): Try[Any] => Unit =
     result => {
@@ -2500,20 +2505,14 @@ object Client {
   ) extends Client[CIO, String] {
 
     def run[A](command: Command[A]): CIO[A] =
-      command.execution match {
-        case Execution.Ordinary =>
-          CIO.async { callback =>
-            val tracked = Events.trackCommand(events, command, callback)
-            Client.completing(tracked)(connection.submit(command, tracked))
+      Client.withBlockingLease(command) { lease =>
+        CIO.async { callback =>
+          val tracked = Events.trackCommand(events, command, callback)
+          Client.completing(tracked) {
+            if (lease == null) connection.submit(command, tracked)
+            else pool.use(command, tracked, lease)
           }
-        case Execution.Blocking =>
-          // acquire a fresh lease per execution: a lease is single-shot (cancel is terminal), so a captured one would make a re-run of this value hang
-          CIO.acquireReleaseWith(CIO.defer(new DedicatedPool.Lease))(lease => CIO.blocking(lease.cancel())) { lease =>
-            CIO.async { callback =>
-              val tracked = Events.trackCommand(events, command, callback)
-              Client.completing(tracked)(pool.use(command, tracked, lease))
-            }
-          }
+        }
       }
 
     def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2301,9 +2301,11 @@ object Client {
     catch { case NonFatal(error) => complete(Failure(error)) }
 
   // acquire a fresh lease per execution: a lease is single-shot (cancel is terminal), so a captured one would make a re-run of this value hang
-  private[internal] def withBlockingLease[A](command: Command[?])(body: DedicatedPool.Lease => CIO[A]): CIO[A] =
-    if (!command.isBlocking) body(null)
-    else CIO.acquireReleaseWith(CIO.defer(new DedicatedPool.Lease))(lease => CIO.blocking(lease.cancel()))(body)
+  private[internal] def withLeaseIfBlocking[A](command: Command[?])(body: DedicatedPool.Lease => CIO[A]): CIO[A] =
+    command.execution match {
+      case Execution.Ordinary => body(null)
+      case Execution.Blocking => CIO.acquireReleaseWith(CIO.defer(new DedicatedPool.Lease))(lease => CIO.blocking(lease.cancel()))(body)
+    }
 
   // attributes the node at the completion site, so a batch that never reaches the wire (a false submit) leaves its callbacks unattributed
   private def attributeOnComplete(cb: Try[Any] => Unit, node: Node): Try[Any] => Unit =
@@ -2471,7 +2473,7 @@ object Client {
           () => connection.isLive,
           events = events
         )
-        new Live(connection, pool, subscriptions, cachingEnabled, events)
+        new Live(new NodeClient(connection, pool), subscriptions, cachingEnabled, events)
       }
       .mapError { error =>
         events.close()
@@ -2497,28 +2499,24 @@ object Client {
     }
 
   final private class Live(
-    connection: MultiplexedConnection,
-    pool: DedicatedPool,
+    nodeClient: NodeClient,
     subscriptions: SubscriptionConnection,
     cachingEnabled: Boolean,
     events: Events
   ) extends Client[CIO, String] {
 
     def run[A](command: Command[A]): CIO[A] =
-      Client.withBlockingLease(command) { lease =>
+      Client.withLeaseIfBlocking(command) { lease =>
         CIO.async { callback =>
           val tracked = Events.trackCommand(events, command, callback)
-          Client.completing(tracked) {
-            if (lease == null) connection.submit(command, tracked)
-            else pool.use(command, tracked, lease)
-          }
+          Client.completing(tracked)(nodeClient.submit(command, asking = false, tracked, lease))
         }
       }
 
     def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =
       if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command))
       else if (!cachingEnabled) run(command) // tracking was never enabled, so run uncached rather than issue an unbacked CLIENT CACHING YES
-      else CIO.async(callback => Client.completing(callback)(connection.cachedSubmit(command, ttl.toMillis, callback)))
+      else CIO.async(callback => Client.completing(callback)(nodeClient.cachedSubmit(command, ttl.toMillis, callback)))
 
     def scanTargets: CIO[Vector[ScanTarget]] = CIO.value(Vector(ScanTarget.any))
 
@@ -2541,7 +2539,7 @@ object Client {
 
     private def acquireScope: CIO[TxScope] =
       CIO.blocking {
-        try new TxScope(pool.acquireForTransaction(), events = events)
+        try new TxScope(nodeClient.acquireForTransaction(), events = events)
         catch {
           case e: SageException => throw e
           case NonFatal(_)      => throw ConnectionLost(mayHaveExecuted = false)
@@ -2549,7 +2547,7 @@ object Client {
       }
 
     private def releaseScope(scope: TxScope): CIO[Unit] =
-      CIO.blocking(pool.releaseTransaction(scope.conn, scope.sealAndReusable()))
+      CIO.blocking(nodeClient.releaseTransaction(scope.conn, scope.sealAndReusable()))
 
     private def submitPipeline[Out, R](p: Pipeline[Out, R]): CIO[Vector[Either[SageException, Any]]] =
       if (p.commands.isEmpty)
@@ -2558,7 +2556,7 @@ object Client {
         CIO.fail(InvalidArgument("a Pipeline cannot carry blocking commands; run them individually on the client"))
       else
         CIO.async { complete =>
-          Client.submitBatchOnOne(events, p.commands, Events.startSpans(events, p.commands), connection.submitAll, complete)
+          Client.submitBatchOnOne(events, p.commands, Events.startSpans(events, p.commands), nodeClient.submitAll, complete)
         }
 
     def subscribeChannels[V: ValueCodec](channel: String, rest: String*): CIO[Subscription[CIO, Message[V]]] =
@@ -2573,8 +2571,7 @@ object Client {
 
     def close: CIO[Unit] = CIO.blocking {
       subscriptions.close()
-      pool.close()
-      connection.close()
+      nodeClient.close()
       events.close()
     }
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -131,7 +131,7 @@ final private[client] class ClusterLive(
         val tracked = Events.trackCommand(events, command, complete, span)
         Client.completing(tracked)(dispatch(command, cluster.maxRedirects, tracked, lease = lease))
       }
-    Client.withBlockingLease(command)(body)
+    Client.withLeaseIfBlocking(command)(body)
   }
 
   def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =
@@ -174,7 +174,7 @@ final private[client] class ClusterLive(
             val tracked = Events.trackCommand(events, command, complete, span)
             Client.completing(tracked)(sendTo(node, command, asking = false, redirectsLeft = 0, tracked, lease))
           }
-        Client.withBlockingLease(command)(body)
+        Client.withLeaseIfBlocking(command)(body)
       case None       => run(command)
     }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -131,9 +131,7 @@ final private[client] class ClusterLive(
         val tracked = Events.trackCommand(events, command, complete, span)
         Client.completing(tracked)(dispatch(command, cluster.maxRedirects, tracked, lease = lease))
       }
-    if (!command.isBlocking) body(null)
-    // acquire a fresh lease per execution: a lease is single-shot (cancel is terminal), so a captured one would make a re-run of this value hang
-    else CIO.acquireReleaseWith(CIO.defer(new DedicatedPool.Lease))(lease => CIO.blocking(lease.cancel()))(body)
+    Client.withBlockingLease(command)(body)
   }
 
   def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =
@@ -176,9 +174,7 @@ final private[client] class ClusterLive(
             val tracked = Events.trackCommand(events, command, complete, span)
             Client.completing(tracked)(sendTo(node, command, asking = false, redirectsLeft = 0, tracked, lease))
           }
-        // mirror run: a blocking command needs a cancelable lease so an interrupt releases the slot instead of leaking it
-        if (!command.isBlocking) body(null)
-        else CIO.acquireReleaseWith(CIO.defer(new DedicatedPool.Lease))(lease => CIO.blocking(lease.cancel()))(body)
+        Client.withBlockingLease(command)(body)
       case None       => run(command)
     }
 
@@ -1114,21 +1110,12 @@ final private[client] class ClusterLive(
       }
 
     private def commandSlot(command: Command[?]): Either[Throwable, Option[Slot]] =
-      if (command.hasMalformedKeys)
-        Left(malformedKeys(command.name))
-      else if (command.keyIndices.isEmpty)
-        Right(None)
-      else {
-        val keyIndices = command.keyIndices
-        val first      = Slot.of(command.args(keyIndices.head))
-        var i          = 1
-        var crossed    = false
-        while (i < keyIndices.length && !crossed) {
-          if (Slot.of(command.args(keyIndices(i))) != first) crossed = true
-          i += 1
-        }
-        if (crossed) Left(crossSlot(command.name, keyIndices.iterator.map(index => Slot.of(command.args(index))).toSet))
-        else Right(Some(first))
+      topologyRef.get().route(command) match {
+        case Route.Malformed        => Left(malformedKeys(command.name))
+        case Route.Keyless          => Right(None)
+        case Route.ToNode(_, slot)  => Right(Some(slot))
+        case Route.Unowned(slot)    => Right(Some(slot))
+        case Route.CrossSlot(slots) => Left(crossSlot(command.name, slots))
       }
 
     private def pipelineSlot[Out, R](p: Pipeline[Out, R]): Either[Throwable, Option[Slot]] = {

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -1109,6 +1109,7 @@ final private[client] class ClusterLive(
         topologyRef.get().nodeForSlot(slot)
       }
 
+    // transaction pinning depends on the key slot, not its current owner, so both owned and unowned routes retain the classified slot
     private def commandSlot(command: Command[?]): Either[Throwable, Option[Slot]] =
       topologyRef.get().route(command) match {
         case Route.Malformed        => Left(malformedKeys(command.name))

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
@@ -43,14 +43,10 @@ final private[client] class ClusterSubscriptions(
   // --- classic state (guarded by lock) ---
   private var classicConn: SubscriptionConnection = null
   private val classicSubs                         = mutable.LinkedHashSet.empty[ClassicSub]
-  private var rehomeRunning                       = false
-  private var rehomeQueued                        = false
 
   // --- sharded state (guarded by lock) ---
-  private val shardConns       = mutable.HashMap.empty[Node, SubscriptionConnection]
-  private val shardSubs        = mutable.LinkedHashSet.empty[ShardSub]
-  private var reconcileRunning = false
-  private var reconcileQueued  = false
+  private val shardConns = mutable.HashMap.empty[Node, SubscriptionConnection]
+  private val shardSubs  = mutable.LinkedHashSet.empty[ShardSub]
 
   private var closed = false
 
@@ -61,6 +57,46 @@ final private[client] class ClusterSubscriptions(
   }
 
   private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
+
+  // single-flight (one running, at most one queued): a mid-pass trigger queues one follow-up rather than racing a concurrent pass
+  final private class CoalescedPass(body: () => Unit) {
+    private var running = false
+    private var queued  = false
+
+    def schedule(): Unit = {
+      val go = locked {
+        if (closed) false
+        else if (running) {
+          queued = true
+          false
+        } else {
+          running = true
+          true
+        }
+      }
+      if (go) offload(run())
+    }
+
+    private def run(): Unit = {
+      body()
+      val again = locked {
+        if (!closed && queued) {
+          queued = false
+          true
+        } else {
+          running = false
+          false
+        }
+      }
+      if (again) offload(run())
+    }
+  }
+
+  private val classicRehome  = new CoalescedPass(() => {
+    refresh()
+    rehomeClassic()
+  })
+  private val shardReconcile = new CoalescedPass(() => reconcileShard())
 
   // --- classic (channels / patterns) -------------------------------------------------------------------------------------------------------
 
@@ -116,40 +152,10 @@ final private[client] class ClusterSubscriptions(
 
   private def onClassicTerminated(): Unit = {
     locked { classicConn = null }
-    scheduleRehomeClassic()
+    classicRehome.schedule()
   }
 
-  // single-flight (one running, at most one queued): a mid-pass trigger queues a follow-up rather than racing a concurrent pass. Refresh the
-  // topology first — the master may be gone, so the re-home target comes from the current topology, not the stale one.
-  private def scheduleRehomeClassic(): Unit = {
-    val go = locked {
-      if (closed) false
-      else if (rehomeRunning) {
-        rehomeQueued = true
-        false
-      } else {
-        rehomeRunning = true
-        true
-      }
-    }
-    if (go) offload(runRehomeClassicPass())
-  }
-
-  private def runRehomeClassicPass(): Unit = {
-    refresh()
-    rehomeClassic()
-    val again = locked {
-      if (!closed && rehomeQueued) {
-        rehomeQueued = false
-        true
-      } else {
-        rehomeRunning = false
-        false
-      }
-    }
-    if (again) offload(runRehomeClassicPass())
-  }
-
+  // refresh first: the failed master may be gone, so the re-home target must come from the current topology
   private def rehomeClassic(): Unit = {
     val subs = locked(if (closed || classicSubs.isEmpty) Vector.empty[ClassicSub] else classicSubs.toVector)
     if (subs.nonEmpty) {
@@ -183,7 +189,7 @@ final private[client] class ClusterSubscriptions(
   }
 
   private def scheduleRehomeRetry(): Unit =
-    if (!locked(closed)) scheduler.after(reconnect.initialDelay)(scheduleRehomeClassic())
+    if (!locked(closed)) scheduler.after(reconnect.initialDelay)(classicRehome.schedule())
 
   // --- sharded (shard channels) ------------------------------------------------------------------------------------------------------------
 
@@ -245,40 +251,11 @@ final private[client] class ClusterSubscriptions(
     // owner, which planFor would not see as unowned — then reconcile onto the current owner
     offload {
       refresh()
-      scheduleReconcile()
+      shardReconcile.schedule()
     }
   }
 
-  def onTopologyChanged(): Unit = scheduleReconcile()
-
-  // single-flight (one running, at most one queued): a mid-pass trigger queues a follow-up rather than racing a concurrent pass that would corrupt the ledger
-  private def scheduleReconcile(): Unit = {
-    val go = locked {
-      if (closed) false
-      else if (reconcileRunning) {
-        reconcileQueued = true
-        false
-      } else {
-        reconcileRunning = true
-        true
-      }
-    }
-    if (go) offload(runReconcilePass())
-  }
-
-  private def runReconcilePass(): Unit = {
-    reconcileShard()
-    val again = locked {
-      if (!closed && reconcileQueued) {
-        reconcileQueued = false
-        true
-      } else {
-        reconcileRunning = false
-        false
-      }
-    }
-    if (again) offload(runReconcilePass())
-  }
+  def onTopologyChanged(): Unit = shardReconcile.schedule()
 
   // re-home each sub onto its channels' current owners. One refresh per pass; an incomplete pass retries so a transient failover failure converges.
   private def reconcileShard(): Unit = {
@@ -300,7 +277,7 @@ final private[client] class ClusterSubscriptions(
 
   // an incomplete placement (owner unreachable, or a Slot still unowned mid-failover) retries after a short delay until it converges
   private def scheduleRetry(): Unit =
-    if (!locked(closed)) scheduler.after(reconnect.initialDelay)(scheduleReconcile())
+    if (!locked(closed)) scheduler.after(reconnect.initialDelay)(shardReconcile.schedule())
 
   private def closeShard(sub: ShardSub): Unit = {
     locked(shardSubs -= sub)

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
@@ -92,6 +92,7 @@ final private[client] class ClusterSubscriptions(
     }
   }
 
+  // refresh first: the failed master may be gone, so the re-home target must come from the current topology
   private val classicRehome  = new CoalescedPass(() => {
     refresh()
     rehomeClassic()
@@ -155,7 +156,6 @@ final private[client] class ClusterSubscriptions(
     classicRehome.schedule()
   }
 
-  // refresh first: the failed master may be gone, so the re-home target must come from the current topology
   private def rehomeClassic(): Unit = {
     val subs = locked(if (closed || classicSubs.isEmpty) Vector.empty[ClassicSub] else classicSubs.toVector)
     if (subs.nonEmpty) {

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
@@ -58,7 +58,7 @@ final private[client] class ClusterSubscriptions(
 
   private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
 
-  // single-flight (one running, at most one queued): a mid-pass trigger queues one follow-up rather than racing a concurrent pass
+  // single-flight under the outer lock: a mid-pass trigger queues one follow-up rather than racing a pass that could corrupt placement
   final private class CoalescedPass(body: () => Unit) {
     private var running = false
     private var queued  = false
@@ -77,19 +77,20 @@ final private[client] class ClusterSubscriptions(
       if (go) offload(run())
     }
 
-    private def run(): Unit = {
-      body()
-      val again = locked {
-        if (!closed && queued) {
-          queued = false
-          true
-        } else {
-          running = false
-          false
+    private def run(): Unit =
+      try body()
+      finally {
+        val again = locked {
+          if (!closed && queued) {
+            queued = false
+            true
+          } else {
+            running = false
+            false
+          }
         }
+        if (again) offload(run())
       }
-      if (again) offload(run())
-    }
   }
 
   // refresh first: the failed master may be gone, so the re-home target must come from the current topology

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -226,7 +226,7 @@ final private[client] class MasterReplicaLive(
           else sendMaster(command, tracked, lease)
         }
       }
-    Client.withBlockingLease(command)(body)
+    Client.withLeaseIfBlocking(command)(body)
   }
 
   def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -226,9 +226,7 @@ final private[client] class MasterReplicaLive(
           else sendMaster(command, tracked, lease)
         }
       }
-    if (!command.isBlocking) body(null)
-    // acquire a fresh lease per execution: a lease is single-shot (cancel is terminal), so a captured one would make a re-run of this value hang
-    else CIO.acquireReleaseWith(CIO.defer(new DedicatedPool.Lease))(lease => CIO.blocking(lease.cancel()))(body)
+    Client.withBlockingLease(command)(body)
   }
 
   def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
@@ -9,8 +9,8 @@ import sage.cluster.Node
 import sage.commands.Command
 
 /**
-  * One cluster Node's connection bundle: the same Multiplexed Connection + Dedicated Pool a standalone client uses, pinned to a single
-  * node. The cluster runtime holds one per master it routes to. `asking` prefixes the command with `ASKING` to follow an `ASK` redirect.
+  * One node's connection bundle: a Multiplexed Connection + Dedicated Pool pinned to that node. A standalone client holds one; the cluster
+  * runtime holds one per master it routes to. `asking` prefixes the command with `ASKING` to follow an `ASK` redirect.
   */
 final private[client] class NodeClient(connection: MultiplexedConnection, pool: DedicatedPool) {
 
@@ -22,7 +22,7 @@ final private[client] class NodeClient(connection: MultiplexedConnection, pool: 
     } else if (asking) connection.submitAsking(command, callback)
     else connection.submit(command, callback)
 
-  def cachedSubmit[A](command: Command[A], ttlMillis: Long, callback: Try[A] => Unit, deferred: () => CommandSpan): Unit =
+  def cachedSubmit[A](command: Command[A], ttlMillis: Long, callback: Try[A] => Unit, deferred: () => CommandSpan = null): Unit =
     connection.cachedSubmit(command, ttlMillis, callback, deferred)
 
   // a pipeline's per-node batch: one round-trip on this node's Multiplexed Connection. False when not connected (nothing submitted), so


### PR DESCRIPTION
## Summary

- centralize blocking-command lease acquisition and cancellation across standalone, cluster, scan-target, and master/replica execution paths
- reuse `ClusterTopology.route` for cluster transaction slot classification
- share the classic and sharded subscription coalescing state machine
- reuse `NodeClient` as the standalone connection/pool bundle, keeping dispatch policy in one place
- keep subscription recovery schedulable when a coalesced pass throws unexpectedly

## Why

These paths carried parallel implementations of the same lifecycle, routing, and scheduling rules. Consolidating them reduces opportunities for behavior to drift and makes future maintenance more localized.

The production diff removes 121 lines and adds 82, for a net reduction of 39 lines. There are no public API changes.

## Validation

- `sbt scalafmtCheck`
- `sbt clientZio/test` — 355 tests passed
- `sbt testUnit` — passed across all effect backends
- two-axis code review — no actionable correctness findings