### PR TITLE
Stabilize NodePool waiter synchronization

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodePool.scala
@@ -61,6 +61,9 @@ final private[client] class NodePool(
 
   def foreachEstablished(f: NodeClient => Unit): Unit = established.values.forEach(nc => f(nc))
 
+  private[internal] def pendingWaiterCount(node: Node): Int =
+    locked(pendingEstablish.get(node).fold(0)(_.waiterCount))
+
   // live nodes first, so a refresh prefers a known-good node
   def candidatesByLiveness: Vector[Node] = {
     val (live, others) = established.asScala.toVector.partition(_._2.isLive)
@@ -188,7 +191,10 @@ private[client] object NodePool {
   final private class Establish {
     private val latch                                           = new CountDownLatch(1)
     private val settled                                         = new java.util.concurrent.atomic.AtomicBoolean(false)
+    private val waiters                                         = new java.util.concurrent.atomic.AtomicInteger(0)
     @volatile private var result: Either[Throwable, NodeClient] = null
+
+    def waiterCount: Int = waiters.get()
 
     def succeed(nc: NodeClient): Unit = settle(Right(nc))
     def fail(error: Throwable): Unit  = settle(Left(error))
@@ -200,11 +206,14 @@ private[client] object NodePool {
       }
 
     def get(): NodeClient = {
-      latch.await()
-      result match {
-        case Right(nc)   => nc
-        case Left(error) => throw error
-      }
+      waiters.incrementAndGet()
+      try {
+        latch.await()
+        result match {
+          case Right(nc)   => nc
+          case Left(error) => throw error
+        }
+      } finally waiters.decrementAndGet(): Unit
     }
   }
 }

--- a/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/NodePoolSpec.scala
@@ -58,11 +58,6 @@ class NodePoolSpec extends munit.FunSuite {
     assert(cond, clue)
   }
 
-  // every waiter parks on the single-flight latch (or, briefly, the pool lock); once all are WAITING at once none holds the lock, so each
-  // must be blocked on the establishment, not still racing toward it
-  private def awaitAllWaiting(threads: Seq[Thread]): Unit =
-    awaitTrue(threads.forall(_.getState == Thread.State.WAITING), "a waiter never blocked on the in-flight establishment")
-
   test("existing answers immediately while an establishment is in flight, and tracks publish and retain") {
     val node  = Node("gated", 6379)
     val gated = new GatedFactory(1)
@@ -101,7 +96,7 @@ class NodePoolSpec extends munit.FunSuite {
       thread.start()
       (thread, result)
     }
-    awaitAllWaiting(waiters.map(_._1)) // every waiter is parked on the original token before retain runs
+    awaitTrue(pool.pendingWaiterCount(node) == waiters.size, "a waiter never blocked on the in-flight establishment")
 
     pool.retain(_ => false)
 


### PR DESCRIPTION
## Summary

- track callers currently blocked on a `NodePool.Establish` latch
- expose that count only inside `sage.client.internal`
- make `NodePoolSpec` wait for all three callers to join the actual single-flight establishment before invalidating it

No stack inspection or generic thread-state sampling remains. Routing and connection behavior are unchanged.

## Root cause

The failed post-merge unit run observed `IndexOutOfBoundsException: 2 is out of bounds (min 0, max 0)` in the ZIO `NodePoolSpec` case. The test treated any `Thread.State.WAITING` as proof that a waiter had joined the pool's single-flight token. Under CI load, a thread could be waiting before it entered the pool. The test then called `retain`, removed the original token, and late callers started fresh connection attempts against a one-attempt `GatedFactory`.

This failure is unrelated to the production behavior changed in #229; that PR did not modify `NodePool` or `NodePoolSpec`.

Failed run: https://github.com/ghostdogpr/sage/actions/runs/30601628866/job/91065388035

## Validation

- `sbt scalafmtCheckAll testUnit`
- 30 consecutive `clientZio/testOnly sage.client.internal.NodePoolSpec` stress repetitions
- focused ZIO `NodePoolSpec` run