### PR TITLE
Make the test suites consistent and drop duplication

### DIFF
--- a/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
+++ b/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
@@ -11,158 +11,114 @@ import sage.backend.*
 
 class CeSmokeSuite extends ServerSuite(Images.redis) {
 
+  private def withNativeClient(body: SageClient => IO[Unit]): Unit =
+    withContainers(server => SageClient.resource(configOf(server)).use(body).unsafeRunSync())
+
   test("an end user connects and round-trips with native Cats Effect") {
-    withContainers { server =>
-      val config = configOf(server)
-
-      val program: IO[Unit] =
-        SageClient.resource(config).use { client =>
-          for {
-            pong   <- client.ping()
-            _      <- (1 to 50).toList.parTraverse_(i => client.set(s"key-$i", s"value-$i"))
-            values <- (1 to 50).toList.parTraverse(i => client.get[String](s"key-$i"))
-          } yield {
-            assertEquals(pong, "PONG")
-            assertEquals(values, (1 to 50).toList.map(i => Some(s"value-$i")))
-          }
-        }
-
-      program.unsafeRunSync()
+    withNativeClient { client =>
+      for {
+        pong   <- client.ping()
+        _      <- (1 to 50).toList.parTraverse_(i => client.set(s"key-$i", s"value-$i"))
+        values <- (1 to 50).toList.parTraverse(i => client.get[String](s"key-$i"))
+      } yield {
+        assertEquals(pong, "PONG")
+        assertEquals(values, (1 to 50).toList.map(i => Some(s"value-$i")))
+      }
     }
   }
 
   test("a pipeline returns a typed tuple natively, surfacing failures per position") {
-    withContainers { server =>
-      val program: IO[Unit] =
-        SageClient.resource(configOf(server)).use { client =>
-          for {
-            _       <- client.set("pipe:a", "x")
-            _       <- client.set("pipe:n", 10)
-            out     <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)))
-            _       <- client.set("pipe:str", "hello")
-            attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")))
-          } yield {
-            assertEquals(out, (Some("x"), 15L))
-            assert(attempt._1 == Right(Some("hello")), attempt._1)
-            assert(attempt._2.isLeft, attempt._2)
-          }
-        }
-
-      program.unsafeRunSync()
+    withNativeClient { client =>
+      for {
+        _       <- client.set("pipe:a", "x")
+        _       <- client.set("pipe:n", 10)
+        out     <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)))
+        _       <- client.set("pipe:str", "hello")
+        attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")))
+      } yield {
+        assertEquals(out, (Some("x"), 15L))
+        assert(attempt._1 == Right(Some("hello")), attempt._1)
+        assert(attempt._2.isLeft, attempt._2)
+      }
     }
   }
 
   test("a transaction commits atomically with native Cats Effect, guarded by WATCH") {
-    withContainers { server =>
-      val program: IO[Unit] =
-        SageClient.resource(configOf(server)).use { client =>
-          for {
-            _   <- client.set("tx:n", 1)
-            out <- client.transaction { tx =>
-                     for {
-                       _   <- tx.watch("tx:n")
-                       _   <- tx.get[Int]("tx:n")
-                       res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)))
-                     } yield res
-                   }
-          } yield assertEquals(out, Some((2L, 6L)))
-        }
-
-      program.unsafeRunSync()
+    withNativeClient { client =>
+      for {
+        _   <- client.set("tx:n", 1)
+        out <- client.transaction { tx =>
+                 for {
+                   _   <- tx.watch("tx:n")
+                   _   <- tx.get[Int]("tx:n")
+                   res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)))
+                 } yield res
+               }
+      } yield assertEquals(out, Some((2L, 6L)))
     }
   }
 
   test("scanAll streams every key as a native fs2 Stream") {
-    withContainers { server =>
-      val program: IO[Unit] =
-        SageClient.resource(configOf(server)).use { client =>
-          for {
-            _    <- (1 to 50).toList.parTraverse_(i => client.set(s"scan-$i", "v"))
-            keys <- client.scanAll(pattern = Some("scan-*"), count = Some(10L)).compile.toVector
-          } yield assertEquals(keys.toSet, (1 to 50).map(i => s"scan-$i").toSet)
-        }
-
-      program.unsafeRunSync()
+    withNativeClient { client =>
+      for {
+        _    <- (1 to 50).toList.parTraverse_(i => client.set(s"scan-$i", "v"))
+        keys <- client.scanAll(pattern = Some("scan-*"), count = Some(10L)).compile.toVector
+      } yield assertEquals(keys.toSet, (1 to 50).map(i => s"scan-$i").toSet)
     }
   }
 
   test("subscribe delivers published messages as a native fs2 Stream") {
-    withContainers { server =>
-      val program: IO[Unit] =
-        SageClient.resource(configOf(server)).use { client =>
-          client.subscribeResource[String]("smoke").use { stream =>
-            for {
-              _        <- (1 to 3).toList.traverse_(i => client.publish("smoke", s"m$i"))
-              messages <- stream.take(3).compile.toVector
-            } yield {
-              assertEquals(messages.map(_.channel).toSet, Set("smoke"))
-              assertEquals(messages.map(_.payload).toList, List("m1", "m2", "m3"))
-            }
-          }
+    withNativeClient { client =>
+      client.subscribeResource[String]("smoke").use { stream =>
+        for {
+          _        <- (1 to 3).toList.traverse_(i => client.publish("smoke", s"m$i"))
+          messages <- stream.take(3).compile.toVector
+        } yield {
+          assertEquals(messages.map(_.channel).toSet, Set("smoke"))
+          assertEquals(messages.map(_.payload).toList, List("m1", "m2", "m3"))
         }
-
-      program.unsafeRunSync()
-    }
-  }
-
-  test("client.rateLimiter admits up to capacity then denies") {
-    withContainers { server =>
-      val program: IO[Unit] =
-        SageClient.resource(configOf(server)).use { client =>
-          val rl = client.rateLimiter[String](RateLimit(capacity = 2, refillTokens = 1, refillPeriod = 1.hour))
-          for {
-            first  <- rl.tryAcquire("smoke")
-            second <- rl.tryAcquire("smoke")
-            denied <- rl.tryAcquire("smoke")
-          } yield {
-            assert(first.isAllowed && second.isAllowed, "the first two are admitted")
-            assert(!denied.isAllowed, "the third is denied once the bucket empties")
-          }
-        }
-
-      program.unsafeRunSync()
+      }
     }
   }
 
   test("hScanAll streams every field/value pair as a native fs2 Stream") {
-    withContainers { server =>
-      val program: IO[Unit] =
-        SageClient.resource(configOf(server)).use { client =>
-          for {
-            _     <- (1 to 50).toList.parTraverse_(i => client.hSet("hscan", (s"f$i", s"v$i")))
-            pairs <- client.hScanAll[String, String]("hscan", count = Some(10L)).compile.toVector
-          } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"f$i" -> s"v$i").toMap)
-        }
-
-      program.unsafeRunSync()
+    withNativeClient { client =>
+      for {
+        _     <- (1 to 50).toList.parTraverse_(i => client.hSet("hscan", (s"f$i", s"v$i")))
+        pairs <- client.hScanAll[String, String]("hscan", count = Some(10L)).compile.toVector
+      } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"f$i" -> s"v$i").toMap)
     }
   }
 
   test("sScanAll streams every member as a native fs2 Stream") {
-    withContainers { server =>
-      val program: IO[Unit] =
-        SageClient.resource(configOf(server)).use { client =>
-          for {
-            _       <- (1 to 50).toList.parTraverse_(i => client.sAdd("sscan", s"m$i"))
-            members <- client.sScanAll[String]("sscan", count = Some(10L)).compile.toVector
-          } yield assertEquals(members.toSet, (1 to 50).map(i => s"m$i").toSet)
-        }
-
-      program.unsafeRunSync()
+    withNativeClient { client =>
+      for {
+        _       <- (1 to 50).toList.parTraverse_(i => client.sAdd("sscan", s"m$i"))
+        members <- client.sScanAll[String]("sscan", count = Some(10L)).compile.toVector
+      } yield assertEquals(members.toSet, (1 to 50).map(i => s"m$i").toSet)
     }
   }
 
   test("zScanAll streams every member/score pair as a native fs2 Stream") {
-    withContainers { server =>
-      val program: IO[Unit] =
-        SageClient.resource(configOf(server)).use { client =>
-          for {
-            _     <- (1 to 50).toList.parTraverse_(i => client.zAdd("zscan")((s"m$i", i.toDouble)))
-            pairs <- client.zScanAll[String]("zscan", count = Some(10L)).compile.toVector
-          } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
-        }
+    withNativeClient { client =>
+      for {
+        _     <- (1 to 50).toList.parTraverse_(i => client.zAdd("zscan")((s"m$i", i.toDouble)))
+        pairs <- client.zScanAll[String]("zscan", count = Some(10L)).compile.toVector
+      } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
+    }
+  }
 
-      program.unsafeRunSync()
+  test("client.rateLimiter admits up to capacity then denies") {
+    withNativeClient { client =>
+      val rl = client.rateLimiter[String](RateLimit(capacity = 2, refillTokens = 1, refillPeriod = 1.hour))
+      for {
+        first  <- rl.tryAcquire("smoke")
+        second <- rl.tryAcquire("smoke")
+        denied <- rl.tryAcquire("smoke")
+      } yield {
+        assert(first.isAllowed && second.isAllowed, "the first two are admitted")
+        assert(!denied.isAllowed, "the third is denied once the bucket empties")
+      }
     }
   }
 }

--- a/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
+++ b/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
@@ -11,173 +11,131 @@ import sage.backend.*
 
 class KyoSmokeSuite extends ServerSuite(Images.redis) {
 
-  test("an end user connects and round-trips with native Kyo") {
+  private def withNativeClient(body: SageClient => Unit < (Scope & Abort[Throwable] & Async)): Unit =
+    withBoundedClient(Duration.Infinity)(body)
+
+  private def withBoundedClient(timeout: Duration)(body: SageClient => Unit < (Scope & Abort[Throwable] & Async)): Unit =
     withContainers { server =>
-      val config = configOf(server)
-
-      val program: Unit < (Scope & Abort[Throwable] & Async) =
-        for {
-          client <- SageClient.scoped(config)
-          pong   <- client.ping()
-          _      <- Async.foreachDiscard(1 to 50)(i => client.set(s"key-$i", s"value-$i"))
-          values <- Async.foreach((1 to 50).toList)(i => client.get[String](s"key-$i"))
-        } yield {
-          assertEquals(pong, "PONG")
-          assertEquals(values.toList, (1 to 50).toList.map(i => Some(s"value-$i")))
-        }
-
+      val program: Unit < (Scope & Abort[Throwable] & Async) = SageClient.scoped(configOf(server)).map(body)
       import AllowUnsafe.embrace.danger
-      KyoApp.Unsafe.runAndBlock(Duration.Infinity)(program).getOrThrow
+      KyoApp.Unsafe.runAndBlock(timeout)(program).getOrThrow
+    }
+
+  test("an end user connects and round-trips with native Kyo") {
+    withNativeClient { client =>
+      for {
+        pong   <- client.ping()
+        _      <- Async.foreachDiscard(1 to 50)(i => client.set(s"key-$i", s"value-$i"))
+        values <- Async.foreach((1 to 50).toList)(i => client.get[String](s"key-$i"))
+      } yield {
+        assertEquals(pong, "PONG")
+        assertEquals(values.toList, (1 to 50).toList.map(i => Some(s"value-$i")))
+      }
     }
   }
 
   test("a pipeline returns a typed tuple natively, surfacing failures per position") {
-    withContainers { server =>
-      val program: Unit < (Scope & Abort[Throwable] & Async) =
-        for {
-          client  <- SageClient.scoped(configOf(server))
-          _       <- client.set("pipe:a", "x")
-          _       <- client.set("pipe:n", 10)
-          out     <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)))
-          _       <- client.set("pipe:str", "hello")
-          attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")))
-        } yield {
-          assertEquals(out, (Some("x"), 15L))
-          assert(attempt._1 == Right(Some("hello")), attempt._1)
-          assert(attempt._2.isLeft, attempt._2)
-        }
-
-      import AllowUnsafe.embrace.danger
-      KyoApp.Unsafe.runAndBlock(Duration.Infinity)(program).getOrThrow
+    withNativeClient { client =>
+      for {
+        _       <- client.set("pipe:a", "x")
+        _       <- client.set("pipe:n", 10)
+        out     <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)))
+        _       <- client.set("pipe:str", "hello")
+        attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")))
+      } yield {
+        assertEquals(out, (Some("x"), 15L))
+        assert(attempt._1 == Right(Some("hello")), attempt._1)
+        assert(attempt._2.isLeft, attempt._2)
+      }
     }
   }
 
   test("a transaction commits atomically with native Kyo, guarded by WATCH") {
-    withContainers { server =>
-      val program: Unit < (Scope & Abort[Throwable] & Async) =
-        for {
-          client <- SageClient.scoped(configOf(server))
-          _      <- client.set("tx:n", 1)
-          out    <- client.transaction { tx =>
-                      for {
-                        _   <- tx.watch("tx:n")
-                        _   <- tx.get[Int]("tx:n")
-                        res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)))
-                      } yield res
-                    }
-        } yield assertEquals(out, Some((2L, 6L)))
-
-      import AllowUnsafe.embrace.danger
-      KyoApp.Unsafe.runAndBlock(Duration.Infinity)(program).getOrThrow
+    withNativeClient { client =>
+      for {
+        _   <- client.set("tx:n", 1)
+        out <- client.transaction { tx =>
+                 for {
+                   _   <- tx.watch("tx:n")
+                   _   <- tx.get[Int]("tx:n")
+                   res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)))
+                 } yield res
+               }
+      } yield assertEquals(out, Some((2L, 6L)))
     }
   }
 
   test("scanAll streams every key as a native Kyo Stream") {
-    withContainers { server =>
-      val program: Unit < (Scope & Abort[Throwable] & Async) =
-        for {
-          client <- SageClient.scoped(configOf(server))
-          _      <- Async.foreachDiscard(1 to 50)(i => client.set(s"scan-$i", "v"))
-          keys   <- client.scanAll(pattern = Some("scan-*"), count = Some(10L)).run
-        } yield assertEquals(keys.toSet, (1 to 50).map(i => s"scan-$i").toSet)
-
-      import AllowUnsafe.embrace.danger
-      KyoApp.Unsafe.runAndBlock(Duration.Infinity)(program).getOrThrow
+    withNativeClient { client =>
+      for {
+        _    <- Async.foreachDiscard(1 to 50)(i => client.set(s"scan-$i", "v"))
+        keys <- client.scanAll(pattern = Some("scan-*"), count = Some(10L)).run
+      } yield assertEquals(keys.toSet, (1 to 50).map(i => s"scan-$i").toSet)
     }
   }
 
   test("subscribe delivers published messages as a native Kyo Stream") {
-    withContainers { server =>
-      val program: Unit < (Scope & Abort[Throwable] & Async) =
-        for {
-          client <- SageClient.scoped(configOf(server))
-          stream <- client.subscribeScoped[String]("smoke")
-          _      <- Kyo.foreachDiscard(1 to 3)(i => client.publish("smoke", s"m$i"))
-          chunk  <- stream.take(3).run
-        } yield {
-          val messages = chunk.toList
-          assertEquals(messages.map(_.channel).toSet, Set("smoke"))
-          assertEquals(messages.map(_.payload), List("m1", "m2", "m3"))
-        }
-
-      import AllowUnsafe.embrace.danger
-      KyoApp.Unsafe.runAndBlock(Duration.Infinity)(program).getOrThrow
+    withNativeClient { client =>
+      for {
+        stream <- client.subscribeScoped[String]("smoke")
+        _      <- Kyo.foreachDiscard(1 to 3)(i => client.publish("smoke", s"m$i"))
+        chunk  <- stream.take(3).run
+      } yield {
+        val messages = chunk.toList
+        assertEquals(messages.map(_.channel).toSet, Set("smoke"))
+        assertEquals(messages.map(_.payload), List("m1", "m2", "m3"))
+      }
     }
   }
 
   test("hScanAll streams every field/value pair as a native Kyo Stream") {
-    withContainers { server =>
-      val program: Unit < (Scope & Abort[Throwable] & Async) =
-        for {
-          client <- SageClient.scoped(configOf(server))
-          _      <- Async.foreachDiscard(1 to 50)(i => client.hSet("hscan", (s"f$i", s"v$i")))
-          pairs  <- client.hScanAll[String, String]("hscan", count = Some(10L)).run
-        } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"f$i" -> s"v$i").toMap)
-
-      import AllowUnsafe.embrace.danger
-      KyoApp.Unsafe.runAndBlock(Duration.Infinity)(program).getOrThrow
+    withNativeClient { client =>
+      for {
+        _     <- Async.foreachDiscard(1 to 50)(i => client.hSet("hscan", (s"f$i", s"v$i")))
+        pairs <- client.hScanAll[String, String]("hscan", count = Some(10L)).run
+      } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"f$i" -> s"v$i").toMap)
     }
   }
 
   test("sScanAll streams every member as a native Kyo Stream") {
-    withContainers { server =>
-      val program: Unit < (Scope & Abort[Throwable] & Async) =
-        for {
-          client  <- SageClient.scoped(configOf(server))
-          _       <- Async.foreachDiscard(1 to 50)(i => client.sAdd("sscan", s"m$i"))
-          members <- client.sScanAll[String]("sscan", count = Some(10L)).run
-        } yield assertEquals(members.toSet, (1 to 50).map(i => s"m$i").toSet)
-
-      import AllowUnsafe.embrace.danger
-      KyoApp.Unsafe.runAndBlock(Duration.Infinity)(program).getOrThrow
+    withNativeClient { client =>
+      for {
+        _       <- Async.foreachDiscard(1 to 50)(i => client.sAdd("sscan", s"m$i"))
+        members <- client.sScanAll[String]("sscan", count = Some(10L)).run
+      } yield assertEquals(members.toSet, (1 to 50).map(i => s"m$i").toSet)
     }
   }
 
   test("zScanAll streams every member/score pair as a native Kyo Stream") {
-    withContainers { server =>
-      val program: Unit < (Scope & Abort[Throwable] & Async) =
-        for {
-          client <- SageClient.scoped(configOf(server))
-          _      <- Async.foreachDiscard(1 to 50)(i => client.zAdd("zscan")((s"m$i", i.toDouble)))
-          pairs  <- client.zScanAll[String]("zscan", count = Some(10L)).run
-        } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
-
-      import AllowUnsafe.embrace.danger
-      KyoApp.Unsafe.runAndBlock(Duration.Infinity)(program).getOrThrow
+    withNativeClient { client =>
+      for {
+        _     <- Async.foreachDiscard(1 to 50)(i => client.zAdd("zscan")((s"m$i", i.toDouble)))
+        pairs <- client.zScanAll[String]("zscan", count = Some(10L)).run
+      } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
     }
   }
 
   // Regression for the 4096-page rechunk that buffered infinite tails; bounded run so a reintroduced regression fails fast, not hangs.
   test("xTail emits replayed entries immediately instead of buffering them") {
-    withContainers { server =>
-      val program: Unit < (Scope & Abort[Throwable] & Async) =
-        for {
-          client  <- SageClient.scoped(configOf(server))
-          _       <- Kyo.foreachDiscard(1 to 3)(i => client.xAdd("xtail", XAddId.Explicit(StreamId(i.toLong, 0L)))(("f", s"v$i")))
-          entries <- client.xTail[String, String]("xtail").take(3).run
-        } yield assertEquals(entries.toList.map(_.fields.head._2), List("v1", "v2", "v3"))
-
-      import AllowUnsafe.embrace.danger
-      KyoApp.Unsafe.runAndBlock(15L.seconds)(program).getOrThrow
+    withBoundedClient(15L.seconds) { client =>
+      for {
+        _       <- Kyo.foreachDiscard(1 to 3)(i => client.xAdd("xtail", XAddId.Explicit(StreamId(i.toLong, 0L)))(("f", s"v$i")))
+        entries <- client.xTail[String, String]("xtail").take(3).run
+      } yield assertEquals(entries.toList.map(_.fields.head._2), List("v1", "v2", "v3"))
     }
   }
 
   test("client.rateLimiter admits up to capacity then denies") {
-    withContainers { server =>
-      val program: Unit < (Scope & Abort[Throwable] & Async) =
-        for {
-          client <- SageClient.scoped(configOf(server))
-          rl      = client.rateLimiter[String](RateLimit(capacity = 2, refillTokens = 1, refillPeriod = FiniteDuration(1L, TimeUnit.HOURS)))
-          first  <- rl.tryAcquire("smoke")
-          second <- rl.tryAcquire("smoke")
-          denied <- rl.tryAcquire("smoke")
-        } yield {
-          assert(first.isAllowed && second.isAllowed, "the first two are admitted")
-          assert(!denied.isAllowed, "the third is denied once the bucket empties")
-        }
-
-      import AllowUnsafe.embrace.danger
-      KyoApp.Unsafe.runAndBlock(15L.seconds)(program).getOrThrow
+    withNativeClient { client =>
+      val rl = client.rateLimiter[String](RateLimit(capacity = 2, refillTokens = 1, refillPeriod = FiniteDuration(1L, TimeUnit.HOURS)))
+      for {
+        first  <- rl.tryAcquire("smoke")
+        second <- rl.tryAcquire("smoke")
+        denied <- rl.tryAcquire("smoke")
+      } yield {
+        assert(first.isAllowed && second.isAllowed, "the first two are admitted")
+        assert(!denied.isAllowed, "the third is denied once the bucket empties")
+      }
     }
   }
 }

--- a/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
+++ b/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
@@ -126,7 +126,7 @@ class KyoSmokeSuite extends ServerSuite(Images.redis) {
   }
 
   test("client.rateLimiter admits up to capacity then denies") {
-    withNativeClient { client =>
+    withBoundedClient(15L.seconds) { client =>
       val rl = client.rateLimiter[String](RateLimit(capacity = 2, refillTokens = 1, refillPeriod = FiniteDuration(1L, TimeUnit.HOURS)))
       for {
         first  <- rl.tryAcquire("smoke")

--- a/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
+++ b/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
@@ -2,182 +2,141 @@ package sage.integration
 
 import scala.concurrent.duration.*
 
-import ox.{fork, supervised}
+import ox.{fork, supervised, Ox}
 
 import sage.*
 import sage.backend.*
 
 class OxSmokeSuite extends ServerSuite(Images.redis) {
 
+  private def withNativeClient(body: Ox ?=> SageClient => Unit): Unit =
+    withContainers(server => supervised(body(SageClient.scoped(configOf(server)))))
+
   test("an end user connects and round-trips with direct-style Ox") {
-    withContainers { server =>
-      val config = configOf(server)
-      supervised {
-        val client = SageClient.scoped(config)
-        assertEquals(client.ping(), "PONG")
-        val values = (1 to 50).toList
-          .map(i =>
-            fork {
-              client.set(s"key-$i", s"value-$i")
-              client.get[String](s"key-$i")
-            }
-          )
-          .map(_.join())
-        assertEquals(values, (1 to 50).toList.map(i => Some(s"value-$i")))
-      }
+    withNativeClient { client =>
+      assertEquals(client.ping(), "PONG")
+      val values = (1 to 50).toList
+        .map(i =>
+          fork {
+            client.set(s"key-$i", s"value-$i")
+            client.get[String](s"key-$i")
+          }
+        )
+        .map(_.join())
+      assertEquals(values, (1 to 50).toList.map(i => Some(s"value-$i")))
     }
   }
 
   test("a pipeline returns a typed tuple natively, surfacing failures per position") {
-    withContainers { server =>
-      supervised {
-        val client  = SageClient.scoped(configOf(server))
-        client.set("pipe:a", "x")
-        client.set("pipe:n", 10)
-        val out     = client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)))
-        assertEquals(out, (Some("x"), 15L))
-        client.set("pipe:str", "hello")
-        val attempt = client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")))
-        assert(attempt._1 == Right(Some("hello")), attempt._1)
-        assert(attempt._2.isLeft, attempt._2)
-      }
+    withNativeClient { client =>
+      client.set("pipe:a", "x")
+      client.set("pipe:n", 10)
+      val out     = client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)))
+      assertEquals(out, (Some("x"), 15L))
+      client.set("pipe:str", "hello")
+      val attempt = client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")))
+      assert(attempt._1 == Right(Some("hello")), attempt._1)
+      assert(attempt._2.isLeft, attempt._2)
     }
   }
 
   test("a transaction commits atomically with direct-style Ox, guarded by WATCH") {
-    withContainers { server =>
-      supervised {
-        val client = SageClient.scoped(configOf(server))
-        client.set("tx:n", 1)
-        val out    = client.transaction { tx =>
-          tx.watch("tx:n")
-          tx.get[Int]("tx:n")
-          tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)))
-        }
-        assertEquals(out, Some((2L, 6L)))
+    withNativeClient { client =>
+      client.set("tx:n", 1)
+      val out = client.transaction { tx =>
+        tx.watch("tx:n")
+        tx.get[Int]("tx:n")
+        tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)))
       }
+      assertEquals(out, Some((2L, 6L)))
     }
   }
 
   test("scanAll streams every key as a native Ox Flow") {
-    withContainers { server =>
-      supervised {
-        val client = SageClient.scoped(configOf(server))
-        (1 to 50).foreach { i =>
-          client.set(s"scan-$i", "v")
-        }
-        val keys   = client.scanAll(pattern = Some("scan-*"), count = Some(10L)).runToList()
-        assertEquals(keys.toSet, (1 to 50).map(i => s"scan-$i").toSet)
-      }
+    withNativeClient { client =>
+      (1 to 50).foreach(i => client.set(s"scan-$i", "v"))
+      val keys = client.scanAll(pattern = Some("scan-*"), count = Some(10L)).runToList()
+      assertEquals(keys.toSet, (1 to 50).map(i => s"scan-$i").toSet)
     }
   }
 
   test("subscribe delivers published messages as a native Ox Flow") {
-    withContainers { server =>
-      supervised {
-        val client   = SageClient.scoped(configOf(server))
-        val stream   = client.subscribeScoped[String]("smoke")
-        (1 to 3).foreach { i =>
-          client.publish("smoke", s"m$i")
-        }
-        val messages = stream.take(3).runToList()
-        assertEquals(messages.map(_.channel).toSet, Set("smoke"))
-        assertEquals(messages.map(_.payload), List("m1", "m2", "m3"))
-      }
+    withNativeClient { client =>
+      val stream   = client.subscribeScoped[String]("smoke")
+      (1 to 3).foreach(i => client.publish("smoke", s"m$i"))
+      val messages = stream.take(3).runToList()
+      assertEquals(messages.map(_.channel).toSet, Set("smoke"))
+      assertEquals(messages.map(_.payload), List("m1", "m2", "m3"))
     }
   }
 
   test("a scoped subscription survives a flow run ending — take(1) must not unsubscribe, only scope close does") {
-    withContainers { server =>
-      supervised {
-        val client = SageClient.scoped(configOf(server))
-        val stream = client.subscribeScoped[String]("scoped-live")
-        client.publish("scoped-live", "a")
-        val first  = stream.take(1).runToList()
-        client.publish("scoped-live", "b")
-        val second = stream.take(1).runToList()
-        assertEquals(first.map(_.payload), List("a"))
-        assertEquals(second.map(_.payload), List("b"))
-      }
+    withNativeClient { client =>
+      val stream = client.subscribeScoped[String]("scoped-live")
+      client.publish("scoped-live", "a")
+      val first  = stream.take(1).runToList()
+      client.publish("scoped-live", "b")
+      val second = stream.take(1).runToList()
+      assertEquals(first.map(_.payload), List("a"))
+      assertEquals(second.map(_.payload), List("b"))
     }
   }
 
   test("a plain subscribe Flow resubscribes on every run instead of yielding an empty stream on re-run") {
-    withContainers { server =>
-      supervised {
-        val client    = SageClient.scoped(configOf(server))
-        val stream    = client.subscribe[String]("rerun")
-        // publish continuously so each run's subscription receives one; the second run must resubscribe, not complete empty
-        val running   = new java.util.concurrent.atomic.AtomicBoolean(true)
-        val publisher = fork {
-          while (running.get()) {
-            client.publish("rerun", "tick")
-            Thread.sleep(50)
-          }
+    withNativeClient { client =>
+      val stream    = client.subscribe[String]("rerun")
+      // publish continuously so each run's subscription receives one; the second run must resubscribe, not complete empty
+      val running   = new java.util.concurrent.atomic.AtomicBoolean(true)
+      val publisher = fork {
+        while (running.get()) {
+          client.publish("rerun", "tick")
+          Thread.sleep(50)
         }
-        try {
-          val first  = stream.take(1).runToList()
-          val second = stream.take(1).runToList()
-          assertEquals(first.map(_.payload), List("tick"))
-          assertEquals(second.map(_.payload), List("tick"))
-        } finally {
-          running.set(false)
-          publisher.join()
-        }
+      }
+      try {
+        val first  = stream.take(1).runToList()
+        val second = stream.take(1).runToList()
+        assertEquals(first.map(_.payload), List("tick"))
+        assertEquals(second.map(_.payload), List("tick"))
+      } finally {
+        running.set(false)
+        publisher.join()
       }
     }
   }
 
   test("hScanAll streams every field/value pair as a native Ox Flow") {
-    withContainers { server =>
-      supervised {
-        val client = SageClient.scoped(configOf(server))
-        (1 to 50).foreach { i =>
-          client.hSet("hscan", (s"f$i", s"v$i"))
-        }
-        val pairs  = client.hScanAll[String, String]("hscan", count = Some(10L)).runToList()
-        assertEquals(pairs.toMap, (1 to 50).map(i => s"f$i" -> s"v$i").toMap)
-      }
+    withNativeClient { client =>
+      (1 to 50).foreach(i => client.hSet("hscan", (s"f$i", s"v$i")))
+      val pairs = client.hScanAll[String, String]("hscan", count = Some(10L)).runToList()
+      assertEquals(pairs.toMap, (1 to 50).map(i => s"f$i" -> s"v$i").toMap)
     }
   }
 
   test("sScanAll streams every member as a native Ox Flow") {
-    withContainers { server =>
-      supervised {
-        val client  = SageClient.scoped(configOf(server))
-        (1 to 50).foreach { i =>
-          client.sAdd("sscan", s"m$i")
-        }
-        val members = client.sScanAll[String]("sscan", count = Some(10L)).runToList()
-        assertEquals(members.toSet, (1 to 50).map(i => s"m$i").toSet)
-      }
+    withNativeClient { client =>
+      (1 to 50).foreach(i => client.sAdd("sscan", s"m$i"))
+      val members = client.sScanAll[String]("sscan", count = Some(10L)).runToList()
+      assertEquals(members.toSet, (1 to 50).map(i => s"m$i").toSet)
     }
   }
 
   test("zScanAll streams every member/score pair as a native Ox Flow") {
-    withContainers { server =>
-      supervised {
-        val client = SageClient.scoped(configOf(server))
-        (1 to 50).foreach { i =>
-          client.zAdd("zscan")((s"m$i", i.toDouble))
-        }
-        val pairs  = client.zScanAll[String]("zscan", count = Some(10L)).runToList()
-        assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
-      }
+    withNativeClient { client =>
+      (1 to 50).foreach(i => client.zAdd("zscan")((s"m$i", i.toDouble)))
+      val pairs = client.zScanAll[String]("zscan", count = Some(10L)).runToList()
+      assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
     }
   }
 
   test("client.rateLimiter admits up to capacity then denies") {
-    withContainers { server =>
-      supervised {
-        val client = SageClient.scoped(configOf(server))
-        val rl     = client.rateLimiter[String](RateLimit(capacity = 2, refillTokens = 1, refillPeriod = 1.hour))
-        val first  = rl.tryAcquire("smoke")
-        val second = rl.tryAcquire("smoke")
-        val denied = rl.tryAcquire("smoke")
-        assert(first.isAllowed && second.isAllowed, "the first two are admitted")
-        assert(!denied.isAllowed, "the third is denied once the bucket empties")
-      }
+    withNativeClient { client =>
+      val rl     = client.rateLimiter[String](RateLimit(capacity = 2, refillTokens = 1, refillPeriod = 1.hour))
+      val first  = rl.tryAcquire("smoke")
+      val second = rl.tryAcquire("smoke")
+      val denied = rl.tryAcquire("smoke")
+      assert(first.isAllowed && second.isAllowed, "the first two are admitted")
+      assert(!denied.isAllowed, "the third is denied once the bucket empties")
     }
   }
 }

--- a/integration-tests/pekko/src/test/scala/sage/integration/PekkoSmokeSuite.scala
+++ b/integration-tests/pekko/src/test/scala/sage/integration/PekkoSmokeSuite.scala
@@ -3,7 +3,6 @@ package sage.integration
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.*
 
-import com.dimafeng.testcontainers.GenericContainer
 import org.apache.pekko.actor.typed.ActorSystem
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.stream.Materializer
@@ -14,163 +13,157 @@ import sage.backend.*
 
 class PekkoSmokeSuite extends ServerSuite(Images.redis) {
 
-  private def withClientMat[A](server: GenericContainer)(body: (SageClient, Materializer, ActorSystem[Nothing]) => Future[A]): A = {
-    given system: ActorSystem[Nothing]      = ActorSystem(Behaviors.empty, "pekko-smoke")
-    given scala.concurrent.ExecutionContext = system.executionContext
-    val mat                                 = Materializer(system)
-    try
-      Await.result(
-        SageClient.connect(configOf(server)).flatMap { client =>
-          body(client, mat, system).transformWith(result => client.close.recover { case _ => () }.transform(_ => result))
-        },
-        30.seconds
-      )
-    finally {
-      system.terminate()
-      Await.ready(system.whenTerminated, 10.seconds): Unit
+  private def withNativeClient[A](body: (SageClient, Materializer, ActorSystem[Nothing]) => Future[A]): A =
+    withContainers { server =>
+      given system: ActorSystem[Nothing]      = ActorSystem(Behaviors.empty, "pekko-smoke")
+      given scala.concurrent.ExecutionContext = system.executionContext
+      val mat                                 = Materializer(system)
+      try
+        Await.result(
+          SageClient.connect(configOf(server)).flatMap { client =>
+            body(client, mat, system).transformWith(result => client.close.recover { case _ => () }.transform(_ => result))
+          },
+          30.seconds
+        )
+      finally {
+        system.terminate()
+        Await.ready(system.whenTerminated, 10.seconds): Unit
+      }
     }
-  }
 
   test("an end user connects and round-trips with scala.concurrent.Future") {
-    withContainers { server =>
-      val values = withClientMat(server) { (client, _, _) =>
-        for {
-          pong <- client.ping()
-          _    <- Future.traverse(1 to 50)(i => client.set(s"key-$i", s"value-$i"))
-          got  <- Future.traverse(1 to 50)(i => client.get[String](s"key-$i"))
-        } yield (pong, got)
-      }
-      assertEquals(values._1, "PONG")
-      assertEquals(values._2.toList, (1 to 50).toList.map(i => Option(s"value-$i")))
+    val values = withNativeClient { (client, _, _) =>
+      for {
+        pong <- client.ping()
+        _    <- Future.traverse(1 to 50)(i => client.set(s"key-$i", s"value-$i"))
+        got  <- Future.traverse(1 to 50)(i => client.get[String](s"key-$i"))
+      } yield (pong, got)
     }
+    assertEquals(values._1, "PONG")
+    assertEquals(values._2.toList, (1 to 50).toList.map(i => Option(s"value-$i")))
   }
 
   test("a pipeline returns a typed tuple natively, surfacing failures per position") {
-    withContainers { server =>
-      val (out, attempt) = withClientMat(server) { (client, _, _) =>
-        for {
-          _       <- client.set("pipe:a", "x")
-          _       <- client.set("pipe:n", 10)
-          out     <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)))
-          _       <- client.set("pipe:str", "hello")
-          attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")))
-        } yield (out, attempt)
-      }
-      assertEquals(out, (Some("x"), 15L))
-      assert(attempt._1 == Right(Some("hello")), attempt._1)
-      assert(attempt._2.isLeft, attempt._2)
+    val (out, attempt) = withNativeClient { (client, _, _) =>
+      for {
+        _       <- client.set("pipe:a", "x")
+        _       <- client.set("pipe:n", 10)
+        out     <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)))
+        _       <- client.set("pipe:str", "hello")
+        attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")))
+      } yield (out, attempt)
     }
+    assertEquals(out, (Some("x"), 15L))
+    assert(attempt._1 == Right(Some("hello")), attempt._1)
+    assert(attempt._2.isLeft, attempt._2)
   }
 
   test("a transaction commits atomically with Future, guarded by WATCH") {
-    withContainers { server =>
-      val out = withClientMat(server) { (client, _, _) =>
-        for {
-          _   <- client.set("tx:n", 1)
-          res <- client.transaction { tx =>
-                   for {
-                     _   <- tx.watch("tx:n")
-                     _   <- tx.get[Int]("tx:n")
-                     res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)))
-                   } yield res
-                 }
-        } yield res
-      }
-      assertEquals(out, Some((2L, 6L)))
+    val out = withNativeClient { (client, _, _) =>
+      for {
+        _   <- client.set("tx:n", 1)
+        res <- client.transaction { tx =>
+                 for {
+                   _   <- tx.watch("tx:n")
+                   _   <- tx.get[Int]("tx:n")
+                   res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)))
+                 } yield res
+               }
+      } yield res
     }
+    assertEquals(out, Some((2L, 6L)))
   }
 
   test("scanAll streams every key as a native Pekko Source") {
-    withContainers { server =>
-      val keys = withClientMat(server) { (client, mat, _) =>
-        given Materializer = mat
-        for {
-          _    <- Future.traverse(1 to 50)(i => client.set(s"scan-$i", "v"))
-          keys <- client.scanAll(pattern = Some("scan-*"), count = Some(10L)).runWith(Sink.seq)
-        } yield keys
-      }
-      assertEquals(keys.toSet, (1 to 50).map(i => s"scan-$i").toSet)
+    val keys = withNativeClient { (client, mat, _) =>
+      given Materializer = mat
+      for {
+        _    <- Future.traverse(1 to 50)(i => client.set(s"scan-$i", "v"))
+        keys <- client.scanAll(pattern = Some("scan-*"), count = Some(10L)).runWith(Sink.seq)
+      } yield keys
     }
+    assertEquals(keys.toSet, (1 to 50).map(i => s"scan-$i").toSet)
   }
 
   test("subscribe delivers published messages as a native Pekko Source") {
-    withContainers { server =>
-      val messages = withClientMat(server) { (client, mat, _) =>
-        given Materializer        = mat
-        val (confirmed, received) =
-          client.subscribe[String]("smoke").take(3).toMat(Sink.seq)(Keep.both).run()
-        for {
-          _        <- confirmed
-          // publish sequentially so the asserted m1/m2/m3 order is deterministic
-          _        <- (1 to 3).foldLeft(Future.successful(0L))((acc, i) => acc.flatMap(_ => client.publish("smoke", s"m$i")))
-          messages <- received
-        } yield messages
-      }
-      assertEquals(messages.map(_.channel).toSet, Set("smoke"))
-      assertEquals(messages.map(_.payload).toList, List("m1", "m2", "m3"))
+    val messages = withNativeClient { (client, mat, _) =>
+      given Materializer        = mat
+      val (confirmed, received) =
+        client.subscribe[String]("smoke").take(3).toMat(Sink.seq)(Keep.both).run()
+      for {
+        _        <- confirmed
+        // publish sequentially so the asserted m1/m2/m3 order is deterministic
+        _        <- (1 to 3).foldLeft(Future.successful(0L))((acc, i) => acc.flatMap(_ => client.publish("smoke", s"m$i")))
+        messages <- received
+      } yield messages
     }
+    assertEquals(messages.map(_.channel).toSet, Set("smoke"))
+    assertEquals(messages.map(_.payload).toList, List("m1", "m2", "m3"))
   }
 
   test("hScanAll streams every field/value pair as a native Pekko Source") {
-    withContainers { server =>
-      val pairs = withClientMat(server) { (client, mat, _) =>
-        given Materializer = mat
-        for {
-          _     <- Future.traverse(1 to 50)(i => client.hSet("hscan", (s"f$i", s"v$i")))
-          pairs <- client.hScanAll[String, String]("hscan", count = Some(10L)).runWith(Sink.seq)
-        } yield pairs
-      }
-      assertEquals(pairs.toMap, (1 to 50).map(i => s"f$i" -> s"v$i").toMap)
+    val pairs = withNativeClient { (client, mat, _) =>
+      given Materializer = mat
+      for {
+        _     <- Future.traverse(1 to 50)(i => client.hSet("hscan", (s"f$i", s"v$i")))
+        pairs <- client.hScanAll[String, String]("hscan", count = Some(10L)).runWith(Sink.seq)
+      } yield pairs
     }
+    assertEquals(pairs.toMap, (1 to 50).map(i => s"f$i" -> s"v$i").toMap)
+  }
+
+  test("sScanAll streams every member as a native Pekko Source") {
+    val members = withNativeClient { (client, mat, _) =>
+      given Materializer = mat
+      for {
+        _       <- Future.traverse(1 to 50)(i => client.sAdd("sscan", s"m$i"))
+        members <- client.sScanAll[String]("sscan", count = Some(10L)).runWith(Sink.seq)
+      } yield members
+    }
+    assertEquals(members.toSet, (1 to 50).map(i => s"m$i").toSet)
   }
 
   test("zScanAll streams every member/score pair as a native Pekko Source") {
-    withContainers { server =>
-      val pairs = withClientMat(server) { (client, mat, _) =>
-        given Materializer = mat
-        for {
-          _     <- Future.traverse(1 to 50)(i => client.zAdd("zscan")((s"m$i", i.toDouble)))
-          pairs <- client.zScanAll[String]("zscan", count = Some(10L)).runWith(Sink.seq)
-        } yield pairs
-      }
-      assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
+    val pairs = withNativeClient { (client, mat, _) =>
+      given Materializer = mat
+      for {
+        _     <- Future.traverse(1 to 50)(i => client.zAdd("zscan")((s"m$i", i.toDouble)))
+        pairs <- client.zScanAll[String]("zscan", count = Some(10L)).runWith(Sink.seq)
+      } yield pairs
     }
+    assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
   }
 
   test("tailing helpers surface an infinite block timeout through the effect because Future cannot interrupt it") {
-    withContainers { server =>
-      withClientMat(server) { (client, mat, system) =>
-        given ActorSystem[Nothing]              = system
-        given Materializer                      = mat
-        given scala.concurrent.ExecutionContext = system.executionContext
-        val tailed                              =
-          client.xTail[String, String]("stream:forever", block = BlockTimeout.Forever).runWith(Sink.ignore).failed
-        val consumed                            =
-          client.xConsume[String, String]("workers", "w1", "stream:forever", block = BlockTimeout.Forever)(_ => Future.unit).completion.failed
-        for {
-          e1 <- tailed
-          e2 <- consumed
-        } yield {
-          assert(e1.isInstanceOf[SageException.InvalidArgument], e1)
-          assert(e2.isInstanceOf[SageException.InvalidArgument], e2)
-        }
+    withNativeClient { (client, mat, system) =>
+      given ActorSystem[Nothing]              = system
+      given Materializer                      = mat
+      given scala.concurrent.ExecutionContext = system.executionContext
+      val tailed                              =
+        client.xTail[String, String]("stream:forever", block = BlockTimeout.Forever).runWith(Sink.ignore).failed
+      val consumed                            =
+        client.xConsume[String, String]("workers", "w1", "stream:forever", block = BlockTimeout.Forever)(_ => Future.unit).completion.failed
+      for {
+        e1 <- tailed
+        e2 <- consumed
+      } yield {
+        assert(e1.isInstanceOf[SageException.InvalidArgument], e1)
+        assert(e2.isInstanceOf[SageException.InvalidArgument], e2)
       }
     }
   }
 
   test("client.rateLimiter admits up to capacity then denies") {
-    withContainers { server =>
-      val (first, second, denied) = withClientMat(server) { (client, _, system) =>
-        given scala.concurrent.ExecutionContext = system.executionContext
-        val rl                                  = client.rateLimiter[String](RateLimit(capacity = 2, refillTokens = 1, refillPeriod = 1.hour))
-        for {
-          a <- rl.tryAcquire("smoke")
-          b <- rl.tryAcquire("smoke")
-          c <- rl.tryAcquire("smoke")
-        } yield (a, b, c)
-      }
-      assert(first.isAllowed && second.isAllowed, "the first two are admitted")
-      assert(!denied.isAllowed, "the third is denied once the bucket empties")
+    val (first, second, denied) = withNativeClient { (client, _, system) =>
+      given scala.concurrent.ExecutionContext = system.executionContext
+      val rl                                  = client.rateLimiter[String](RateLimit(capacity = 2, refillTokens = 1, refillPeriod = 1.hour))
+      for {
+        a <- rl.tryAcquire("smoke")
+        b <- rl.tryAcquire("smoke")
+        c <- rl.tryAcquire("smoke")
+      } yield (a, b, c)
     }
+    assert(first.isAllowed && second.isAllowed, "the first two are admitted")
+    assert(!denied.isAllowed, "the third is denied once the bucket empties")
   }
 }

--- a/integration-tests/shared/src/test/scala/sage/integration/Eventually.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/Eventually.scala
@@ -1,0 +1,31 @@
+package sage.integration
+
+import scala.concurrent.duration.*
+
+import kyo.compat.*
+
+/**
+  * Polling for state a server reaches on its own schedule. The action is a thunk, not by-name: a by-name `CIO` erases to the same shape the
+  * Future and Ox cells give the effect itself, and casts at run time.
+  */
+object Eventually {
+
+  /**
+    * Re-runs `action` until `holds` accepts its result, yielding whatever was seen last once the attempts run out.
+    */
+  def value[A](attempts: Int, interval: FiniteDuration = 100.millis)(action: () => CIO[A])(holds: A => Boolean): CIO[A] =
+    action().flatMap { seen =>
+      if (holds(seen) || attempts <= 1) CIO.value(seen)
+      else CIO.sleep(interval).flatMap(_ => value(attempts - 1, interval)(action)(holds))
+    }
+
+  /**
+    * Like [[value]], but fails with `orFail`'s message when the state never arrives.
+    */
+  def converges[A](attempts: Int, interval: FiniteDuration = 100.millis)(action: () => CIO[A])(holds: A => Boolean)(
+    orFail: A => String
+  ): CIO[Unit] =
+    value(attempts, interval)(action)(holds).flatMap { seen =>
+      if (holds(seen)) CIO.value(()) else CIO.fail(new RuntimeException(orFail(seen)))
+    }
+}

--- a/integration-tests/shared/src/test/scala/sage/integration/Eventually.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/Eventually.scala
@@ -11,7 +11,7 @@ import kyo.compat.*
 object Eventually {
 
   /**
-    * Re-runs `action` until `holds` accepts its result, yielding whatever was seen last once the attempts run out.
+    * Runs `action` up to `attempts` times, `interval` apart, yielding the first result `holds` accepts or the last one seen.
     */
   def value[A](attempts: Int, interval: FiniteDuration = 100.millis)(action: () => CIO[A])(holds: A => Boolean): CIO[A] =
     action().flatMap { seen =>

--- a/integration-tests/shared/src/test/scala/sage/integration/RoundTripSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/RoundTripSuite.scala
@@ -1,7 +1,5 @@
 package sage.integration
 
-import scala.concurrent.duration.*
-
 import kyo.compat.*
 
 import sage.Bytes
@@ -16,31 +14,23 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
     withClient(client => client.ping().map(reply => assertEquals(reply, "PONG")))
   }
 
-  test("set then get returns the value") {
+  test("values round-trip per call type, and a missing key is None") {
     withClient { client =>
       for {
-        _     <- client.set("greeting", "hello")
-        value <- client.get[String]("greeting")
-      } yield assertEquals(value, Some("hello"))
-    }
-  }
-
-  test("heterogeneous value types coexist on one client") {
-    withClient { client =>
-      for {
-        _     <- client.set("count", 42)
-        _     <- client.set("flag", true)
-        count <- client.get[Int]("count")
-        flag  <- client.get[Boolean]("flag")
+        _        <- client.set("greeting", "hello")
+        _        <- client.set("count", 42)
+        _        <- client.set("flag", true)
+        greeting <- client.get[String]("greeting")
+        count    <- client.get[Int]("count")
+        flag     <- client.get[Boolean]("flag")
+        missing  <- client.get[String]("missing-key")
       } yield {
+        assertEquals(greeting, Some("hello"))
         assertEquals(count, Some(42))
         assertEquals(flag, Some(true))
+        assertEquals(missing, None)
       }
     }
-  }
-
-  test("get of a missing key is None") {
-    withClient(client => client.get[String]("missing-key").map(value => assertEquals(value, None)))
   }
 
   test("concurrent fibers pipeline onto the Multiplexed Connection and match FIFO") {
@@ -208,11 +198,7 @@ abstract class RoundTripSuite(image: String) extends ServerSuite(image) {
     client.run(clientList).map(_.linesIterator.count(_.nonEmpty))
 
   private def awaitConnectionCount(client: Client[CIO, String], expected: Int, attempts: Int): CIO[Unit] =
-    connectionCount(client).flatMap { count =>
-      if (count == expected) CIO.value(())
-      else if (attempts <= 1) CIO.fail(new AssertionError(s"expected $expected connections, still $count"))
-      else CIO.sleep(100.millis).flatMap(_ => awaitConnectionCount(client, expected, attempts - 1))
-    }
+    Eventually.converges(attempts)(() => connectionCount(client))(_ == expected)(count => s"expected $expected connections, still $count")
 }
 
 class RedisRoundTripSuite extends RoundTripSuite(Images.redis)

--- a/integration-tests/shared/src/test/scala/sage/integration/Ttls.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/Ttls.scala
@@ -1,0 +1,31 @@
+package sage.integration
+
+import scala.concurrent.duration.*
+
+import sage.commands.{FieldTtl, Ttl}
+
+/**
+  * Ttl inspection the command suites share: a server-reported expiry is only ever asserted within a bound.
+  */
+object Ttls {
+
+  def remaining(ttl: Ttl): Option[FiniteDuration] =
+    ttl match {
+      case Ttl.Expires(value) => Some(value)
+      case _                  => None
+    }
+
+  private def remaining(ttl: FieldTtl): Option[FiniteDuration] =
+    ttl match {
+      case FieldTtl.Expires(value) => Some(value)
+      case _                       => None
+    }
+
+  def expires(ttl: Ttl): Boolean = remaining(ttl).exists(_ > Duration.Zero)
+
+  def expires(ttl: FieldTtl): Boolean = remaining(ttl).exists(_ > Duration.Zero)
+
+  def expiresWithin(ttl: Ttl, bound: FiniteDuration): Boolean = remaining(ttl).exists(value => value > Duration.Zero && value <= bound)
+
+  def expiresWithin(ttl: FieldTtl, bound: FiniteDuration): Boolean = remaining(ttl).exists(value => value > Duration.Zero && value <= bound)
+}

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterFailoverSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterFailoverSuite.scala
@@ -11,7 +11,7 @@ import kyo.compat.*
 import sage.client.{ClusterConfig, Endpoint, SageConfig, Topology}
 import sage.client.internal.Client
 import sage.commands.Commands
-import sage.integration.{ContainerClient, Images}
+import sage.integration.{ContainerClient, Eventually, Images}
 
 /**
   * Drives cluster failover recovery against a real multi-node cluster: three masters and their replicas in one container. When a master
@@ -76,11 +76,9 @@ abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends
   // the replication barrier: poll the victim's own replica until it holds every victim-owned key. WAIT keys off the calling connection's last
   // write, so it would not cover writes the cluster client sent on its own routed connections; reading the replica directly proves recovery.
   private def awaitReplicated(container: FixedHostPortGenericContainer, replicaPort: Int, expected: Set[String], attempts: Int): CIO[Unit] =
-    CIO.blocking(parseKeys(cli(container, replicaPort, "keys", "*")).toSet).flatMap { have =>
-      if (expected.subsetOf(have)) CIO.value(())
-      else if (attempts <= 0) CIO.fail(new RuntimeException(s"victim's replica did not catch up; missing ${(expected -- have).take(5)}"))
-      else CIO.sleep(100.millis).flatMap(_ => awaitReplicated(container, replicaPort, expected, attempts - 1))
-    }
+    Eventually.converges(attempts)(() => CIO.blocking(parseKeys(cli(container, replicaPort, "keys", "*")).toSet))(expected.subsetOf)(have =>
+      s"victim's replica did not catch up; missing ${(expected -- have).take(5)}"
+    )
 
   // wait for every node to answer, form the cluster (idempotent across a re-run sharing the container), and wait for it to converge
   private def formCluster(container: FixedHostPortGenericContainer): CIO[Unit] =
@@ -99,18 +97,14 @@ abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends
     }
 
   private def awaitPortsUp(container: FixedHostPortGenericContainer, attempts: Int): CIO[Unit] =
-    CIO.blocking(ports.forall(p => cli(container, p, "ping").contains("PONG"))).flatMap { up =>
-      if (up) CIO.value(())
-      else if (attempts <= 0) CIO.fail(new RuntimeException("cluster nodes did not start"))
-      else CIO.sleep(300.millis).flatMap(_ => awaitPortsUp(container, attempts - 1))
-    }
+    Eventually.converges(attempts, 300.millis)(() => CIO.blocking(ports.forall(p => cli(container, p, "ping").contains("PONG"))))(identity)(_ =>
+      "cluster nodes did not start"
+    )
 
   private def awaitClusterOk(container: FixedHostPortGenericContainer, attempts: Int): CIO[Unit] =
-    CIO.blocking(cli(container, victim, "cluster", "info").contains("cluster_state:ok")).flatMap { ok =>
-      if (ok) CIO.value(())
-      else if (attempts <= 0) CIO.fail(new RuntimeException("cluster did not converge"))
-      else CIO.sleep(500.millis).flatMap(_ => awaitClusterOk(container, attempts - 1))
-    }
+    Eventually.converges(attempts, 500.millis)(() => CIO.blocking(cli(container, victim, "cluster", "info").contains("cluster_state:ok")))(identity)(
+      _ => "cluster did not converge"
+    )
 
   // `cluster_state:ok` flips before every node will actually serve writes, so a freshly formed cluster can briefly answer CLUSTERDOWN; retry
   // each write across that warm-up window, as a real application would, so the failover the test means to exercise is not masked by a startup race
@@ -148,11 +142,9 @@ abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends
 
   // retries until the node accepts the write (e.g. a replica once it is promoted to master)
   private def writeDirect(container: FixedHostPortGenericContainer, port: Int, key: String, value: String, attempts: Int): CIO[Unit] =
-    CIO.blocking(cli(container, port, "set", key, value)).flatMap { out =>
-      if (out.contains("OK")) CIO.value(())
-      else if (attempts <= 0) CIO.fail(new RuntimeException(s"could not write $key on $port: $out"))
-      else CIO.sleep(200.millis).flatMap(_ => writeDirect(container, port, key, value, attempts - 1))
-    }
+    Eventually.converges(attempts, 200.millis)(() => CIO.blocking(cli(container, port, "set", key, value)))(_.contains("OK"))(out =>
+      s"could not write $key on $port: $out"
+    )
 
   private def masterId(container: FixedHostPortGenericContainer, port: Int): String = cli(container, port, "cluster", "myid").trim
 

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterSuite.scala
@@ -12,7 +12,7 @@ import sage.SageException.{DecodeError, ServerError}
 import sage.client.{Endpoint, SageConfig, Topology}
 import sage.client.internal.{Client, ScanTarget}
 import sage.commands.{Command, Commands, FlushMode, ScanCursor}
-import sage.integration.{ContainerClient, Images}
+import sage.integration.{ContainerClient, Eventually, Images}
 import sage.protocol.Frame
 
 /**
@@ -59,17 +59,10 @@ abstract class ClusterSuite(image: String, serverBinary: String, supportsNumbere
     } yield ()
 
   private def awaitClusterOk(admin0: Client[CIO, String], attempts: Int): CIO[Unit] =
-    admin0.run(clusterInfo).flatMap { info =>
-      if (info.contains("cluster_state:ok")) CIO.value(())
-      else if (attempts <= 0) CIO.fail(new RuntimeException(s"cluster did not converge: $info"))
-      else CIO.sleep(100.millis).flatMap(_ => awaitClusterOk(admin0, attempts - 1))
-    }
+    Eventually.converges(attempts)(() => admin0.run(clusterInfo))(_.contains("cluster_state:ok"))(info => s"cluster did not converge: $info")
 
   private def awaitCached(client: Client[CIO, String], key: String, expected: String, attempts: Int): CIO[Option[String]] =
-    client.cached(Commands.get[String, String](key), 1.minute).flatMap { value =>
-      if (value.contains(expected) || attempts <= 1) CIO.value(value)
-      else CIO.sleep(100.millis).flatMap(_ => awaitCached(client, key, expected, attempts - 1))
-    }
+    Eventually.value(attempts)(() => client.cached(Commands.get[String, String](key), 1.minute))(_.contains(expected))
 
   // one shared container per suite, so the cluster is formed once and all routing exercised in a single test
   test("single-key commands, pipelines, and transactions route against a real cluster") {

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/CachingSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/CachingSuite.scala
@@ -8,7 +8,7 @@ import kyo.compat.*
 import sage.SageException.NotCacheable
 import sage.client.internal.Client
 import sage.commands.Commands
-import sage.integration.{Images, ServerSuite}
+import sage.integration.{Eventually, Images, ServerSuite}
 
 abstract class CachingSuite(image: String) extends ServerSuite(image) {
 
@@ -21,10 +21,7 @@ abstract class CachingSuite(image: String) extends ServerSuite(image) {
 
   // cached reads served locally never re-contact the server, so an external write only shows up once its invalidation push lands; poll
   private def awaitCached(client: Client[CIO, String], key: String, expected: String, attempts: Int): CIO[Option[String]] =
-    client.cached(Commands.get[String, String](key), 1.minute).flatMap { value =>
-      if (value.contains(expected) || attempts <= 1) CIO.value(value)
-      else CIO.sleep(100.millis).flatMap(_ => awaitCached(client, key, expected, attempts - 1))
-    }
+    Eventually.value(attempts)(() => client.cached(Commands.get[String, String](key), 1.minute))(_.contains(expected))
 
   test("a repeated cached read is served locally and a server-side write evicts it via invalidation") {
     withReaderAndWriter { (reader, writer) =>

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/KeysSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/KeysSuite.scala
@@ -9,6 +9,7 @@ import kyo.compat.*
 import sage.client.internal.Client
 import sage.commands.*
 import sage.integration.{Images, ServerSuite}
+import sage.integration.Ttls.{expiresWithin, remaining}
 
 abstract class KeysSuite(image: String) extends ServerSuite(image) {
 
@@ -58,7 +59,7 @@ abstract class KeysSuite(image: String) extends ServerSuite(image) {
         missing   <- client.expire("keys-expire-missing", 60.seconds)
       } yield {
         assertEquals(applied, true)
-        assert(remaining(ttl).exists(r => r > Duration.Zero && r <= 60.seconds))
+        assert(expiresWithin(ttl, 60.seconds))
         assertEquals(persisted, true)
         assertEquals(cleared, Ttl.NoExpiry)
         assertEquals(missing, false)
@@ -350,12 +351,6 @@ abstract class KeysSuite(image: String) extends ServerSuite(image) {
       }
     loop(ScanCursor.start, Set.empty)
   }
-
-  private def remaining(ttl: Ttl): Option[FiniteDuration] =
-    ttl match {
-      case Ttl.Expires(value) => Some(value)
-      case _                  => None
-    }
 }
 
 class RedisKeysSuite extends KeysSuite(Images.redis)

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/RedisArraysSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/RedisArraysSuite.scala
@@ -8,7 +8,7 @@ import sage.integration.{Images, ServerSuite}
 /**
   * The Array (`AR*`) data type is Redis-only (no Valkey counterpart) and shipped as a preview, so it has a single-server suite.
   */
-class ArraysSuite extends ServerSuite(Images.redis) {
+class RedisArraysSuite extends ServerSuite(Images.redis) {
 
   test("ARSET/ARGET/ARLEN/ARCOUNT cover writes, reads, and length") {
     withClient { client =>

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/RedisHashFieldExpirySuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/RedisHashFieldExpirySuite.scala
@@ -8,6 +8,7 @@ import kyo.compat.*
 
 import sage.commands.*
 import sage.integration.{Images, ServerSuite}
+import sage.integration.Ttls.{expires, expiresWithin}
 
 /**
   * Hash field-expiration is a Redis-only family (absent in Valkey 8.1), so it has no cross-server counterpart.
@@ -24,10 +25,7 @@ class RedisHashFieldExpirySuite extends ServerSuite(Images.redis) {
         afterTtl <- client.hTtl("hfe-ttl")("a")
       } yield {
         assertEquals(set, Vector(FieldExpiry.Updated, FieldExpiry.NoField))
-        assert(ttl(0) match {
-          case FieldTtl.Expires(d) => d > Duration.Zero && d <= 100.seconds
-          case _                   => false
-        })
+        assert(expiresWithin(ttl(0), 100.seconds))
         assertEquals(ttl(1), FieldTtl.NoExpiry)
         assertEquals(ttl(2), FieldTtl.NoField)
         assertEquals(persist, Vector(FieldPersist.Persisted, FieldPersist.NoExpiry))
@@ -67,10 +65,7 @@ class RedisHashFieldExpirySuite extends ServerSuite(Images.redis) {
         ttl  <- client.hpTtl("hfe-px")("a", "missing")
         time <- client.hpExpireTime("hfe-px")("a")
       } yield {
-        assert(ttl(0) match {
-          case FieldTtl.Expires(d) => d > Duration.Zero
-          case _                   => false
-        })
+        assert(expires(ttl(0)))
         assertEquals(ttl(1), FieldTtl.NoField)
         assertEquals(time, Vector(FieldExpiryTime.At(at)))
       }
@@ -98,10 +93,7 @@ class RedisHashFieldExpirySuite extends ServerSuite(Images.redis) {
         ttl <- client.hTtl("hfe-getex")("a")
       } yield {
         assertEquals(got, Vector(Some("1")))
-        assert(ttl(0) match {
-          case FieldTtl.Expires(d) => d > Duration.Zero
-          case _                   => false
-        })
+        assert(expires(ttl(0)))
       }
     }
   }
@@ -117,10 +109,7 @@ class RedisHashFieldExpirySuite extends ServerSuite(Images.redis) {
         aNew    <- client.hGet[String, String]("hfe-setex", "a")
       } yield {
         assertEquals(created, true)
-        assert(ttl(0) match {
-          case FieldTtl.Expires(_) => true
-          case _                   => false
-        })
+        assert(expires(ttl(0)))
         assertEquals(blocked, false)
         assertEquals(aStill, Some("1"))
         assertEquals(updated, true)

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/RedisStringExtrasSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/RedisStringExtrasSuite.scala
@@ -6,6 +6,7 @@ import kyo.compat.*
 
 import sage.commands.*
 import sage.integration.{Images, ServerSuite}
+import sage.integration.Ttls.expires
 
 /**
   * DIGEST/DELEX/MSETEX/INCREX are Redis-only string commands (absent in Valkey 8.1), so they have no cross-server counterpart.
@@ -58,10 +59,7 @@ class RedisStringExtrasSuite extends ServerSuite(Images.redis) {
       } yield {
         assertEquals(set, true)
         assertEquals(a, Some("1"))
-        assert(ttl match {
-          case Ttl.Expires(d) => d > Duration.Zero
-          case _              => false
-        })
+        assert(expires(ttl))
         assertEquals(blocked, false)
         assertEquals(aStill, Some("1"))
       }
@@ -78,10 +76,7 @@ class RedisStringExtrasSuite extends ServerSuite(Images.redis) {
         viaFlt <- client.increxByFloat("sx-incr-f", 1.5)
       } yield {
         assertEquals(first, IncrExResult(5L, 5L))
-        assert(ttl match {
-          case Ttl.Expires(d) => d > Duration.Zero
-          case _              => false
-        })
+        assert(expires(ttl))
         assertEquals(capped, IncrExResult(10L, 5L))
         assertEquals(reject, IncrExResult(10L, 0L))
         assertEquals(viaFlt, IncrExResult(1.5, 1.5))

--- a/integration-tests/shared/src/test/scala/sage/integration/commands/StringsSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/commands/StringsSuite.scala
@@ -8,6 +8,7 @@ import kyo.compat.*
 
 import sage.commands.{GetExpiry, LcsMatch, MatchRange, SetCondition, SetExpiry, Ttl}
 import sage.integration.{Images, ServerSuite}
+import sage.integration.Ttls.expiresWithin
 
 abstract class StringsSuite(image: String) extends ServerSuite(image) {
 
@@ -200,12 +201,6 @@ abstract class StringsSuite(image: String) extends ServerSuite(image) {
       }
     }
   }
-
-  private def expiresWithin(ttl: Ttl, bound: FiniteDuration): Boolean =
-    ttl match {
-      case Ttl.Expires(remaining) => remaining > Duration.Zero && remaining <= bound
-      case _                      => false
-    }
 }
 
 class RedisStringsSuite extends StringsSuite(Images.redis)

--- a/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
@@ -12,7 +12,7 @@ import sage.SageException.DecodeError
 import sage.client.{Endpoint, MasterReplicaConfig, ReadFrom, SageConfig, Topology}
 import sage.client.internal.Client
 import sage.commands.{Command, Commands}
-import sage.integration.{ContainerClient, Images}
+import sage.integration.{ContainerClient, Eventually, Images}
 import sage.protocol.Frame
 
 /**
@@ -328,11 +328,9 @@ abstract class MasterReplicaStaleReplicaSuite(image: String, serverBinary: Strin
     } yield ()
 
   private def awaitLinkDown(replica: Client[CIO, String], attempts: Int): CIO[Unit] =
-    replica.run(infoReplication).flatMap { info =>
-      if (info.contains("master_link_status:down")) CIO.value(())
-      else if (attempts <= 0) CIO.fail(new RuntimeException(s"replica link never went down: $info"))
-      else CIO.sleep(100.millis).flatMap(_ => awaitLinkDown(replica, attempts - 1))
-    }
+    Eventually.converges(attempts)(() => replica.run(infoReplication))(_.contains("master_link_status:down"))(info =>
+      s"replica link never went down: $info"
+    )
 
   test("a replica answering MASTERDOWN falls through to the master under ReplicaPreferred, and fails a strict Replica read") {
     withContainers { server =>

--- a/integration-tests/shared/src/test/scala/sage/integration/ratelimit/RateLimiterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/ratelimit/RateLimiterSuite.scala
@@ -5,8 +5,8 @@ import scala.concurrent.duration.*
 import kyo.compat.*
 
 import sage.SageException.ServerError
-import sage.commands.Ttl
 import sage.integration.{Images, ServerSuite}
+import sage.integration.Ttls.remaining
 import sage.ratelimit.{Decision, RateLimit, RateLimiter}
 
 abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
@@ -269,10 +269,7 @@ abstract class RateLimiterSuite(image: String) extends ServerSuite(image) {
           case Decision.Denied(_, retryAfter) => assertEquals(retryAfter, 5.seconds)
           case other                          => fail(s"expected Denied, got $other")
         }
-        pttl match {
-          case Ttl.Expires(remaining) => assert(remaining > 2.seconds && remaining <= 5.seconds, s"pttl was $remaining")
-          case other                  => fail(s"expected an expiry, got $other")
-        }
+        assert(remaining(pttl).exists(left => left > 2.seconds && left <= 5.seconds), s"pttl was $pttl")
       }
     }
   }

--- a/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
+++ b/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
@@ -8,255 +8,174 @@ import zio.*
 
 import sage.*
 import sage.backend.*
+import sage.client.{DedicatedPoolConfig, SageConfig}
 
 class ZioSmokeSuite extends ServerSuite(Images.redis) {
 
-  test("an end user connects and round-trips with native ZIO") {
+  private def withNativeClient(body: SageClient => RIO[Scope, Unit]): Unit = withTunedClient(identity)(body)
+
+  private def withTunedClient(tune: SageConfig => SageConfig)(body: SageClient => RIO[Scope, Unit]): Unit =
     withContainers { server =>
-      val config = configOf(server)
-
-      val program: Task[Unit] =
-        ZIO.scoped {
-          for {
-            client <- SageClient.scoped(config)
-            pong   <- client.ping()
-            _      <- ZIO.foreachParDiscard(1 to 50)(i => client.set(s"key-$i", s"value-$i"))
-            values <- ZIO.foreachPar((1 to 50).toList)(i => client.get[String](s"key-$i"))
-          } yield {
-            assertEquals(pong, "PONG")
-            assertEquals(values, (1 to 50).toList.map(i => Some(s"value-$i")))
-          }
-        }
-
+      val program: Task[Unit] = ZIO.scoped(SageClient.scoped(tune(configOf(server))).flatMap(body))
       Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    }
+
+  test("an end user connects and round-trips with native ZIO") {
+    withNativeClient { client =>
+      for {
+        pong   <- client.ping()
+        _      <- ZIO.foreachParDiscard(1 to 50)(i => client.set(s"key-$i", s"value-$i"))
+        values <- ZIO.foreachPar((1 to 50).toList)(i => client.get[String](s"key-$i"))
+      } yield {
+        assertEquals(pong, "PONG")
+        assertEquals(values, (1 to 50).toList.map(i => Some(s"value-$i")))
+      }
     }
   }
 
   test("a pipeline returns a typed tuple natively, surfacing failures per position") {
-    withContainers { server =>
-      val program: Task[Unit] =
-        ZIO.scoped {
-          for {
-            client  <- SageClient.scoped(configOf(server))
-            _       <- client.set("pipe:a", "x")
-            _       <- client.set("pipe:n", 10)
-            out     <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)))
-            _       <- client.set("pipe:str", "hello")
-            attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")))
-          } yield {
-            assertEquals(out, (Some("x"), 15L))
-            assert(attempt._1 == Right(Some("hello")), attempt._1)
-            assert(attempt._2.isLeft, attempt._2)
-          }
-        }
-
-      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    withNativeClient { client =>
+      for {
+        _       <- client.set("pipe:a", "x")
+        _       <- client.set("pipe:n", 10)
+        out     <- client.pipeline((Commands.get[String, String]("pipe:a"), Commands.incrBy[String]("pipe:n", 5)))
+        _       <- client.set("pipe:str", "hello")
+        attempt <- client.pipelineAttempt((Commands.get[String, String]("pipe:str"), Commands.incr[String]("pipe:str")))
+      } yield {
+        assertEquals(out, (Some("x"), 15L))
+        assert(attempt._1 == Right(Some("hello")), attempt._1)
+        assert(attempt._2.isLeft, attempt._2)
+      }
     }
   }
 
   test("a transaction commits atomically with native ZIO, guarded by WATCH") {
-    withContainers { server =>
-      val program: Task[Unit] =
-        ZIO.scoped {
-          for {
-            client <- SageClient.scoped(configOf(server))
-            _      <- client.set("tx:n", 1)
-            out    <- client.transaction { tx =>
-                        for {
-                          _   <- tx.watch("tx:n")
-                          _   <- tx.get[Int]("tx:n")
-                          res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)))
-                        } yield res
-                      }
-          } yield assertEquals(out, Some((2L, 6L)))
-        }
-
-      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    withNativeClient { client =>
+      for {
+        _   <- client.set("tx:n", 1)
+        out <- client.transaction { tx =>
+                 for {
+                   _   <- tx.watch("tx:n")
+                   _   <- tx.get[Int]("tx:n")
+                   res <- tx.exec((Commands.incr[String]("tx:n"), Commands.incrBy[String]("tx:n", 4)))
+                 } yield res
+               }
+      } yield assertEquals(out, Some((2L, 6L)))
     }
   }
 
   test("an interrupted blocking command releases its pooled slot instead of leaking it") {
-    withContainers { server =>
-      val config              = configOf(server).copy(dedicatedPool =
-        sage.client.DedicatedPoolConfig(maxConnections = 2, acquireTimeout = FiniteDuration(1L, TimeUnit.SECONDS))
-      )
-      val program: Task[Unit] =
-        ZIO.scoped {
-          for {
-            client <- SageClient.scoped(config)
-            _      <- ZIO.foreachDiscard(1 to 4)(_ => client.blPop[String]("leak:empty")(BlockTimeout.Forever).timeout(Duration.fromMillis(150)))
-            none   <- client.blPop[String]("leak:empty")(BlockTimeout.After(FiniteDuration(100L, TimeUnit.MILLISECONDS)))
-          } yield assertEquals(none, None)
-        }
-
-      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    val pool = DedicatedPoolConfig(maxConnections = 2, acquireTimeout = FiniteDuration(1L, TimeUnit.SECONDS))
+    withTunedClient(_.copy(dedicatedPool = pool)) { client =>
+      for {
+        _    <- ZIO.foreachDiscard(1 to 4)(_ => client.blPop[String]("leak:empty")(BlockTimeout.Forever).timeout(Duration.fromMillis(150)))
+        none <- client.blPop[String]("leak:empty")(BlockTimeout.After(FiniteDuration(100L, TimeUnit.MILLISECONDS)))
+      } yield assertEquals(none, None)
     }
   }
 
   test("re-running the same blocking command value succeeds each round instead of hanging after the first") {
-    withContainers { server =>
-      val program: Task[Unit] =
-        ZIO.scoped {
-          for {
-            client <- SageClient.scoped(configOf(server))
-            blPop   = client.blPop[String]("h1:reuse")(BlockTimeout.After(FiniteDuration(100L, TimeUnit.MILLISECONDS)))
-            first  <- blPop
-            second <- blPop.timeout(Duration.fromSeconds(5))
-          } yield {
-            assertEquals(first, None)
-            assert(second.isDefined, "re-running the same blocking effect hung: its lease was captured and single-shot")
-            assertEquals(second.flatten, None)
-          }
-        }
-
-      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    withNativeClient { client =>
+      val blPop = client.blPop[String]("h1:reuse")(BlockTimeout.After(FiniteDuration(100L, TimeUnit.MILLISECONDS)))
+      for {
+        first  <- blPop
+        second <- blPop.timeout(Duration.fromSeconds(5))
+      } yield {
+        assertEquals(first, None)
+        assert(second.isDefined, "re-running the same blocking effect hung: its lease was captured and single-shot")
+        assertEquals(second.flatten, None)
+      }
     }
   }
 
   test("scanAll streams every key as a native ZStream") {
-    withContainers { server =>
-      val program: Task[Unit] =
-        ZIO.scoped {
-          for {
-            client <- SageClient.scoped(configOf(server))
-            _      <- ZIO.foreachParDiscard(1 to 50)(i => client.set(s"scan-$i", "v"))
-            keys   <- client.scanAll(pattern = Some("scan-*"), count = Some(10L)).runCollect
-          } yield assertEquals(keys.toSet, (1 to 50).map(i => s"scan-$i").toSet)
-        }
-
-      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    withNativeClient { client =>
+      for {
+        _    <- ZIO.foreachParDiscard(1 to 50)(i => client.set(s"scan-$i", "v"))
+        keys <- client.scanAll(pattern = Some("scan-*"), count = Some(10L)).runCollect
+      } yield assertEquals(keys.toSet, (1 to 50).map(i => s"scan-$i").toSet)
     }
   }
 
   test("subscribe delivers published messages as a native ZStream") {
-    withContainers { server =>
-      val program: Task[Unit] =
-        ZIO.scoped {
-          for {
-            client   <- SageClient.scoped(configOf(server))
-            stream   <- client.subscribeScoped[String]("smoke")
-            _        <- ZIO.foreachDiscard(1 to 3)(i => client.publish("smoke", s"m$i"))
-            messages <- stream.take(3).runCollect
-          } yield {
-            assertEquals(messages.map(_.channel).toSet, Set("smoke"))
-            assertEquals(messages.map(_.payload).toList, List("m1", "m2", "m3"))
-          }
-        }
-
-      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    withNativeClient { client =>
+      for {
+        stream   <- client.subscribeScoped[String]("smoke")
+        _        <- ZIO.foreachDiscard(1 to 3)(i => client.publish("smoke", s"m$i"))
+        messages <- stream.take(3).runCollect
+      } yield {
+        assertEquals(messages.map(_.channel).toSet, Set("smoke"))
+        assertEquals(messages.map(_.payload).toList, List("m1", "m2", "m3"))
+      }
     }
   }
 
   test("hScanAll streams every field/value pair as a native ZStream") {
-    withContainers { server =>
-      val program: Task[Unit] =
-        ZIO.scoped {
-          for {
-            client <- SageClient.scoped(configOf(server))
-            _      <- ZIO.foreachParDiscard(1 to 50)(i => client.hSet("hscan", (s"f$i", s"v$i")))
-            pairs  <- client.hScanAll[String, String]("hscan", count = Some(10L)).runCollect
-          } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"f$i" -> s"v$i").toMap)
-        }
-
-      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    withNativeClient { client =>
+      for {
+        _     <- ZIO.foreachParDiscard(1 to 50)(i => client.hSet("hscan", (s"f$i", s"v$i")))
+        pairs <- client.hScanAll[String, String]("hscan", count = Some(10L)).runCollect
+      } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"f$i" -> s"v$i").toMap)
     }
   }
 
   test("sScanAll streams every member as a native ZStream") {
-    withContainers { server =>
-      val program: Task[Unit] =
-        ZIO.scoped {
-          for {
-            client  <- SageClient.scoped(configOf(server))
-            _       <- ZIO.foreachParDiscard(1 to 50)(i => client.sAdd("sscan", s"m$i"))
-            members <- client.sScanAll[String]("sscan", count = Some(10L)).runCollect
-          } yield assertEquals(members.toSet, (1 to 50).map(i => s"m$i").toSet)
-        }
-
-      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    withNativeClient { client =>
+      for {
+        _       <- ZIO.foreachParDiscard(1 to 50)(i => client.sAdd("sscan", s"m$i"))
+        members <- client.sScanAll[String]("sscan", count = Some(10L)).runCollect
+      } yield assertEquals(members.toSet, (1 to 50).map(i => s"m$i").toSet)
     }
   }
 
   test("zScanAll streams every member/score pair as a native ZStream") {
-    withContainers { server =>
-      val program: Task[Unit] =
-        ZIO.scoped {
-          for {
-            client <- SageClient.scoped(configOf(server))
-            _      <- ZIO.foreachParDiscard(1 to 50)(i => client.zAdd("zscan")((s"m$i", i.toDouble)))
-            pairs  <- client.zScanAll[String]("zscan", count = Some(10L)).runCollect
-          } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
-        }
-
-      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    withNativeClient { client =>
+      for {
+        _     <- ZIO.foreachParDiscard(1 to 50)(i => client.zAdd("zscan")((s"m$i", i.toDouble)))
+        pairs <- client.zScanAll[String]("zscan", count = Some(10L)).runCollect
+      } yield assertEquals(pairs.toMap, (1 to 50).map(i => s"m$i" -> i.toDouble).toMap)
     }
   }
 
   test("xRangeAll pages every entry as a native ZStream") {
-    withContainers { server =>
-      val program: Task[Unit] =
-        ZIO.scoped {
-          for {
-            client  <- SageClient.scoped(configOf(server))
-            _       <- ZIO.foreachDiscard(1 to 50)(i => client.xAdd("xrangeall", XAddId.Explicit(StreamId(i.toLong, 0L)))(("f", s"v$i")))
-            entries <- client.xRangeAll[String, String]("xrangeall", batch = 10L).runCollect
-          } yield assertEquals(entries.map(_.id).toList, (1 to 50).map(i => StreamId(i.toLong, 0L)).toList)
-        }
-
-      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    withNativeClient { client =>
+      for {
+        _       <- ZIO.foreachDiscard(1 to 50)(i => client.xAdd("xrangeall", XAddId.Explicit(StreamId(i.toLong, 0L)))(("f", s"v$i")))
+        entries <- client.xRangeAll[String, String]("xrangeall", batch = 10L).runCollect
+      } yield assertEquals(entries.map(_.id).toList, (1 to 50).map(i => StreamId(i.toLong, 0L)).toList)
     }
   }
 
   test("xConsume tails a group and auto-acks each entry after the handler succeeds") {
-    withContainers { server =>
-      val program: Task[Unit] =
-        ZIO.scoped {
-          for {
-            client <- SageClient.scoped(configOf(server))
-            _      <- ZIO.foreachDiscard(1 to 3)(i => client.xAdd("xconsume", XAddId.Explicit(StreamId(i.toLong, 0L)))(("f", s"v$i")))
-            _      <- client.xGroupCreate("xconsume", "g", GroupStartId.At(StreamId(0L, 0L)))
-            seen   <- Ref.make(Vector.empty[String])
-            fiber  <- client
-                        .xConsume[String, String](
-                          "g",
-                          "c",
-                          "xconsume",
-                          block = BlockTimeout.After(scala.concurrent.duration.FiniteDuration(200L, java.util.concurrent.TimeUnit.MILLISECONDS))
-                        ) { entry =>
-                          seen.update(_ :+ entry.fields.head._2)
-                        }
-                        .fork
-            _      <- seen.get.repeatUntil(_.size >= 3).timeoutFail(new RuntimeException("xConsume did not deliver"))(Duration.fromSeconds(10))
-            _      <- fiber.interrupt
-            got    <- seen.get
-            pend   <- client.xPending("xconsume", "g")
-          } yield {
-            assertEquals(got.sorted, Vector("v1", "v2", "v3"))
-            assertEquals(pend.total, 0L)
-          }
-        }
-
-      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    withNativeClient { client =>
+      val block = BlockTimeout.After(FiniteDuration(200L, TimeUnit.MILLISECONDS))
+      for {
+        _     <- ZIO.foreachDiscard(1 to 3)(i => client.xAdd("xconsume", XAddId.Explicit(StreamId(i.toLong, 0L)))(("f", s"v$i")))
+        _     <- client.xGroupCreate("xconsume", "g", GroupStartId.At(StreamId(0L, 0L)))
+        seen  <- Ref.make(Vector.empty[String])
+        fiber <- client.xConsume[String, String]("g", "c", "xconsume", block = block)(entry => seen.update(_ :+ entry.fields.head._2)).fork
+        _     <- seen.get.repeatUntil(_.size >= 3).timeoutFail(new RuntimeException("xConsume did not deliver"))(Duration.fromSeconds(10))
+        _     <- fiber.interrupt
+        got   <- seen.get
+        pend  <- client.xPending("xconsume", "g")
+      } yield {
+        assertEquals(got.sorted, Vector("v1", "v2", "v3"))
+        assertEquals(pend.total, 0L)
+      }
     }
   }
 
   test("client.rateLimiter admits up to capacity then denies") {
-    withContainers { server =>
-      val program: Task[Unit] =
-        ZIO.scoped {
-          for {
-            client <- SageClient.scoped(configOf(server))
-            rl      = client.rateLimiter[String](RateLimit(capacity = 2, refillTokens = 1, refillPeriod = FiniteDuration(1L, TimeUnit.HOURS)))
-            first  <- rl.tryAcquire("smoke")
-            second <- rl.tryAcquire("smoke")
-            denied <- rl.tryAcquire("smoke")
-          } yield {
-            assert(first.isAllowed && second.isAllowed, "the first two are admitted")
-            assert(!denied.isAllowed, "the third is denied once the bucket empties")
-          }
-        }
-
-      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
+    withNativeClient { client =>
+      val rl = client.rateLimiter[String](RateLimit(capacity = 2, refillTokens = 1, refillPeriod = FiniteDuration(1L, TimeUnit.HOURS)))
+      for {
+        first  <- rl.tryAcquire("smoke")
+        second <- rl.tryAcquire("smoke")
+        denied <- rl.tryAcquire("smoke")
+      } yield {
+        assert(first.isAllowed && second.isAllowed, "the first two are admitted")
+        assert(!denied.isAllowed, "the third is denied once the bucket empties")
+      }
     }
   }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
@@ -4,6 +4,8 @@ import scala.collection.mutable
 import scala.concurrent.duration.*
 import scala.util.{Failure, Success, Try}
 
+import Replies.bulk
+
 import sage.Bytes
 import sage.SageException.{ConnectionLost, NotConnected, TimedOut}
 import sage.client.{BackoffConfig, DedicatedPoolConfig, WatchdogConfig}
@@ -12,21 +14,11 @@ import sage.protocol.Frame
 
 class DedicatedPoolSpec extends munit.FunSuite {
 
-  private val helloReply: Frame =
-    Frame.Map(
-      Vector(
-        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
-        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
-        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
-        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
-      )
-    )
-
-  private val popReply: Frame = Frame.Array(Vector(Frame.BulkString(Bytes.utf8("k")), Frame.BulkString(Bytes.utf8("v"))))
+  private val popReply: Frame = Frame.Array(Vector(bulk("k"), bulk("v")))
 
   // HELLO always answers so the bootstrap succeeds; the blocking command's reply is the test's to script
   private def replyWith(blocking: Seq[Frame]): Bytes => Seq[Frame] =
-    payload => if (payload.asUtf8String.contains("HELLO")) Seq(helloReply) else blocking
+    payload => if (payload.asUtf8String.contains("HELLO")) Seq(Replies.hello) else blocking
 
   private def make(
     respond: Bytes => Seq[Frame],
@@ -193,7 +185,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
           bumped = true
           live = Some(MultiplexedConnection.Generation.initial.next)
         }
-        Seq(helloReply)
+        Seq(Replies.hello)
       } else Seq(popReply)
     val (pool, scheduler, transports)                 = make(respond, liveGeneration = () => live)
     var result: Option[Try[Option[(String, String)]]] = None

--- a/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/MultiplexedConnectionSpec.scala
@@ -4,6 +4,8 @@ import scala.collection.mutable
 import scala.concurrent.duration.*
 import scala.util.{Failure, Success, Try}
 
+import Replies.bulk
+
 import sage.Bytes
 import sage.SageException.{ConnectionLost, DecodeError, NotConnected, ServerError}
 import sage.client.{BackoffConfig, WatchdogConfig}
@@ -41,7 +43,7 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     connection.submit(Connection.ping(), r => first = Some(r))
     connection.submit(Strings.get[String, String]("key"), r => second = Some(r))
     transports.head.emit(Frame.SimpleString("PONG"))
-    transports.head.emit(Frame.BulkString(Bytes.utf8("value")))
+    transports.head.emit(bulk("value"))
     assertEquals(first, Some(Success("PONG")))
     assertEquals(second, Some(Success(Some("value"))))
   }
@@ -599,7 +601,7 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
   }
 
   private def invalidationOf(redisKey: String): Frame =
-    Frame.Push(Vector(Frame.BulkString(Bytes.utf8("invalidate")), Frame.Array(Vector(Frame.BulkString(Bytes.utf8(redisKey))))))
+    Frame.Push(Vector(bulk("invalidate"), Frame.Array(Vector(bulk(redisKey)))))
 
   test("a cached read fetches once, then serves repeats locally until an invalidation push evicts it") {
     val (connection, _, transports) = cachedConnection()
@@ -609,7 +611,7 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     connection.cachedSubmit(get, 60000L, r => first = Some(r))
     assertEquals(transports.head.written.length, 1) // one batch: [CLIENT CACHING YES, GET foo]
     transports.head.emit(Frame.SimpleString("OK"))  // CLIENT CACHING YES reply, discarded
-    transports.head.emit(Frame.BulkString(Bytes.utf8("bar")))
+    transports.head.emit(bulk("bar"))
     assertEquals(first, Some(Success(Some("bar"))))
 
     var second: Option[Try[Option[String]]] = None
@@ -622,7 +624,7 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     connection.cachedSubmit(get, 60000L, r => third = Some(r))
     assertEquals(transports.head.written.length, 2) // evicted -> refetch
     transports.head.emit(Frame.SimpleString("OK"))
-    transports.head.emit(Frame.BulkString(Bytes.utf8("baz")))
+    transports.head.emit(bulk("baz"))
     assertEquals(third, Some(Success(Some("baz"))))
   }
 
@@ -632,16 +634,16 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
 
     connection.cachedSubmit(get, 60000L, _ => ())
     transports.head.emit(Frame.SimpleString("OK"))
-    transports.head.emit(Frame.BulkString(Bytes.utf8("bar")))
+    transports.head.emit(bulk("bar"))
     assertEquals(transports.head.written.length, 1)
 
-    transports.head.emit(Frame.Push(Vector(Frame.BulkString(Bytes.utf8("invalidate")), Frame.Null))) // FLUSHALL/tracking-drop form
+    transports.head.emit(Frame.Push(Vector(bulk("invalidate"), Frame.Null))) // FLUSHALL/tracking-drop form
 
     var afterFlush: Option[Try[Option[String]]] = None
     connection.cachedSubmit(get, 60000L, r => afterFlush = Some(r))
     assertEquals(transports.head.written.length, 2) // flushed -> refetch
     transports.head.emit(Frame.SimpleString("OK"))
-    transports.head.emit(Frame.BulkString(Bytes.utf8("baz")))
+    transports.head.emit(bulk("baz"))
     assertEquals(afterFlush, Some(Success(Some("baz"))))
   }
 
@@ -651,7 +653,7 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
 
     connection.cachedSubmit(get, 1000L, _ => ())
     transports.head.emit(Frame.SimpleString("OK"))
-    transports.head.emit(Frame.BulkString(Bytes.utf8("bar")))
+    transports.head.emit(bulk("bar"))
     assertEquals(transports.head.written.length, 1)
 
     scheduler.advance(1001.millis)                  // past the TTL
@@ -665,7 +667,7 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
 
     connection.cachedSubmit(get, 60000L, _ => ())
     transports.head.emit(Frame.SimpleString("OK"))
-    transports.head.emit(Frame.BulkString(Bytes.utf8("bar")))
+    transports.head.emit(bulk("bar"))
 
     transports.head.emit(Frame.SimpleString("stray")) // nothing pending -> discard -> reconnect
     assertEquals(connection.currentState, MultiplexedConnection.State.Reconnecting)
@@ -676,7 +678,7 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     connection.cachedSubmit(get, 60000L, r => afterReconnect = Some(r))
     assertEquals(transports(1).written.length, 1) // fresh generation, empty cache -> refetch
     transports(1).emit(Frame.SimpleString("OK"))
-    transports(1).emit(Frame.BulkString(Bytes.utf8("baz")))
+    transports(1).emit(bulk("baz"))
     assertEquals(afterReconnect, Some(Success(Some("baz"))))
   }
 
@@ -688,7 +690,7 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
 
     connection.cachedSubmit(get, 60000L, _ => ()) // miss -> fetch
     transports.head.emit(Frame.SimpleString("OK"))
-    transports.head.emit(Frame.BulkString(Bytes.utf8("bar")))
+    transports.head.emit(bulk("bar"))
     assertEquals(tracer.log.toVector, Vector("start:GET", "settled:Succeeded"))
 
     connection.cachedSubmit(get, 60000L, _ => ())                               // served locally
@@ -712,7 +714,7 @@ class MultiplexedConnectionSpec extends munit.FunSuite {
     val respond: Bytes => Seq[Frame]                    = payload => {
       val text = payload.asUtf8String
       if (text.contains("TRACKING")) Seq(Frame.SimpleError("ERR unknown subcommand TRACKING"))
-      else if (text.contains("GET")) Seq(Frame.BulkString(Bytes.utf8("bar")))
+      else if (text.contains("GET")) Seq(bulk("bar"))
       else Nil
     }
     val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {

--- a/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
@@ -16,18 +16,8 @@ import sage.protocol.Frame
 
 class NodePoolSpec extends munit.FunSuite {
 
-  private val helloReply: Frame =
-    Frame.Map(
-      Vector(
-        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
-        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
-        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
-        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
-      )
-    )
-
   private def respond(payload: Bytes): Seq[Frame] =
-    if (payload.asUtf8String.contains("HELLO")) Seq(helloReply) else Nil
+    if (payload.asUtf8String.contains("HELLO")) Seq(Replies.hello) else Nil
 
   private def newPool(factory: Node => MultiplexedConnection.TransportFactory, events: Events = Events.disabled): NodePool =
     new NodePool(

--- a/sage-client/shared/src/test/scala/sage/client/internal/ReadRoutingSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ReadRoutingSpec.scala
@@ -66,16 +66,6 @@ class ReadRoutingSpec extends munit.FunSuite {
     assert(!ReadRouting.replicaEligible(cmd("HSCAN", isReadOnly = true, cursorBound = true)))
   }
 
-  private val helloReply: Frame =
-    Frame.Map(
-      Vector(
-        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
-        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
-        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
-        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
-      )
-    )
-
   private val ping = Connection.ping(None)
 
   final private class Fixture(readFrom: ReadFrom = ReadFrom.Replica, unreachable: Set[Node] = Set.empty, refusing: Set[Node] = Set.empty) {
@@ -83,7 +73,7 @@ class ReadRoutingSpec extends munit.FunSuite {
     val refreshes                                                       = new AtomicInteger()
     private val transports                                              = new ConcurrentHashMap[Node, FakeTransport]()
     private def respond(node: Node)(payload: Bytes): Seq[Frame]         =
-      if (payload.asUtf8String.contains("HELLO")) Seq(helloReply)
+      if (payload.asUtf8String.contains("HELLO")) Seq(Replies.hello)
       else if (refusing(node)) Seq(Frame.SimpleError("LOADING the dataset is loading"))
       else Seq(Frame.SimpleString("PONG"))
     private val factory: Node => MultiplexedConnection.TransportFactory = node =>

--- a/sage-client/shared/src/test/scala/sage/client/internal/Replies.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/Replies.scala
@@ -1,0 +1,61 @@
+package sage.client.internal
+
+import sage.Bytes
+import sage.cluster.{Node, Slot}
+import sage.protocol.Frame
+
+/**
+  * The scripted server replies the client specs share: the RESP3 handshake, `ROLE` and `CLUSTER SLOTS`.
+  */
+object Replies {
+
+  def bulk(value: String): Frame = Frame.BulkString(Bytes.utf8(value))
+
+  val ok: Frame     = Frame.SimpleString("OK")
+  val pong: Frame   = Frame.SimpleString("PONG")
+  val queued: Frame = Frame.SimpleString("QUEUED")
+
+  val hello: Frame =
+    Frame.Map(
+      Vector(
+        bulk("server")  -> bulk("redis"),
+        bulk("version") -> bulk("8.0.0"),
+        bulk("proto")   -> Frame.Integer(3),
+        bulk("role")    -> bulk("master")
+      )
+    )
+
+  /**
+    * One `CLUSTER SLOTS` entry: host, port, then the id the server appends.
+    */
+  private def nodeEntry(node: Node): Frame = Frame.Array(Vector(bulk(node.host), Frame.Integer(node.port.toLong), bulk(s"${node.host}-id")))
+
+  def clusterSlots(ranges: (Node, Int, Int)*): Frame =
+    Frame.Array(ranges.toVector.map { case (node, start, end) =>
+      Frame.Array(Vector(Frame.Integer(start.toLong), Frame.Integer(end.toLong), nodeEntry(node)))
+    })
+
+  /**
+    * A one-shard topology covering the whole slot space, its master followed by its replicas.
+    */
+  def clusterShard(master: Node, replicas: Node*): Frame =
+    Frame.Array(
+      Vector(
+        Frame.Array(
+          Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeEntry(master)) ++ replicas.toVector.map(nodeEntry)
+        )
+      )
+    )
+
+  def masterRole(replicas: Node*): Frame =
+    Frame.Array(
+      Vector(
+        bulk("master"),
+        Frame.Integer(0L),
+        Frame.Array(replicas.toVector.map(replica => Frame.Array(Vector(bulk(replica.host), bulk(replica.port.toString), bulk("0")))))
+      )
+    )
+
+  def replicaRole(master: Node, state: String = "connected"): Frame =
+    Frame.Array(Vector(bulk("slave"), bulk(master.host), Frame.Integer(master.port.toLong), bulk(state), Frame.Integer(0L)))
+}

--- a/sage-client/shared/src/test/scala/sage/client/internal/ScriptedTransport.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ScriptedTransport.scala
@@ -1,0 +1,24 @@
+package sage.client.internal
+
+import sage.Bytes
+import sage.protocol.Frame
+
+/**
+  * Transport factories over a [[FakeTransport]]; `capturing` also hands back the most-recently-created one.
+  */
+object ScriptedTransport {
+
+  def factory(respond: Bytes => Seq[Frame]): MultiplexedConnection.TransportFactory =
+    (onFrame, onClosed) => new FakeTransport(onFrame, onClosed, respond)
+
+  def capturing(factory: MultiplexedConnection.TransportFactory): (MultiplexedConnection.TransportFactory, () => FakeTransport) = {
+    var last: FakeTransport                             = null
+    val wrapped: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
+      last = factory(onFrame, onClosed).asInstanceOf[FakeTransport]
+      last
+    }
+    (wrapped, () => last)
+  }
+
+  def apply(respond: Bytes => Seq[Frame]): (MultiplexedConnection.TransportFactory, () => FakeTransport) = capturing(factory(respond))
+}

--- a/sage-client/shared/src/test/scala/sage/client/internal/ScriptedTransport.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/ScriptedTransport.scala
@@ -1,5 +1,7 @@
 package sage.client.internal
 
+import java.util.concurrent.atomic.AtomicReference
+
 import sage.Bytes
 import sage.protocol.Frame
 
@@ -8,17 +10,25 @@ import sage.protocol.Frame
   */
 object ScriptedTransport {
 
-  def factory(respond: Bytes => Seq[Frame]): MultiplexedConnection.TransportFactory =
+  type Factory = (Frame => Unit, () => Unit) => FakeTransport
+
+  def factory(respond: Bytes => Seq[Frame]): Factory =
     (onFrame, onClosed) => new FakeTransport(onFrame, onClosed, respond)
 
-  def capturing(factory: MultiplexedConnection.TransportFactory): (MultiplexedConnection.TransportFactory, () => FakeTransport) = {
-    var last: FakeTransport                             = null
-    val wrapped: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
-      last = factory(onFrame, onClosed).asInstanceOf[FakeTransport]
-      last
+  def capturing(factory: Factory): (Factory, () => FakeTransport) = {
+    val created          = new AtomicReference[FakeTransport]()
+    val wrapped: Factory = (onFrame, onClosed) => {
+      val transport = factory(onFrame, onClosed)
+      created.set(transport)
+      transport
     }
-    (wrapped, () => last)
+    def last()           =
+      created.get() match {
+        case null      => throw new IllegalStateException("no transport has been created yet")
+        case transport => transport
+      }
+    (wrapped, last)
   }
 
-  def apply(respond: Bytes => Seq[Frame]): (MultiplexedConnection.TransportFactory, () => FakeTransport) = capturing(factory(respond))
+  def apply(respond: Bytes => Seq[Frame]): (Factory, () => FakeTransport) = capturing(factory(respond))
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SubscriptionConnectionSpec.scala
@@ -6,6 +6,8 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.collection.mutable
 import scala.concurrent.duration.*
 
+import Replies.bulk
+
 import sage.Bytes
 import sage.SageException.NotConnected
 import sage.client.{BackoffConfig, WatchdogConfig}
@@ -30,7 +32,7 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
   // a SUBSCRIBE/PSUBSCRIBE is a RESP array `*K`; K-1 of those elements are channel names, each acknowledged by one confirmation push
   private def confirmations(kind: String, payload: String): Seq[Frame] = {
     val names = payload.drop(1).takeWhile(_ != '\r').toInt - 1
-    (1 to names).map(i => Frame.Push(Vector(Frame.BulkString(Bytes.utf8(kind)), Frame.BulkString(Bytes.utf8("?")), Frame.Integer(i.toLong))))
+    (1 to names).map(i => Frame.Push(Vector(bulk(kind), bulk("?"), Frame.Integer(i.toLong))))
   }
 
   private def make(
@@ -56,18 +58,18 @@ class SubscriptionConnectionSpec extends munit.FunSuite {
     transport.written.exists(_.asUtf8String.contains(s"\r\n$command\r\n"))
 
   private def message(channel: String, payload: String): Frame =
-    Frame.Push(Vector(Frame.BulkString(Bytes.utf8("message")), Frame.BulkString(Bytes.utf8(channel)), Frame.BulkString(Bytes.utf8(payload))))
+    Frame.Push(Vector(bulk("message"), bulk(channel), bulk(payload)))
 
   private def shardMessage(channel: String, payload: String): Frame =
-    Frame.Push(Vector(Frame.BulkString(Bytes.utf8("smessage")), Frame.BulkString(Bytes.utf8(channel)), Frame.BulkString(Bytes.utf8(payload))))
+    Frame.Push(Vector(bulk("smessage"), bulk(channel), bulk(payload)))
 
   private def patternMessage(pattern: String, channel: String, payload: String): Frame =
     Frame.Push(
       Vector(
-        Frame.BulkString(Bytes.utf8("pmessage")),
-        Frame.BulkString(Bytes.utf8(pattern)),
-        Frame.BulkString(Bytes.utf8(channel)),
-        Frame.BulkString(Bytes.utf8(payload))
+        bulk("pmessage"),
+        bulk(pattern),
+        bulk(channel),
+        bulk(payload)
       )
     )
 

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -8,7 +8,8 @@ import kyo.compat.*
 
 import sage.Bytes
 import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, InvalidArgument, NotConnected, ServerError, UnsupportedServer}
-import sage.client.internal.{ClusterLive, CountingScheduler, FakeTransport, ManualScheduler, MultiplexedConnection, Scheduler}
+import sage.client.internal.{ClusterLive, CountingScheduler, FakeTransport, ManualScheduler, MultiplexedConnection, Replies, Scheduler}
+import sage.client.internal.Replies.bulk
 import sage.cluster.{Node, Slot}
 import sage.commands.{BroadcastReduce, Command, Connection, Json, JsonPath, Keys, Scripting, Server, Strings}
 import sage.protocol.Frame
@@ -21,26 +22,8 @@ class ClusterClientSpec extends munit.FunSuite {
   private val nodeB    = Node("b", 6379)
   private val nodeDead = Node("dead", 6379)
 
-  private val helloReply: Frame =
-    Frame.Map(
-      Vector(
-        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
-        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
-        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
-        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
-      )
-    )
-
-  private def nodeFrame(node: Node): Frame =
-    Frame.Array(Vector(Frame.BulkString(Bytes.utf8(node.host)), Frame.Integer(node.port.toLong), Frame.BulkString(Bytes.utf8(s"${node.host}-id"))))
-
-  private def slotsFrame(ranges: (Node, Int, Int)*): Frame =
-    Frame.Array(ranges.toVector.map { case (node, start, end) =>
-      Frame.Array(Vector(Frame.Integer(start.toLong), Frame.Integer(end.toLong), nodeFrame(node)))
-    })
-
   private def subscribed(kind: String, channel: String): Frame =
-    Frame.Push(Vector(Frame.BulkString(Bytes.utf8(kind)), Frame.BulkString(Bytes.utf8(channel)), Frame.Integer(1)))
+    Frame.Push(Vector(bulk(kind), bulk(channel), Frame.Integer(1)))
 
   /**
     * A cluster of fake per-node transports. `behaviour` scripts each node's reply to a written command (HELLO and CLUSTER SLOTS are
@@ -75,7 +58,7 @@ class ClusterClientSpec extends munit.FunSuite {
         val respond: Bytes => Seq[Frame] = payload => {
           val text = payload.asUtf8String
           if (text.contains("HELLO"))
-            if (unreachable(node) || flakyHello.remove(node)) Seq(Frame.SimpleError("ERR node is down")) else Seq(helloReply)
+            if (unreachable(node) || flakyHello.remove(node)) Seq(Frame.SimpleError("ERR node is down")) else Seq(Replies.hello)
           else if (text.contains("TRACKING")) Seq(Frame.SimpleString("OK"))
           else behaviour(node, text)
         }
@@ -139,7 +122,12 @@ class ClusterClientSpec extends munit.FunSuite {
   private def awaitAtLeast(counter: java.util.concurrent.atomic.AtomicInteger, target: Int, clue: String): Unit =
     await(s"$clue (saw ${counter.get()}, wanted $target)")(counter.get() >= target)
 
-  private def wholeClusterOn(node: Node): Frame = slotsFrame((node, 0, Slot.Count - 1))
+  private def wholeClusterOn(node: Node): Frame = Replies.clusterSlots((node, 0, Slot.Count - 1))
+
+  // nodeA owns the lower half of the slot space, nodeB the upper half
+  private val mid: Int = Slot.Count / 2
+
+  private val splitCluster: Frame = Replies.clusterSlots((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1))
 
   test("a seed that owns no slots fails the bootstrap rather than adopting an empty topology") {
     val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(Frame.Array(Vector.empty)) else Seq(Frame.Null)
@@ -162,7 +150,7 @@ class ClusterClientSpec extends munit.FunSuite {
       if (text.contains("CLUSTER")) if (emptySlotsAfterRedirect.get) Seq(Frame.Array(Vector.empty)) else Seq(wholeClusterOn(nodeA))
       else if (node == nodeA && emptySlotsAfterRedirect.compareAndSet(false, true))
         Seq(Frame.SimpleError(s"MOVED ${Slot.of(Bytes.utf8("foo")).value} a:6379"))
-      else Seq(Frame.BulkString(Bytes.utf8(node.host)))
+      else Seq(bulk(node.host))
     val fixture                 = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.flatMap { result =>
@@ -172,11 +160,9 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("routes a single-key command to the slot's owner") {
-    // nodeA owns the lower half, nodeB the upper half
-    val mid       = Slot.Count / 2
     val behaviour = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
-      else Seq(Frame.BulkString(Bytes.utf8(node.host)))
+      if (text.contains("CLUSTER")) Seq(splitCluster)
+      else Seq(bulk(node.host))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     val key   = "foo"
@@ -193,7 +179,7 @@ class ClusterClientSpec extends munit.FunSuite {
   test("a cached read routes to the slot's master as [CLIENT CACHING YES, read] and serves a repeat locally") {
     val behaviour = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
-      else if (text.contains("GET")) Seq(Frame.SimpleString("OK"), Frame.BulkString(Bytes.utf8(node.host))) // [CACHING, GET] batch → two replies
+      else if (text.contains("GET")) Seq(Frame.SimpleString("OK"), bulk(node.host)) // [CACHING, GET] batch → two replies
       else Seq(Frame.Null)
     val fixture   = new Fixture(behaviour, Vector(nodeA), caching = true)
 
@@ -213,7 +199,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val behaviour = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
       // the ASK target receives [ASKING, GET foo] (one payload, two replies); it must not receive CLIENT CACHING YES
-      else if (node == nodeB && text.contains("ASKING")) Seq(Frame.SimpleString("OK"), Frame.BulkString(Bytes.utf8("v")))
+      else if (node == nodeB && text.contains("ASKING")) Seq(Frame.SimpleString("OK"), bulk("v"))
       else if (text.contains("GET")) Seq(Frame.SimpleString("OK"), Frame.SimpleError(s"ASK $slot b:6379"))
       else Seq(Frame.Null)
     val fixture   = new Fixture(behaviour, Vector(nodeA), caching = true)
@@ -234,10 +220,10 @@ class ClusterClientSpec extends munit.FunSuite {
     val moved     = new java.util.concurrent.atomic.AtomicBoolean(false)
     val behaviour = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) // topology never changes, so only a flush keeps reads fresh
-      else if (node == nodeB && text.contains("GET")) Seq(Frame.SimpleString("OK"), Frame.BulkString(Bytes.utf8("fresh")))
+      else if (node == nodeB && text.contains("GET")) Seq(Frame.SimpleString("OK"), bulk("fresh"))
       else if (node == nodeA && text.contains("GET"))
         if (moved.get) Seq(Frame.SimpleString("OK"), Frame.SimpleError("MOVED 0 b:6379"))
-        else Seq(Frame.SimpleString("OK"), Frame.BulkString(Bytes.utf8("stale")))
+        else Seq(Frame.SimpleString("OK"), bulk("stale"))
       else Seq(Frame.Null)
     val fixture   = new Fixture(behaviour, Vector(nodeA), caching = true)
 
@@ -258,7 +244,7 @@ class ClusterClientSpec extends munit.FunSuite {
   test("a command to an established node dispatches inline, with no zero-delay scheduler hop") {
     val counting  = new CountingScheduler
     val behaviour =
-      (node: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.BulkString(Bytes.utf8(node.host)))
+      (node: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(bulk(node.host))
     val fixture   = new Fixture(behaviour, Vector(nodeA), scheduler = counting)
 
     val before = counting.zeroDelays.get()
@@ -272,7 +258,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val counting  = new CountingScheduler
     val behaviour = (_: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
-      else Seq(Frame.BulkString(Bytes.utf8("v1")), Frame.BulkString(Bytes.utf8("v2")))
+      else Seq(bulk("v1"), bulk("v2"))
     val fixture   = new Fixture(behaviour, Vector(nodeA), scheduler = counting)
 
     val before = counting.zeroDelays.get()
@@ -284,9 +270,8 @@ class ClusterClientSpec extends munit.FunSuite {
 
   test("a broadcast to established masters dispatches inline, with no zero-delay scheduler hop") {
     val counting  = new CountingScheduler
-    val mid       = Slot.Count / 2
     val behaviour = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      if (text.contains("CLUSTER")) Seq(splitCluster)
       else if (text.contains("DBSIZE")) Seq(Frame.Integer(if (node == nodeA) 2L else 3L))
       else Seq(Frame.Null)
     val fixture   = new Fixture(behaviour, Vector(nodeA), scheduler = counting)
@@ -304,11 +289,11 @@ class ClusterClientSpec extends munit.FunSuite {
     val counting  = new CountingScheduler
     val nodeR     = Node("r", 6379)
     def slots     =
-      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+      Replies.clusterShard(nodeA, nodeR)
     val behaviour = (_: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(slots)
       else if (text.contains("READONLY")) Seq(Frame.SimpleString("OK"))
-      else Seq(Frame.BulkString(Bytes.utf8("v1")), Frame.BulkString(Bytes.utf8("v2")))
+      else Seq(bulk("v1"), bulk("v2"))
     val fixture   = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.Replica, scheduler = counting)
 
     val pipe = fixture.live.pipeline((Strings.get[String, String]("{x}1"), Strings.get[String, String]("{x}2")))
@@ -322,16 +307,14 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("KEYS broadcasts to every slot-owning master and concatenates the per-node slices") {
-    // nodeA owns the lower half, nodeB the upper half; KEYS is node-local, so each returns only its own keys
-    val mid             = Slot.Count / 2
-    val aKeys           = Vector("a1", "a2")
-    val bKeys           = Vector("b1")
-    def bulk(s: String) = Frame.BulkString(Bytes.utf8(s))
-    val behaviour       = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+    // KEYS is node-local, so each master returns only its own keys
+    val aKeys     = Vector("a1", "a2")
+    val bKeys     = Vector("b1")
+    val behaviour = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(splitCluster)
       else if (text.contains("KEYS")) Seq(Frame.Array((if (node == nodeA) aKeys else bKeys).map(bulk)))
       else Seq(Frame.Null)
-    val fixture         = new Fixture(behaviour, Vector(nodeA))
+    val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.run(Keys.keys[String]("*")).unsafeRun.map { result =>
       assertEquals(result.toSet, (aKeys ++ bKeys).toSet)
@@ -341,9 +324,8 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("WAIT broadcasts to every slot-owning master and returns the weakest shard's count") {
-    val mid       = Slot.Count / 2
     val behaviour = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      if (text.contains("CLUSTER")) Seq(splitCluster)
       else if (text.contains("WAIT")) Seq(Frame.Integer(if (node == nodeA) 2L else 1L))
       else Seq(Frame.Null)
     val fixture   = new Fixture(behaviour, Vector(nodeA))
@@ -356,9 +338,8 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("WAIT fails when any master fails, rather than reporting a partial durability signal") {
-    val mid       = Slot.Count / 2
     val behaviour = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      if (text.contains("CLUSTER")) Seq(splitCluster)
       else if (text.contains("WAIT")) Seq(if (node == nodeA) Frame.Integer(2L) else Frame.SimpleError("ERR replication offset unavailable"))
       else Seq(Frame.Null)
     val fixture   = new Fixture(behaviour, Vector(nodeA))
@@ -369,10 +350,9 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("WAIT surfaces a malformed master reply rather than hiding it behind a valid one") {
-    val mid       = Slot.Count / 2
     val behaviour = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
-      else if (text.contains("WAIT")) Seq(if (node == nodeA) Frame.Integer(2L) else Frame.BulkString(Bytes.utf8("nonsense")))
+      if (text.contains("CLUSTER")) Seq(splitCluster)
+      else if (text.contains("WAIT")) Seq(if (node == nodeA) Frame.Integer(2L) else bulk("nonsense"))
       else Seq(Frame.Null)
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
@@ -382,9 +362,8 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("WAIT fails when a master's connection cannot be established, not only on a server error") {
-    val mid       = Slot.Count / 2
     val behaviour = (_: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      if (text.contains("CLUSTER")) Seq(splitCluster)
       else if (text.contains("WAIT")) Seq(Frame.Integer(2L))
       else Seq(Frame.Null)
     val fixture   = new Fixture(behaviour, Vector(nodeA), unreachable = Set(nodeB))
@@ -395,10 +374,9 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("a broadcast retries a master whose establish failed transiently instead of failing the whole command") {
-    val mid       = Slot.Count / 2
     val behaviour = (_: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
-      else if (text.contains("SCRIPT")) Seq(Frame.BulkString(Bytes.utf8("digest")))
+      if (text.contains("CLUSTER")) Seq(splitCluster)
+      else if (text.contains("SCRIPT")) Seq(bulk("digest"))
       else Seq(Frame.Null)
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
@@ -410,12 +388,11 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("a broadcast fails fast rather than chasing a master a refresh no longer lists") {
-    val mid       = Slot.Count / 2
     val owned     = new java.util.concurrent.atomic.AtomicBoolean(true)
     val behaviour = (_: Node, text: String) =>
       if (text.contains("CLUSTER"))
-        Seq(if (owned.get()) slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)) else wholeClusterOn(nodeA))
-      else if (text.contains("SCRIPT")) Seq(Frame.BulkString(Bytes.utf8("digest")))
+        Seq(if (owned.get()) splitCluster else wholeClusterOn(nodeA))
+      else if (text.contains("SCRIPT")) Seq(bulk("digest"))
       else Seq(Frame.Null)
     val fixture   = new Fixture(behaviour, Vector(nodeA), unreachable = Set(nodeB))
 
@@ -428,9 +405,8 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("a broadcast refreshes the topology when a master answers READONLY") {
-    val mid       = Slot.Count / 2
     val behaviour = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      if (text.contains("CLUSTER")) Seq(splitCluster)
       else if (text.contains("FLUSHALL"))
         Seq(if (node == nodeA) Frame.SimpleString("OK") else Frame.SimpleError("READONLY You can't write against a read only replica"))
       else Seq(Frame.Null)
@@ -443,12 +419,11 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("maxRedirects = 0 refuses to retry a broadcast but still adopts a topology, so the next one succeeds") {
-    val mid        = Slot.Count / 2
     val departed   = new java.util.concurrent.atomic.AtomicBoolean(false)
     val behaviour  = (_: Node, text: String) =>
       if (text.contains("CLUSTER"))
-        Seq(if (departed.get()) wholeClusterOn(nodeA) else slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
-      else if (text.contains("SCRIPT")) Seq(Frame.BulkString(Bytes.utf8("digest")))
+        Seq(if (departed.get()) wholeClusterOn(nodeA) else splitCluster)
+      else if (text.contains("SCRIPT")) Seq(bulk("digest"))
       else Seq(Frame.Null)
     val fixture    = new Fixture(behaviour, Vector(nodeA), unreachable = Set(nodeB), cluster = ClusterConfig(maxRedirects = 0))
     val scriptLoad = Scripting.scriptLoad("return 1")
@@ -470,9 +445,8 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("a broadcast fold that throws on a reply arriving after dispatch fails the command rather than hanging the caller") {
-    val mid       = Slot.Count / 2
     val behaviour =
-      (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1))) else Nil
+      (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(splitCluster) else Nil
     val fixture   = new Fixture(behaviour, Vector(nodeA))
     val throwing  = Command[Long](
       "WAIT",
@@ -492,9 +466,8 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("WAIT fails when a master's connection drops while the barrier is pending, rather than returning partially or hanging") {
-    val mid       = Slot.Count / 2
     val behaviour = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      if (text.contains("CLUSTER")) Seq(splitCluster)
       else if (text.contains("WAIT")) if (node == nodeA) Seq(Frame.Integer(2L)) else Nil
       else Seq(Frame.Null)
     val fixture   = new Fixture(behaviour, Vector(nodeA))
@@ -506,10 +479,9 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("WAITAOF broadcasts to every slot-owning master and returns component-wise minimums") {
-    val mid                               = Slot.Count / 2
     def pair(local: Long, replicas: Long) = Frame.Array(Vector(Frame.Integer(local), Frame.Integer(replicas)))
     val behaviour                         = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      if (text.contains("CLUSTER")) Seq(splitCluster)
       else if (text.contains("WAITAOF")) Seq(if (node == nodeA) pair(2L, 2L) else pair(1L, 3L))
       else Seq(Frame.Null)
     val fixture                           = new Fixture(behaviour, Vector(nodeA))
@@ -522,9 +494,8 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("DBSIZE broadcasts to every slot-owning master and sums shard counts into the cluster total") {
-    val mid       = Slot.Count / 2
     val behaviour = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      if (text.contains("CLUSTER")) Seq(splitCluster)
       else if (text.contains("DBSIZE")) Seq(Frame.Integer(if (node == nodeA) 2L else 3L))
       else Seq(Frame.Null)
     val fixture   = new Fixture(behaviour, Vector(nodeA))
@@ -537,9 +508,8 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("DBSIZE fails when any master fails, rather than reporting a partial count") {
-    val mid       = Slot.Count / 2
     val behaviour = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      if (text.contains("CLUSTER")) Seq(splitCluster)
       else if (text.contains("DBSIZE")) Seq(if (node == nodeA) Frame.Integer(2L) else Frame.SimpleError("ERR unavailable"))
       else Seq(Frame.Null)
     val fixture   = new Fixture(behaviour, Vector(nodeA))
@@ -550,10 +520,9 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("SCRIPT EXISTS broadcasts to every master and reports a sha present only when every master has it") {
-    val mid                = Slot.Count / 2
     def flags(bits: Long*) = Frame.Array(bits.map(Frame.Integer(_)).toVector)
     val behaviour          = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      if (text.contains("CLUSTER")) Seq(splitCluster)
       else if (text.contains("SCRIPT")) Seq(if (node == nodeA) flags(1L, 1L) else flags(1L, 0L))
       else Seq(Frame.Null)
     val fixture            = new Fixture(behaviour, Vector(nodeA))
@@ -566,9 +535,8 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("SCRIPT EXISTS fails when any master fails, rather than reporting a partial answer") {
-    val mid       = Slot.Count / 2
     val behaviour = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      if (text.contains("CLUSTER")) Seq(splitCluster)
       else if (text.contains("SCRIPT"))
         Seq(if (node == nodeA) Frame.Array(Vector(Frame.Integer(1L))) else Frame.SimpleError("ERR unavailable"))
       else Seq(Frame.Null)
@@ -580,13 +548,12 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("a broadcast leg retries a LOADING master on its own node, so one loading node does not fail the command") {
-    val mid       = Slot.Count / 2
     val attempts  = new java.util.concurrent.atomic.AtomicInteger(0)
     val behaviour = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+      if (text.contains("CLUSTER")) Seq(splitCluster)
       else if (text.contains("SCRIPT"))
         if (node == nodeB && attempts.getAndIncrement() == 0) Seq(Frame.SimpleError("LOADING Redis is loading the dataset in memory"))
-        else Seq(Frame.BulkString(Bytes.utf8("sha1")))
+        else Seq(bulk("sha1"))
       else Seq(Frame.SimpleString("OK"))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
@@ -597,14 +564,13 @@ class ClusterClientSpec extends munit.FunSuite {
   }
 
   test("a broadcast leg surfaces a CLUSTERDOWN instead of retrying the node that may no longer be a master") {
-    val mid          = Slot.Count / 2
     val clusterCalls = new java.util.concurrent.atomic.AtomicInteger(0)
     val behaviour    = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) {
         clusterCalls.incrementAndGet()
-        Seq(slotsFrame((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1)))
+        Seq(splitCluster)
       } else if (text.contains("SCRIPT"))
-        Seq(if (node == nodeB) Frame.SimpleError("CLUSTERDOWN The cluster is down") else Frame.BulkString(Bytes.utf8("sha1")))
+        Seq(if (node == nodeB) Frame.SimpleError("CLUSTERDOWN The cluster is down") else bulk("sha1"))
       else Seq(Frame.SimpleString("OK"))
     val fixture      = new Fixture(behaviour, Vector(nodeA))
 
@@ -621,12 +587,12 @@ class ClusterClientSpec extends munit.FunSuite {
   test("under ReplicaPreferred a replica answering MASTERDOWN falls through to the master") {
     val nodeR                   = Node("r", 6379)
     def slotsWithReplica: Frame =
-      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+      Replies.clusterShard(nodeA, nodeR)
     val behaviour               = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(slotsWithReplica)
       else if (text.contains("GET"))
         if (node == nodeR) Seq(Frame.SimpleError("MASTERDOWN Link with MASTER is down and replica-serve-stale-data is set to 'no'"))
-        else Seq(Frame.BulkString(Bytes.utf8("from-master")))
+        else Seq(bulk("from-master"))
       else Seq(Frame.SimpleString("OK"))
     val fixture                 = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.ReplicaPreferred)
 
@@ -641,7 +607,7 @@ class ClusterClientSpec extends munit.FunSuite {
     */
   private def replicaDiesMidRead(readFrom: ReadFrom, replica: Node): Fixture = {
     val slots            =
-      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(replica)))))
+      Replies.clusterShard(nodeA, replica)
     var fixture: Fixture = null
     val behaviour        = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(slots)
@@ -649,7 +615,7 @@ class ClusterClientSpec extends munit.FunSuite {
         if (node == replica) {
           fixture.drop(replica)
           Seq.empty
-        } else Seq(Frame.BulkString(Bytes.utf8("from-master")))
+        } else Seq(bulk("from-master"))
       else Seq(Frame.SimpleString("OK"))
     fixture = new Fixture(behaviour, Vector(nodeA), readFrom = readFrom)
     fixture
@@ -678,12 +644,12 @@ class ClusterClientSpec extends munit.FunSuite {
   test("under a strict Replica policy a replica answering MASTERDOWN fails the read rather than reaching the master") {
     val nodeR                   = Node("r", 6379)
     def slotsWithReplica: Frame =
-      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+      Replies.clusterShard(nodeA, nodeR)
     val behaviour               = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(slotsWithReplica)
       else if (text.contains("GET"))
         if (node == nodeR) Seq(Frame.SimpleError("MASTERDOWN Link with MASTER is down and replica-serve-stale-data is set to 'no'"))
-        else Seq(Frame.BulkString(Bytes.utf8("from-master")))
+        else Seq(bulk("from-master"))
       else Seq(Frame.SimpleString("OK"))
     val fixture                 = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.Replica)
 
@@ -697,11 +663,11 @@ class ClusterClientSpec extends munit.FunSuite {
     val nodeR                   = Node("r", 6379)
     // CLUSTER SLOTS lists nodeR as nodeA's replica for the whole keyspace
     def slotsWithReplica: Frame =
-      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+      Replies.clusterShard(nodeA, nodeR)
     val behaviour               = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(slotsWithReplica)
       else if (text.contains("READONLY")) Seq(Frame.SimpleString("OK"))
-      else Seq(Frame.BulkString(Bytes.utf8(if (node == nodeR) "from-replica" else "from-master")))
+      else Seq(bulk(if (node == nodeR) "from-replica" else "from-master"))
     val fixture                 = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.Replica)
 
     fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
@@ -716,12 +682,12 @@ class ClusterClientSpec extends munit.FunSuite {
     val nodeR     = Node("r", 6379)
     val moved     = new java.util.concurrent.atomic.AtomicBoolean(true)
     def slots     =
-      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+      Replies.clusterShard(nodeA, nodeR)
     val behaviour = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(slots)
       else if (text.contains("READONLY")) Seq(Frame.SimpleString("OK"))
       else if (node == nodeR && moved.get()) Seq(Frame.SimpleError(s"MOVED 12182 ${nodeB.host}:${nodeB.port}"))
-      else Seq(Frame.BulkString(Bytes.utf8("value")))
+      else Seq(bulk("value"))
     val fixture   =
       new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.Replica, cluster = ClusterConfig(maxRedirects = 0))
     val get       = Strings.get[String, String]("foo")
@@ -737,7 +703,7 @@ class ClusterClientSpec extends munit.FunSuite {
   test("under a Replica policy a write still goes to the master") {
     val nodeR     = Node("r", 6379)
     def slots     =
-      Frame.Array(Vector(Frame.Array(Vector(Frame.Integer(0L), Frame.Integer((Slot.Count - 1).toLong), nodeFrame(nodeA), nodeFrame(nodeR)))))
+      Replies.clusterShard(nodeA, nodeR)
     val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(slots) else Seq(Frame.SimpleString("OK"))
     val fixture   = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.Replica)
 
@@ -750,7 +716,7 @@ class ClusterClientSpec extends munit.FunSuite {
   test("a replica-preferred read with no known replica schedules a topology refresh") {
     val scheduler = new ManualScheduler
     val behaviour =
-      (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.BulkString(Bytes.utf8("from-master")))
+      (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(bulk("from-master"))
     val fixture   = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.ReplicaPreferred, scheduler = scheduler)
     val before    = fixture.clusterSlotsCount(nodeA)
 
@@ -764,7 +730,7 @@ class ClusterClientSpec extends munit.FunSuite {
   test("a keyless replica-preferred read with no known replica schedules a topology refresh") {
     val scheduler = new ManualScheduler
     val behaviour =
-      (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.BulkString(Bytes.utf8("k")))
+      (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(bulk("k"))
     val fixture   = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.ReplicaPreferred, scheduler = scheduler)
     val before    = fixture.clusterSlotsCount(nodeA)
 
@@ -808,7 +774,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val behaviour = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
       else if (node == nodeA) Seq(Frame.SimpleError(s"MOVED ${Slot.of(Bytes.utf8("foo")).value} b:6379"))
-      else Seq(Frame.BulkString(Bytes.utf8("from-b")))
+      else Seq(bulk("from-b"))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
@@ -821,7 +787,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val behaviour = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
       else if (node == nodeA) Seq(Frame.SimpleError(s"ASK ${Slot.of(Bytes.utf8("foo")).value} b:6379"))
-      else Seq(Frame.SimpleString("OK"), Frame.BulkString(Bytes.utf8("asked"))) // ASKING reply, then the command's
+      else Seq(Frame.SimpleString("OK"), bulk("asked")) // ASKING reply, then the command's
     val fixture = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.run(Strings.get[String, String]("foo")).unsafeRun.map { result =>
@@ -837,7 +803,7 @@ class ClusterClientSpec extends munit.FunSuite {
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
       else if (text.contains("GET"))
         if (attempts.getAndIncrement() == 0) Seq(Frame.SimpleError("TRYAGAIN Multiple keys request during rehashing of slot"))
-        else Seq(Frame.BulkString(Bytes.utf8("value")))
+        else Seq(bulk("value"))
       else Seq(Frame.SimpleString("OK"))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
@@ -856,7 +822,7 @@ class ClusterClientSpec extends munit.FunSuite {
         Seq(wholeClusterOn(nodeA))
       } else if (text.contains("GET"))
         if (attempts.getAndIncrement() == 0) Seq(Frame.SimpleError("LOADING Redis is loading the dataset in memory"))
-        else Seq(Frame.BulkString(Bytes.utf8("value")))
+        else Seq(bulk("value"))
       else Seq(Frame.SimpleString("OK"))
     val fixture      = new Fixture(behaviour, Vector(nodeA))
 
@@ -873,7 +839,7 @@ class ClusterClientSpec extends munit.FunSuite {
       if (text.contains("CLUSTER")) Seq(if (clusterCalls.incrementAndGet() == 1) wholeClusterOn(nodeA) else wholeClusterOn(nodeB))
       // the batch carries both positions; the retries reach nodeB one at a time
       else if (text.contains("GET"))
-        if (node == nodeA) Seq.fill(2)(Frame.SimpleError("CLUSTERDOWN The cluster is down")) else Seq(Frame.BulkString(Bytes.utf8("from-b")))
+        if (node == nodeA) Seq.fill(2)(Frame.SimpleError("CLUSTERDOWN The cluster is down")) else Seq(bulk("from-b"))
       else Seq(Frame.SimpleString("OK"))
     val fixture      = new Fixture(behaviour, Vector(nodeA))
 
@@ -892,7 +858,7 @@ class ClusterClientSpec extends munit.FunSuite {
         if (call > 1) Thread.sleep(300)
         Seq(if (call == 1) wholeClusterOn(nodeA) else wholeClusterOn(nodeB))
       } else if (text.contains("GET"))
-        Seq(if (node == nodeA) Frame.SimpleError("CLUSTERDOWN The cluster is down") else Frame.BulkString(Bytes.utf8("from-b")))
+        Seq(if (node == nodeA) Frame.SimpleError("CLUSTERDOWN The cluster is down") else bulk("from-b"))
       else Seq(Frame.SimpleString("OK"))
     val fixture      = new Fixture(behaviour, Vector(nodeA))
 
@@ -962,9 +928,9 @@ class ClusterClientSpec extends munit.FunSuite {
     val behaviour = (_: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
       else if (text.contains(keyA))
-        Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("a-value")), Frame.Null)))
+        Seq(Frame.Array(Vector(bulk("a-value"), Frame.Null)))
       else if (text.contains(keyB))
-        Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("b-value")), Frame.BulkString(Bytes.utf8("b-value")))))
+        Seq(Frame.Array(Vector(bulk("b-value"), bulk("b-value"))))
       else Seq(Frame.SimpleError("ERR unexpected command"))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
@@ -982,8 +948,8 @@ class ClusterClientSpec extends munit.FunSuite {
     assert(Slot.of(Bytes.utf8(keyA)) != Slot.of(Bytes.utf8(keyB)), "test keys must hash to different slots")
     val behaviour = (_: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
-      else if (text.contains(keyA)) Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("[1]")))))
-      else if (text.contains(keyB)) Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("[2]")))))
+      else if (text.contains(keyA)) Seq(Frame.Array(Vector(bulk("[1]"))))
+      else if (text.contains(keyB)) Seq(Frame.Array(Vector(bulk("[2]"))))
       else Seq(Frame.SimpleError("ERR unexpected command"))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
@@ -1024,7 +990,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val second    = "{same}two"
     val behaviour = (_: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
-      else Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("one")), Frame.BulkString(Bytes.utf8("two")))))
+      else Seq(Frame.Array(Vector(bulk("one"), bulk("two"))))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.run(Strings.mGet[String, String](first, second)).unsafeRun.map { result =>
@@ -1071,7 +1037,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val keyB      = "{b}"
     val behaviour = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(splitOn(Slot.of(Bytes.utf8(keyB)).value))
-      else Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8(node.host)))))
+      else Seq(Frame.Array(Vector(bulk(node.host))))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.run(Strings.mGet[String, String](keyA, keyB)).unsafeRun.map { result =>
@@ -1087,7 +1053,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val behaviour = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(splitOn(Slot.of(Bytes.utf8(keyB)).value))
       else if (node == nodeB) Seq(Frame.SimpleError("ERR subgroup unavailable"))
-      else Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("ok")))))
+      else Seq(Frame.Array(Vector(bulk("ok"))))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.run(Strings.mGet[String, String](keyA, keyB)).unsafeRun.failed.map { error =>
@@ -1103,7 +1069,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val behaviour = (_: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
       else if (text.contains(keyA)) Seq(Frame.Array(Vector.empty))
-      else Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("b")))))
+      else Seq(Frame.Array(Vector(bulk("b"))))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.run(Strings.mGet[String, String](keyA, keyB)).unsafeRun.failed.map { error =>
@@ -1118,8 +1084,8 @@ class ClusterClientSpec extends munit.FunSuite {
     val behaviour = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
       else if (node == nodeA && text.contains(keyB)) Seq(Frame.SimpleError(s"MOVED $slotB b:6379"))
-      else if (text.contains(keyA)) Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("a")))))
-      else Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("b")))))
+      else if (text.contains(keyA)) Seq(Frame.Array(Vector(bulk("a"))))
+      else Seq(Frame.Array(Vector(bulk("b"))))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.run(Strings.mGet[String, String](keyA, keyB)).unsafeRun.map { result =>
@@ -1206,11 +1172,12 @@ class ClusterClientSpec extends munit.FunSuite {
 
   test("absorbs a failover: an unreachable owner triggers a refresh and the command retries on the new master") {
     val key                  = "foo"
-    val mid                  = Slot.of(Bytes.utf8(key)).value // the upper range starts here, so `key` lands in it
+    val keySlot              = Slot.of(Bytes.utf8(key)).value // the upper range starts here, so `key` lands in it
     @volatile var failedOver = false
     val behaviour            = (node: Node, text: String) =>
-      if (text.contains("CLUSTER")) Seq(slotsFrame((nodeA, 0, mid - 1), (if (failedOver) nodeB else nodeDead, mid, Slot.Count - 1)))
-      else Seq(Frame.BulkString(Bytes.utf8(node.host)))
+      if (text.contains("CLUSTER"))
+        Seq(Replies.clusterSlots((nodeA, 0, keySlot - 1), (if (failedOver) nodeB else nodeDead, keySlot, Slot.Count - 1)))
+      else Seq(bulk(node.host))
     val fixture              = new Fixture(behaviour, Vector(nodeA), unreachable = Set(nodeDead))
 
     failedOver = true // the master for `key` has been replaced by nodeB; the stale topology still points at the dead node
@@ -1222,7 +1189,7 @@ class ClusterClientSpec extends munit.FunSuite {
 
   test("close is terminal: a command after close fails rather than reconnecting") {
     val behaviour =
-      (node: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(Frame.BulkString(Bytes.utf8(node.host)))
+      (node: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(bulk(node.host))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.close.unsafeRun.flatMap { _ =>
@@ -1238,7 +1205,7 @@ class ClusterClientSpec extends munit.FunSuite {
     if (slot > 0) ranges += ((nodeA, 0, slot - 1))
     ranges += ((nodeB, slot, slot))
     if (slot < Slot.Count - 1) ranges += ((nodeA, slot + 1, Slot.Count - 1))
-    slotsFrame(ranges.toVector*)
+    Replies.clusterSlots(ranges.toVector*)
   }
 
   private val keyA  = "{a}"
@@ -1249,7 +1216,7 @@ class ClusterClientSpec extends munit.FunSuite {
     assert(Slot.of(Bytes.utf8(keyA)).value != slotB, "test keys must hash to different slots")
     // each node answers a GET with its own host, so the merged result reveals which node served which position
     val behaviour =
-      (node: Node, text: String) => if (text.contains("CLUSTER")) Seq(splitOn(slotB)) else Seq(Frame.BulkString(Bytes.utf8(node.host)))
+      (node: Node, text: String) => if (text.contains("CLUSTER")) Seq(splitOn(slotB)) else Seq(bulk(node.host))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.pipelineAttempt((Strings.get[String, String](keyA), Strings.get[String, String](keyB))).unsafeRun.map { result =>
@@ -1262,9 +1229,9 @@ class ClusterClientSpec extends munit.FunSuite {
   test("a pipeline transparently executes a cross-slot MGET at its logical position") {
     val behaviour = (_: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
-      else if (text.contains("MGET") && text.contains(keyA)) Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("a")))))
-      else if (text.contains("MGET") && text.contains(keyB)) Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("b")))))
-      else Seq(Frame.BulkString(Bytes.utf8("tail")))
+      else if (text.contains("MGET") && text.contains(keyA)) Seq(Frame.Array(Vector(bulk("a"))))
+      else if (text.contains("MGET") && text.contains(keyB)) Seq(Frame.Array(Vector(bulk("b"))))
+      else Seq(bulk("tail"))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.pipeline((Strings.mGet[String, String](keyA, keyB), Strings.get[String, String]("{a}tail"))).unsafeRun.map { result =>
@@ -1276,7 +1243,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val behaviour = (_: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
       else if (text.contains("EXISTS")) Seq(Frame.Integer(1L))
-      else Seq(Frame.BulkString(Bytes.utf8("tail")))
+      else Seq(bulk("tail"))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.pipeline((Keys.exists(keyA, keyB), Strings.get[String, String]("{a}tail"))).unsafeRun.map { result =>
@@ -1288,7 +1255,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val behaviour = (_: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
       else if (text.contains("MSET")) Seq(Frame.SimpleString("OK"))
-      else Seq(Frame.BulkString(Bytes.utf8("tail")))
+      else Seq(bulk("tail"))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.pipeline((Strings.mSet(keyA -> "a", keyB -> "b"), Strings.get[String, String]("{a}tail"))).unsafeRun.map { result =>
@@ -1300,7 +1267,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val behaviour = (node: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(splitOn(slotB))
       else if (node == nodeB) Seq(Frame.SimpleError("WRONGTYPE Operation against a key holding the wrong kind of value"))
-      else Seq(Frame.BulkString(Bytes.utf8("ok")))
+      else Seq(bulk("ok"))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.pipelineAttempt((Strings.get[String, String](keyA), Strings.get[String, String](keyB))).unsafeRun.map { case (first, second) =>
@@ -1312,7 +1279,7 @@ class ClusterClientSpec extends munit.FunSuite {
   test("a single-slot pipeline routes to one node and returns the typed tuple") {
     val behaviour = (_: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
-      else Seq(Frame.BulkString(Bytes.utf8("v1")), Frame.BulkString(Bytes.utf8("v2")))
+      else Seq(bulk("v1"), bulk("v2"))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live.pipeline((Strings.get[String, String]("{x}1"), Strings.get[String, String]("{x}2"))).unsafeRun.map { result =>
@@ -1338,7 +1305,7 @@ class ClusterClientSpec extends munit.FunSuite {
     // get, ping, get all hash/route to one node; the keyless ping must stay between the two gets on the wire, not be reordered to the end
     val behaviour = (_: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
-      else Seq(Frame.BulkString(Bytes.utf8("v1")), Frame.SimpleString("PONG"), Frame.BulkString(Bytes.utf8("v2")))
+      else Seq(bulk("v1"), Frame.SimpleString("PONG"), bulk("v2"))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
     fixture.live
@@ -1458,7 +1425,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val behaviour = (_: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
       else if (text.contains("MULTI"))
-        Seq(Frame.SimpleString("OK"), Frame.SimpleString("QUEUED"), Frame.Array(Vector(Frame.BulkString(Bytes.utf8("v")))))
+        Seq(Frame.SimpleString("OK"), Frame.SimpleString("QUEUED"), Frame.Array(Vector(bulk("v"))))
       else Seq(Frame.SimpleString("OK"))
     // gate the dedicated (second) transport of nodeA so the transaction's first acquire parks mid-connect
     val fixture   = new Fixture(behaviour, Vector(nodeA), connectGate = (node, index) => if (node == nodeA && index == 1) gate.await())
@@ -1483,7 +1450,7 @@ class ClusterClientSpec extends munit.FunSuite {
     val behaviour = (_: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
       else if (text.contains("MULTI"))
-        Seq(Frame.SimpleString("OK"), Frame.SimpleString("QUEUED"), Frame.Array(Vector(Frame.BulkString(Bytes.utf8("v")))))
+        Seq(Frame.SimpleString("OK"), Frame.SimpleString("QUEUED"), Frame.Array(Vector(bulk("v"))))
       else Seq(Frame.SimpleString("OK"))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 
@@ -1558,7 +1525,7 @@ class ClusterClientSpec extends munit.FunSuite {
   test("a cluster transaction still accepts KEYS, an existing broadcast command, returning the pinned node's keys") {
     val behaviour = (_: Node, text: String) =>
       if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
-      else if (text.contains("KEYS")) Seq(Frame.Array(Vector(Frame.BulkString(Bytes.utf8("k1")))))
+      else if (text.contains("KEYS")) Seq(Frame.Array(Vector(bulk("k1"))))
       else Seq(Frame.SimpleString("OK"))
     val fixture   = new Fixture(behaviour, Vector(nodeA))
 

--- a/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ConnectSpec.scala
@@ -10,7 +10,8 @@ import kyo.compat.*
 
 import sage.{Bytes, Outcome, SageEvent, SageListener}
 import sage.SageException.{ConnectionFailed, InvalidArgument, NotConnected, UnsupportedServer}
-import sage.client.internal.{Client, Events, FakeTransport, ManualScheduler, MultiplexedConnection}
+import sage.client.internal.{Client, Events, FakeTransport, ManualScheduler, MultiplexedConnection, Replies, ScriptedTransport}
+import sage.client.internal.Replies.{ok, pong}
 import sage.commands.{Command, Execution, Server}
 import sage.protocol.Frame
 
@@ -18,32 +19,13 @@ class ConnectSpec extends munit.FunSuite {
 
   private given ExecutionContext = munitExecutionContext
 
-  private val helloReply: Frame =
-    Frame.Map(
-      Vector(
-        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
-        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
-        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
-        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
-      )
-    )
-
   private val helloThenPong: Bytes => Seq[Frame] = payload =>
-    if (payload.asUtf8String.contains("HELLO")) Seq(helloReply)
-    else if (payload.asUtf8String.contains("PING")) Seq(Frame.SimpleString("PONG"))
-    else Seq(Frame.SimpleString("OK")) // CLIENT TRACKING/SETINFO and SELECT bootstrap commands all answer OK
-
-  private def scripted(reply: Bytes => Seq[Frame]): (MultiplexedConnection.TransportFactory, () => FakeTransport) = {
-    var transport: FakeTransport                        = null
-    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
-      transport = new FakeTransport(onFrame, onClosed, reply)
-      transport
-    }
-    (factory, () => transport)
-  }
+    if (payload.asUtf8String.contains("HELLO")) Seq(Replies.hello)
+    else if (payload.asUtf8String.contains("PING")) Seq(pong)
+    else Seq(ok) // CLIENT TRACKING/SETINFO and SELECT bootstrap commands all answer OK
 
   test("connect performs the HELLO 3 handshake and yields a working client") {
-    val (factory, _) = scripted(helloThenPong)
+    val (factory, _) = ScriptedTransport(helloThenPong)
     Client.connectWith(factory).flatMap(client => client.ping()).unsafeRun.map { result =>
       assertEquals(result, "PONG")
     }
@@ -64,7 +46,7 @@ class ConnectSpec extends munit.FunSuite {
   }
 
   test("a server without RESP3 is rejected with UnsupportedServer and the connection is released") {
-    val (factory, transport) = scripted(_ => Seq(Frame.SimpleError("ERR unknown command 'HELLO'")))
+    val (factory, transport) = ScriptedTransport(_ => Seq(Frame.SimpleError("ERR unknown command 'HELLO'")))
     Client.connectWith(factory).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[UnsupportedServer], s"unexpected error: $error")
       assertEquals(transport().closeCount, 1)
@@ -72,7 +54,7 @@ class ConnectSpec extends munit.FunSuite {
   }
 
   test("a NOPROTO rejection maps to UnsupportedServer") {
-    val (factory, _) = scripted(_ => Seq(Frame.SimpleError("NOPROTO unsupported protocol version")))
+    val (factory, _) = ScriptedTransport(_ => Seq(Frame.SimpleError("NOPROTO unsupported protocol version")))
     Client.connectWith(factory).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[UnsupportedServer], s"unexpected error: $error")
     }
@@ -136,7 +118,7 @@ class ConnectSpec extends munit.FunSuite {
   }
 
   test("the ZIO artifact lowers to a native ZIO") {
-    val (factory, _)                            = scripted(helloThenPong)
+    val (factory, _)                            = ScriptedTransport(helloThenPong)
     val native: zio.ZIO[Any, Throwable, String] = Client.connectWith(factory).flatMap(client => client.ping()).lower
     CIO.lift(native).unsafeRun.map(result => assertEquals(result, "PONG"))
   }
@@ -144,9 +126,9 @@ class ConnectSpec extends munit.FunSuite {
   private def assertBarrierRidesMux(barrier: Command[?], barrierReply: Frame, token: String): scala.concurrent.Future[Unit] = {
     val transports                                      = new ConcurrentLinkedQueue[FakeTransport]()
     val reply: Bytes => Seq[Frame]                      = payload =>
-      if (payload.asUtf8String.contains("HELLO")) Seq(helloReply)
+      if (payload.asUtf8String.contains("HELLO")) Seq(Replies.hello)
       else if (payload.asUtf8String.contains(token)) Seq(barrierReply)
-      else Seq(Frame.SimpleString("OK"))
+      else Seq(ok)
     val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
       val transport = new FakeTransport(onFrame, onClosed, reply)
       transports.add(transport)
@@ -177,7 +159,7 @@ class ConnectSpec extends munit.FunSuite {
   }
 
   test("a pipeline carrying a blocking command fails fast without reaching the socket") {
-    val (factory, transport) = scripted(helloThenPong)
+    val (factory, transport) = ScriptedTransport(helloThenPong)
     val blocking             = Vector(Command("BLPOP", Command.NoKeys, Vector.empty, _ => Right(()), Execution.Blocking))
     Client.connectWith(factory).flatMap(_.pipeline(blocking)).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[InvalidArgument], s"unexpected error: $error")
@@ -186,7 +168,7 @@ class ConnectSpec extends munit.FunSuite {
   }
 
   test("a pipeline that fails fast while disconnected reports a failed completion per position") {
-    val (factory, transport) = scripted(helloThenPong)
+    val (factory, transport) = ScriptedTransport(helloThenPong)
     val scheduler            = new ManualScheduler // so the post-drop reconnect stays pending and the connection stays not-live
     val completions          = new ConcurrentLinkedQueue[SageEvent.CommandCompleted]()
     val latch                = new CountDownLatch(2)
@@ -225,7 +207,7 @@ class ConnectSpec extends munit.FunSuite {
   }
 
   test("an empty pipeline succeeds without a round-trip") {
-    val (factory, transport) = scripted(helloThenPong)
+    val (factory, transport) = ScriptedTransport(helloThenPong)
     val empty                = Vector.empty[Command[Long]]
     Client.connectWith(factory).flatMap(_.pipeline(empty)).unsafeRun.map { result =>
       assertEquals(result, Vector.empty[Long])

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaPipelineSpec.scala
@@ -9,7 +9,8 @@ import scala.jdk.CollectionConverters.*
 import kyo.compat.*
 
 import sage.{Bytes, CommandSpan, CommandTracer, Outcome, SageEvent, SageListener}
-import sage.client.internal.{CountingScheduler, Events, FakeTransport, MasterReplicaLive, MultiplexedConnection, Scheduler}
+import sage.client.internal.{CountingScheduler, Events, FakeTransport, MasterReplicaLive, MultiplexedConnection, Replies, Scheduler}
+import sage.client.internal.Replies.ok
 import sage.cluster.Node
 import sage.commands.{Command, Connection}
 import sage.protocol.Frame
@@ -21,43 +22,16 @@ class MasterReplicaPipelineSpec extends munit.FunSuite {
   private val master  = Node("master-host", 7000)
   private val replica = Node("replica-host", 7001)
 
-  private val helloReply: Frame =
-    Frame.Map(
-      Vector(
-        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
-        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
-        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
-        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
-      )
-    )
-
-  private val roleReply: Frame =
-    Frame.Array(
-      Vector(
-        Frame.BulkString(Bytes.utf8("master")),
-        Frame.Integer(0L),
-        Frame.Array(
-          Vector(
-            Frame.Array(
-              Vector(
-                Frame.BulkString(Bytes.utf8(replica.host)),
-                Frame.BulkString(Bytes.utf8(replica.port.toString)),
-                Frame.BulkString(Bytes.utf8("0"))
-              )
-            )
-          )
-        )
-      )
-    )
+  private val roleReply: Frame = Replies.masterRole(replica)
 
   // one reply per command occurrence in a batch; only the master answers ROLE; other bootstrap commands each get a single OK
   private def respondFor(node: Node): Bytes => Seq[Frame] = payload => {
     val s = payload.asUtf8String
-    if (s.contains("HELLO")) Seq(helloReply)
+    if (s.contains("HELLO")) Seq(Replies.hello)
     else if (s.contains("ROLE")) if (node == master) Seq(roleReply) else Nil
     else {
       val batch = occurrences(s, "PREAD") + occurrences(s, "PWRITE")
-      if (batch > 0) Seq.fill(batch)(Frame.SimpleString("OK")) else Seq(Frame.SimpleString("OK"))
+      if (batch > 0) Seq.fill(batch)(ok) else Seq(ok)
     }
   }
 

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -13,7 +13,8 @@ import kyo.compat.*
 
 import sage.{Bytes, SageEvent}
 import sage.SageException.{ConnectionFailed, NotConnected, TimedOut}
-import sage.client.internal.{ConnectFailureRecorder, Events, FakeTransport, MasterReplicaLive, MultiplexedConnection, Scheduler}
+import sage.client.internal.{ConnectFailureRecorder, Events, FakeTransport, MasterReplicaLive, MultiplexedConnection, Replies, Scheduler}
+import sage.client.internal.Replies.{masterRole, replicaRole}
 import sage.cluster.Node
 import sage.commands.{Command, Connection}
 import sage.protocol.Frame
@@ -23,46 +24,6 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
   private val primary           = Node("primary-endpoint", 6379)
   private val reader            = Node("reader-endpoint", 6379)
   private val advertisedReplica = Node("10.0.0.7", 6379)
-
-  private val helloReply: Frame =
-    Frame.Map(
-      Vector(
-        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
-        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
-        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
-        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
-      )
-    )
-
-  private def masterRole(replicas: Node*): Frame =
-    Frame.Array(
-      Vector(
-        Frame.BulkString(Bytes.utf8("master")),
-        Frame.Integer(0L),
-        Frame.Array(
-          replicas.toVector.map(replica =>
-            Frame.Array(
-              Vector(
-                Frame.BulkString(Bytes.utf8(replica.host)),
-                Frame.BulkString(Bytes.utf8(replica.port.toString)),
-                Frame.BulkString(Bytes.utf8("0"))
-              )
-            )
-          )
-        )
-      )
-    )
-
-  private def replicaRole(master: Node, state: String = "connected"): Frame =
-    Frame.Array(
-      Vector(
-        Frame.BulkString(Bytes.utf8("slave")),
-        Frame.BulkString(Bytes.utf8(master.host)),
-        Frame.Integer(master.port.toLong),
-        Frame.BulkString(Bytes.utf8(state)),
-        Frame.Integer(0L)
-      )
-    )
 
   private val readCommand: Command[Long] =
     Command("ZSCORE", Command.NoKeys, Vector.empty, (_: Frame) => Right(1L), isReadOnly = true)
@@ -119,7 +80,7 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
         val respond: Bytes => Seq[Frame] = payload => {
           val text  = payload.asUtf8String
           val reads = text.sliding("ZSCORE".length).count(_ == "ZSCORE")
-          if (text.contains("HELLO")) Seq(helloReply)
+          if (text.contains("HELLO")) Seq(Replies.hello)
           else if (text.contains("ROLE")) roles.get(node).toSeq
           else if (reads > 0 && node == diesOnRead) {
             kill(node)

--- a/sage-client/zio/src/test/scala/sage/client/TransactionSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/TransactionSpec.scala
@@ -4,9 +4,9 @@ import scala.concurrent.ExecutionContext
 
 import kyo.compat.*
 
-import sage.Bytes
 import sage.SageException.{InvalidArgument, ServerError, TransactionDiscarded}
-import sage.client.internal.{Client, FakeTransport, MultiplexedConnection}
+import sage.client.internal.{Client, MultiplexedConnection, Replies, ScriptedTransport}
+import sage.client.internal.Replies.{bulk, ok, queued}
 import sage.commands.{Command, Commands, Execution}
 import sage.protocol.Frame
 
@@ -14,46 +14,18 @@ class TransactionSpec extends munit.FunSuite {
 
   private given ExecutionContext = munitExecutionContext
 
-  private val helloReply: Frame =
-    Frame.Map(
-      Vector(
-        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
-        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
-        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
-        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
-      )
-    )
-
-  private val ok: Frame     = Frame.SimpleString("OK")
-  private val queued: Frame = Frame.SimpleString("QUEUED")
-
   // Scripts a dedicated connection: HELLO bootstraps, WATCH/UNWATCH answer OK, the pipelined MULTI…EXEC batch (one write) answers with the
   // supplied frame sequence, and a read GET answers a value. The batch carries "MULTI", so it is matched before the bare command names.
-  private def scripted(execReplies: Seq[Frame], getReply: Frame = Frame.BulkString(Bytes.utf8("v"))): MultiplexedConnection.TransportFactory =
-    (onFrame, onClosed) =>
-      new FakeTransport(
-        onFrame,
-        onClosed,
-        respond = payload => {
-          val text = payload.asUtf8String
-          if (text.contains("HELLO")) Seq(helloReply)
-          else if (text.contains("MULTI")) execReplies
-          else if (text.contains("UNWATCH")) Seq(ok)
-          else if (text.contains("WATCH")) Seq(ok)
-          else if (text.contains("GET")) Seq(getReply)
-          else Seq(ok)
-        }
-      )
-
-  // wraps a factory so the most-recently-created transport (the dedicated connection) can be inspected after the run
-  private def capturing(factory: MultiplexedConnection.TransportFactory): (MultiplexedConnection.TransportFactory, () => FakeTransport) = {
-    var last: FakeTransport                             = null
-    val wrapped: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => {
-      last = factory(onFrame, onClosed).asInstanceOf[FakeTransport]
-      last
+  private def scripted(execReplies: Seq[Frame], getReply: Frame = bulk("v")): MultiplexedConnection.TransportFactory =
+    ScriptedTransport.factory { payload =>
+      val text = payload.asUtf8String
+      if (text.contains("HELLO")) Seq(Replies.hello)
+      else if (text.contains("MULTI")) execReplies
+      else if (text.contains("UNWATCH")) Seq(ok)
+      else if (text.contains("WATCH")) Seq(ok)
+      else if (text.contains("GET")) Seq(getReply)
+      else Seq(ok)
     }
-    (wrapped, () => last)
-  }
 
   private val twoIncrements = (Commands.incr[String]("a"), Commands.incr[String]("b"))
 
@@ -102,7 +74,7 @@ class TransactionSpec extends munit.FunSuite {
   }
 
   test("discard issues UNWATCH and runs no EXEC") {
-    val (factory, transport) = capturing(scripted(Seq(ok)))
+    val (factory, transport) = ScriptedTransport.capturing(scripted(Seq(ok)))
     Client
       .connectWith(factory)
       .flatMap(client => client.transaction(tx => tx.watch("a").flatMap(_ => tx.discard)))
@@ -134,7 +106,7 @@ class TransactionSpec extends munit.FunSuite {
   }
 
   test("an empty transaction with watches still issues MULTI/EXEC so a concurrent change can abort it") {
-    val (factory, transport) = capturing(scripted(Seq(ok, Frame.Null))) // MULTI ok, EXEC null = watched key changed
+    val (factory, transport) = ScriptedTransport.capturing(scripted(Seq(ok, Frame.Null))) // MULTI ok, EXEC null = watched key changed
     Client
       .connectWith(factory)
       .flatMap(client => client.transaction(tx => tx.watch("a").flatMap(_ => tx.exec(noCommands))))
@@ -146,7 +118,7 @@ class TransactionSpec extends munit.FunSuite {
   }
 
   test("an empty transaction with no watch is a no-op that never reaches the socket") {
-    val (factory, transport) = capturing(scripted(Seq(ok)))
+    val (factory, transport) = ScriptedTransport.capturing(scripted(Seq(ok)))
     Client
       .connectWith(factory)
       .flatMap(_.transaction(_.exec(noCommands)))
@@ -166,7 +138,7 @@ class TransactionSpec extends munit.FunSuite {
   }
 
   test("running a blocking command in the read phase fails fast rather than hanging the leased connection") {
-    val (factory, transport) = capturing(scripted(Seq(ok)))
+    val (factory, transport) = ScriptedTransport.capturing(scripted(Seq(ok)))
     val blocking             = Command("BLPOP", Command.NoKeys, Vector.empty, _ => Right(()), Execution.Blocking)
     Client.connectWith(factory).flatMap(_.transaction(_.run(blocking))).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[InvalidArgument], s"unexpected error: $error")

--- a/sage-client/zio/src/test/scala/sage/client/TransactionSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/TransactionSpec.scala
@@ -5,7 +5,7 @@ import scala.concurrent.ExecutionContext
 import kyo.compat.*
 
 import sage.SageException.{InvalidArgument, ServerError, TransactionDiscarded}
-import sage.client.internal.{Client, MultiplexedConnection, Replies, ScriptedTransport}
+import sage.client.internal.{Client, Replies, ScriptedTransport}
 import sage.client.internal.Replies.{bulk, ok, queued}
 import sage.commands.{Command, Commands, Execution}
 import sage.protocol.Frame
@@ -16,7 +16,7 @@ class TransactionSpec extends munit.FunSuite {
 
   // Scripts a dedicated connection: HELLO bootstraps, WATCH/UNWATCH answer OK, the pipelined MULTI…EXEC batch (one write) answers with the
   // supplied frame sequence, and a read GET answers a value. The batch carries "MULTI", so it is matched before the bare command names.
-  private def scripted(execReplies: Seq[Frame], getReply: Frame = bulk("v")): MultiplexedConnection.TransportFactory =
+  private def scripted(execReplies: Seq[Frame], getReply: Frame = bulk("v")): ScriptedTransport.Factory =
     ScriptedTransport.factory { payload =>
       val text = payload.asUtf8String
       if (text.contains("HELLO")) Seq(Replies.hello)

--- a/sage-client/zio/src/test/scala/sage/client/internal/TxScopeFaultSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/internal/TxScopeFaultSpec.scala
@@ -15,22 +15,12 @@ class TxScopeFaultSpec extends munit.FunSuite {
 
   private given ExecutionContext = munitExecutionContext
 
-  private val helloReply: Frame =
-    Frame.Map(
-      Vector(
-        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
-        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("8.0.0")),
-        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
-        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
-      )
-    )
-
   private val readonly = Frame.SimpleError("READONLY You can't write against a read only replica.")
 
   private def txScope(respond: Bytes => Seq[Frame]): (Client.TxScope, mutable.ArrayBuffer[Throwable]) = {
     val scheduler                                       = new ManualScheduler
     val gen                                             = MultiplexedConnection.Generation.initial
-    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) => new FakeTransport(onFrame, onClosed, respond)
+    val factory: MultiplexedConnection.TransportFactory = ScriptedTransport.factory(respond)
     val pool                                            =
       new DedicatedPool(factory, Vector(Connection.hello()), scheduler, () => true, () => Some(gen), _ == gen, DedicatedPoolConfig(), 1000L)
     val faults                                          = mutable.ArrayBuffer.empty[Throwable]
@@ -44,20 +34,20 @@ class TxScopeFaultSpec extends munit.FunSuite {
   }
 
   test("a READONLY command fault invokes the onFault hook") {
-    val (scope, faults) = txScope(p => if (p.asUtf8String.contains("HELLO")) Seq(helloReply) else Seq(readonly))
+    val (scope, faults) = txScope(p => if (p.asUtf8String.contains("HELLO")) Seq(Replies.hello) else Seq(readonly))
     scope.run(Strings.set("k", "v")).unsafeRun.failed.map { _ =>
       assert(faults.exists(isOwnershipFault), s"expected an ownership fault, got $faults")
     }
   }
 
   test("a synchronous failure while submitting completes the effect instead of hanging") {
-    val (scope, _) = txScope(p => if (p.asUtf8String.contains("HELLO")) Seq(helloReply) else throw ConnectionLost(mayHaveExecuted = false))
+    val (scope, _) = txScope(p => if (p.asUtf8String.contains("HELLO")) Seq(Replies.hello) else throw ConnectionLost(mayHaveExecuted = false))
     scope.run(Strings.set("k", "v")).unsafeRun.failed.map(e => assert(e.isInstanceOf[ConnectionLost], s"expected ConnectionLost, got $e"))
   }
 
   test("a transaction whose EXEC hits a READONLY invokes the onFault hook") {
     val respond: Bytes => Seq[Frame] = p =>
-      if (p.asUtf8String.contains("HELLO")) Seq(helloReply)
+      if (p.asUtf8String.contains("HELLO")) Seq(Replies.hello)
       else if (p.asUtf8String.contains("MULTI")) Seq(Frame.SimpleString("OK"), readonly, Frame.SimpleError("EXECABORT discarded"))
       else Seq(Frame.SimpleString("OK"))
     val (scope, faults)              = txScope(respond)

--- a/sage-core/src/test/scala/sage/cluster/SplitPlanSpec.scala
+++ b/sage-core/src/test/scala/sage/cluster/SplitPlanSpec.scala
@@ -1,17 +1,13 @@
 package sage.cluster
 
 import sage.Bytes
+import sage.cluster.TopologyFixtures.{keyed, keyless}
 import sage.commands.{Command, Pipeline}
 
 class SplitPlanSpec extends munit.FunSuite {
 
   private val a = Node("a", 6379)
   private val b = Node("b", 6379)
-
-  private def keyed(keys: String*): Command[Long] =
-    Command("X", keys.indices.toVector, keys.toVector.map(Bytes.utf8), _ => Right(0L))
-
-  private val keyless: Command[Long] = Command("PING", Command.NoKeys, Vector.empty, _ => Right(0L))
 
   private val sFoo = Slot.of(Bytes.utf8("foo"))
   private val sBar = Slot.of(Bytes.utf8("bar"))

--- a/sage-core/src/test/scala/sage/cluster/TopologyFixtures.scala
+++ b/sage-core/src/test/scala/sage/cluster/TopologyFixtures.scala
@@ -1,0 +1,18 @@
+package sage.cluster
+
+import sage.Bytes
+import sage.commands.Command
+
+/**
+  * The synthetic commands and shards the routing specs share.
+  */
+object TopologyFixtures {
+
+  def keyed(keys: String*): Command[Long] =
+    Command("X", keys.indices.toVector, keys.toVector.map(Bytes.utf8), _ => Right(0L))
+
+  val keyless: Command[Long] = Command("PING", Command.NoKeys, Vector.empty, _ => Right(0L))
+
+  def covering(node: Node, from: Int, to: Int): Shard =
+    Shard(node, Vector.empty, Vector(SlotRange(Slot.unsafe(from), Slot.unsafe(to))))
+}

--- a/sage-core/src/test/scala/sage/cluster/TopologySpec.scala
+++ b/sage-core/src/test/scala/sage/cluster/TopologySpec.scala
@@ -1,20 +1,13 @@
 package sage.cluster
 
 import sage.Bytes
+import sage.cluster.TopologyFixtures.{covering, keyed, keyless}
 import sage.commands.Command
 
 class TopologySpec extends munit.FunSuite {
 
   private val a = Node("a", 6379)
   private val b = Node("b", 6379)
-
-  private def keyed(keys: String*): Command[Long] =
-    Command("X", keys.indices.toVector, keys.toVector.map(Bytes.utf8), _ => Right(0L))
-
-  private val keyless: Command[Long] = Command("PING", Command.NoKeys, Vector.empty, _ => Right(0L))
-
-  private def covering(node: Node, from: Int, to: Int): Shard =
-    Shard(node, Vector.empty, Vector(SlotRange(Slot.unsafe(from), Slot.unsafe(to))))
 
   private val whole = ClusterTopology.from(Vector(covering(a, 0, Slot.Count - 1)))
 

--- a/sage-core/src/test/scala/sage/commands/ArraysSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ArraysSpec.scala
@@ -1,11 +1,9 @@
 package sage.commands
 
-import sage.Bytes
 import sage.protocol.Frame
+import sage.protocol.Frames.{bulk, map}
 
 class ArraysSpec extends munit.FunSuite {
-
-  private def bulk(s: String): Frame = Frame.BulkString(Bytes.utf8(s))
 
   test("ARGET decodes a value and a null") {
     assertEquals(Reply.run(Arrays.arGet[String, String]("a", 1L), bulk("b")), Right(Some("b")))
@@ -60,14 +58,12 @@ class ArraysSpec extends munit.FunSuite {
   }
 
   test("ARINFO decodes the core fields and leniently fills the structural ones") {
-    val reply = Frame.Map(
-      Vector(
-        bulk("count")             -> Frame.Integer(4L),
-        bulk("len")               -> Frame.Integer(101L),
-        bulk("next-insert-index") -> Frame.Integer(0L),
-        bulk("slices")            -> Frame.Integer(1L),
-        bulk("slice-size")        -> Frame.Integer(4096L)
-      )
+    val reply = map(
+      "count"             -> Frame.Integer(4L),
+      "len"               -> Frame.Integer(101L),
+      "next-insert-index" -> Frame.Integer(0L),
+      "slices"            -> Frame.Integer(1L),
+      "slice-size"        -> Frame.Integer(4096L)
     )
     assertEquals(
       Reply.run(Arrays.arInfo("a"), reply),
@@ -76,14 +72,12 @@ class ArraysSpec extends munit.FunSuite {
   }
 
   test("ARINFO FULL decodes the avg-* fields as doubles") {
-    val reply = Frame.Map(
-      Vector(
-        bulk("count")             -> Frame.Integer(4L),
-        bulk("len")               -> Frame.Integer(101L),
-        bulk("next-insert-index") -> Frame.Integer(0L),
-        bulk("sparse-slices")     -> Frame.Integer(1L),
-        bulk("avg-sparse-size")   -> Frame.Double(4.0)
-      )
+    val reply = map(
+      "count"             -> Frame.Integer(4L),
+      "len"               -> Frame.Integer(101L),
+      "next-insert-index" -> Frame.Integer(0L),
+      "sparse-slices"     -> Frame.Integer(1L),
+      "avg-sparse-size"   -> Frame.Double(4.0)
     )
     Reply.run(Arrays.arInfoFull("a"), reply) match {
       case Right(info) =>
@@ -96,6 +90,6 @@ class ArraysSpec extends munit.FunSuite {
   }
 
   test("ARINFO fails when a core field is absent") {
-    assert(Reply.run(Arrays.arInfo("a"), Frame.Map(Vector(bulk("len") -> Frame.Integer(1L)))).isLeft)
+    assert(Reply.run(Arrays.arInfo("a"), map("len" -> Frame.Integer(1L))).isLeft)
   }
 }

--- a/sage-core/src/test/scala/sage/commands/BroadcastFolds.scala
+++ b/sage-core/src/test/scala/sage/commands/BroadcastFolds.scala
@@ -1,0 +1,15 @@
+package sage.commands
+
+import sage.protocol.Frame
+
+/**
+  * Reaches the reducer a broadcast command carries, so a spec can fold multi-master replies without a cluster.
+  */
+trait BroadcastFolds { this: munit.FunSuite =>
+
+  protected def fold(command: Command[?]): (Frame, Frame) => Frame =
+    command.broadcast match {
+      case BroadcastReduce.Fold(combine) => combine
+      case other                         => fail(s"expected a Fold broadcast, got $other")
+    }
+}

--- a/sage-core/src/test/scala/sage/commands/ClusterSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ClusterSpec.scala
@@ -1,14 +1,13 @@
 package sage.commands
 
-import sage.Bytes
 import sage.SageException.DecodeError
 import sage.cluster.{Node, Shard, Slot, SlotRange}
 import sage.protocol.Frame
+import sage.protocol.Frames.bulk
 
 class ClusterSpec extends munit.FunSuite {
 
   private def int(value: Long): Frame                          = Frame.Integer(value)
-  private def bulk(text: String): Frame                        = Frame.BulkString(Bytes.utf8(text))
   private def node(host: String, port: Int, id: String): Frame =
     Frame.Array(Vector(bulk(host), int(port.toLong), bulk(id)))
 

--- a/sage-core/src/test/scala/sage/commands/CommandSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/CommandSpec.scala
@@ -1,25 +1,11 @@
 package sage.commands
 
-import java.time.Instant
-
-import sage.{Bytes, SageException}
+import sage.Bytes
+import sage.SageException.{DecodeError, ServerError}
 import sage.protocol.{Frame, RespParser}
+import sage.protocol.Frames.bulk
 
 class CommandSpec extends munit.FunSuite {
-
-  test("expireAt with an extreme instant saturates instead of throwing while building the command") {
-    val command = Keys.expireAt("k", Instant.MAX)
-    assertEquals(command.name, "PEXPIREAT")
-    assert(command.args.exists(_.sameBytes(Bytes.utf8(Long.MaxValue.toString))), command.args.map(_.asUtf8String))
-  }
-
-  test("GET encodes against the golden wire frame") {
-    assertEquals(Strings.get[String, String]("foo").encode.asUtf8String, "*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n")
-  }
-
-  test("SET encodes against the golden wire frame") {
-    assertEquals(Strings.set("foo", "bar").encode.asUtf8String, "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\nbar\r\n")
-  }
 
   test("cacheable marks deterministic key-state reads, not writes, time-varying, or non-deterministic reads") {
     assert(Strings.get[String, String]("foo").cacheable)
@@ -48,19 +34,6 @@ class CommandSpec extends munit.FunSuite {
     assert(!Keys.sortRo[String, String]("k", get = Vector("d_*")).cacheable && Keys.sortRo[String, String]("k", get = Vector("d_*")).isReadOnly)
   }
 
-  test("PING encodes against the golden wire frame, with and without a message") {
-    assertEquals(Connection.ping().encode.asUtf8String, "*1\r\n$4\r\nPING\r\n")
-    assertEquals(Connection.ping(Some("hi")).encode.asUtf8String, "*2\r\n$4\r\nPING\r\n$2\r\nhi\r\n")
-  }
-
-  test("HELLO encodes against the golden wire frame, with and without credentials") {
-    assertEquals(Connection.hello().encode.asUtf8String, "*2\r\n$5\r\nHELLO\r\n$1\r\n3\r\n")
-    assertEquals(
-      Connection.hello(Some(("user", "pass"))).encode.asUtf8String,
-      "*5\r\n$5\r\nHELLO\r\n$1\r\n3\r\n$4\r\nAUTH\r\n$4\r\nuser\r\n$4\r\npass\r\n"
-    )
-  }
-
   test("multi-word command names encode one bulk string per word") {
     val command = Command[Unit]("CONFIG GET", Vector.empty, Vector(Bytes.utf8("maxmemory")), _ => Right(()))
     assertEquals(command.encode.asUtf8String, "*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$9\r\nmaxmemory\r\n")
@@ -68,8 +41,7 @@ class CommandSpec extends munit.FunSuite {
 
   test("a command's encoded bytes parse back as an array of bulk strings") {
     val parser   = new RespParser
-    val expected =
-      Frame.Array(Vector(Frame.BulkString(Bytes.utf8("SET")), Frame.BulkString(Bytes.utf8("key")), Frame.BulkString(Bytes.utf8("value"))))
+    val expected = Frame.Array(Vector(bulk("SET"), bulk("key"), bulk("value")))
     assertEquals(parser.feed(Strings.set("key", "value").encode), Right(Vector(expected)))
   }
 
@@ -81,90 +53,23 @@ class CommandSpec extends munit.FunSuite {
     assertEquals(Connection.ping().keyIndices, Vector.empty[Int])
   }
 
-  test("GET decodes a missing key as None") {
-    assertEquals(Reply.run(Strings.get[String, String]("foo"), Frame.Null), Right(None))
-  }
-
-  test("GET decodes a present value as Some") {
-    assertEquals(Reply.run(Strings.get[String, String]("foo"), Frame.BulkString(Bytes.utf8("bar"))), Right(Some("bar")))
-  }
-
-  test("SET decodes +OK as true") {
-    assertEquals(Reply.run(Strings.set("foo", "bar"), Frame.SimpleString("OK")), Right(true))
-  }
-
-  test("PING decodes PONG and an echoed message") {
-    assertEquals(Reply.run(Connection.ping(), Frame.SimpleString("PONG")), Right("PONG"))
-    assertEquals(Reply.run(Connection.ping(Some("hi")), Frame.BulkString(Bytes.utf8("hi"))), Right("hi"))
-  }
-
   test("a top-level error frame becomes a ServerError for any command") {
-    assertEquals(
-      Reply.run(Strings.get[String, String]("foo"), Frame.SimpleError("ERR oops")),
-      Left(SageException.ServerError("ERR", "oops"))
-    )
-    assertEquals(
-      Reply.run(Strings.set("foo", "bar"), Frame.BulkError(Bytes.utf8("WRONGTYPE bad"))),
-      Left(SageException.ServerError("WRONGTYPE", "bad"))
-    )
+    assertEquals(Reply.run(Strings.get[String, String]("foo"), Frame.SimpleError("ERR oops")), Left(ServerError("ERR", "oops")))
+    assertEquals(Reply.run(Strings.set("foo", "bar"), Frame.BulkError(Bytes.utf8("WRONGTYPE bad"))), Left(ServerError("WRONGTYPE", "bad")))
   }
 
   test("an unexpected frame shape becomes a DecodeError naming expected and actual") {
     Reply.run(Strings.mSet(("foo", "bar")), Frame.Integer(1)) match {
-      case Left(error: SageException.DecodeError) =>
+      case Left(error: DecodeError) =>
         assertEquals(error.expected, "simple string 'OK'")
         assertEquals(error.actual, "integer 1")
-      case other                                  => fail(s"expected a DecodeError, got $other")
+      case other                    => fail(s"expected a DecodeError, got $other")
     }
   }
 
   test("map transforms the decoded result") {
     val exists = Strings.get[String, String]("foo").map(_.isDefined)
-    assertEquals(Reply.run(exists, Frame.BulkString(Bytes.utf8("bar"))), Right(true))
+    assertEquals(Reply.run(exists, bulk("bar")), Right(true))
     assertEquals(Reply.run(exists, Frame.Null), Right(false))
-  }
-
-  test("HELLO decodes the fields it needs and ignores unknown entries") {
-    val reply = Frame.Map(
-      Vector(
-        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
-        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("7.4.0")),
-        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(3),
-        Frame.BulkString(Bytes.utf8("id"))      -> Frame.Integer(42),
-        Frame.BulkString(Bytes.utf8("mode"))    -> Frame.BulkString(Bytes.utf8("standalone")),
-        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master")),
-        Frame.BulkString(Bytes.utf8("modules")) -> Frame.Array(Vector.empty)
-      )
-    )
-    assertEquals(Reply.run(Connection.hello(), reply), Right(HelloReply("redis", "7.4.0", 3, "master")))
-  }
-
-  test("HELLO rejects a proto other than 3, including values beyond Int range") {
-    def reply(proto: Long) = Frame.Map(
-      Vector(
-        Frame.BulkString(Bytes.utf8("server"))  -> Frame.BulkString(Bytes.utf8("redis")),
-        Frame.BulkString(Bytes.utf8("version")) -> Frame.BulkString(Bytes.utf8("7.4.0")),
-        Frame.BulkString(Bytes.utf8("proto"))   -> Frame.Integer(proto),
-        Frame.BulkString(Bytes.utf8("role"))    -> Frame.BulkString(Bytes.utf8("master"))
-      )
-    )
-    Reply.run(Connection.hello(), reply(2)) match {
-      case Left(error: SageException.DecodeError) =>
-        assertEquals(error.expected, "proto 3")
-        assertEquals(error.actual, "proto 2")
-      case other                                  => fail(s"expected a DecodeError, got $other")
-    }
-    Reply.run(Connection.hello(), reply(2147483648L)) match {
-      case Left(error: SageException.DecodeError) => assertEquals(error.actual, "proto 2147483648")
-      case other                                  => fail(s"expected a DecodeError, got $other")
-    }
-  }
-
-  test("HELLO reports a missing required field") {
-    val reply = Frame.Map(Vector(Frame.BulkString(Bytes.utf8("server")) -> Frame.BulkString(Bytes.utf8("redis"))))
-    Reply.run(Connection.hello(), reply) match {
-      case Left(error: SageException.DecodeError) => assertEquals(error.expected, "map entry 'version'")
-      case other                                  => fail(s"expected a DecodeError, got $other")
-    }
   }
 }

--- a/sage-core/src/test/scala/sage/commands/ConnectionSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ConnectionSpec.scala
@@ -1,0 +1,48 @@
+package sage.commands
+
+import sage.SageException.DecodeError
+import sage.protocol.Frame
+import sage.protocol.Frames.{bulk, map}
+
+class ConnectionSpec extends munit.FunSuite {
+
+  test("PING decodes PONG and an echoed message") {
+    assertEquals(Reply.run(Connection.ping(), Frame.SimpleString("PONG")), Right("PONG"))
+    assertEquals(Reply.run(Connection.ping(Some("hi")), bulk("hi")), Right("hi"))
+  }
+
+  test("HELLO decodes the fields it needs and ignores unknown entries") {
+    val reply = map(
+      "server"  -> bulk("redis"),
+      "version" -> bulk("7.4.0"),
+      "proto"   -> Frame.Integer(3),
+      "id"      -> Frame.Integer(42),
+      "mode"    -> bulk("standalone"),
+      "role"    -> bulk("master"),
+      "modules" -> Frame.Array(Vector.empty)
+    )
+    assertEquals(Reply.run(Connection.hello(), reply), Right(HelloReply("redis", "7.4.0", 3, "master")))
+  }
+
+  test("HELLO rejects a proto other than 3, including values beyond Int range") {
+    def reply(proto: Long) =
+      map("server" -> bulk("redis"), "version" -> bulk("7.4.0"), "proto" -> Frame.Integer(proto), "role" -> bulk("master"))
+    Reply.run(Connection.hello(), reply(2)) match {
+      case Left(error: DecodeError) =>
+        assertEquals(error.expected, "proto 3")
+        assertEquals(error.actual, "proto 2")
+      case other                    => fail(s"expected a DecodeError, got $other")
+    }
+    Reply.run(Connection.hello(), reply(2147483648L)) match {
+      case Left(error: DecodeError) => assertEquals(error.actual, "proto 2147483648")
+      case other                    => fail(s"expected a DecodeError, got $other")
+    }
+  }
+
+  test("HELLO reports a missing required field") {
+    Reply.run(Connection.hello(), map("server" -> bulk("redis"))) match {
+      case Left(error: DecodeError) => assertEquals(error.expected, "map entry 'version'")
+      case other                    => fail(s"expected a DecodeError, got $other")
+    }
+  }
+}

--- a/sage-core/src/test/scala/sage/commands/FunctionsSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/FunctionsSpec.scala
@@ -4,11 +4,9 @@ import scala.concurrent.duration.*
 
 import sage.Bytes
 import sage.protocol.Frame
+import sage.protocol.Frames.{bulk, map}
 
 class FunctionsSpec extends munit.FunSuite {
-
-  private def bulk(value: String): Frame            = Frame.BulkString(Bytes.utf8(value))
-  private def map(entries: (String, Frame)*): Frame = Frame.Map(entries.toVector.map { case (k, v) => bulk(k) -> v })
 
   test("FCALL returns the raw frame and computes key indices") {
     assertEquals(Reply.run(Functions.fCall("f", Seq("k"), Seq("a")), Frame.Integer(7L)), Right(Frame.Integer(7L)))

--- a/sage-core/src/test/scala/sage/commands/HashesSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/HashesSpec.scala
@@ -1,14 +1,12 @@
 package sage.commands
 
-import sage.Bytes
 import sage.protocol.Frame
+import sage.protocol.Frames.{bulk, map}
 
 class HashesSpec extends munit.FunSuite {
 
-  private def bulk(value: String): Frame = Frame.BulkString(Bytes.utf8(value))
-
   test("HGETALL decodes a RESP3 map frame into a field-keyed map") {
-    val reply = Frame.Map(Vector((bulk("f1"), bulk("v1")), (bulk("f2"), bulk("v2"))))
+    val reply = map("f1" -> bulk("v1"), "f2" -> bulk("v2"))
     assertEquals(Reply.run(Hashes.hGetAll[String, String, String]("h"), reply), Right(Map("f1" -> "v1", "f2" -> "v2")))
     assertEquals(Reply.run(Hashes.hGetAll[String, String, String]("h"), Frame.Map(Vector.empty)), Right(Map.empty[String, String]))
   }

--- a/sage-core/src/test/scala/sage/commands/KeysSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/KeysSpec.scala
@@ -4,8 +4,8 @@ import java.time.Instant
 
 import scala.concurrent.duration.*
 
-import sage.Bytes
 import sage.protocol.Frame
+import sage.protocol.Frames.bulk
 
 class KeysSpec extends munit.FunSuite {
 
@@ -46,8 +46,8 @@ class KeysSpec extends munit.FunSuite {
   test("SCAN decodes a mid-iteration page with a next cursor") {
     val reply = Frame.Array(
       Vector(
-        Frame.BulkString(Bytes.utf8("17")),
-        Frame.Array(Vector(Frame.BulkString(Bytes.utf8("a")), Frame.BulkString(Bytes.utf8("b"))))
+        bulk("17"),
+        Frame.Array(Vector(bulk("a"), bulk("b")))
       )
     )
     Reply.run(Keys.scan[String](ScanCursor.start), reply) match {
@@ -59,7 +59,7 @@ class KeysSpec extends munit.FunSuite {
   }
 
   test("SCAN decodes a zero cursor as iteration complete, even with keys in the page") {
-    val reply = Frame.Array(Vector(Frame.BulkString(Bytes.utf8("0")), Frame.Array(Vector(Frame.BulkString(Bytes.utf8("last"))))))
+    val reply = Frame.Array(Vector(bulk("0"), Frame.Array(Vector(bulk("last")))))
     Reply.run(Keys.scan[String](ScanCursor.start), reply) match {
       case Right(page) =>
         assertEquals(page.items, Vector("last"))
@@ -69,7 +69,7 @@ class KeysSpec extends munit.FunSuite {
   }
 
   test("a returned cursor feeds the next SCAN call") {
-    val reply = Frame.Array(Vector(Frame.BulkString(Bytes.utf8("17")), Frame.Array(Vector.empty)))
+    val reply = Frame.Array(Vector(bulk("17"), Frame.Array(Vector.empty)))
     Reply.run(Keys.scan[String](ScanCursor.start), reply) match {
       case Right(ScanPage(_, Some(next))) =>
         assertEquals(Keys.scan[String](next).args.head.asUtf8String, "17")
@@ -84,7 +84,7 @@ class KeysSpec extends munit.FunSuite {
 
   test("RANDOMKEY decodes null as None on an empty database") {
     assertEquals(Reply.run(Keys.randomKey[String], Frame.Null), Right(None))
-    assertEquals(Reply.run(Keys.randomKey[String], Frame.BulkString(Bytes.utf8("k"))), Right(Some("k")))
+    assertEquals(Reply.run(Keys.randomKey[String], bulk("k")), Right(Some("k")))
   }
 
   test("multi-key commands mark every position for the slot engine") {
@@ -119,5 +119,11 @@ class KeysSpec extends munit.FunSuite {
     assertEquals(Strings.set("k", "v", expiry = SetExpiry.In(500.micros)).args.last.asUtf8String, "1")
     assertEquals(Strings.getEx[String, String]("k", GetExpiry.In(500.micros)).args.last.asUtf8String, "1")
     assertEquals(Keys.expireAt("k", Instant.ofEpochSecond(2000000000L, 1)).args(1).asUtf8String, "2000000000001")
+  }
+
+  test("an extreme instant saturates instead of throwing while building the command") {
+    val command = Keys.expireAt("k", Instant.MAX)
+    assertEquals(command.name, "PEXPIREAT")
+    assertEquals(command.args(1).asUtf8String, Long.MaxValue.toString)
   }
 }

--- a/sage-core/src/test/scala/sage/commands/ListsSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ListsSpec.scala
@@ -1,11 +1,9 @@
 package sage.commands
 
-import sage.Bytes
 import sage.protocol.Frame
+import sage.protocol.Frames.bulk
 
 class ListsSpec extends munit.FunSuite {
-
-  private def bulk(value: String): Frame = Frame.BulkString(Bytes.utf8(value))
 
   test("LPOP with a count collapses a missing list's null to an empty vector") {
     assertEquals(Reply.run(Lists.lPopCount[String, String]("l", 2L), Frame.Null), Right(Vector.empty[String]))

--- a/sage-core/src/test/scala/sage/commands/ScriptingSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ScriptingSpec.scala
@@ -1,19 +1,14 @@
 package sage.commands
 
-import sage.Bytes
 import sage.SageException.DecodeError
 import sage.protocol.Frame
+import sage.protocol.Frames.bulk
 
-class ScriptingSpec extends munit.FunSuite {
-
-  private def bulk(value: String): Frame = Frame.BulkString(Bytes.utf8(value))
+class ScriptingSpec extends munit.FunSuite with BroadcastFolds {
 
   private def flags(bits: Long*): Frame = Frame.Array(bits.iterator.map(Frame.Integer(_)).toVector)
 
-  private val existsFold: (Frame, Frame) => Frame = {
-    val BroadcastReduce.Fold(combine) = Scripting.scriptExists("x").broadcast: @unchecked
-    combine
-  }
+  private def existsFold: (Frame, Frame) => Frame = fold(Scripting.scriptExists("x"))
 
   test("EVAL returns the raw RESP3 frame untouched") {
     assertEquals(Reply.run(Scripting.eval("return 1"), Frame.Integer(1L)), Right(Frame.Integer(1L)))

--- a/sage-core/src/test/scala/sage/commands/ServerSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ServerSpec.scala
@@ -4,15 +4,13 @@ import java.time.Instant
 
 import scala.concurrent.duration.*
 
-import sage.Bytes
 import sage.protocol.Frame
+import sage.protocol.Frames.{bulk, map}
 
-class ServerSpec extends munit.FunSuite {
-
-  private def bulk(value: String): Frame = Frame.BulkString(Bytes.utf8(value))
+class ServerSpec extends munit.FunSuite with BroadcastFolds {
 
   test("CONFIG GET decodes a RESP3 map and the RESP2 flat-array shape alike") {
-    val resp3 = Frame.Map(Vector(bulk("maxmemory") -> bulk("100mb"), bulk("save") -> bulk("3600 1")))
+    val resp3 = map("maxmemory" -> bulk("100mb"), "save" -> bulk("3600 1"))
     assertEquals(Reply.run(Server.configGet("*"), resp3), Right(Map("maxmemory" -> "100mb", "save" -> "3600 1")))
     val resp2 = Frame.Array(Vector(bulk("maxmemory"), bulk("100mb")))
     assertEquals(Reply.run(Server.configGet("*"), resp2), Right(Map("maxmemory" -> "100mb")))
@@ -106,12 +104,6 @@ class ServerSpec extends munit.FunSuite {
     assert(!Server.flushAll().requiresClusterWideTxResult, "FLUSHALL stays legal in a cluster transaction")
     assert(!Server.flushDb().requiresClusterWideTxResult, "FLUSHDB stays legal in a cluster transaction")
   }
-
-  private def fold(command: Command[?]): (Frame, Frame) => Frame =
-    command.broadcast match {
-      case BroadcastReduce.Fold(f) => f
-      case other                   => fail(s"expected a Fold broadcast, got $other")
-    }
 
   test("WAIT/WAITAOF fold differing multi-master replies to the weakest shard") {
     val waitFold = fold(Server.waitReplicas(1L, 1.second))

--- a/sage-core/src/test/scala/sage/commands/SetsSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/SetsSpec.scala
@@ -1,11 +1,9 @@
 package sage.commands
 
-import sage.Bytes
 import sage.protocol.Frame
+import sage.protocol.Frames.bulk
 
 class SetsSpec extends munit.FunSuite {
-
-  private def bulk(value: String): Frame = Frame.BulkString(Bytes.utf8(value))
 
   test("SMEMBERS decodes a RESP3 set frame into a Set, empty included") {
     assertEquals(Reply.run(Sets.sMembers[String, String]("s"), Frame.Set(Vector(bulk("a"), bulk("b")))), Right(Set("a", "b")))

--- a/sage-core/src/test/scala/sage/commands/SortedSetsSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/SortedSetsSpec.scala
@@ -1,11 +1,10 @@
 package sage.commands
 
-import sage.Bytes
 import sage.protocol.Frame
+import sage.protocol.Frames.bulk
 
 class SortedSetsSpec extends munit.FunSuite {
 
-  private def bulk(value: String): Frame                 = Frame.BulkString(Bytes.utf8(value))
   private def pair(member: String, score: Double): Frame = Frame.Array(Vector(bulk(member), Frame.Double(score)))
 
   test("ZSCORE decodes a RESP3 double, null as None, and rejects a bulk string") {

--- a/sage-core/src/test/scala/sage/commands/StreamsSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/StreamsSpec.scala
@@ -4,12 +4,11 @@ import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration.FiniteDuration
 
-import sage.Bytes
 import sage.protocol.Frame
+import sage.protocol.Frames.{bulk, map}
 
 class StreamsSpec extends munit.FunSuite {
 
-  private def bulk(value: String): Frame                = Frame.BulkString(Bytes.utf8(value))
   private def entry(id: String, fields: String*): Frame = Frame.Array(Vector(bulk(id), Frame.Array(fields.toVector.map(bulk))))
 
   test("XADD decodes the generated id; NOMKSTREAM decodes null as None") {
@@ -18,7 +17,7 @@ class StreamsSpec extends munit.FunSuite {
     assertEquals(Reply.run(Streams.xAddNoMkStream("k")(("f", "v")), bulk("5-0")), Right(Some(StreamId(5L, 0L))))
   }
 
-  test("XRANGE decodes entries, preserving field order and a missing-stream null as empty? (present array)") {
+  test("XRANGE decodes entries, preserving field order") {
     val reply = Frame.Array(Vector(entry("1-0", "a", "1", "b", "2"), entry("2-0", "c", "3")))
     assertEquals(
       Reply.run(Streams.xRange[String, String, String]("k"), reply),
@@ -27,7 +26,7 @@ class StreamsSpec extends munit.FunSuite {
   }
 
   test("XREAD decodes a RESP3 map of stream -> entries, and null/timeout as an empty vector") {
-    val reply = Frame.Map(Vector(bulk("s1") -> Frame.Array(Vector(entry("1-0", "f", "v")))))
+    val reply = map("s1" -> Frame.Array(Vector(entry("1-0", "f", "v"))))
     assertEquals(
       Reply.run(Streams.xRead[String, String, String](("s1", ReadId.New))(), reply),
       Right(Vector("s1" -> Vector(StreamEntry(StreamId(1L, 0L), Vector("f" -> "v")))))
@@ -98,19 +97,17 @@ class StreamsSpec extends munit.FunSuite {
   }
 
   test("XINFO STREAM decodes leniently: 7.0 fields present, and absent as None") {
-    val withNew = Frame.Map(
-      Vector(
-        bulk("length")                  -> Frame.Integer(2L),
-        bulk("radix-tree-keys")         -> Frame.Integer(1L),
-        bulk("radix-tree-nodes")        -> Frame.Integer(2L),
-        bulk("last-generated-id")       -> bulk("5-0"),
-        bulk("max-deleted-entry-id")    -> bulk("3-0"),
-        bulk("entries-added")           -> Frame.Integer(7L),
-        bulk("recorded-first-entry-id") -> bulk("1-0"),
-        bulk("groups")                  -> Frame.Integer(1L),
-        bulk("first-entry")             -> entry("1-0", "f", "v"),
-        bulk("last-entry")              -> entry("5-0", "g", "w")
-      )
+    val withNew = map(
+      "length"                  -> Frame.Integer(2L),
+      "radix-tree-keys"         -> Frame.Integer(1L),
+      "radix-tree-nodes"        -> Frame.Integer(2L),
+      "last-generated-id"       -> bulk("5-0"),
+      "max-deleted-entry-id"    -> bulk("3-0"),
+      "entries-added"           -> Frame.Integer(7L),
+      "recorded-first-entry-id" -> bulk("1-0"),
+      "groups"                  -> Frame.Integer(1L),
+      "first-entry"             -> entry("1-0", "f", "v"),
+      "last-entry"              -> entry("5-0", "g", "w")
     )
     val info    = Reply.run(StreamInfo.xInfoStream[String, String, String]("k"), withNew).toOption.get
     assertEquals(info.length, 2L)
@@ -118,16 +115,14 @@ class StreamsSpec extends munit.FunSuite {
     assertEquals(info.maxDeletedEntryId, Some(StreamId(3L, 0L)))
     assertEquals(info.firstEntry, Some(StreamEntry(StreamId(1L, 0L), Vector("f" -> "v"))))
 
-    val legacy = Frame.Map(
-      Vector(
-        bulk("length")            -> Frame.Integer(0L),
-        bulk("radix-tree-keys")   -> Frame.Integer(0L),
-        bulk("radix-tree-nodes")  -> Frame.Integer(1L),
-        bulk("last-generated-id") -> bulk("0-0"),
-        bulk("groups")            -> Frame.Integer(0L),
-        bulk("first-entry")       -> Frame.Null,
-        bulk("last-entry")        -> Frame.Null
-      )
+    val legacy = map(
+      "length"            -> Frame.Integer(0L),
+      "radix-tree-keys"   -> Frame.Integer(0L),
+      "radix-tree-nodes"  -> Frame.Integer(1L),
+      "last-generated-id" -> bulk("0-0"),
+      "groups"            -> Frame.Integer(0L),
+      "first-entry"       -> Frame.Null,
+      "last-entry"        -> Frame.Null
     )
     val old    = Reply.run(StreamInfo.xInfoStream[String, String, String]("k"), legacy).toOption.get
     assertEquals(old.entriesAdded, None)
@@ -138,15 +133,13 @@ class StreamsSpec extends munit.FunSuite {
   test("XINFO GROUPS decodes entries-read/lag as optional, tolerating a null lag") {
     val reply = Frame.Array(
       Vector(
-        Frame.Map(
-          Vector(
-            bulk("name")              -> bulk("g1"),
-            bulk("consumers")         -> Frame.Integer(2L),
-            bulk("pending")           -> Frame.Integer(3L),
-            bulk("last-delivered-id") -> bulk("5-0"),
-            bulk("entries-read")      -> Frame.Integer(5L),
-            bulk("lag")               -> Frame.Null
-          )
+        map(
+          "name"              -> bulk("g1"),
+          "consumers"         -> Frame.Integer(2L),
+          "pending"           -> Frame.Integer(3L),
+          "last-delivered-id" -> bulk("5-0"),
+          "entries-read"      -> Frame.Integer(5L),
+          "lag"               -> Frame.Null
         )
       )
     )
@@ -159,25 +152,21 @@ class StreamsSpec extends munit.FunSuite {
   test("XINFO STREAM FULL decodes the 4-element group PEL row and the 3-element consumer PEL row") {
     val groupPel    = Frame.Array(Vector(Frame.Array(Vector(bulk("1-0"), bulk("c1"), Frame.Integer(1000L), Frame.Integer(2L)))))
     val consumerPel = Frame.Array(Vector(Frame.Array(Vector(bulk("1-0"), Frame.Integer(1000L), Frame.Integer(2L)))))
-    val consumer    = Frame.Map(Vector(bulk("name") -> bulk("c1"), bulk("pel-count") -> Frame.Integer(1L), bulk("pending") -> consumerPel))
-    val group       = Frame.Map(
-      Vector(
-        bulk("name")              -> bulk("g1"),
-        bulk("last-delivered-id") -> bulk("1-0"),
-        bulk("pel-count")         -> Frame.Integer(1L),
-        bulk("pending")           -> groupPel,
-        bulk("consumers")         -> Frame.Array(Vector(consumer))
-      )
+    val consumer    = map("name" -> bulk("c1"), "pel-count" -> Frame.Integer(1L), "pending" -> consumerPel)
+    val group       = map(
+      "name"              -> bulk("g1"),
+      "last-delivered-id" -> bulk("1-0"),
+      "pel-count"         -> Frame.Integer(1L),
+      "pending"           -> groupPel,
+      "consumers"         -> Frame.Array(Vector(consumer))
     )
-    val reply       = Frame.Map(
-      Vector(
-        bulk("length")            -> Frame.Integer(1L),
-        bulk("radix-tree-keys")   -> Frame.Integer(1L),
-        bulk("radix-tree-nodes")  -> Frame.Integer(2L),
-        bulk("last-generated-id") -> bulk("1-0"),
-        bulk("entries")           -> Frame.Array(Vector(entry("1-0", "f", "v"))),
-        bulk("groups")            -> Frame.Array(Vector(group))
-      )
+    val reply       = map(
+      "length"            -> Frame.Integer(1L),
+      "radix-tree-keys"   -> Frame.Integer(1L),
+      "radix-tree-nodes"  -> Frame.Integer(2L),
+      "last-generated-id" -> bulk("1-0"),
+      "entries"           -> Frame.Array(Vector(entry("1-0", "f", "v"))),
+      "groups"            -> Frame.Array(Vector(group))
     )
     val full        = Reply.run(StreamInfo.xInfoStreamFull[String, String, String]("k"), reply).toOption.get
     assertEquals(full.entries.map(_.id), Vector(StreamId(1L, 0L)))

--- a/sage-core/src/test/scala/sage/commands/StringsSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/StringsSpec.scala
@@ -3,8 +3,14 @@ package sage.commands
 import sage.Bytes
 import sage.SageException.DecodeError
 import sage.protocol.Frame
+import sage.protocol.Frames.bulk
 
 class StringsSpec extends munit.FunSuite {
+
+  test("GET decodes a present value as Some and a missing key as None") {
+    assertEquals(Reply.run(Strings.get[String, String]("k"), bulk("v")), Right(Some("v")))
+    assertEquals(Reply.run(Strings.get[String, String]("k"), Frame.Null), Right(None))
+  }
 
   test("SET decodes +OK as true and null as false") {
     assertEquals(Reply.run(Strings.set("k", "v"), Frame.SimpleString("OK")), Right(true))
@@ -21,17 +27,17 @@ class StringsSpec extends munit.FunSuite {
   }
 
   test("setGet decodes the previous value and null when the key was absent") {
-    assertEquals(Reply.run(Strings.setGet("k", "v"), Frame.BulkString(Bytes.utf8("old"))), Right(Some("old")))
+    assertEquals(Reply.run(Strings.setGet("k", "v"), bulk("old")), Right(Some("old")))
     assertEquals(Reply.run(Strings.setGet[String, String]("k", "v"), Frame.Null), Right(None))
   }
 
   test("MGET decodes positionally with None for missing keys") {
-    val reply = Frame.Array(Vector(Frame.BulkString(Bytes.utf8("1")), Frame.Null, Frame.BulkString(Bytes.utf8("3"))))
+    val reply = Frame.Array(Vector(bulk("1"), Frame.Null, bulk("3")))
     assertEquals(Reply.run(Strings.mGet[String, String]("a", "b", "c"), reply), Right(Vector(Some("1"), None, Some("3"))))
   }
 
   test("MGET propagates an element decode failure") {
-    val reply = Frame.Array(Vector(Frame.BulkString(Bytes.utf8("1")), Frame.Integer(2)))
+    val reply = Frame.Array(Vector(bulk("1"), Frame.Integer(2)))
     assert(Reply.run(Strings.mGet[String, String]("a", "b"), reply).isLeft)
   }
 
@@ -42,8 +48,8 @@ class StringsSpec extends munit.FunSuite {
   }
 
   test("INCRBYFLOAT decodes the float bulk string reply") {
-    assertEquals(Reply.run(Strings.incrByFloat("k", 0.1), Frame.BulkString(Bytes.utf8("3.0e3"))), Right(3000.0))
-    Reply.run(Strings.incrByFloat("k", 0.1), Frame.BulkString(Bytes.utf8("abc"))) match {
+    assertEquals(Reply.run(Strings.incrByFloat("k", 0.1), bulk("3.0e3")), Right(3000.0))
+    Reply.run(Strings.incrByFloat("k", 0.1), bulk("abc")) match {
       case Left(error: DecodeError) => assertEquals(error.actual, "bulk string 'abc'")
       case other                    => fail(s"expected a DecodeError, got $other")
     }

--- a/sage-core/src/test/scala/sage/protocol/Frames.scala
+++ b/sage-core/src/test/scala/sage/protocol/Frames.scala
@@ -1,0 +1,13 @@
+package sage.protocol
+
+import sage.Bytes
+
+/**
+  * Frame constructors the specs share.
+  */
+object Frames {
+
+  def bulk(value: String): Frame = Frame.BulkString(Bytes.utf8(value))
+
+  def map(entries: (String, Frame)*): Frame = Frame.Map(entries.toVector.map { case (key, value) => bulk(key) -> value })
+}

--- a/sage-core/src/test/scala/sage/ratelimit/RateLimiterSpec.scala
+++ b/sage-core/src/test/scala/sage/ratelimit/RateLimiterSpec.scala
@@ -81,14 +81,14 @@ class RateLimiterSpec extends munit.FunSuite {
     assert(RateLimiter.sha.forall(c => c.isDigit || ('a' to 'f').contains(c)))
   }
 
-  test("Decision helpers") {
+  test("a Decision reports whether it admitted and how many tokens are left") {
     assert(Decision.Allowed(5, 1.second).isAllowed)
     assertEquals(Decision.Allowed(5, 1.second).remainingTokens, 5L)
     assert(!Decision.Denied(2, 1.second).isAllowed)
     assertEquals(Decision.Denied(2, 1.second).remainingTokens, 2L)
   }
 
-  test("RateLimit smart constructors") {
+  test("the smart constructors expand a rate and a burst into capacity and refill") {
     assertEquals(RateLimit.perSecond(10), RateLimit(10, 10, 1.second))
     assertEquals(RateLimit(100, 1.minute, burst = 200), RateLimit(200, 100, 1.minute))
   }

--- a/sage-opentelemetry/src/test/scala/sage/opentelemetry/OpenTelemetryCommandTracerSpec.scala
+++ b/sage-opentelemetry/src/test/scala/sage/opentelemetry/OpenTelemetryCommandTracerSpec.scala
@@ -13,7 +13,7 @@ import sage.Outcome
 import sage.cluster.Node
 import sage.commands.Command
 
-class OpenTelemetryCommandTracerTest extends munit.FunSuite {
+class OpenTelemetryCommandTracerSpec extends munit.FunSuite {
 
   // a fresh in-memory SDK + tracer per test, so finished spans never leak across tests
   private def fixture: (OpenTelemetrySdk, InMemorySpanExporter) = {


### PR DESCRIPTION
A pass over every test suite for consistency and duplication. Test-only: no production source is touched. 52 files, +1043/−1392.

## Shared fixtures replace copies

| helper | folds |
| --- | --- |
| `sage.protocol.Frames` | ten private `bulk` helpers in the core command specs, plus the inline `Frame.BulkString(Bytes.utf8(...))` spelling across the core and client specs |
| `sage.cluster.TopologyFixtures` | the keyed/keyless/covering commands duplicated by `TopologySpec` and `SplitPlanSpec` |
| `sage.commands.BroadcastFolds` | the two different spellings of reaching a broadcast reducer (`ServerSpec` used a helper, `ScriptingSpec` an unchecked pattern match) |
| `sage.client.internal.Replies` | the RESP3 handshake reply duplicated verbatim in nine client specs, plus the `ROLE` and `CLUSTER SLOTS` shapes |
| `sage.client.internal.ScriptedTransport` | the scripted transport factories duplicated across `ConnectSpec`, `TransactionSpec` and `TxScopeFaultSpec` |
| `sage.integration.Eventually` | eight hand-rolled poll-until-converged loops (cached read, cluster forming, replica catch-up, link down, connection count, direct write) |
| `sage.integration.Ttls` | the five bespoke `Ttl`/`FieldTtl` pattern matches |

## Duplicated tests removed

- `CommandSpec` no longer re-asserts golden wire frames for GET/SET/PING/HELLO — `CommandSamplesSpec` already asserts the wire for every sample, those four included — nor SET/GET decoding that `StringsSpec` covers. Its Connection tests move to a `ConnectionSpec` (the only family without one), leaving `CommandSpec` about the Command/Reply machinery; the extreme-instant expiry moves to `KeysSpec` beside the other expiry-precision cases.
- `RoundTripSuite`'s three basic value tests become one, keeping every assertion.
- `ClusterClientSpec` hoists the split-slot topology that twenty tests each rebuilt.

## Consistency

- `OpenTelemetryCommandTracerTest` → `OpenTelemetryCommandTracerSpec` and `ArraysSuite` → `RedisArraysSuite`, matching the `*Spec` / `Redis*Suite` naming every sibling uses.
- The five backend smoke suites now share one per-suite client helper instead of repeating the container-scope-run scaffolding in every test, and Pekko gains the `sScanAll` case the other four already had.
- Test names that read as notes-to-self are written as sentences (`"Decision helpers"`, and one that ended in `empty? (present array)`).

Both backends are still exercised by every integration suite that had them.

## Behaviour notes

- `Eventually`'s `attempts` is the total number of attempts. The six converted loops that previously read `attempts <= 0` ran one extra attempt, so their windows shrink by a single interval (100–500 ms out of 10–30 s); the two that read `attempts <= 1` are unchanged.
- `Eventually` takes a thunk rather than a by-name action: a by-name `CIO` erases to the shape the Future and Ox cells give the effect itself, and casts at run time.

## Verification

- `sbt check testUnit` — 1938 unit tests pass across core, opentelemetry and all five client cells; every compile-only cell still compiles.
- Integration suites run against Docker: all five backend smoke suites, `RoundTrip`/`Keys`/`Strings`/`Caching` on Redis **and** Valkey, `RedisArrays`, `RedisHashFieldExpiry`, `RedisStringExtras`, `RedisRateLimiter`, `RedisCluster`, `RedisClusterFailover`, `RedisMasterReplica` and `RedisMasterReplicaStaleReplica` — every suite whose helpers this touched.