### PR TITLE
Deduplicate shared idioms in the client internals

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/Bootstrap.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Bootstrap.scala
@@ -41,27 +41,30 @@ private[client] object Bootstrap {
     onTolerated: Command[?] => Unit = _ => ()
   ): Unit =
     commands.foreach { command =>
-      val latch   = new CountDownLatch(1)
-      val outcome = new AtomicReference[Try[Any]]()
-      submit(
-        command,
-        result => {
-          outcome.set(result)
-          latch.countDown()
-        }
-      )
-      if (!latch.await(connectTimeoutMillis, TimeUnit.MILLISECONDS)) {
-        close()
-        throw ConnectionLost(mayHaveExecuted = false)
-      }
-      outcome.get() match {
-        case Failure(_: ServerError) if bestEffort(command) => onTolerated(command)
-        case Failure(error)                                 =>
+      awaitReply[Any](connectTimeoutMillis)(callback => submit(command, callback)) match {
+        case None                                                 =>
+          close()
+          throw ConnectionLost(mayHaveExecuted = false)
+        case Some(Failure(_: ServerError)) if bestEffort(command) => onTolerated(command)
+        case Some(Failure(error))                                 =>
           close()
           throw error
-        case Success(_)                                     => ()
+        case Some(Success(_))                                     => ()
       }
     }
+
+  /**
+    * Submits one command and blocks the calling thread for its reply; `None` is the timeout.
+    */
+  def awaitReply[A](timeoutMillis: Long)(submit: (Try[A] => Unit) => Unit): Option[Try[A]] = {
+    val latch   = new CountDownLatch(1)
+    val outcome = new AtomicReference[Try[A]]()
+    submit { result =>
+      outcome.set(result)
+      latch.countDown()
+    }
+    if (latch.await(timeoutMillis, TimeUnit.MILLISECONDS)) Some(outcome.get()) else None
+  }
 
   /**
     * Whether a server-error reply to this command may be tolerated during bootstrap. `CLIENT SETINFO` qualifies because it is library

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2419,18 +2419,8 @@ object Client {
       connectWith(
         (onFrame, onClosed) => SocketTransport.connect(endpoint.host, endpoint.port, config.connectTimeout, upgrade, onFrame, onClosed),
         Scheduler.real,
-        config.reconnect,
-        config.watchdog,
-        config.connectTimeout,
-        config.closeTimeout,
-        config.dedicatedPool,
-        config.pubsub,
-        config.auth,
-        config.clientCache.maxBytes,
-        config.clientCache.enabled,
-        Events(config.listeners, config.tracer, serverNode = Some(Node(endpoint.host, endpoint.port))),
-        config.database,
-        config.clientName
+        config,
+        Events(config.listeners, config.tracer, serverNode = Some(Node(endpoint.host, endpoint.port)))
       )
     }
 
@@ -2438,39 +2428,41 @@ object Client {
   private[client] def connectWith(
     factory: MultiplexedConnection.TransportFactory,
     scheduler: Scheduler = Scheduler.real,
-    reconnect: BackoffConfig = defaults.reconnect,
-    watchdog: WatchdogConfig = defaults.watchdog,
-    connectTimeout: FiniteDuration = defaults.connectTimeout,
-    closeTimeout: FiniteDuration = defaults.closeTimeout,
-    dedicatedPool: DedicatedPoolConfig = defaults.dedicatedPool,
-    pubsub: PubSubConfig = defaults.pubsub,
-    auth: Option[AuthConfig] = None,
-    cacheMaxBytes: Long = defaults.clientCache.maxBytes,
-    cachingEnabled: Boolean = defaults.clientCache.enabled,
-    events: Events = Events.disabled,
-    database: Int = 0,
-    clientName: Option[String] = None
+    config: SageConfig = defaults,
+    events: Events = Events.disabled
   ): CIO[Client[CIO, String]] = {
-    val bootstrap            = Bootstrap.commands(auth, database, clientName)
+    val cachingEnabled       = config.clientCache.enabled
+    val connectTimeout       = config.connectTimeout
+    val bootstrap            = Bootstrap.commands(config.auth, config.database, config.clientName)
     // only the Multiplexed Connection caches reads, so only it enables tracking; the dedicated pool and subscription connection keep the
     // plain bootstrap. Tracking is skipped entirely when caching is disabled, so a server that denies CLIENT TRACKING still connects.
     val multiplexedBootstrap = if (cachingEnabled) bootstrap :+ Connection.clientTrackingOnOptin else bootstrap
     CIO
       .blocking(
-        MultiplexedConnection
-          .connect(factory, scheduler, multiplexedBootstrap, reconnect, watchdog, connectTimeout, closeTimeout, cacheMaxBytes, None, events)
+        MultiplexedConnection.connect(
+          factory,
+          scheduler,
+          multiplexedBootstrap,
+          config.reconnect,
+          config.watchdog,
+          connectTimeout,
+          config.closeTimeout,
+          config.clientCache.maxBytes,
+          None,
+          events
+        )
       )
       .map { connection =>
-        val pool          = DedicatedPool.forConnection(factory, bootstrap, scheduler, connection, dedicatedPool, connectTimeout.toMillis)
+        val pool          = DedicatedPool.forConnection(factory, bootstrap, scheduler, connection, config.dedicatedPool, connectTimeout.toMillis)
         // lazy: no socket is opened until the first subscription, and it is gated on the Multiplexed Connection being live
         val subscriptions = new SubscriptionConnection(
           factory,
           bootstrap,
           scheduler,
-          reconnect,
-          watchdog,
+          config.reconnect,
+          config.watchdog,
           connectTimeout.toMillis,
-          pubsub.bufferSize,
+          config.pubsub.bufferSize,
           () => connection.isLive,
           events = events
         )
@@ -2642,15 +2634,6 @@ object Client {
       case success                  => complete(success)
     }
 
-    // an EXEC fault arrives as an error *frame* in a Success, invisible to `faulting`, so scan the top level and the EXEC array
-    private def refreshOnExecFault(frames: Vector[Frame]): Unit = {
-      val nested = frames.lastOption match {
-        case Some(Frame.Array(elems)) => elems.iterator
-        case _                        => Iterator.empty[Frame]
-      }
-      (frames.iterator ++ nested).flatMap(TxSupport.errorOf).foreach(message => onFault(ServerError.of(message)))
-    }
-
     // The lock makes "reject if released, else submit" atomic with the finalizer's seal-and-decide ([[sealAndReusable]]): a command
     // submitted under it is in-flight before the finalizer reads quiescence, so a handle captured past the block and raced against release
     // either submits onto a connection the finalizer then declines to recycle, or is rejected outright — never onto a re-borrowed one.
@@ -2735,7 +2718,7 @@ object Client {
           }
           .flatMap { frames =>
             armed.set(false) // EXEC clears WATCH/MULTI state server-side whether it committed or aborted
-            refreshOnExecFault(frames)
+            TxSupport.execErrors(frames).foreach(onFault)
             TxSupport.interpretExec(p.commands, frames)
           }
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -1,7 +1,6 @@
 package sage.client.internal
 
 import java.util.Locale
-import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.util.concurrent.locks.ReentrantLock
 
@@ -111,7 +110,7 @@ final private[client] class ClusterLive(
     while (candidates.hasNext) {
       val node = candidates.next()
       try
-        querySlotsVia(node, getOrEstablish(node)) match {
+        querySlotsVia(node) match {
           case Right(shards) =>
             adopt(node, shards)
             startRefreshPoll()
@@ -127,8 +126,7 @@ final private[client] class ClusterLive(
   def run[A](command: Command[A]): CIO[A] = {
     def body(lease: DedicatedPool.Lease): CIO[A] =
       CIO.async[A] { complete =>
-        val span    = Events.startSpan(events, command)
-        val tracked = Events.trackCommand(events, command, complete, span)
+        val tracked = Events.trackCommand(events, command, complete)
         Client.completing(tracked)(dispatch(command, cluster.maxRedirects, tracked, lease = lease))
       }
     Client.withLeaseIfBlocking(command)(body)
@@ -138,8 +136,7 @@ final private[client] class ClusterLive(
     if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command))
     else if (!cachingEnabled)
       CIO.async[A] { complete =>
-        val span    = Events.startSpan(events, command)
-        val tracked = Events.trackCommand(events, command, complete, span)
+        val tracked = Events.trackCommand(events, command, complete)
         Client.completing(tracked)(dispatch(command, cluster.maxRedirects, tracked, allowReplica = false))
       }
     else
@@ -170,8 +167,7 @@ final private[client] class ClusterLive(
       case Some(node) =>
         def body(lease: DedicatedPool.Lease): CIO[A] =
           CIO.async[A] { complete =>
-            val span    = Events.startSpan(events, command)
-            val tracked = Events.trackCommand(events, command, complete, span)
+            val tracked = Events.trackCommand(events, command, complete)
             Client.completing(tracked)(sendTo(node, command, asking = false, redirectsLeft = 0, tracked, lease))
           }
         Client.withLeaseIfBlocking(command)(body)
@@ -218,7 +214,7 @@ final private[client] class ClusterLive(
       if (command.allMasters)
         if (slotOwningMasters(topology).forall(node => masterPool.existing(node) != null))
           broadcast(topology, command, redirectsLeft, complete, masterPool.existing)
-        else offload(broadcast(topology, command, redirectsLeft, complete, establishOrNull))
+        else scheduler.offload(broadcast(topology, command, redirectsLeft, complete, masterPool.getOrEstablishOrNull))
       else
         topology.route(command) match {
           case Route.ToNode(node, slot) =>
@@ -229,7 +225,7 @@ final private[client] class ClusterLive(
             if (allowReplica && readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command))
               sendKeylessRead(topology, command, redirectsLeft, complete)
             else sendToAny(topology, command, redirectsLeft, complete, lease, cacheCtx)
-          case Route.Unowned(_)         => offload(onUnowned(command, redirectsLeft, complete, lease, cacheCtx))
+          case Route.Unowned(_)         => scheduler.offload(onUnowned(command, redirectsLeft, complete, lease, cacheCtx))
           case Route.CrossSlot(slots)   =>
             multiSlotPolicy(command) match {
               case Some(policy) => scatterMultiSlot(command, policy, redirectsLeft, complete, allowReplica, cacheCtx)
@@ -389,7 +385,7 @@ final private[client] class ClusterLive(
             complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
           case RedirectKind.Moved                       =>
             refresh(force = true)
-            offload(dispatch(command, redirectsLeft - 1, complete))
+            scheduler.offload(dispatch(command, redirectsLeft - 1, complete))
         }
       // only a loss that provably never ran may re-dispatch, per onUnreachable's contract
       case Fault.Lost(executed)           =>
@@ -490,14 +486,14 @@ final private[client] class ClusterLive(
   private def submitBroadcast[B](node: Node, command: Command[B], resolve: Node => NodeClient, attemptsLeft: Int, settle: Try[B] => Unit): Unit = {
     val nc = resolve(node)
     // the dispatch fast path resolves inline on the caller, which the retry's refresh would block
-    if (nc == null) offload(retryBroadcast(node, command, NotConnected(), refreshFirst = true, attemptsLeft, settle))
+    if (nc == null) scheduler.offload(retryBroadcast(node, command, NotConnected(), refreshFirst = true, attemptsLeft, settle))
     else
       nc.submit[B](
         command,
         asking = false,
         {
           case Success(value) => settle(Success(value))
-          case Failure(error) => offload(onBroadcastFailure(node, command, error, attemptsLeft, settle))
+          case Failure(error) => scheduler.offload(onBroadcastFailure(node, command, error, attemptsLeft, settle))
         }
       )
   }
@@ -532,7 +528,7 @@ final private[client] class ClusterLive(
       afterBackoff(attemptsLeft) {
         if (refreshFirst) refresh(force = true)
         if (closed || !slotOwningMasters(topologyRef.get()).contains(node)) settle(Failure(error))
-        else submitBroadcast(node, command, establishOrNull, attemptsLeft - 1, settle)
+        else submitBroadcast(node, command, masterPool.getOrEstablishOrNull, attemptsLeft - 1, settle)
       }
 
   private def collectFrames(frames: java.util.concurrent.atomic.AtomicReferenceArray[Frame], size: Int): Vector[Frame] = {
@@ -579,10 +575,8 @@ final private[client] class ClusterLive(
     val existing = masterPool.existing(node)
     if (existing != null) submitTo(existing, node, command, asking, redirectsLeft, complete, lease, cacheCtx)
     else
-      offload {
-        val nc =
-          try getOrEstablish(node)
-          catch { case NonFatal(_) => null }
+      scheduler.offload {
+        val nc = masterPool.getOrEstablishOrNull(node)
         if (nc == null) onUnreachable(command, redirectsLeft, complete, lease, cacheCtx)
         else submitTo(nc, node, command, asking, redirectsLeft, complete, lease, cacheCtx)
       }
@@ -602,7 +596,7 @@ final private[client] class ClusterLive(
       case Success(value) =>
         Events.attributeNode(complete, node)
         complete(Success(value))
-      case Failure(error) => offload(onFailure(node, command, error, redirectsLeft, complete, lease, cacheCtx))
+      case Failure(error) => scheduler.offload(onFailure(node, command, error, redirectsLeft, complete, lease, cacheCtx))
     }
     if (cacheCtx != null && !asking) nc.cachedSubmit[A](command, cacheCtx.ttlMillis, onReply, cacheCtx.deferred)
     else nc.submit[A](command, asking, onReply, lease)
@@ -664,16 +658,7 @@ final private[client] class ClusterLive(
     complete: Try[A] => Unit,
     lease: DedicatedPool.Lease = null,
     cacheCtx: Cached = null
-  ): Unit =
-    if (redirectsLeft <= 0) {
-      refreshBeforeFailing()
-      complete(Failure(NotConnected()))
-    } else {
-      refresh(force = true)
-      afterBackoff(redirectsLeft)(
-        dispatch(command, redirectsLeft - 1, complete, allowReplica = replicaAllowed(cacheCtx), lease = lease, cacheCtx = cacheCtx)
-      )
-    }
+  ): Unit = onRetryable(command, NotConnected(), refreshFirst = true, redirectsLeft, complete, lease, cacheCtx)
 
   // a self-clearing refusal (-TRYAGAIN, -LOADING, -MASTERDOWN, -CLUSTERDOWN): retry bounded and jittered
   private def onRetryable[A](
@@ -726,8 +711,6 @@ final private[client] class ClusterLive(
   private def pickNode(topology: ClusterTopology): Option[Node] =
     masterPool.firstLiveNode.orElse(topology.shards.headOption.map(_.master))
 
-  private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
-
   private def crossSlot(name: String, slots: Set[Slot]): CrossSlot =
     CrossSlot(s"$name: keys span ${slots.size} slots; a single command must touch exactly one")
 
@@ -735,7 +718,7 @@ final private[client] class ClusterLive(
     InvalidArgument(s"$name: declared key positions fall outside its arguments")
 
   // a transaction never follows a redirect, so an ownership move must be adopted before the caller can retry: bypass the throttle window
-  private def forceRefresh(): Unit = offload(refresh(force = true))
+  private def forceRefresh(): Unit = scheduler.offload(refresh(force = true))
 
   // --- pipelines (split per node, batch each, merge in submission order) ----------------------------------------------------------------
 
@@ -820,10 +803,8 @@ final private[client] class ClusterLive(
       val existing = masterPool.existing(node)
       if (existing != null) submitBatch(node, existing, indices, p, emits, reroute, useReplica)
       else
-        offload {
-          val nc =
-            try getOrEstablish(node)
-            catch { case NonFatal(_) => null }
+        scheduler.offload {
+          val nc = masterPool.getOrEstablishOrNull(node)
           submitBatch(node, nc, indices, p, emits, reroute, useReplica)
         }
     }
@@ -846,7 +827,7 @@ final private[client] class ClusterLive(
         case Success(_)     => settle(index, result)
         // a fault's disposition can block on CLUSTER SLOTS, whose reply needs this very reader thread
         case Failure(error) =>
-          offload {
+          scheduler.offload {
             Fault.categorize(error) match {
               // ASK keeps the slot's owner, so re-routing by topology bounces off the exporting node and burns a redirect; follow it straight
               // to the importing node with ASKING. MOVED and connection loss re-route normally.
@@ -900,7 +881,7 @@ final private[client] class ClusterLive(
       val command = Connection.watch(key, rest*)
       CIO.async[Unit] { complete =>
         val tracked = Events.trackSpan(events, command, complete)
-        offload(withConn(command, tracked) { c =>
+        scheduler.offload(withConn(command, tracked) { c =>
           armed.set(true)
           c.submit(command, faulting(tracked))
         })
@@ -919,12 +900,12 @@ final private[client] class ClusterLive(
       else
         CIO.async[A] { complete =>
           val tracked = Events.trackSpan(events, command, complete)
-          offload(withConn(command, tracked)(c => c.submit(command, faulting(tracked))))
+          scheduler.offload(withConn(command, tracked)(c => c.submit(command, faulting(tracked))))
         }
 
     def discard: CIO[Unit] =
       CIO.async[Unit] { complete =>
-        offload {
+        scheduler.offload {
           lock.lock()
           try
             if (released) complete(Failure(TxSupport.scopeReleasedError))
@@ -956,15 +937,8 @@ final private[client] class ClusterLive(
       case success                  => complete(success)
     }
 
-    // EXEC replies arrive as a Success carrying raw frames, so an ownership fault is an error *frame*, invisible to `faulting`; scan the top
-    // level and the EXEC array and refresh on any non-terminal one so the caller's retry re-pins
-    private def refreshOnExecFault(frames: Vector[Frame]): Unit = {
-      val nested = frames.lastOption match {
-        case Some(Frame.Array(elems)) => elems.iterator
-        case _                        => Iterator.empty[Frame]
-      }
-      refreshFor((frames.iterator ++ nested).flatMap(TxSupport.errorOf).map(m => Fault.categorize(ServerError.of(m))).toVector)
-    }
+    private def refreshOnExecFault(frames: Vector[Frame]): Unit =
+      refreshFor(TxSupport.execErrors(frames).map(Fault.categorize).toVector)
 
     private[sage] def exec[Out, R](p: Pipeline[Out, R]): CIO[Option[Out]] =
       runExec(p).flatMap {
@@ -992,7 +966,7 @@ final private[client] class ClusterLive(
         CIO
           .async[Vector[Frame]] { complete =>
             val tracked = Events.trackSpan(events, Connection.multi, complete)
-            offload(submitExec(p, tracked))
+            scheduler.offload(submitExec(p, tracked))
           }
           .flatMap { frames =>
             armed.set(false) // EXEC clears WATCH/MULTI state server-side whether it committed or aborted
@@ -1157,10 +1131,6 @@ final private[client] class ClusterLive(
 
   private def getOrEstablish(node: Node): NodeClient = masterPool.getOrEstablish(node)
 
-  private def establishOrNull(node: Node): NodeClient =
-    try getOrEstablish(node)
-    catch { case NonFatal(_) => null }
-
   private def flushNode(node: Node): Unit =
     if (cachingEnabled) {
       val nc = masterPool.existing(node)
@@ -1169,7 +1139,7 @@ final private[client] class ClusterLive(
 
   // --- topology refresh (single-flight, throttled) -------------------------------------------------------------------------------------
 
-  private def triggerRefresh(): Unit = offload(refresh(force = false))
+  private def triggerRefresh(): Unit = scheduler.offload(refresh(force = false))
 
   private def startRefreshPoll(): Unit = refreshThrottle.startPolling(cluster.topologyRefreshInterval)(triggerRefresh())
 
@@ -1189,34 +1159,24 @@ final private[client] class ClusterLive(
     candidates.iterator.flatMap(trySlots).nextOption()
 
   private def trySlots(node: Node): Option[(Node, Vector[Shard])] =
-    try querySlotsVia(node, getOrEstablish(node)).toOption.map(node -> _)
+    try querySlotsVia(node).toOption.map(node -> _)
     catch { case NonFatal(_) => None }
 
   // a node outside a formed cluster answers CLUSTER SLOTS with an empty array: a non-answer, not a topology owning no slots
-  private def querySlotsVia(node: Node, nc: NodeClient): Either[Throwable, Vector[Shard]] = {
-    val latch   = new CountDownLatch(1)
-    val outcome = new AtomicReference[Try[Vector[Shard]]]()
-    nc.submit[Vector[Shard]](
-      Cluster.slots,
-      asking = false,
-      result => {
-        outcome.set(result)
-        latch.countDown()
-      }
-    )
-    if (!latch.await(connectTimeout.toMillis, TimeUnit.MILLISECONDS))
-      Left(TimedOut(s"CLUSTER SLOTS on ${node.host}:${node.port} timed out after ${connectTimeout.toMillis}ms"))
-    else
-      outcome.get() match {
-        case Success(shards) if shards.nonEmpty =>
-          Right(shards)
-        case Success(_)                         =>
-          Left(UnsupportedServer(s"${node.host}:${node.port} owns no slots: it is not part of a formed cluster"))
-        case Failure(error: ServerError)        =>
-          Left(UnsupportedServer(s"${node.host}:${node.port} rejected CLUSTER SLOTS: ${error.getMessage}"))
-        case Failure(error)                     =>
-          Left(error)
-      }
+  private def querySlotsVia(node: Node): Either[Throwable, Vector[Shard]] = {
+    val nc = getOrEstablish(node)
+    Bootstrap.awaitReply[Vector[Shard]](connectTimeout.toMillis)(callback => nc.submit(Cluster.slots, asking = false, callback)) match {
+      case None                                     =>
+        Left(TimedOut(s"CLUSTER SLOTS on ${node.host}:${node.port} timed out after ${connectTimeout.toMillis}ms"))
+      case Some(Success(shards)) if shards.nonEmpty =>
+        Right(shards)
+      case Some(Success(_))                         =>
+        Left(UnsupportedServer(s"${node.host}:${node.port} owns no slots: it is not part of a formed cluster"))
+      case Some(Failure(error: ServerError))        =>
+        Left(UnsupportedServer(s"${node.host}:${node.port} rejected CLUSTER SLOTS: ${error.getMessage}"))
+      case Some(Failure(error))                     =>
+        Left(error)
+    }
   }
 
   // prunes bundles for masters it no longer lists, so a vanished node's reconnect loop cannot leak; an empty announce-IP from CLUSTER SLOTS

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterSubscriptions.scala
@@ -3,7 +3,6 @@ package sage.client.internal
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.collection.mutable
-import scala.concurrent.duration.*
 import scala.util.control.NonFatal
 
 import SubscriptionConnection.{Kind, RawSubscription, Sink}
@@ -56,8 +55,6 @@ final private[client] class ClusterSubscriptions(
     finally lock.unlock()
   }
 
-  private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
-
   // single-flight under the outer lock: a mid-pass trigger queues one follow-up rather than racing a pass that could corrupt placement
   final private class CoalescedPass(body: () => Unit) {
     private var running = false
@@ -74,7 +71,7 @@ final private[client] class ClusterSubscriptions(
           true
         }
       }
-      if (go) offload(run())
+      if (go) scheduler.offload(run())
     }
 
     private def run(): Unit =
@@ -89,7 +86,7 @@ final private[client] class ClusterSubscriptions(
             false
           }
         }
-        if (again) offload(run())
+        if (again) scheduler.offload(run())
       }
   }
 
@@ -250,7 +247,7 @@ final private[client] class ClusterSubscriptions(
     locked(shardConns.remove(node))
     // a drop may mean the slot migrated (server sends sunsubscribe then disconnects); force a refresh — stale topology still names the dead
     // owner, which planFor would not see as unowned — then reconcile onto the current owner
-    offload {
+    scheduler.offload {
       refresh()
       shardReconcile.schedule()
     }

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -53,17 +53,13 @@ final private[client] class DedicatedPool(
     * Runs a blocking command on a borrowed Dedicated Connection, releasing it when the reply (or a failure) arrives. Returns immediately;
     * the acquire — which may wait for a slot or open a socket — is offloaded so the calling fiber is never blocked.
     */
-  def use[A](command: Command[A], callback: Try[A] => Unit): Unit = leaseAndSubmit(command, asking = false, callback, new DedicatedPool.Lease)
-
-  def use[A](command: Command[A], callback: Try[A] => Unit, lease: DedicatedPool.Lease): Unit =
+  def use[A](command: Command[A], callback: Try[A] => Unit, lease: DedicatedPool.Lease = new DedicatedPool.Lease): Unit =
     leaseAndSubmit(command, asking = false, callback, lease)
 
   /**
     * Runs a blocking command redirected by `ASK`: `ASKING` then the command, back-to-back on one exclusively-leased connection, so their
     * wire adjacency is automatic. The `ASKING` reply is discarded; the command's reply releases the connection.
     */
-  def useAsking[A](command: Command[A], callback: Try[A] => Unit): Unit = leaseAndSubmit(command, asking = true, callback, new DedicatedPool.Lease)
-
   def useAsking[A](command: Command[A], callback: Try[A] => Unit, lease: DedicatedPool.Lease): Unit =
     leaseAndSubmit(command, asking = true, callback, lease)
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -1,6 +1,5 @@
 package sage.client.internal
 
-import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 
@@ -74,8 +73,6 @@ final private[client] class MasterReplicaLive(
   @volatile private var subscriptions: SubscriptionConnection = null
 
   private val refreshThrottle = new RefreshThrottle(scheduler, masterReplica.minRefreshInterval.toMillis)
-
-  private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
 
   // --- discovery -----------------------------------------------------------------------------------------------------------------------
 
@@ -159,7 +156,7 @@ final private[client] class MasterReplicaLive(
           config.connectTimeout,
           config.closeTimeout,
           config.dedicatedPool,
-          node = Some(node),
+          node = node,
           events = Events.disabled
         )
       catch {
@@ -167,29 +164,17 @@ final private[client] class MasterReplicaLive(
           reportProbeFailure(node, error)
           throw error
       }
-    try {
-      val latch   = new CountDownLatch(1)
-      val outcome = new AtomicReference[Try[Role]]()
-      nc.submit[Role](
-        Server.role,
-        asking = false,
-        result => {
-          outcome.set(result)
-          latch.countDown()
-        }
-      )
-      if (!latch.await(config.connectTimeout.toMillis, TimeUnit.MILLISECONDS)) {
-        val error = TimedOut(s"ROLE timed out after ${config.connectTimeout.toMillis}ms")
-        reportProbeFailure(node, error)
-        None
-      } else
-        outcome.get() match {
-          case Success(role)  => Some(role)
-          case Failure(error) =>
-            reportProbeFailure(node, error)
-            None
-        }
-    } finally nc.close()
+    try
+      Bootstrap.awaitReply[Role](config.connectTimeout.toMillis)(callback => nc.submit(Server.role, asking = false, callback)) match {
+        case Some(Success(role))  => Some(role)
+        case Some(Failure(error)) =>
+          reportProbeFailure(node, error)
+          None
+        case None                 =>
+          reportProbeFailure(node, TimedOut(s"ROLE timed out after ${config.connectTimeout.toMillis}ms"))
+          None
+      }
+    finally nc.close()
   }
 
   private def reportProbeFailure(node: Node, error: Throwable): Unit =
@@ -219,8 +204,7 @@ final private[client] class MasterReplicaLive(
   def run[A](command: Command[A]): CIO[A] = {
     def body(lease: DedicatedPool.Lease): CIO[A] =
       CIO.async[A] { complete =>
-        val span    = Events.startSpan(events, command)
-        val tracked = Events.trackCommand(events, command, complete, span)
+        val tracked = Events.trackCommand(events, command, complete)
         Client.completing(tracked) {
           if (readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command)) sendRead(command, tracked)
           else sendMaster(command, tracked, lease)
@@ -233,8 +217,7 @@ final private[client] class MasterReplicaLive(
     if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command))
     else if (!cachingEnabled)
       CIO.async[A] { complete =>
-        val span    = Events.startSpan(events, command)
-        val tracked = Events.trackCommand(events, command, complete, span)
+        val tracked = Events.trackCommand(events, command, complete)
         Client.completing(tracked)(sendMaster(command, tracked))
       }
     else
@@ -264,10 +247,8 @@ final private[client] class MasterReplicaLive(
     val existing = masterPool.existing(node)
     if (existing != null) submitMaster(existing, node, complete, submit)
     else
-      offload {
-        val nc =
-          try masterPool.getOrEstablish(node)
-          catch { case NonFatal(_) => null }
+      scheduler.offload {
+        val nc = masterPool.getOrEstablishOrNull(node)
         if (nc == null) {
           triggerRefresh()
           onDown()
@@ -368,10 +349,8 @@ final private[client] class MasterReplicaLive(
           val existing = masterPool.existing(master)
           if (existing != null) submitOn(Some((master, existing)))
           else
-            offload {
-              val nc =
-                try masterPool.getOrEstablish(master)
-                catch { case NonFatal(_) => null }
+            scheduler.offload {
+              val nc = masterPool.getOrEstablishOrNull(master)
               submitOn(Option(nc).map(master -> _))
             }
         }

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
@@ -60,14 +60,26 @@ private[client] object NodeClient {
     closeTimeout: FiniteDuration,
     dedicatedPool: DedicatedPoolConfig,
     cacheMaxBytes: Long = 0L,
-    node: Option[Node] = None,
+    node: Node,
     events: Events = Events.disabled,
     dedicatedBootstrap: Option[Vector[Command[?]]] = None,
     onConstructed: MultiplexedConnection => Unit = _ => ()
   ): NodeClient = {
     val connection =
       MultiplexedConnection
-        .connect(factory, scheduler, bootstrap, reconnect, watchdog, connectTimeout, closeTimeout, cacheMaxBytes, node, events, onConstructed)
+        .connect(
+          factory,
+          scheduler,
+          bootstrap,
+          reconnect,
+          watchdog,
+          connectTimeout,
+          closeTimeout,
+          cacheMaxBytes,
+          Some(node),
+          events,
+          onConstructed
+        )
     val pool       =
       DedicatedPool.forConnection(factory, dedicatedBootstrap.getOrElse(bootstrap), scheduler, connection, dedicatedPool, connectTimeout.toMillis)
     new NodeClient(connection, pool)

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.locks.ReentrantLock
 import scala.collection.mutable
 import scala.concurrent.duration.*
 import scala.jdk.CollectionConverters.*
+import scala.util.control.NonFatal
 
 import sage.SageEvent
 import sage.SageException.NotConnected
@@ -99,7 +100,7 @@ final private[client] class NodePool(
             closeTimeout,
             dedicatedPool,
             cacheMaxBytes,
-            Some(node),
+            node,
             events,
             dedicatedBootstrap,
             onConstructed = conn => {
@@ -143,6 +144,13 @@ final private[client] class NodePool(
       }
     }
   }
+
+  /**
+    * As [[getOrEstablish]], blocking to connect if need be, but `null` rather than throwing when the connect fails.
+    */
+  def getOrEstablishOrNull(node: Node): NodeClient =
+    try getOrEstablish(node)
+    catch { case NonFatal(_) => null }
 
   // drops/closes bundles `keep` rejects and invalidates in-flight establishments for rejected nodes, so neither leaks; closes are offloaded
   def retain(keep: Node => Boolean): Unit = {

--- a/sage-client/shared/src/main/scala/sage/client/internal/ReadRouting.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ReadRouting.scala
@@ -3,9 +3,7 @@ package sage.client.internal
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success, Try}
-import scala.util.control.NonFatal
 
 import sage.SageException.NotConnected
 import sage.client.ReadFrom
@@ -94,8 +92,8 @@ final private[client] class ReadRouting(
           if (existing.isLive) submit(existing, node, command, rest, complete)(onFault)
           else walk(command, rest, master, complete)(onFault)
         else
-          offload {
-            val nc = establishOrNull(pool, node)
+          scheduler.offload {
+            val nc = pool.getOrEstablishOrNull(node)
             if (nc == null || !nc.isLive) walk(command, rest, master, complete)(onFault)
             else submit(nc, node, command, rest, complete)(onFault)
           }
@@ -114,7 +112,7 @@ final private[client] class ReadRouting(
       val node = it.next()
       val nc   = poolFor(node, master).existing(node)
       if (nc == null) {
-        offload(onPick(establishOne(candidates, master)))
+        scheduler.offload(onPick(establishOne(candidates, master)))
         return
       }
       if (nc.isLive) {
@@ -135,7 +133,7 @@ final private[client] class ReadRouting(
         case success @ Success(_) =>
           Events.attributeNode(complete, node)
           complete(success)
-        case Failure(error)       => offload(onFault(node, error, rest))
+        case Failure(error)       => scheduler.offload(onFault(node, error, rest))
       }
     )
 
@@ -143,17 +141,11 @@ final private[client] class ReadRouting(
     val it = candidates.iterator
     while (it.hasNext) {
       val node = it.next()
-      val nc   = establishOrNull(poolFor(node, master), node)
+      val nc   = poolFor(node, master).getOrEstablishOrNull(node)
       if (nc != null && nc.isLive) return Some((node, nc))
     }
     None
   }
 
-  private def establishOrNull(pool: NodePool, node: Node): NodeClient =
-    try pool.getOrEstablish(node)
-    catch { case NonFatal(_) => null }
-
   private def poolFor(node: Node, master: Node): NodePool = if (node == master) masterPool else replicaPool
-
-  private def offload(body: => Unit): Unit = scheduler.after(Duration.Zero)(body)
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Scheduler.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Scheduler.scala
@@ -21,6 +21,8 @@ private[client] trait Scheduler {
   def after(delay: FiniteDuration)(task: => Unit): Unit
 
   def every(interval: FiniteDuration)(task: => Unit): Scheduler.Cancelable
+
+  final def offload(task: => Unit): Unit = after(Duration.Zero)(task)
 }
 
 private[client] object Scheduler {

--- a/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SubscriptionConnection.scala
@@ -52,9 +52,7 @@ final private[client] class SubscriptionConnection(
   private var current: Conn = null
   // connections still being opened; a set, since a reconnect and a fresh attach can be establishing at once
   private val establishing  = mutable.Set.empty[Conn]
-  private val channelSinks  = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
-  private val patternSinks  = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
-  private val shardSinks    = mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]]
+  private val sinksByKind   = Array.fill(Kind.values.length)(mutable.HashMap.empty[String, mutable.LinkedHashSet[Sink]])
 
   // SUBSCRIBE-ack accounting (guarded by `lock`): the server confirms each subscribed name with one push frame in send order, so a subscribe
   // waits until `subscribeConfirmed` catches `subscribeSent` before returning — otherwise `subscribe` then `publish` races across the sockets.
@@ -75,12 +73,7 @@ final private[client] class SubscriptionConnection(
     finally lock.unlock()
   }
 
-  private def sinksFor(kind: Kind): mutable.HashMap[String, mutable.LinkedHashSet[Sink]] =
-    kind match {
-      case Kind.Channel => channelSinks
-      case Kind.Pattern => patternSinks
-      case Kind.Shard   => shardSinks
-    }
+  private def sinksFor(kind: Kind): mutable.HashMap[String, mutable.LinkedHashSet[Sink]] = sinksByKind(kind.ordinal)
 
   // --- standalone conveniences: the connection owns the sink -------------------------------------------------------------------------------
 
@@ -174,7 +167,7 @@ final private[client] class SubscriptionConnection(
 
   def isEmpty: Boolean = locked(isEmptyUnlocked)
 
-  private def isEmptyUnlocked: Boolean = channelSinks.isEmpty && patternSinks.isEmpty && shardSinks.isEmpty
+  private def isEmptyUnlocked: Boolean = sinksByKind.forall(_.isEmpty)
 
   // --- shared establish/dispatch machinery -------------------------------------------------------------------------------------------------
 
@@ -206,14 +199,12 @@ final private[client] class SubscriptionConnection(
         subscribeConfirmed = 0L
         pingSentAtMillis = 0L
         lastReplyAtMillis = scheduler.nowMillis
-        val channels = channelSinks.keys.toVector
-        val patterns = patternSinks.keys.toVector
-        val shards   = shardSinks.keys.toVector
-        try {
-          if (channels.nonEmpty) sendSubscribe(conn, Kind.Channel, channels)
-          if (patterns.nonEmpty) sendSubscribe(conn, Kind.Pattern, patterns)
-          if (shards.nonEmpty) sendSubscribe(conn, Kind.Shard, shards)
-        } catch {
+        val pending = Kind.values.map(kind => kind -> sinksFor(kind).keys.toVector)
+        try
+          pending.foreach { case (kind, names) =>
+            if (names.nonEmpty) sendSubscribe(conn, kind, names)
+          }
+        catch {
           // resubscribe write failed: drop this socket and clear current so a superseded generation can't keep dispatching, then rethrow
           case e: Throwable =>
             current = null
@@ -221,7 +212,7 @@ final private[client] class SubscriptionConnection(
             failure = e
         }
         if (failure == null)
-          if (channels.isEmpty && patterns.isEmpty && shards.isEmpty) {
+          if (pending.forall(_._2.isEmpty)) {
             // everything closed during the establish; tear back down rather than hold an idle socket open
             teardown = conn
             current = null
@@ -374,9 +365,12 @@ final private[client] class SubscriptionConnection(
       case Frame.Push(elements) =>
         // not touching lastReplyAtMillis: a push proves only the read path, so push-only traffic must still get the idle keepalive PING
         Pubsub.decode(elements) match {
-          case Some(Pubsub.Event.Message(channel, payload))            => dispatch(channelSinks, channel, Delivery.Channel(channel, payload))
-          case Some(Pubsub.Event.ShardMessage(channel, payload))       => dispatch(shardSinks, channel, Delivery.Channel(channel, payload))
-          case Some(Pubsub.Event.PatternMessage(pattern, ch, payload)) => dispatch(patternSinks, pattern, Delivery.Pattern(pattern, ch, payload))
+          case Some(Pubsub.Event.Message(channel, payload))            =>
+            dispatch(sinksFor(Kind.Channel), channel, Delivery.Channel(channel, payload))
+          case Some(Pubsub.Event.ShardMessage(channel, payload))       =>
+            dispatch(sinksFor(Kind.Shard), channel, Delivery.Channel(channel, payload))
+          case Some(Pubsub.Event.PatternMessage(pattern, ch, payload)) =>
+            dispatch(sinksFor(Kind.Pattern), pattern, Delivery.Pattern(pattern, ch, payload))
           case Some(_: Pubsub.Event.Subscribed)                        =>
             // conn eq current: a late ack from a superseded generation must not advance this generation's count
             locked(if (conn eq current) {
@@ -455,25 +449,16 @@ final private[client] class SubscriptionConnection(
   }
 
   // close socket/watchdog but keep the sinks (unlike close), so a re-home re-attaches them
-  def shutdown(): Unit = {
-    val toClose = locked {
-      val conns = markClosed()
-      channelSinks.clear()
-      patternSinks.clear()
-      shardSinks.clear()
-      conns
-    }
-    toClose.foreach(_.close())
-  }
+  def shutdown(): Unit = tearDown(terminateSinks = false)
 
-  def close(): Unit = {
+  def close(): Unit = tearDown(terminateSinks = true)
+
+  private def tearDown(terminateSinks: Boolean): Unit = {
     var sinks: Set[Sink] = Set.empty
     val toClose          = locked {
-      sinks = (channelSinks.values.flatten ++ patternSinks.values.flatten ++ shardSinks.values.flatten).toSet
+      if (terminateSinks) sinks = sinksByKind.iterator.flatMap(_.values.flatten).toSet
       val conns = markClosed()
-      channelSinks.clear()
-      patternSinks.clear()
-      shardSinks.clear()
+      sinksByKind.foreach(_.clear())
       conns
     }
     // terminate before close: conn.close() joins the reader, which only exits Sink.offer once its sink is closed — closing first deadlocks.

--- a/sage-client/shared/src/main/scala/sage/client/internal/TxSupport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/TxSupport.scala
@@ -7,7 +7,7 @@ import scala.util.{Failure, Success, Try}
 import kyo.compat.*
 
 import sage.SageException
-import sage.SageException.{DecodeError, ProtocolError, TransactionDiscarded}
+import sage.SageException.{DecodeError, ProtocolError, ServerError, TransactionDiscarded}
 import sage.commands.{Command, Reply}
 import sage.protocol.Frame
 
@@ -67,6 +67,15 @@ private[internal] object TxSupport {
       case Frame.BulkError(message)   => Some(message.asUtf8String)
       case _                          => None
     }
+
+  // an EXEC fault is an error frame carried in a Success, sitting either at the top level or inside the EXEC array
+  def execErrors(frames: Vector[Frame]): Iterator[ServerError] = {
+    val nested = frames.lastOption match {
+      case Some(Frame.Array(elems)) => elems.iterator
+      case _                        => Iterator.empty[Frame]
+    }
+    (frames.iterator ++ nested).flatMap(errorOf).map(ServerError.of)
+  }
 
   // a state error, not an argument, so deliberately outside the sealed hierarchy: a scope captured past its block
   def scopeReleasedError: IllegalStateException =


### PR DESCRIPTION
Eleven self-contained refactors in `sage/client/internal`, from a duplication audit of that directory. Net **-74 lines** (242 deleted, 168 added) across 12 files. No public API change.

## Shared helpers replacing copies

| Helper | Replaces |
|---|---|
| `NodePool.getOrEstablishOrNull` | 6 copies of `try getOrEstablish catch NonFatal => null` |
| `Scheduler.offload` | 4 private one-line `offload` defs |
| `Bootstrap.awaitReply` | the latch + `AtomicReference` + bounded await written 3 times |
| `TxSupport.execErrors` | the EXEC fault walk spelled out in both transaction scopes |

`ReadRouting` and `ClusterLive` carried the node-resolution idiom as the same private method under the same name in two files, and `ClusterLive` then ignored its own copy and inlined it twice more.

`execErrors` is the one with a drift argument rather than a line-count argument: "an EXEC fault can sit at the top level or inside the EXEC array" is protocol knowledge, and encoding it twice means a missed frame shape fixed in one scope silently stays broken in the other.

## Shapes simplified

* `connectWith` takes `SageConfig` whole instead of 13 flattened fields, so a new config knob no longer costs three coordinated edits. The hand-written defaults matched `SageConfig`'s (`auth = None`, `database = 0`, `clientName = None`), so this is behaviour preserving.
* `SubscriptionConnection` indexes its three sink registries by `Kind` ordinal instead of keeping three parallel maps handled as a group at seven sites; `shutdown`/`close` collapse into one `tearDown`.
* `onUnreachable` delegates to `onRetryable`. The two were identical apart from the error and an always-true `refreshFirst`.
* `DedicatedPool.use` takes a default lease instead of an overload pair. The two-arg `useAsking` had no callers at all.
* `NodeClient.connect` takes `node: Node`. Both call sites passed `Some`, so the `Option` and its `None` default were unreachable.
* `querySlotsVia` resolves its own connection instead of having both call sites pass `getOrEstablish(node)`.

Also drops the redundant `Events.startSpan` line at five sites where the three-arg `trackCommand` already starts the span. That is strictly cheaper: it skips `startSpan` entirely when events are disabled, which the old code did not.

## Worth a reviewer's eye

**One behaviour change.** `onUnreachable` now constructs `NotConnected` on every attempt rather than only the terminal one, so a failing attempt fills one extra stack trace. That path already forces a topology refresh and starts a virtual thread, so the cost is noise against it, but it is a real change rather than a pure no-op.

**Two invariants I checked rather than assumed:**
* `Kind.values` enumerates in declaration order (Channel, Pattern, Shard), so `goLive`'s resubscribe ordering, which the SUBSCRIBE-ack accounting depends on, is unchanged.
* `tearDown` still snapshots the sinks before `markClosed()` and terminates before closing, preserving the ordering that the comment there exists to protect.

`dispatch` still takes the map and is indexed with a literal `Kind`, so the per-push path stays a single array read and never touches `Kind.values`.

## Verification

* Clean (not incremental) build, plus `Test/compile` across every backend cell
* 355 client unit tests; shared specs also green under a second backend cell
* Integration suites against **both Redis and Valkey**: cluster, cluster failover, master-replica (including demotion, connection-loss, replica-down, stale-replica), pub/sub, caching, round-trip, server admin
* `scalafmtCheckAll` clean

## Deliberately not included

A `withClient` wrapper around the resolve-or-offload skeleton was considered and rejected: today the `offload {...}` thunk is only built in the taken branch, whereas a plain wrapper must allocate the `use` closure (capturing up to 7 values in `sendTo`) before the established-vs-not test, adding a closure per command on cluster master dispatch. It would only be acceptable as an `inline` def, which needs `scheduler` promoted to a constructor val.
