### PR TITLE
Fix preferred read pipeline fallback

### DIFF
--- a/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
@@ -349,11 +349,13 @@ abstract class MasterReplicaStaleReplicaSuite(image: String, serverBinary: Strin
                 _             <- connectAndUse(replicaCfg)(refuseStaleReads)
                 _             <- preferred.set("sd:k", "v")
                 fallback      <- preferred.get[String]("sd:k")
+                batchFallback <- preferred.pipeline(Seq.fill(2)(Commands.get[String, String]("sd:k")))
                 strictFailed  <- strict.get[String]("sd:k").fold(_ => CIO.value(false), _ => CIO.value(true))
               } yield {
                 assertEquals(warmStrict, Some("from-replica"))
                 assertEquals(warmPreferred, Some("from-replica"))
                 assertEquals(fallback, Some("v"))
+                assertEquals(batchFallback, Vector(Some("v"), Some("v")))
                 assert(strictFailed, "strict Replica read should fail when the only replica refuses to serve stale data")
               }
             }

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2315,6 +2315,47 @@ object Client {
       cb(result)
     }
 
+  final private[internal] class TrackedBatch(
+    events: Events,
+    commands: Vector[Command[?]],
+    spans: Vector[CommandSpan],
+    complete: Try[Vector[Either[SageException, Any]]] => Unit
+  ) {
+    private val collector = new TxSupport.IndexedCollector[Either[SageException, Any]](commands.length, complete)
+    private val tracked   = Vector.tabulate(commands.length) { i =>
+      val span = if (spans.isEmpty) CommandSpan.noop else spans(i)
+      Events.trackCommand[Any](events, commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)), span)
+    }
+
+    def callbacks(node: Option[Node]): Vector[Try[Any] => Unit] =
+      node match {
+        case Some(n) => tracked.map(attributeOnComplete(_, n))
+        case None    => tracked
+      }
+
+    def settleAll(node: Node, results: Vector[Try[Any]]): Unit =
+      results.indices.foreach { i =>
+        Events.attributeNode(tracked(i), node)
+        tracked(i)(results(i))
+      }
+
+    def failUnsent(): Unit = {
+      val error = NotConnected()
+      tracked.foreach(Events.abandonSpan(_, error))
+      if (events.emitsEvents)
+        commands.foreach(c => events.emit(SageEvent.CommandCompleted(c.name, None, Duration.Zero, Outcome.Failed(error))))
+      complete(Failure(error))
+    }
+  }
+
+  private[internal] def trackBatch(
+    events: Events,
+    commands: Vector[Command[?]],
+    spans: Vector[CommandSpan],
+    complete: Try[Vector[Either[SageException, Any]]] => Unit
+  ): TrackedBatch =
+    new TrackedBatch(events, commands, spans, complete)
+
   // a pipeline batched onto a single connection: scatter each reply into its submission-order slot, and on a disconnect report a failed
   // completion per position before failing the effect once. Shared by standalone/master-replica; the cluster runtime splits per node instead.
   private[internal] def submitBatchOnOne(
@@ -2325,29 +2366,8 @@ object Client {
     complete: Try[Vector[Either[SageException, Any]]] => Unit,
     node: Option[Node] = None
   ): Unit = {
-    val collector = new TxSupport.IndexedCollector[Either[SageException, Any]](commands.length, complete)
-    val tracked   = Vector.tabulate(commands.length) { i =>
-      val span = if (spans.isEmpty) CommandSpan.noop else spans(i)
-      Events.trackCommand[Any](events, commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)), span)
-    }
-    val callbacks = node match {
-      case Some(n) => tracked.map(attributeOnComplete(_, n))
-      case None    => tracked
-    }
-    if (!submitAll(commands, callbacks)) failUnsentBatch(events, commands, tracked, complete)
-  }
-
-  private[internal] def failUnsentBatch(
-    events: Events,
-    commands: Vector[Command[?]],
-    tracked: Vector[Try[Any] => Unit],
-    complete: Try[Vector[Either[SageException, Any]]] => Unit
-  ): Unit = {
-    val error = NotConnected()
-    tracked.foreach(Events.abandonSpan(_, error))
-    if (events.emitsEvents)
-      commands.foreach(c => events.emit(SageEvent.CommandCompleted(c.name, None, Duration.Zero, Outcome.Failed(error))))
-    complete(Failure(error))
+    val batch = trackBatch(events, commands, spans, complete)
+    if (!submitAll(commands, batch.callbacks(node))) batch.failUnsent()
   }
 
   /**

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2340,7 +2340,7 @@ object Client {
         tracked(i)(results(i))
       }
 
-    def failUnsent(onUnsent: () => Unit = () => ()): Unit = {
+    def failUnsent(onUnsent: () => Unit): Unit = {
       val error = NotConnected()
       onUnsent()
       tracked.foreach(Events.abandonSpan(_, error))
@@ -2358,8 +2358,8 @@ object Client {
     spans: Vector[CommandSpan],
     submitAll: (Vector[Command[?]], Vector[Try[Any] => Unit]) => Boolean,
     complete: Try[Vector[Either[SageException, Any]]] => Unit,
-    node: Option[Node] = None,
-    onUnsent: () => Unit = () => ()
+    onUnsent: () => Unit,
+    node: Option[Node] = None
   ): Unit = {
     val batch = new TrackedBatch(events, commands, spans, complete)
     if (!submitAll(commands, batch.callbacks(node))) batch.failUnsent(onUnsent)
@@ -2571,7 +2571,14 @@ object Client {
         CIO.fail(InvalidArgument("a Pipeline cannot carry blocking commands; run them individually on the client"))
       else
         CIO.async { complete =>
-          Client.submitBatchOnOne(events, p.commands, Events.startSpans(events, p.commands), nodeClient.submitAll, complete)
+          Client.submitBatchOnOne(
+            events,
+            p.commands,
+            Events.startSpans(events, p.commands),
+            nodeClient.submitAll,
+            complete,
+            onUnsent = () => ()
+          )
         }
 
     def subscribeChannels[V: ValueCodec](channel: String, rest: String*): CIO[Subscription[CIO, Message[V]]] =

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2321,7 +2321,8 @@ object Client {
     spans: Vector[CommandSpan],
     complete: Try[Vector[Either[SageException, Any]]] => Unit
   ) {
-    private val collector = new TxSupport.IndexedCollector[Either[SageException, Any]](commands.length, complete)
+    private val collector =
+      new TxSupport.IndexedCollector[Either[SageException, Any]](commands.length, results => complete(Success(results)))
     private val tracked   = Vector.tabulate(commands.length) { i =>
       val span = if (spans.isEmpty) CommandSpan.noop else spans(i)
       Events.trackCommand[Any](events, commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)), span)
@@ -2339,22 +2340,15 @@ object Client {
         tracked(i)(results(i))
       }
 
-    def failUnsent(): Unit = {
+    def failUnsent(onUnsent: () => Unit = () => ()): Unit = {
       val error = NotConnected()
+      onUnsent()
       tracked.foreach(Events.abandonSpan(_, error))
       if (events.emitsEvents)
         commands.foreach(c => events.emit(SageEvent.CommandCompleted(c.name, None, Duration.Zero, Outcome.Failed(error))))
       complete(Failure(error))
     }
   }
-
-  private[internal] def trackBatch(
-    events: Events,
-    commands: Vector[Command[?]],
-    spans: Vector[CommandSpan],
-    complete: Try[Vector[Either[SageException, Any]]] => Unit
-  ): TrackedBatch =
-    new TrackedBatch(events, commands, spans, complete)
 
   // a pipeline batched onto a single connection: scatter each reply into its submission-order slot, and on a disconnect report a failed
   // completion per position before failing the effect once. Shared by standalone/master-replica; the cluster runtime splits per node instead.
@@ -2364,10 +2358,11 @@ object Client {
     spans: Vector[CommandSpan],
     submitAll: (Vector[Command[?]], Vector[Try[Any] => Unit]) => Boolean,
     complete: Try[Vector[Either[SageException, Any]]] => Unit,
-    node: Option[Node] = None
+    node: Option[Node] = None,
+    onUnsent: () => Unit = () => ()
   ): Unit = {
-    val batch = trackBatch(events, commands, spans, complete)
-    if (!submitAll(commands, batch.callbacks(node))) batch.failUnsent()
+    val batch = new TrackedBatch(events, commands, spans, complete)
+    if (!submitAll(commands, batch.callbacks(node))) batch.failUnsent(onUnsent)
   }
 
   /**

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2334,13 +2334,20 @@ object Client {
       case Some(n) => tracked.map(attributeOnComplete(_, n))
       case None    => tracked
     }
-    if (!submitAll(commands, callbacks)) {
-      val error = NotConnected()
-      tracked.foreach(Events.abandonSpan(_, error))
-      if (events.emitsEvents)
-        commands.foreach(c => events.emit(SageEvent.CommandCompleted(c.name, None, Duration.Zero, Outcome.Failed(error))))
-      complete(Failure(error))
-    }
+    if (!submitAll(commands, callbacks)) failUnsentBatch(events, commands, tracked, complete)
+  }
+
+  private[internal] def failUnsentBatch(
+    events: Events,
+    commands: Vector[Command[?]],
+    tracked: Vector[Try[Any] => Unit],
+    complete: Try[Vector[Either[SageException, Any]]] => Unit
+  ): Unit = {
+    val error = NotConnected()
+    tracked.foreach(Events.abandonSpan(_, error))
+    if (events.emitsEvents)
+      commands.foreach(c => events.emit(SageEvent.CommandCompleted(c.name, None, Duration.Zero, Outcome.Failed(error))))
+    complete(Failure(error))
   }
 
   /**

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -760,7 +760,8 @@ final private[client] class ClusterLive(
     plan: SplitPlan
   ): Unit = {
     val n                         = p.commands.length
-    val collector                 = new TxSupport.IndexedCollector[Either[SageException, Any]](n, complete)
+    val collector                 =
+      new TxSupport.IndexedCollector[Either[SageException, Any]](n, results => complete(Success(results)))
     val emits                     = Vector.tabulate(n) { i =>
       val span = if (deferred.isEmpty) CommandSpan.noop else Events.startDeferred(deferred(i))
       Events.trackCommand[Any](events, p.commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)), span)

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -796,8 +796,8 @@ final private[client] class ClusterLive(
     if (useReplica) {
       val replicas = topologyRef.get().shards.collectFirst { case s if s.master == node => s.replicas }.getOrElse(Vector.empty)
       reads.pickOne(reads.candidatesFor(node, replicas), node) {
-        case Some((target, nc)) => submitBatch(target, nc, indices, p, emits, reroute, useReplica)
-        case None               => indices.foreach(reroute)
+        case Some(picked) => submitBatch(picked.node, picked.client, indices, p, emits, reroute, useReplica)
+        case None         => indices.foreach(reroute)
       }
     } else {
       val existing = masterPool.existing(node)

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -331,22 +331,50 @@ final private[client] class MasterReplicaLive(
       CIO.fail(InvalidArgument("a Pipeline cannot carry blocking commands; run them individually on the client"))
     else
       CIO.async { complete =>
-        val spans                                              = Events.startSpans(events, p.commands)
+        val spans      = Events.startSpans(events, p.commands)
         // all-or-nothing: a fully replica-eligible pipeline batches on a replica, else the master, never split
-        val useReplica                                         = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
-        def submitOn(picked: Option[(Node, NodeClient)]): Unit = {
-          // no reachable node fires no wire fault, so re-discover here or a stale replica set / down master strands the pipeline forever
-          if (picked.isEmpty) triggerRefresh()
-          val submit = picked match {
-            case Some((_, nc)) => nc.submitAll
-            case None          => (_: Vector[Command[?]], _: Vector[Try[Any] => Unit]) => false
+        val useReplica = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
+        val master     = masterNodeRef.get()
+        if (useReplica) {
+          val collector                                                        = new TxSupport.IndexedCollector[Either[SageException, Any]](p.commands.length, complete)
+          val tracked                                                          = Vector.tabulate(p.commands.length) { i =>
+            val span = if (spans.isEmpty) CommandSpan.noop else spans(i)
+            Events.trackCommand[Any](events, p.commands(i), result => collector.set(i, TxSupport.toEither(result)), span)
           }
-          Client.submitBatchOnOne(events, p.commands, spans, submit, complete, picked.map(_._1))
-        }
-        val master                                             = masterNodeRef.get()
-        if (useReplica) reads.pickOne(reads.candidatesFor(master, replicasRef.get()), master)(submitOn)
-        else {
-          val existing = masterPool.existing(master)
+          def failUnsent(): Unit                                               = {
+            // no reachable node fires no wire fault, so re-discover here or a stale replica set / down master strands the pipeline forever
+            triggerRefresh()
+            Client.failUnsentBatch(events, p.commands, tracked, complete)
+          }
+          def submitOn(picked: Option[(Node, NodeClient, Vector[Node])]): Unit =
+            picked match {
+              case Some((node, nc, rest)) =>
+                val callbacks = Vector.tabulate(p.commands.length) { i => (result: Try[Any]) =>
+                  result match {
+                    case Success(_)     =>
+                      Events.attributeNode(tracked(i), node)
+                      tracked(i)(result)
+                    // deciding whether the Node can serve this read may establish the fallback and must stay off the reply thread
+                    case Failure(error) =>
+                      scheduler.offload(onReadFault(node, node == master, error, p.commands(i), rest, master, tracked(i)))
+                  }
+                }
+                // the liveness race lost before anything reached the wire: retain batching while trying the remaining candidates
+                if (!nc.submitAll(p.commands, callbacks))
+                  if (rest.nonEmpty) reads.pickOneWithRest(rest, master)(submitOn)
+                  else failUnsent()
+              case None                   => failUnsent()
+            }
+          reads.pickOneWithRest(reads.candidatesFor(master, replicasRef.get()), master)(submitOn)
+        } else {
+          def submitOn(picked: Option[(Node, NodeClient)]): Unit = {
+            val submit = picked match {
+              case Some((_, nc)) => nc.submitAll
+              case None          => (_: Vector[Command[?]], _: Vector[Try[Any] => Unit]) => false
+            }
+            Client.submitBatchOnOne(events, p.commands, spans, submit, complete, picked.map(_._1))
+          }
+          val existing                                           = masterPool.existing(master)
           if (existing != null) submitOn(Some((master, existing)))
           else
             scheduler.offload {

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -290,7 +290,7 @@ final private[client] class MasterReplicaLive(
     command: Command[A],
     complete: Try[A] => Unit
   ): Unit =
-    disposeReadFaults(route, Vector(error), offload = false)(
+    handleReadFaults(route, Vector(error), RetryExecution.Inline)(
       remaining => walkRead(command, remaining, route.master, complete),
       () => {
         Events.attributeNode(complete, route.node)
@@ -300,7 +300,11 @@ final private[client] class MasterReplicaLive(
 
   final private case class ReadRoute(node: Node, master: Node, remaining: Vector[Node])
 
-  private def disposeReadFaults(route: ReadRoute, errors: Vector[Throwable], offload: Boolean)(
+  private enum RetryExecution {
+    case Inline, Offloaded
+  }
+
+  private def handleReadFaults(route: ReadRoute, errors: Vector[Throwable], retryExecution: RetryExecution)(
     retry: Vector[Node] => Unit,
     settle: () => Unit
   ): Unit = {
@@ -310,10 +314,14 @@ final private[client] class MasterReplicaLive(
       def continue(): Unit =
         if (route.remaining.nonEmpty) retry(route.remaining)
         else {
+          // an ownership fault already requested the same throttled refresh above
           if (!ownershipFault) triggerRefresh()
           settle()
         }
-      if (offload) scheduler.offload(continue()) else continue()
+      retryExecution match {
+        case RetryExecution.Inline    => continue()
+        case RetryExecution.Offloaded => scheduler.offload(continue())
+      }
     } else settle()
   }
 
@@ -356,7 +364,7 @@ final private[client] class MasterReplicaLive(
                 val attempt   = new TxSupport.IndexedCollector[Try[Any]](
                   p.commands.length,
                   results =>
-                    disposeReadFaults(route, results.collect { case Failure(error) => error }, offload = true)(
+                    handleReadFaults(route, results.collect { case Failure(error) => error }, RetryExecution.Offloaded)(
                       remaining => reads.pickOne(remaining, master)(submitOn),
                       () => batch.settleAll(node, results)
                     )
@@ -381,8 +389,8 @@ final private[client] class MasterReplicaLive(
               spans,
               submit,
               complete,
-              picked.map(_._1),
-              refreshOnUnsent
+              onUnsent = refreshOnUnsent,
+              node = picked.map(_._1)
             )
           }
           val existing                                           = masterPool.existing(master)

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -282,31 +282,39 @@ final private[client] class MasterReplicaLive(
   }
 
   private def walkRead[A](command: Command[A], candidates: Vector[Node], master: Node, complete: Try[A] => Unit): Unit =
-    reads.walk(command, candidates, master, complete)((node, error, rest) =>
-      onReadFault(node, node == master, error, command, rest, master, complete)
-    )
+    reads.walk(command, candidates, master, complete)((node, error, rest) => onReadFault(ReadRoute(node, master, rest), error, command, complete))
 
   private def onReadFault[A](
-    node: Node,
-    isMaster: Boolean,
+    route: ReadRoute,
     error: Throwable,
     command: Command[A],
-    rest: Vector[Node],
-    master: Node,
     complete: Try[A] => Unit
-  ): Unit = {
-    if (isMaster && isOwnershipFault(error)) triggerRefresh()
-    def fail(): Unit = {
-      Events.attributeNode(complete, node)
-      complete(Failure(error))
-    }
-    if (servesNoRead(error))
-      if (rest.nonEmpty) walkRead(command, rest, master, complete)
-      else {
-        triggerRefresh()
-        fail()
+  ): Unit =
+    disposeReadFaults(route, Vector(error), offload = false)(
+      remaining => walkRead(command, remaining, route.master, complete),
+      () => {
+        Events.attributeNode(complete, route.node)
+        complete(Failure(error))
       }
-    else fail()
+    )
+
+  final private case class ReadRoute(node: Node, master: Node, remaining: Vector[Node])
+
+  private def disposeReadFaults(route: ReadRoute, errors: Vector[Throwable], offload: Boolean)(
+    retry: Vector[Node] => Unit,
+    settle: () => Unit
+  ): Unit = {
+    val ownershipFault = route.node == route.master && errors.exists(isOwnershipFault)
+    if (ownershipFault) triggerRefresh()
+    if (errors.exists(servesNoRead)) {
+      def continue(): Unit =
+        if (route.remaining.nonEmpty) retry(route.remaining)
+        else {
+          if (!ownershipFault) triggerRefresh()
+          settle()
+        }
+      if (offload) scheduler.offload(continue()) else continue()
+    } else settle()
   }
 
   private def isOwnershipFault(error: Throwable): Boolean = Fault.categorize(error) match {
@@ -331,50 +339,27 @@ final private[client] class MasterReplicaLive(
       CIO.fail(InvalidArgument("a Pipeline cannot carry blocking commands; run them individually on the client"))
     else
       CIO.async { complete =>
-        val spans      = Events.startSpans(events, p.commands)
+        val spans           = Events.startSpans(events, p.commands)
         // all-or-nothing: a fully replica-eligible pipeline batches on a replica, else the master, never split
-        val useReplica = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
-        val master     = masterNodeRef.get()
+        val useReplica      = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
+        val master          = masterNodeRef.get()
+        val refreshOnUnsent = () => triggerRefresh()
         if (useReplica) {
-          val batch                                              = Client.trackBatch(events, p.commands, spans, complete)
-          def failUnsent(): Unit                                 = {
+          val batch                                              = new Client.TrackedBatch(events, p.commands, spans, complete)
+          def failUnsent(): Unit                                 =
             // no reachable node fires no wire fault, so re-discover here or a stale replica set / down master strands the pipeline forever
-            triggerRefresh()
-            batch.failUnsent()
-          }
+            batch.failUnsent(refreshOnUnsent)
           def submitOn(picked: Option[ReadRouting.Picked]): Unit =
             picked match {
               case Some(ReadRouting.Picked(node, nc, rest)) =>
+                val route     = ReadRoute(node, master, rest)
                 val attempt   = new TxSupport.IndexedCollector[Try[Any]](
                   p.commands.length,
-                  {
-                    case Success(results) =>
-                      if (
-                        results.exists {
-                          case Failure(error) => servesNoRead(error)
-                          case _              => false
-                        }
-                      )
-                        // candidate selection may establish a connection and must stay off the reply thread
-                        scheduler.offload {
-                          if (rest.nonEmpty) reads.pickOne(rest, master)(submitOn)
-                          else {
-                            triggerRefresh()
-                            batch.settleAll(node, results)
-                          }
-                        }
-                      else {
-                        if (
-                          node == master && results.exists {
-                            case Failure(error) => isOwnershipFault(error)
-                            case _              => false
-                          }
-                        )
-                          triggerRefresh()
-                        batch.settleAll(node, results)
-                      }
-                    case Failure(error)   => complete(Failure(error)) // IndexedCollector cannot produce this
-                  }
+                  results =>
+                    disposeReadFaults(route, results.collect { case Failure(error) => error }, offload = true)(
+                      remaining => reads.pickOne(remaining, master)(submitOn),
+                      () => batch.settleAll(node, results)
+                    )
                 )
                 val callbacks = Vector.tabulate(p.commands.length)(i => (result: Try[Any]) => attempt.set(i, result))
                 // the selected connection died before reserving the batch; retry the whole batch on the remaining candidates
@@ -394,13 +379,10 @@ final private[client] class MasterReplicaLive(
               events,
               p.commands,
               spans,
-              (commands, callbacks) => {
-                val accepted = submit(commands, callbacks)
-                if (!accepted) triggerRefresh()
-                accepted
-              },
+              submit,
               complete,
-              picked.map(_._1)
+              picked.map(_._1),
+              refreshOnUnsent
             )
           }
           val existing                                           = masterPool.existing(master)

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -336,43 +336,72 @@ final private[client] class MasterReplicaLive(
         val useReplica = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
         val master     = masterNodeRef.get()
         if (useReplica) {
-          val collector                                                        = new TxSupport.IndexedCollector[Either[SageException, Any]](p.commands.length, complete)
-          val tracked                                                          = Vector.tabulate(p.commands.length) { i =>
-            val span = if (spans.isEmpty) CommandSpan.noop else spans(i)
-            Events.trackCommand[Any](events, p.commands(i), result => collector.set(i, TxSupport.toEither(result)), span)
-          }
-          def failUnsent(): Unit                                               = {
+          val batch                                              = Client.trackBatch(events, p.commands, spans, complete)
+          def failUnsent(): Unit                                 = {
             // no reachable node fires no wire fault, so re-discover here or a stale replica set / down master strands the pipeline forever
             triggerRefresh()
-            Client.failUnsentBatch(events, p.commands, tracked, complete)
+            batch.failUnsent()
           }
-          def submitOn(picked: Option[(Node, NodeClient, Vector[Node])]): Unit =
+          def submitOn(picked: Option[ReadRouting.Picked]): Unit =
             picked match {
-              case Some((node, nc, rest)) =>
-                val callbacks = Vector.tabulate(p.commands.length) { i => (result: Try[Any]) =>
-                  result match {
-                    case Success(_)     =>
-                      Events.attributeNode(tracked(i), node)
-                      tracked(i)(result)
-                    // deciding whether the Node can serve this read may establish the fallback and must stay off the reply thread
-                    case Failure(error) =>
-                      scheduler.offload(onReadFault(node, node == master, error, p.commands(i), rest, master, tracked(i)))
+              case Some(ReadRouting.Picked(node, nc, rest)) =>
+                val attempt   = new TxSupport.IndexedCollector[Try[Any]](
+                  p.commands.length,
+                  {
+                    case Success(results) =>
+                      if (
+                        results.exists {
+                          case Failure(error) => servesNoRead(error)
+                          case _              => false
+                        }
+                      )
+                        // candidate selection may establish a connection and must stay off the reply thread
+                        scheduler.offload {
+                          if (rest.nonEmpty) reads.pickOne(rest, master)(submitOn)
+                          else {
+                            triggerRefresh()
+                            batch.settleAll(node, results)
+                          }
+                        }
+                      else {
+                        if (
+                          node == master && results.exists {
+                            case Failure(error) => isOwnershipFault(error)
+                            case _              => false
+                          }
+                        )
+                          triggerRefresh()
+                        batch.settleAll(node, results)
+                      }
+                    case Failure(error)   => complete(Failure(error)) // IndexedCollector cannot produce this
                   }
-                }
-                // the liveness race lost before anything reached the wire: retain batching while trying the remaining candidates
+                )
+                val callbacks = Vector.tabulate(p.commands.length)(i => (result: Try[Any]) => attempt.set(i, result))
+                // the selected connection died before reserving the batch; retry the whole batch on the remaining candidates
                 if (!nc.submitAll(p.commands, callbacks))
-                  if (rest.nonEmpty) reads.pickOneWithRest(rest, master)(submitOn)
+                  if (rest.nonEmpty) reads.pickOne(rest, master)(submitOn)
                   else failUnsent()
-              case None                   => failUnsent()
+              case None                                     => failUnsent()
             }
-          reads.pickOneWithRest(reads.candidatesFor(master, replicasRef.get()), master)(submitOn)
+          reads.pickOne(reads.candidatesFor(master, replicasRef.get()), master)(submitOn)
         } else {
           def submitOn(picked: Option[(Node, NodeClient)]): Unit = {
             val submit = picked match {
               case Some((_, nc)) => nc.submitAll
               case None          => (_: Vector[Command[?]], _: Vector[Try[Any] => Unit]) => false
             }
-            Client.submitBatchOnOne(events, p.commands, spans, submit, complete, picked.map(_._1))
+            Client.submitBatchOnOne(
+              events,
+              p.commands,
+              spans,
+              (commands, callbacks) => {
+                val accepted = submit(commands, callbacks)
+                if (!accepted) triggerRefresh()
+                accepted
+              },
+              complete,
+              picked.map(_._1)
+            )
           }
           val existing                                           = masterPool.existing(master)
           if (existing != null) submitOn(Some((master, existing)))

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
@@ -26,7 +26,7 @@ final private[client] class NodeClient(connection: MultiplexedConnection, pool: 
     connection.cachedSubmit(command, ttlMillis, callback, deferred)
 
   // a pipeline's per-node batch: one round-trip on this node's Multiplexed Connection. False when not connected (nothing submitted), so
-  // the caller re-routes each position rather than fabricating per-position errors. Blocking commands never reach here (rejected up front).
+  // the caller can re-route the batch rather than fabricating per-position errors. Blocking commands never reach here (rejected up front).
   def submitAll(commands: Vector[Command[?]], callbacks: Vector[Try[Any] => Unit]): Boolean =
     connection.submitAll(commands, callbacks)
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/ReadRouting.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ReadRouting.scala
@@ -16,6 +16,8 @@ import sage.commands.Command
   */
 private[client] object ReadRouting {
 
+  final case class Picked(node: Node, client: NodeClient, remaining: Vector[Node])
+
   // an ordinary (non-blocking) read; writes, blocking reads, cursor-bound scans (whose cursor is node-local), and `cached` reads (gated
   // separately) never reach here
   def replicaEligible(command: Command[?]): Boolean = command.isReadOnly && !command.isBlocking && !command.cursorBound
@@ -103,31 +105,23 @@ final private[client] class ReadRouting(
     }
 
   /**
-    * The one Node a batch of reads should land on with its connection, established if need be, or `None` when no candidate can serve the
-    * read. `onPick` runs on the caller's thread while a live candidate is already established, and off it otherwise.
+    * The one Node a batch of reads should land on with its connection and the candidates after it, established if need be, or `None` when no
+    * candidate can serve the read. `onPick` runs on the caller's thread while a live candidate is already established, and off it otherwise.
     */
-  def pickOne(candidates: Vector[Node], master: Node)(onPick: Option[(Node, NodeClient)] => Unit): Unit =
-    pickOneWithRest(candidates, master)(picked => onPick(picked.map { case (node, nc, _) => (node, nc) }))
-
-  /**
-    * As [[pickOne]], retaining the candidates after the selected Node so a failed read batch can fall through without reconsidering the Node
-    * that just refused it.
-    */
-  def pickOneWithRest(candidates: Vector[Node], master: Node)(onPick: Option[(Node, NodeClient, Vector[Node])] => Unit): Unit = {
-    val it = candidates.iterator
-    var i  = 0
-    while (it.hasNext) {
-      val node = it.next()
+  def pickOne(candidates: Vector[Node], master: Node)(onPick: Option[ReadRouting.Picked] => Unit): Unit = {
+    var remaining = candidates
+    while (remaining.nonEmpty) {
+      val node = remaining.head
       val nc   = poolFor(node, master).existing(node)
       if (nc == null) {
         scheduler.offload(onPick(establishOneWithRest(candidates, master)))
         return
       }
       if (nc.isLive) {
-        onPick(Some((node, nc, candidates.drop(i + 1))))
+        onPick(Some(ReadRouting.Picked(node, nc, remaining.tail)))
         return
       }
-      i += 1
+      remaining = remaining.tail
     }
     onPick(None)
   }
@@ -146,14 +140,13 @@ final private[client] class ReadRouting(
       }
     )
 
-  private def establishOneWithRest(candidates: Vector[Node], master: Node): Option[(Node, NodeClient, Vector[Node])] = {
-    val it = candidates.iterator
-    var i  = 0
-    while (it.hasNext) {
-      val node = it.next()
+  private def establishOneWithRest(candidates: Vector[Node], master: Node): Option[ReadRouting.Picked] = {
+    var remaining = candidates
+    while (remaining.nonEmpty) {
+      val node = remaining.head
       val nc   = poolFor(node, master).getOrEstablishOrNull(node)
-      if (nc != null && nc.isLive) return Some((node, nc, candidates.drop(i + 1)))
-      i += 1
+      if (nc != null && nc.isLive) return Some(ReadRouting.Picked(node, nc, remaining.tail))
+      remaining = remaining.tail
     }
     None
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/ReadRouting.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ReadRouting.scala
@@ -106,19 +106,28 @@ final private[client] class ReadRouting(
     * The one Node a batch of reads should land on with its connection, established if need be, or `None` when no candidate can serve the
     * read. `onPick` runs on the caller's thread while a live candidate is already established, and off it otherwise.
     */
-  def pickOne(candidates: Vector[Node], master: Node)(onPick: Option[(Node, NodeClient)] => Unit): Unit = {
+  def pickOne(candidates: Vector[Node], master: Node)(onPick: Option[(Node, NodeClient)] => Unit): Unit =
+    pickOneWithRest(candidates, master)(picked => onPick(picked.map { case (node, nc, _) => (node, nc) }))
+
+  /**
+    * As [[pickOne]], retaining the candidates after the selected Node so a failed read batch can fall through without reconsidering the Node
+    * that just refused it.
+    */
+  def pickOneWithRest(candidates: Vector[Node], master: Node)(onPick: Option[(Node, NodeClient, Vector[Node])] => Unit): Unit = {
     val it = candidates.iterator
+    var i  = 0
     while (it.hasNext) {
       val node = it.next()
       val nc   = poolFor(node, master).existing(node)
       if (nc == null) {
-        scheduler.offload(onPick(establishOne(candidates, master)))
+        scheduler.offload(onPick(establishOneWithRest(candidates, master)))
         return
       }
       if (nc.isLive) {
-        onPick(Some((node, nc)))
+        onPick(Some((node, nc, candidates.drop(i + 1))))
         return
       }
+      i += 1
     }
     onPick(None)
   }
@@ -137,12 +146,14 @@ final private[client] class ReadRouting(
       }
     )
 
-  private def establishOne(candidates: Vector[Node], master: Node): Option[(Node, NodeClient)] = {
+  private def establishOneWithRest(candidates: Vector[Node], master: Node): Option[(Node, NodeClient, Vector[Node])] = {
     val it = candidates.iterator
+    var i  = 0
     while (it.hasNext) {
       val node = it.next()
       val nc   = poolFor(node, master).getOrEstablishOrNull(node)
-      if (nc != null && nc.isLive) return Some((node, nc))
+      if (nc != null && nc.isLive) return Some((node, nc, candidates.drop(i + 1)))
+      i += 1
     }
     None
   }

--- a/sage-client/shared/src/main/scala/sage/client/internal/ReadRouting.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ReadRouting.scala
@@ -57,6 +57,16 @@ final private[client] class ReadRouting(
 
   private val cursors = new ConcurrentHashMap[Node, AtomicInteger]()
 
+  private enum Lookup {
+    case Existing, Establish
+  }
+
+  private enum Selection {
+    case Found(picked: ReadRouting.Picked)
+    case NeedsEstablish
+    case Exhausted
+  }
+
   /**
     * The candidates for `master`'s replicas under the policy, advancing that master's cursor once.
     */
@@ -108,23 +118,18 @@ final private[client] class ReadRouting(
     * The one Node a batch of reads should land on with its connection and the candidates after it, established if need be, or `None` when no
     * candidate can serve the read. `onPick` runs on the caller's thread while a live candidate is already established, and off it otherwise.
     */
-  def pickOne(candidates: Vector[Node], master: Node)(onPick: Option[ReadRouting.Picked] => Unit): Unit = {
-    var remaining = candidates
-    while (remaining.nonEmpty) {
-      val node = remaining.head
-      val nc   = poolFor(node, master).existing(node)
-      if (nc == null) {
-        scheduler.offload(onPick(establishOneWithRest(candidates, master)))
-        return
-      }
-      if (nc.isLive) {
-        onPick(Some(ReadRouting.Picked(node, nc, remaining.tail)))
-        return
-      }
-      remaining = remaining.tail
+  def pickOne(candidates: Vector[Node], master: Node)(onPick: Option[ReadRouting.Picked] => Unit): Unit =
+    select(candidates, master, Lookup.Existing) match {
+      case Selection.Found(picked)  => onPick(Some(picked))
+      case Selection.Exhausted      => onPick(None)
+      case Selection.NeedsEstablish =>
+        scheduler.offload {
+          select(candidates, master, Lookup.Establish) match {
+            case Selection.Found(picked) => onPick(Some(picked))
+            case _                       => onPick(None)
+          }
+        }
     }
-    onPick(None)
-  }
 
   private def submit[A](nc: NodeClient, node: Node, command: Command[A], rest: Vector[Node], complete: Try[A] => Unit)(
     onFault: (Node, Throwable, Vector[Node]) => Unit
@@ -140,15 +145,20 @@ final private[client] class ReadRouting(
       }
     )
 
-  private def establishOneWithRest(candidates: Vector[Node], master: Node): Option[ReadRouting.Picked] = {
+  private def select(candidates: Vector[Node], master: Node, lookup: Lookup): Selection = {
     var remaining = candidates
     while (remaining.nonEmpty) {
       val node = remaining.head
-      val nc   = poolFor(node, master).getOrEstablishOrNull(node)
-      if (nc != null && nc.isLive) return Some(ReadRouting.Picked(node, nc, remaining.tail))
+      val pool = poolFor(node, master)
+      val nc   = lookup match {
+        case Lookup.Existing  => pool.existing(node)
+        case Lookup.Establish => pool.getOrEstablishOrNull(node)
+      }
+      if (nc == null && lookup == Lookup.Existing) return Selection.NeedsEstablish
+      if (nc != null && nc.isLive) return Selection.Found(ReadRouting.Picked(node, nc, remaining.tail))
       remaining = remaining.tail
     }
-    None
+    Selection.Exhausted
   }
 
   private def poolFor(node: Node, master: Node): NodePool = if (node == master) masterPool else replicaPool

--- a/sage-client/shared/src/main/scala/sage/client/internal/ReadRouting.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ReadRouting.scala
@@ -57,8 +57,10 @@ final private[client] class ReadRouting(
 
   private val cursors = new ConcurrentHashMap[Node, AtomicInteger]()
 
-  private enum Lookup {
-    case Existing, Establish
+  private enum CandidateState {
+    case Unknown
+    case Unavailable
+    case Connected(client: NodeClient)
   }
 
   private enum Selection {
@@ -119,12 +121,13 @@ final private[client] class ReadRouting(
     * candidate can serve the read. `onPick` runs on the caller's thread while a live candidate is already established, and off it otherwise.
     */
   def pickOne(candidates: Vector[Node], master: Node)(onPick: Option[ReadRouting.Picked] => Unit): Unit =
-    select(candidates, master, Lookup.Existing) match {
+    select(candidates, master, existingCandidate) match {
       case Selection.Found(picked)  => onPick(Some(picked))
       case Selection.Exhausted      => onPick(None)
       case Selection.NeedsEstablish =>
         scheduler.offload {
-          select(candidates, master, Lookup.Establish) match {
+          // restart the full order so a previously dead candidate may reconnect before the first unknown one
+          select(candidates, master, establishCandidate) match {
             case Selection.Found(picked) => onPick(Some(picked))
             case _                       => onPick(None)
           }
@@ -145,20 +148,30 @@ final private[client] class ReadRouting(
       }
     )
 
-  private def select(candidates: Vector[Node], master: Node, lookup: Lookup): Selection = {
+  private def select(candidates: Vector[Node], master: Node, lookup: (NodePool, Node) => CandidateState): Selection = {
     var remaining = candidates
     while (remaining.nonEmpty) {
       val node = remaining.head
       val pool = poolFor(node, master)
-      val nc   = lookup match {
-        case Lookup.Existing  => pool.existing(node)
-        case Lookup.Establish => pool.getOrEstablishOrNull(node)
+      lookup(pool, node) match {
+        case CandidateState.Unknown       => return Selection.NeedsEstablish
+        case CandidateState.Unavailable   => ()
+        case CandidateState.Connected(nc) =>
+          if (nc.isLive) return Selection.Found(ReadRouting.Picked(node, nc, remaining.tail))
       }
-      if (nc == null && lookup == Lookup.Existing) return Selection.NeedsEstablish
-      if (nc != null && nc.isLive) return Selection.Found(ReadRouting.Picked(node, nc, remaining.tail))
       remaining = remaining.tail
     }
     Selection.Exhausted
+  }
+
+  private def existingCandidate(pool: NodePool, node: Node): CandidateState = {
+    val nc = pool.existing(node)
+    if (nc == null) CandidateState.Unknown else CandidateState.Connected(nc)
+  }
+
+  private def establishCandidate(pool: NodePool, node: Node): CandidateState = {
+    val nc = pool.getOrEstablishOrNull(node)
+    if (nc == null) CandidateState.Unavailable else CandidateState.Connected(nc)
   }
 
   private def poolFor(node: Node, master: Node): NodePool = if (node == master) masterPool else replicaPool

--- a/sage-client/shared/src/main/scala/sage/client/internal/TxSupport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/TxSupport.scala
@@ -87,13 +87,13 @@ private[internal] object TxSupport {
     * no done-guard is needed. This is the collect-all shape shared by the standalone and cluster pipelines; the connection's fail-fast
     * RawBatch deliberately keeps its own.
     */
-  final class IndexedCollector[A](n: Int, complete: Try[Vector[A]] => Unit) {
+  final class IndexedCollector[A](n: Int, complete: Vector[A] => Unit) {
     private val slots     = new AtomicReferenceArray[A](n)
     private val remaining = new AtomicInteger(n)
 
     def set(index: Int, value: A): Unit = {
       slots.set(index, value)
-      if (remaining.decrementAndGet() == 0) complete(Success(Vector.tabulate(n)(slots.get)))
+      if (remaining.decrementAndGet() == 0) complete(Vector.tabulate(n)(slots.get))
     }
   }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/EventsSpec.scala
@@ -238,7 +238,8 @@ class EventsSpec extends munit.FunSuite {
         true
       },
       _ => (),
-      Some(node)
+      onUnsent = () => (),
+      node = Some(node)
     )
     assertEquals(rec.events.collect { case c: SageEvent.CommandCompleted => c.node }, Vector(Some(node)))
     assert(tracer.log.contains(s"routed:${node.host}:${node.port}"), s"expected routedTo the selected node, got ${tracer.log.toVector}")
@@ -249,7 +250,15 @@ class EventsSpec extends munit.FunSuite {
     val rec                                                                = new Recording(Some(tracer))
     val commands                                                           = Vector(Connection.ping(None), Connection.ping(None))
     var completed: scala.util.Try[Vector[Either[sage.SageException, Any]]] = null
-    Client.submitBatchOnOne(rec, commands, Events.startSpans(rec, commands), (_, _) => false, r => completed = r, Some(Node("replica", 7001)))
+    Client.submitBatchOnOne(
+      rec,
+      commands,
+      Events.startSpans(rec, commands),
+      (_, _) => false,
+      r => completed = r,
+      onUnsent = () => (),
+      node = Some(Node("replica", 7001))
+    )
     assert(completed != null && completed.isFailure, s"an unsubmitted batch must fail the effect, got $completed")
     assertEquals(rec.events.collect { case c: SageEvent.CommandCompleted => c.node }, Vector(None, None))
     assert(!tracer.log.exists(_.startsWith("routed:")), s"an unsent batch must route no span, got ${tracer.log.toVector}")

--- a/sage-client/shared/src/test/scala/sage/client/internal/ReadRoutingSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ReadRoutingSpec.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 
 import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
 import scala.util.{Success, Try}
 
 import sage.Bytes
@@ -75,7 +76,11 @@ class ReadRoutingSpec extends munit.FunSuite {
     private def respond(node: Node)(payload: Bytes): Seq[Frame]         =
       if (payload.asUtf8String.contains("HELLO")) Seq(Replies.hello)
       else if (refusing(node)) Seq(Frame.SimpleError("LOADING the dataset is loading"))
-      else Seq(Frame.SimpleString("PONG"))
+      else {
+        val text  = payload.asUtf8String
+        val pings = text.sliding("PING".length).count(_ == "PING")
+        Seq.fill(math.max(1, pings))(Frame.SimpleString("PONG"))
+      }
     private val factory: Node => MultiplexedConnection.TransportFactory = node =>
       (onFrame, onClosed) =>
         if (unreachable(node)) throw new IOException(s"unreachable $node")
@@ -102,6 +107,7 @@ class ReadRoutingSpec extends munit.FunSuite {
     def establish(node: Node): Unit                                     = replicaPool.getOrEstablish(node): Unit
     def kill(node: Node): Unit                                          = transports.get(node).close()
     def wrote(node: Node): Boolean                                      = transports.get(node).written.exists(_.asUtf8String.contains("PING"))
+    def written(node: Node): Vector[String]                             = transports.get(node).written.map(_.asUtf8String)
     def close(): Unit                                                   = {
       masterPool.close()
       replicaPool.close()
@@ -168,9 +174,9 @@ class ReadRoutingSpec extends munit.FunSuite {
   test("pickOne answers the first live candidate, without offloading") {
     val fixture = new Fixture()
     fixture.establish(r1)
-    val picked  = new AtomicReference[Option[(Node, NodeClient)]]()
+    val picked  = new AtomicReference[Option[ReadRouting.Picked]]()
     fixture.reads.pickOne(Vector(r1), m)(picked.set)
-    assertEquals(picked.get(), Some((r1, fixture.replicaPool.existing(r1))))
+    assertEquals(picked.get(), Some(ReadRouting.Picked(r1, fixture.replicaPool.existing(r1), Vector.empty)))
     fixture.close()
   }
 
@@ -178,15 +184,42 @@ class ReadRoutingSpec extends munit.FunSuite {
     val fixture = new Fixture()
     fixture.establish(r1)
     fixture.kill(r1)
-    val picked  = new AtomicReference[Option[(Node, NodeClient)]]()
+    val picked  = new AtomicReference[Option[ReadRouting.Picked]]()
     fixture.reads.pickOne(Vector(r1), m)(picked.set)
     assertEquals(picked.get(), None)
     fixture.close()
   }
 
+  test("pickOne retries an unsent batch on the remaining candidate as one batch") {
+    val fixture   = new Fixture()
+    fixture.establish(r1)
+    fixture.establish(r2)
+    val results   = new java.util.concurrent.ConcurrentLinkedQueue[Try[Any]]()
+    val commands  = Vector(ping, ping)
+    val callbacks = Vector.fill(commands.length)((result: Try[Any]) => results.add(result): Unit)
+
+    def submitOn(picked: Option[ReadRouting.Picked]): Unit =
+      picked match {
+        case Some(ReadRouting.Picked(node, client, remaining)) =>
+          if (node == r1) fixture.kill(r1) // selected while live, disconnected before submitAll reserves the generation
+          if (!client.submitAll(commands, callbacks))
+            fixture.reads.pickOne(remaining, m)(submitOn)
+        case None                                              => fail("the remaining live candidate should accept the batch")
+      }
+
+    fixture.reads.pickOne(Vector(r1, r2), m)(submitOn)
+
+    assertEquals(results.size(), commands.length)
+    assert(results.asScala.forall(_.isSuccess))
+    val fallbackWrites = fixture.written(r2).filter(_.contains("PING"))
+    assertEquals(fallbackWrites.length, 1, "the retry must remain one transport batch")
+    assertEquals(fallbackWrites.head.sliding("PING".length).count(_ == "PING"), commands.length)
+    fixture.close()
+  }
+
   test("pickOne offloads to establish, then answers None when no candidate can be reached") {
     val fixture = new Fixture(unreachable = Set(r1, r2))
-    val picked  = new AtomicReference[Option[(Node, NodeClient)]]()
+    val picked  = new AtomicReference[Option[ReadRouting.Picked]]()
     fixture.reads.pickOne(Vector(r1, r2), m)(picked.set)
     assertEquals(picked.get(), null, "establishing must not run on the caller's thread")
     fixture.scheduler.advance(Duration.Zero)

--- a/sage-client/shared/src/test/scala/sage/client/internal/ReadRoutingSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ReadRoutingSpec.scala
@@ -180,6 +180,16 @@ class ReadRoutingSpec extends munit.FunSuite {
     fixture.close()
   }
 
+  test("pickOne returns the candidates after the selected node") {
+    val fixture = new Fixture()
+    fixture.establish(r1)
+    fixture.establish(r2)
+    val picked  = new AtomicReference[Option[ReadRouting.Picked]]()
+    fixture.reads.pickOne(Vector(r1, r2), m)(picked.set)
+    assertEquals(picked.get(), Some(ReadRouting.Picked(r1, fixture.replicaPool.existing(r1), Vector(r2))))
+    fixture.close()
+  }
+
   test("pickOne answers None when every candidate is established but dead") {
     val fixture = new Fixture()
     fixture.establish(r1)

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
@@ -1,6 +1,7 @@
 package sage.client
 
 import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicReference
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.*
@@ -19,27 +20,34 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
 
   private given ExecutionContext = munitExecutionContext
 
-  private val master  = Node("master-host", 7000)
-  private val replica = Node("replica-host", 7001)
-
-  private val roleReply: Frame = Replies.masterRole(replica)
+  private val master   = Node("master-host", 7000)
+  private val replica  = Node("replica-host", 7001)
+  private val replica2 = Node("replica2-host", 7002)
 
   // one reply per command occurrence in a batch; only the master answers ROLE; other bootstrap commands each get a single OK
   private def respondFor(
     node: Node,
-    readFailure: Option[(Node, Frame)],
-    readsByNode: ConcurrentLinkedQueue[Node]
+    role: Frame,
+    readFailure: AtomicReference[Option[(Node, Frame)]],
+    readsByNode: ConcurrentLinkedQueue[Node],
+    readBatches: ConcurrentLinkedQueue[(Node, Int)],
+    disconnectOnRead: Option[Node],
+    disconnect: () => Unit
   ): Bytes => Seq[Frame] = payload => {
     val s = payload.asUtf8String
     if (s.contains("HELLO")) Seq(Replies.hello)
-    else if (s.contains("ROLE")) if (node == master) Seq(roleReply) else Nil
+    else if (s.contains("ROLE")) if (node == master) Seq(role) else Nil
     else {
       val reads  = occurrences(s, "PREAD")
       val writes = occurrences(s, "PWRITE")
       (0 until reads).foreach(_ => readsByNode.add(node))
-      if (reads + writes == 0) Seq(ok)
+      if (reads > 0) { readBatches.add(node -> reads): Unit }
+      if (reads > 0 && disconnectOnRead.contains(node)) {
+        disconnect()
+        Seq.empty
+      } else if (reads + writes == 0) Seq(ok)
       else
-        Seq.fill(reads)(readFailure.collect { case (`node`, failure) => failure }.getOrElse(ok)) ++ Seq.fill(writes)(ok)
+        Seq.fill(reads)(readFailure.get().collect { case (`node`, failure) => failure }.getOrElse(ok)) ++ Seq.fill(writes)(ok)
     }
   }
 
@@ -70,16 +78,24 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
     completions: ConcurrentLinkedQueue[SageEvent.CommandCompleted],
     tracer: RoutingTracer,
     latch: CountDownLatch,
-    readsByNode: ConcurrentLinkedQueue[Node]
+    readsByNode: ConcurrentLinkedQueue[Node],
+    readBatches: ConcurrentLinkedQueue[(Node, Int)],
+    readFailure: AtomicReference[Option[(Node, Frame)]]
   )
 
   private def build(
     readFrom: ReadFrom,
     scheduler: Scheduler = Scheduler.real,
-    readFailure: Option[(Node, Frame)] = None
+    readFailure: Option[(Node, Frame)] = None,
+    disconnectOnRead: Option[Node] = None,
+    includeSecondReplica: Boolean = false
   ): Fixture = {
     val completions                                             = new ConcurrentLinkedQueue[SageEvent.CommandCompleted]()
     val readsByNode                                             = new ConcurrentLinkedQueue[Node]()
+    val readBatches                                             = new ConcurrentLinkedQueue[(Node, Int)]()
+    val readFailureRef                                          = new AtomicReference(readFailure)
+    val replicas                                                = if (includeSecondReplica) Vector(replica, replica2) else Vector(replica)
+    val role                                                    = Replies.masterRole(replicas*)
     val latch                                                   = new CountDownLatch(2)
     val listener                                                = new SageListener {
       def onEvent(event: SageEvent): Unit = event match {
@@ -91,7 +107,16 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
     }
     val tracer                                                  = new RoutingTracer
     val factory: Node => MultiplexedConnection.TransportFactory =
-      node => (onFrame, onClosed) => new FakeTransport(onFrame, onClosed, respondFor(node, readFailure, readsByNode))
+      node =>
+        (onFrame, onClosed) => {
+          var transport: FakeTransport = null
+          transport = new FakeTransport(
+            onFrame,
+            onClosed,
+            respondFor(node, role, readFailureRef, readsByNode, readBatches, disconnectOnRead, () => transport.close())
+          )
+          transport
+        }
     val live                                                    =
       new MasterReplicaLive(
         factory,
@@ -103,7 +128,7 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
         Events(Vector(listener), Some(tracer))
       )
     live.bootstrapRoles()
-    Fixture(live, completions, tracer, latch, readsByNode)
+    Fixture(live, completions, tracer, latch, readsByNode, readBatches, readFailureRef)
   }
 
   test("a command to the established master dispatches inline, with no zero-delay scheduler hop") {
@@ -173,6 +198,7 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
       .map { _ =>
         assert(f.latch.await(2, TimeUnit.SECONDS), "expected a completion per pipeline position")
         assertEquals(f.readsByNode.asScala.toVector, Vector(replica, replica, master, master))
+        assertEquals(f.readBatches.asScala.toVector, Vector(replica -> 2, master -> 2))
         assertEquals(f.completions.asScala.toVector.map(_.node), Vector(Some(master), Some(master)))
         f.live.close.unsafeRun
       }
@@ -195,6 +221,20 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
       }
   }
 
+  test("a terminal pipeline error settles without a scheduler hop") {
+    val counting = new CountingScheduler
+    val f        = build(ReadFrom.ReplicaPreferred, scheduler = counting)
+    f.live.pipeline(Seq(readCmd, readCmd)).unsafeRun.flatMap { _ =>
+      f.readFailure.set(Some(replica -> Frame.SimpleError("WRONGTYPE Operation against a key holding the wrong kind of value")))
+      val before = counting.zeroDelays.get()
+      f.live.pipelineAttempt(Seq(readCmd, readCmd)).unsafeRun.map { results =>
+        assert(results.forall(_.isLeft), s"expected terminal command errors, got $results")
+        assertEquals(counting.zeroDelays.get(), before, "a terminal server reply must settle without a scheduler hop")
+        f.live.close.unsafeRun
+      }
+    }
+  }
+
   test("a MasterPreferred read-only pipeline falls back when the master cannot serve reads") {
     val f = build(
       ReadFrom.MasterPreferred,
@@ -206,7 +246,40 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
       .map { _ =>
         assert(f.latch.await(2, TimeUnit.SECONDS), "expected a completion per pipeline position")
         assertEquals(f.readsByNode.asScala.toVector, Vector(master, master, replica, replica))
+        assertEquals(f.readBatches.asScala.toVector, Vector(master -> 2, replica -> 2))
         assertEquals(f.completions.asScala.toVector.map(_.node), Vector(Some(replica), Some(replica)))
+        f.live.close.unsafeRun
+      }
+  }
+
+  test("a ReplicaPreferred read-only pipeline falls back when the replica disconnects after submission") {
+    val f = build(ReadFrom.ReplicaPreferred, disconnectOnRead = Some(replica))
+    f.live
+      .pipeline(Seq(readCmd, readCmd))
+      .unsafeRun
+      .map { _ =>
+        assert(f.latch.await(2, TimeUnit.SECONDS), "expected a completion per pipeline position")
+        assertEquals(f.readsByNode.asScala.toVector, Vector(replica, replica, master, master))
+        assertEquals(f.readBatches.asScala.toVector, Vector(replica -> 2, master -> 2))
+        assertEquals(f.completions.asScala.toVector.map(_.node), Vector(Some(master), Some(master)))
+        f.live.close.unsafeRun
+      }
+  }
+
+  test("a strict Replica read-only pipeline falls through to the next replica as one batch") {
+    val f = build(
+      ReadFrom.Replica,
+      readFailure = Some(replica -> Frame.SimpleError("MASTERDOWN Link with MASTER is down")),
+      includeSecondReplica = true
+    )
+    f.live
+      .pipeline(Seq(readCmd, readCmd))
+      .unsafeRun
+      .map { _ =>
+        assert(f.latch.await(2, TimeUnit.SECONDS), "expected a completion per pipeline position")
+        assertEquals(f.readsByNode.asScala.toVector, Vector(replica, replica, replica2, replica2))
+        assertEquals(f.readBatches.asScala.toVector, Vector(replica -> 2, replica2 -> 2))
+        assertEquals(f.completions.asScala.toVector.map(_.node), Vector(Some(replica2), Some(replica2)))
         f.live.close.unsafeRun
       }
   }

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
@@ -24,33 +24,6 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
   private val replica  = Node("replica-host", 7001)
   private val replica2 = Node("replica2-host", 7002)
 
-  // one reply per command occurrence in a batch; only the master answers ROLE; other bootstrap commands each get a single OK
-  private def respondFor(
-    node: Node,
-    role: Frame,
-    readFailure: AtomicReference[Option[(Node, Frame)]],
-    readsByNode: ConcurrentLinkedQueue[Node],
-    readBatches: ConcurrentLinkedQueue[(Node, Int)],
-    disconnectOnRead: Option[Node],
-    disconnect: () => Unit
-  ): Bytes => Seq[Frame] = payload => {
-    val s = payload.asUtf8String
-    if (s.contains("HELLO")) Seq(Replies.hello)
-    else if (s.contains("ROLE")) if (node == master) Seq(role) else Nil
-    else {
-      val reads  = occurrences(s, "PREAD")
-      val writes = occurrences(s, "PWRITE")
-      (0 until reads).foreach(_ => readsByNode.add(node))
-      if (reads > 0) { readBatches.add(node -> reads): Unit }
-      if (reads > 0 && disconnectOnRead.contains(node)) {
-        disconnect()
-        Seq.empty
-      } else if (reads + writes == 0) Seq(ok)
-      else
-        Seq.fill(reads)(readFailure.get().collect { case (`node`, failure) => failure }.getOrElse(ok)) ++ Seq.fill(writes)(ok)
-    }
-  }
-
   private def occurrences(haystack: String, needle: String): Int = {
     var count = 0
     var from  = haystack.indexOf(needle)
@@ -73,15 +46,57 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
   private val readCmd: Command[Unit]  = Command("PREAD", Command.NoKeys, Vector.empty, (_: Frame) => Right(()), isReadOnly = true)
   private val writeCmd: Command[Unit] = Command("PWRITE", Command.NoKeys, Vector.empty, (_: Frame) => Right(()), isReadOnly = false)
 
+  // one reply per command occurrence in a batch; only the master answers ROLE; other bootstrap commands each get a single OK
+  final private class PipelineScript(role: Frame, failure: Option[(Node, Frame)], disconnectOnRead: Option[Node]) {
+    val readsByNode = new ConcurrentLinkedQueue[Node]()
+    val readBatches = new ConcurrentLinkedQueue[(Node, Int)]()
+    val readFailure = new AtomicReference(failure)
+    val readReplies = new AtomicReference[Option[(Node, Vector[Frame])]](None)
+
+    val factory: Node => MultiplexedConnection.TransportFactory =
+      node =>
+        (onFrame, onClosed) => {
+          var transport: FakeTransport = null
+          transport = new FakeTransport(onFrame, onClosed, respondFor(node, () => transport.close()))
+          transport
+        }
+
+    private def respondFor(node: Node, disconnect: () => Unit): Bytes => Seq[Frame] = payload => {
+      val s = payload.asUtf8String
+      if (s.contains("HELLO")) Seq(Replies.hello)
+      else if (s.contains("ROLE")) if (node == master) Seq(role) else Nil
+      else {
+        val reads  = occurrences(s, "PREAD")
+        val writes = occurrences(s, "PWRITE")
+        (0 until reads).foreach(_ => readsByNode.add(node))
+        if (reads > 0) { readBatches.add(node -> reads): Unit }
+        if (reads > 0 && disconnectOnRead.contains(node)) {
+          disconnect()
+          Seq.empty
+        } else if (reads + writes == 0) Seq(ok)
+        else {
+          val scripted =
+            readReplies.get().collect { case (`node`, frames) => frames }.getOrElse {
+              Vector.fill(reads)(readFailure.get().collect { case (`node`, frame) => frame }.getOrElse(ok))
+            }
+          scripted ++ Seq.fill(writes)(ok)
+        }
+      }
+    }
+  }
+
   final private case class Fixture(
     live: MasterReplicaLive,
     completions: ConcurrentLinkedQueue[SageEvent.CommandCompleted],
     tracer: RoutingTracer,
     latch: CountDownLatch,
-    readsByNode: ConcurrentLinkedQueue[Node],
-    readBatches: ConcurrentLinkedQueue[(Node, Int)],
-    readFailure: AtomicReference[Option[(Node, Frame)]]
-  )
+    script: PipelineScript
+  ) {
+    def readsByNode: ConcurrentLinkedQueue[Node]                    = script.readsByNode
+    def readBatches: ConcurrentLinkedQueue[(Node, Int)]             = script.readBatches
+    def readFailure: AtomicReference[Option[(Node, Frame)]]         = script.readFailure
+    def readReplies: AtomicReference[Option[(Node, Vector[Frame])]] = script.readReplies
+  }
 
   private def build(
     readFrom: ReadFrom,
@@ -90,14 +105,12 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
     disconnectOnRead: Option[Node] = None,
     includeSecondReplica: Boolean = false
   ): Fixture = {
-    val completions                                             = new ConcurrentLinkedQueue[SageEvent.CommandCompleted]()
-    val readsByNode                                             = new ConcurrentLinkedQueue[Node]()
-    val readBatches                                             = new ConcurrentLinkedQueue[(Node, Int)]()
-    val readFailureRef                                          = new AtomicReference(readFailure)
-    val replicas                                                = if (includeSecondReplica) Vector(replica, replica2) else Vector(replica)
-    val role                                                    = Replies.masterRole(replicas*)
-    val latch                                                   = new CountDownLatch(2)
-    val listener                                                = new SageListener {
+    val completions = new ConcurrentLinkedQueue[SageEvent.CommandCompleted]()
+    val replicas    = if (includeSecondReplica) Vector(replica, replica2) else Vector(replica)
+    val role        = Replies.masterRole(replicas*)
+    val script      = new PipelineScript(role, readFailure, disconnectOnRead)
+    val latch       = new CountDownLatch(2)
+    val listener    = new SageListener {
       def onEvent(event: SageEvent): Unit = event match {
         case c: SageEvent.CommandCompleted if c.name == "PREAD" || c.name == "PWRITE" =>
           completions.add(c)
@@ -105,21 +118,10 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
         case _                                                                        => ()
       }
     }
-    val tracer                                                  = new RoutingTracer
-    val factory: Node => MultiplexedConnection.TransportFactory =
-      node =>
-        (onFrame, onClosed) => {
-          var transport: FakeTransport = null
-          transport = new FakeTransport(
-            onFrame,
-            onClosed,
-            respondFor(node, role, readFailureRef, readsByNode, readBatches, disconnectOnRead, () => transport.close())
-          )
-          transport
-        }
-    val live                                                    =
+    val tracer      = new RoutingTracer
+    val live        =
       new MasterReplicaLive(
-        factory,
+        script.factory,
         scheduler,
         Vector(Connection.hello(None)),
         SageConfig(readFrom = readFrom),
@@ -128,7 +130,7 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
         Events(Vector(listener), Some(tracer))
       )
     live.bootstrapRoles()
-    Fixture(live, completions, tracer, latch, readsByNode, readBatches, readFailureRef)
+    Fixture(live, completions, tracer, latch, script)
   }
 
   test("a command to the established master dispatches inline, with no zero-delay scheduler hop") {
@@ -233,6 +235,29 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
         f.live.close.unsafeRun
       }
     }
+  }
+
+  test("a retryable position retries a mixed-result pipeline as one batch") {
+    val f = build(ReadFrom.ReplicaPreferred)
+    f.readReplies.set(
+      Some(
+        replica -> Vector(
+          Frame.SimpleError("WRONGTYPE Operation against a key holding the wrong kind of value"),
+          Frame.SimpleError("MASTERDOWN Link with MASTER is down")
+        )
+      )
+    )
+    f.live
+      .pipelineAttempt(Seq(readCmd, readCmd))
+      .unsafeRun
+      .map { results =>
+        assert(results.forall(_.isRight), s"the fallback attempt should replace every result from the refused node, got $results")
+        assert(f.latch.await(2, TimeUnit.SECONDS), "expected a completion per pipeline position")
+        assertEquals(f.readsByNode.asScala.toVector, Vector(replica, replica, master, master))
+        assertEquals(f.readBatches.asScala.toVector, Vector(replica -> 2, master -> 2))
+        assertEquals(f.completions.asScala.toVector.map(_.node), Vector(Some(master), Some(master)))
+        f.live.close.unsafeRun
+      }
   }
 
   test("a MasterPreferred read-only pipeline falls back when the master cannot serve reads") {

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
@@ -25,13 +25,21 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
   private val roleReply: Frame = Replies.masterRole(replica)
 
   // one reply per command occurrence in a batch; only the master answers ROLE; other bootstrap commands each get a single OK
-  private def respondFor(node: Node): Bytes => Seq[Frame] = payload => {
+  private def respondFor(
+    node: Node,
+    readFailure: Option[(Node, Frame)],
+    readsByNode: ConcurrentLinkedQueue[Node]
+  ): Bytes => Seq[Frame] = payload => {
     val s = payload.asUtf8String
     if (s.contains("HELLO")) Seq(Replies.hello)
     else if (s.contains("ROLE")) if (node == master) Seq(roleReply) else Nil
     else {
-      val batch = occurrences(s, "PREAD") + occurrences(s, "PWRITE")
-      if (batch > 0) Seq.fill(batch)(ok) else Seq(ok)
+      val reads  = occurrences(s, "PREAD")
+      val writes = occurrences(s, "PWRITE")
+      (0 until reads).foreach(_ => readsByNode.add(node))
+      if (reads + writes == 0) Seq(ok)
+      else
+        Seq.fill(reads)(readFailure.collect { case (`node`, failure) => failure }.getOrElse(ok)) ++ Seq.fill(writes)(ok)
     }
   }
 
@@ -61,11 +69,17 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
     live: MasterReplicaLive,
     completions: ConcurrentLinkedQueue[SageEvent.CommandCompleted],
     tracer: RoutingTracer,
-    latch: CountDownLatch
+    latch: CountDownLatch,
+    readsByNode: ConcurrentLinkedQueue[Node]
   )
 
-  private def build(readFrom: ReadFrom, scheduler: Scheduler = Scheduler.real): Fixture = {
+  private def build(
+    readFrom: ReadFrom,
+    scheduler: Scheduler = Scheduler.real,
+    readFailure: Option[(Node, Frame)] = None
+  ): Fixture = {
     val completions                                             = new ConcurrentLinkedQueue[SageEvent.CommandCompleted]()
+    val readsByNode                                             = new ConcurrentLinkedQueue[Node]()
     val latch                                                   = new CountDownLatch(2)
     val listener                                                = new SageListener {
       def onEvent(event: SageEvent): Unit = event match {
@@ -77,7 +91,7 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
     }
     val tracer                                                  = new RoutingTracer
     val factory: Node => MultiplexedConnection.TransportFactory =
-      node => (onFrame, onClosed) => new FakeTransport(onFrame, onClosed, respondFor(node))
+      node => (onFrame, onClosed) => new FakeTransport(onFrame, onClosed, respondFor(node, readFailure, readsByNode))
     val live                                                    =
       new MasterReplicaLive(
         factory,
@@ -89,7 +103,7 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
         Events(Vector(listener), Some(tracer))
       )
     live.bootstrapRoles()
-    Fixture(live, completions, tracer, latch)
+    Fixture(live, completions, tracer, latch, readsByNode)
   }
 
   test("a command to the established master dispatches inline, with no zero-delay scheduler hop") {
@@ -144,6 +158,55 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
         assertEquals(nodes, Vector(Some(master), Some(master)), s"a write forces the whole batch to the master, got $nodes")
         val routed = f.tracer.routed.asScala.toVector.filter(p => p._1 == "PWRITE" || p._1 == "PREAD")
         assertEquals(routed, Vector("PWRITE" -> master, "PREAD" -> master), s"tracer should route both commands to the master, got $routed")
+        f.live.close.unsafeRun
+      }
+  }
+
+  test("a ReplicaPreferred read-only pipeline falls back when the replica cannot serve reads") {
+    val f = build(
+      ReadFrom.ReplicaPreferred,
+      readFailure = Some(replica -> Frame.SimpleError("MASTERDOWN Link with MASTER is down"))
+    )
+    f.live
+      .pipeline(Seq(readCmd, readCmd))
+      .unsafeRun
+      .map { _ =>
+        assert(f.latch.await(2, TimeUnit.SECONDS), "expected a completion per pipeline position")
+        assertEquals(f.readsByNode.asScala.toVector, Vector(replica, replica, master, master))
+        assertEquals(f.completions.asScala.toVector.map(_.node), Vector(Some(master), Some(master)))
+        f.live.close.unsafeRun
+      }
+  }
+
+  test("a ReplicaPreferred read-only pipeline does not fall back after a command error") {
+    val f = build(
+      ReadFrom.ReplicaPreferred,
+      readFailure = Some(replica -> Frame.SimpleError("WRONGTYPE Operation against a key holding the wrong kind of value"))
+    )
+    f.live
+      .pipelineAttempt(Seq(readCmd, readCmd))
+      .unsafeRun
+      .map { results =>
+        assert(results.forall(_.isLeft), s"expected the replica's command errors, got $results")
+        assert(f.latch.await(2, TimeUnit.SECONDS), "expected a completion per pipeline position")
+        assertEquals(f.readsByNode.asScala.toVector, Vector(replica, replica))
+        assertEquals(f.completions.asScala.toVector.map(_.node), Vector(Some(replica), Some(replica)))
+        f.live.close.unsafeRun
+      }
+  }
+
+  test("a MasterPreferred read-only pipeline falls back when the master cannot serve reads") {
+    val f = build(
+      ReadFrom.MasterPreferred,
+      readFailure = Some(master -> Frame.SimpleError("LOADING Redis is loading the dataset in memory"))
+    )
+    f.live
+      .pipeline(Seq(readCmd, readCmd))
+      .unsafeRun
+      .map { _ =>
+        assert(f.latch.await(2, TimeUnit.SECONDS), "expected a completion per pipeline position")
+        assertEquals(f.readsByNode.asScala.toVector, Vector(master, master, replica, replica))
+        assertEquals(f.completions.asScala.toVector.map(_.node), Vector(Some(replica), Some(replica)))
         f.live.close.unsafeRun
       }
   }

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -65,24 +65,29 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     events: Events = Events.disabled,
     minRefreshInterval: FiniteDuration = 50.millis,
     topologyRefreshInterval: Option[FiniteDuration] = None,
-    scheduler: Scheduler = Scheduler.real
+    scheduler: Scheduler = Scheduler.real,
+    failDial: (Node, Int) => Boolean = (_, _) => false
   ) {
 
     val roles                                                           = TrieMap.from(initialRoles)
     @volatile var writesFailReadonly                                    = false
     @volatile var diesOnRead: Node                                      = null
     private val dials                                                   = new ConcurrentLinkedQueue[Node]()
+    private val roleRequests                                            = new ConcurrentLinkedQueue[Node]()
     private val transports                                              = new ConcurrentLinkedQueue[(Node, FakeTransport)]()
     private val factory: Node => MultiplexedConnection.TransportFactory = node =>
       (onFrame, onClosed) => {
+        val attempt                      = dials.asScala.count(_ == node)
         dials.add(node)
-        if (unreachable(node)) throw new IOException(s"cannot reach $node")
+        if (unreachable(node) || failDial(node, attempt)) throw new IOException(s"cannot reach $node")
         val respond: Bytes => Seq[Frame] = payload => {
           val text  = payload.asUtf8String
           val reads = text.sliding("ZSCORE".length).count(_ == "ZSCORE")
           if (text.contains("HELLO")) Seq(Replies.hello)
-          else if (text.contains("ROLE")) roles.get(node).toSeq
-          else if (reads > 0 && node == diesOnRead) {
+          else if (text.contains("ROLE")) {
+            roleRequests.add(node)
+            roles.get(node).toSeq
+          } else if (reads > 0 && node == diesOnRead) {
             kill(node)
             Nil
           } else if (reads > 0) Seq.fill(reads)(Frame.Integer(1L))
@@ -106,7 +111,8 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
       events
     )
 
-    def dialled: Vector[Node] = dials.asScala.toVector
+    def dialled: Vector[Node]             = dials.asScala.toVector
+    def roleRequestCount(node: Node): Int = roleRequests.asScala.count(_ == node)
 
     private def kill(node: Node): Unit =
       transports.asScala.toVector.collect { case (`node`, transport) => transport }.foreach(_.close())
@@ -124,6 +130,9 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
 
     def readPipeline(): Unit =
       scala.concurrent.Await.result(live.pipeline(Seq(readCommand, readCommand)).unsafeRun, 10.seconds): Unit
+
+    def writePipeline(): Try[Unit] =
+      Try(scala.concurrent.Await.result(live.pipeline(Seq(writeCommand, writeCommand)).unsafeRun, 10.seconds): Unit)
 
     def awaitTrue(condition: => Boolean, clue: String, timeout: FiniteDuration = 5.seconds): Unit = {
       val deadline = System.nanoTime() + timeout.toNanos
@@ -399,6 +408,23 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
       },
       "replica-preferred pipelines did not reconsider the connected replica",
       timeout = 1.second
+    )
+    fixture.close()
+  }
+
+  test("an unsent master pipeline triggers role re-discovery") {
+    val fixture = new Fixture(
+      seeds = Vector(primary),
+      initialRoles = Map(primary -> masterRole(advertisedReplica)),
+      failDial = (node, attempt) => node == primary && attempt == 1
+    )
+    fixture.live.bootstrapRoles()
+    assertEquals(fixture.roleRequestCount(primary), 1)
+
+    assert(fixture.writePipeline().isFailure, "the master connection establishment should fail")
+    fixture.awaitTrue(
+      fixture.roleRequestCount(primary) >= 2,
+      "an unsent master pipeline did not trigger role re-discovery"
     )
     fixture.close()
   }


### PR DESCRIPTION
## What changed

- preserve the remaining read candidates when selecting a node for a master-replica pipeline
- retry an entire read-only pipeline batch on the next candidate after a node-local refusal or connection loss
- retain batching when the selected connection dies before submission
- settle terminal-only attempts on the reply thread and attribute every position to the terminal batch node
- trigger role re-discovery when a master-only pipeline cannot be submitted
- share pipeline tracking and completion bookkeeping with the existing single-node batch path
- narrow the shared indexed collector to its actual success-only completion shape and adapt the cluster caller
- share one fault-disposition path between ordinary reads and read-only pipelines
- add fake-transport coverage for preferred and strict replica routing, terminal errors, pre-send loss, post-submit disconnects, batching, and master re-discovery
- extend the real Redis/Valkey stale-replica integration test to cover read-only pipelines

## Why

Master-replica pipelines previously selected one candidate and settled every batch reply immediately. A reachable replica returning MASTERDOWN under ReplicaPreferred therefore failed the whole pipeline instead of falling back to the master. The same gap affected MasterPreferred when its master could not serve reads, and connection loss races could strand a batch.

## Impact

Read-only pipelines now honor the same ordered candidate fallback as ordinary reads while remaining one batch on one node per attempt. Replica never reaches the master, but can fall through to another replica. An attempt containing only terminal command errors settles on its reply thread. If any position reports a node-level retryable fault, the whole read-only batch is retried, including positions that already returned a terminal result, and final attribution comes from the terminal attempt. Pipelines containing writes retain master routing and now re-discover roles after an unsent batch.

## Validation

- `sbt check testUnit`
- `sbt itZio` — 394 integration tests passed
- focused master-replica pipeline, topology, and read-routing specs
- targeted Redis and Valkey stale-replica suites
