### PR TITLE
Sweep PUBSUB introspection and MEMORY PURGE across every master

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -43,6 +43,8 @@ Commands mirror the server's documented groups, and the methods are named one-fo
 
 The full surface lives on the client and on `Commands`; the [API docs](https://javadoc.io/doc/com.github.ghostdogpr/sage-core_3/) list every method with its signature.
 
+A command carrying a key routes to that key's slot. A keyless one has no slot to route by, so in a cluster it either runs on every master or is answered by a single node — see [commands that run on every master](/configuration#commands-that-run-on-every-master).
+
 ## Typed keys and values
 
 Keys and values are typed, and a codec converts each to and from wire bytes. The **key type is fixed on the client**: the default `SageClient` is String-keyed, so a command only ever needs the value type at the call site:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,9 +60,19 @@ stay pinned to one slot.
 
 ### Commands that run on every master
 
-No node sees the whole keyspace, and a cluster replicates neither the script nor the function cache. So `scriptLoad`, `scriptExists`, `scriptFlush`,
-the `function*` mutations, `flushAll`, `flushDb`, `keys`, `dbSize`, `waitReplicas`, and `waitAof` run on every slot-owning master, and their replies
-are folded into one. There is no partial result: if one master fails, the call fails.
+No node sees the whole keyspace, a cluster replicates neither the script nor the function cache, and a node answers pub/sub introspection only for
+the subscribers attached to it. So `scriptLoad`, `scriptExists`, `scriptFlush`, the `function*` mutations, `flushAll`, `flushDb`, `keys`, `dbSize`,
+`waitReplicas`, `waitAof`, `memoryPurge`, and the `pubsub*` introspection forms run on every slot-owning master, and their replies are folded into
+one: `keys` returns the whole keyspace, `dbSize` the cluster total, `pubsubChannels` every active channel, `pubsubNumSub` the summed subscriber
+count. There is no partial result: if one master fails, the call fails.
+
+None of them can go in a pipeline, which batches per node — run them on the client directly; `dbSize` is also rejected inside a transaction, which
+pins to one node. Only masters are visited, so a subscriber connected through a replica is not counted by `pubsubNumSub`, and `pubsubNumPat` counts
+a pattern once per master holding it.
+
+The keyless administrative commands — `info`, `configGet`, `configSet`, `slowLog*`, `latency*`, `commandLog*`, `functionDump` — are answered by a
+single master instead. Note that `configSet` sets the parameter on one master, not across the cluster. A keyless *read* such as `randomKey` is also
+answered by one node, but follows the [read routing](#read-routing) policy, so it can be served by a replica.
 
 This is also the one case where Sage does not retry a `-CLUSTERDOWN` for you; see
 [Refusals Sage retries for you](/error-handling#refusals-sage-retries-for-you).

--- a/docs/pipelines-transactions.md
+++ b/docs/pipelines-transactions.md
@@ -74,6 +74,8 @@ for {
 
 :::
 
+In a cluster, a pipeline batches per node, so it cannot carry a [command that runs on every master](/configuration#commands-that-run-on-every-master). Those are rejected up front rather than partially applied; run them on the client directly.
+
 ## Transactions
 
 A transaction runs a pipeline atomically via `MULTI`/`EXEC` on a leased dedicated connection. Open one with `transaction { tx => … }`: inside the scope you may `watch` keys, run ordinary reads (`tx.get`, `tx.run`, …), decide, and then `exec` a pipeline (or abandon the scope to discard it).

--- a/docs/pubsub.md
+++ b/docs/pubsub.md
@@ -95,4 +95,8 @@ ZIO.scoped {
 
 Sage holds one sharded subscription connection per owning node and re-homes the affected subscriptions automatically when a slot migrates or a node fails over.
 
+## Introspection
+
+`pubsubChannels`, `pubsubShardChannels`, `pubsubNumSub`, `pubsubShardNumSub`, and `pubsubNumPat` report the live subscription state. A server answers only for the subscribers attached to *it*, so in a cluster Sage [runs them on every master](/configuration#commands-that-run-on-every-master) and merges the replies.
+
 See [Configuration](/configuration) for how to connect to a cluster.

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterFailoverSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterFailoverSuite.scala
@@ -19,58 +19,39 @@ import sage.integration.{ContainerClient, Eventually, Images}
   * `CLUSTER SLOTS` and re-dispatches, bounded by `maxRedirects`. That bound is shorter than an election, so, as with a real application, the
   * caller retries across the failover window while the client refreshes the topology underneath.
   *
-  * A cluster node announces a single address used for both gossip and clients, so the testcontainers-mapped random ports the other suites use
-  * cannot work here: gossip needs an address the nodes reach each other on. The escape is a fixed 1:1 host-port mapping plus
-  * `cluster-announce-ip 127.0.0.1`, so `127.0.0.1:<port>` resolves to the same node inside the container (gossip) and from the host (the test).
-  * The cost is fixed host ports (7100-7105), which must be free on the host — the only single-host scheme a multi-node cluster admits short of
-  * Linux-only host networking.
+  * The fixed host ports are 7100-7105; see [[MultiNodeCluster]] for why a multi-node cluster cannot use mapped random ports.
   */
-abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends munit.FunSuite with TestContainerForEach with ContainerClient {
+abstract class ClusterFailoverSuite(val image: String, val serverBinary: String)
+  extends munit.FunSuite
+  with TestContainerForEach
+  with ContainerClient
+  with MultiNodeCluster {
 
-  private val ports  = 7100 to 7105
-  private val victim = 7100 // redis-cli --cluster-create makes the first nodes masters, so 7100 is a master with a replica to promote
+  protected val ports: Seq[Int] = 7100 to 7105
+  private val victim            = 7100 // redis-cli --cluster-create makes the first nodes masters, so 7100 is a master with a replica to promote
 
-  // each node needs its own cluster-config-file (they otherwise collide on nodes.conf); a low node-timeout keeps the failover election short
-  override val containerDef: FixedHostPortGenericContainer.Def = {
-    val starts = ports
-      .map(p =>
-        s"$serverBinary --port $p --cluster-enabled yes --cluster-config-file nodes-$p.conf --cluster-node-timeout 2000 " +
-          // --repl-diskless-sync-delay 0: start the replica's initial sync immediately, not after the default 5s window, so it is a live copy
-          // before the failover rather than still in wait_bgsave
-          s"--cluster-announce-ip 127.0.0.1 --repl-diskless-sync-delay 0 --save '' --appendonly no --protected-mode no --daemonize yes"
-      )
-      .mkString("; ")
-    FixedHostPortGenericContainer.Def(
-      image,
-      command = Seq("sh", "-c", s"$starts; tail -f /dev/null"),
-      portBindings = ports.map(p => (p, p)).toSeq
-    )
-  }
+  override protected val replicasPerMaster: Option[Int] = Some(1)
+
+  // start the replica's initial sync immediately, not after the default 5s window, so it is a live copy before the failover
+  override protected val extraServerFlags: Vector[String] = Vector("--repl-diskless-sync-delay 0")
+
+  override val containerDef: FixedHostPortGenericContainer.Def = clusterContainerDef
 
   given ExecutionContext = munitExecutionContext
 
   // forming a six-node cluster and waiting out an election runs past munit's 30s default on a loaded CI box
   override def munitTimeout: Duration = 120.seconds
 
-  private def exec(container: FixedHostPortGenericContainer, args: String*): String = {
-    val result = container.execInContainer(args*)
-    result.getStdout + result.getStderr
-  }
-
-  private def cli(container: FixedHostPortGenericContainer, port: Int, args: String*): String =
-    exec(container, ("redis-cli" +: "-p" +: port.toString +: args)*)
-
   private def parseKeys(out: String): Vector[String] =
     out.split("\n").iterator.map(_.trim).filter(_.nonEmpty).toVector
 
-  // the victim master's own replica, parsed from CLUSTER NODES (a `slave` line whose master id is the victim's own id)
   private def victimReplicaPort(container: FixedHostPortGenericContainer): Int = {
-    val myId  = cli(container, victim, "cluster", "myid").trim
-    val nodes = cli(container, victim, "cluster", "nodes")
-    parseKeys(nodes).iterator
-      .map(_.split("\\s+"))
-      .collectFirst { case f if f.length > 3 && f(2).contains("slave") && f(3) == myId => f(1).split("@")(0).split(":")(1).toInt }
-      .getOrElse(throw new RuntimeException(s"no replica found for victim $victim:\n$nodes"))
+    val nodes = clusterNodes(container, victim)
+    val myId  =
+      nodes.collectFirst { case node if node.isMyself => node.id }.getOrElse(throw new RuntimeException(s"victim $victim has no myself line"))
+    nodes
+      .collectFirst { case node if node.isReplica && node.masterId == myId => node.port }
+      .getOrElse(throw new RuntimeException(s"no replica found for victim $victim among ${nodes.map(_.port)}"))
   }
 
   // the replication barrier: poll the victim's own replica until it holds every victim-owned key. WAIT keys off the calling connection's last
@@ -78,32 +59,6 @@ abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends
   private def awaitReplicated(container: FixedHostPortGenericContainer, replicaPort: Int, expected: Set[String], attempts: Int): CIO[Unit] =
     Eventually.converges(attempts)(() => CIO.blocking(parseKeys(cli(container, replicaPort, "keys", "*")).toSet))(expected.subsetOf)(have =>
       s"victim's replica did not catch up; missing ${(expected -- have).take(5)}"
-    )
-
-  // wait for every node to answer, form the cluster (idempotent across a re-run sharing the container), and wait for it to converge
-  private def formCluster(container: FixedHostPortGenericContainer): CIO[Unit] =
-    awaitPortsUp(container, 60).flatMap { _ =>
-      CIO.blocking(cli(container, victim, "cluster", "info").contains("cluster_state:ok")).flatMap { ok =>
-        if (ok) CIO.value(())
-        else
-          CIO
-            .blocking {
-              val create = Vector("redis-cli", "--cluster", "create") ++ ports.map(p => s"127.0.0.1:$p") ++
-                Vector("--cluster-replicas", "1", "--cluster-yes")
-              exec(container, create*)
-            }
-            .flatMap(_ => awaitClusterOk(container, 60))
-      }
-    }
-
-  private def awaitPortsUp(container: FixedHostPortGenericContainer, attempts: Int): CIO[Unit] =
-    Eventually.converges(attempts, 300.millis)(() => CIO.blocking(ports.forall(p => cli(container, p, "ping").contains("PONG"))))(identity)(_ =>
-      "cluster nodes did not start"
-    )
-
-  private def awaitClusterOk(container: FixedHostPortGenericContainer, attempts: Int): CIO[Unit] =
-    Eventually.converges(attempts, 500.millis)(() => CIO.blocking(cli(container, victim, "cluster", "info").contains("cluster_state:ok")))(identity)(
-      _ => "cluster did not converge"
     )
 
   // `cluster_state:ok` flips before every node will actually serve writes, so a freshly formed cluster can briefly answer CLUSTERDOWN; retry
@@ -148,32 +103,12 @@ abstract class ClusterFailoverSuite(image: String, serverBinary: String) extends
 
   private def masterId(container: FixedHostPortGenericContainer, port: Int): String = cli(container, port, "cluster", "myid").trim
 
-  // queried via the victim, so its own line carries the `myself` flag
-  private def clusterNodeLines(container: FixedHostPortGenericContainer): Vector[Array[String]] =
-    parseKeys(cli(container, victim, "cluster", "nodes")).map(_.split("\\s+"))
-
   private def masterPortsExcludingVictim(container: FixedHostPortGenericContainer): Vector[Int] =
-    clusterNodeLines(container)
-      .filter(f => f.length > 2 && f(2).contains("master"))
-      .map(f => f(1).split("@")(0).split(":")(1).toInt)
-      .filter(_ != victim)
+    clusterNodes(container, victim).filter(_.isMaster).map(_.port).filter(_ != victim)
 
-  // slot tokens are `start-end` or a single slot; `[...]` migration markers are not owned slots
-  private def slotCount(fields: Array[String]): Int =
-    fields
-      .drop(8)
-      .filterNot(_.startsWith("["))
-      .map { token =>
-        val parts = token.split("-")
-        if (parts.length == 2) parts(1).toInt - parts(0).toInt + 1 else 1
-      }
-      .sum
-
+  // queried on the node itself, so its own line carries the `myself` flag
   private def ownSlotCount(container: FixedHostPortGenericContainer, port: Int): Int =
-    parseKeys(cli(container, port, "cluster", "nodes"))
-      .map(_.split("\\s+"))
-      .collectFirst { case f if f.length > 2 && f(2).contains("myself") => slotCount(f) }
-      .getOrElse(0)
+    clusterNodes(container, port).collectFirst { case node if node.isMyself => node.ownedSlotCount }.getOrElse(0)
 
   private def reshard(container: FixedHostPortGenericContainer, fromId: String, toId: String, slots: Int): String =
     exec(

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterMultiMasterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterMultiMasterSuite.scala
@@ -1,0 +1,155 @@
+package sage.integration.cluster
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.*
+
+import com.dimafeng.testcontainers.FixedHostPortGenericContainer
+import com.dimafeng.testcontainers.munit.TestContainerForAll
+import kyo.compat.*
+
+import sage.SageException.InvalidArgument
+import sage.client.{Endpoint, SageConfig, Topology}
+import sage.client.internal.Client
+import sage.commands.Commands
+import sage.integration.{ContainerClient, Eventually, Images}
+
+/**
+  * Drives the keyless broadcast routing against a real multi-master cluster: three masters, no replicas, in one container. A node answers
+  * `PUBSUB` introspection only for the subscribers attached to it, so the merge across masters needs more than one master to be visible;
+  * [[ClusterSuite]] forms a single-node cluster owning every slot and cannot express it. Subscribers are attached with `redis-cli` on chosen
+  * nodes, so no assertion depends on which master Sage pins its own subscription connection to.
+  *
+  * Each backend takes its own port range so the Redis and Valkey rows cannot collide on the host.
+  */
+abstract class ClusterMultiMasterSuite(val image: String, val serverBinary: String, basePort: Int)
+  extends munit.FunSuite
+  with TestContainerForAll
+  with ContainerClient
+  with MultiNodeCluster {
+
+  protected val ports: Seq[Int] = basePort to (basePort + 2)
+
+  override val containerDef: FixedHostPortGenericContainer.Def = clusterContainerDef
+
+  given ExecutionContext = munitExecutionContext
+
+  override def munitTimeout: Duration = 120.seconds
+
+  private val config = SageConfig(topology = Topology.Cluster(Vector(Endpoint("127.0.0.1", basePort))))
+
+  private def subscribeOn(container: FixedHostPortGenericContainer, port: Int, verb: String, name: String): Unit = {
+    exec(container, "sh", "-c", s"nohup redis-cli -p $port $verb $name > /dev/null 2>&1 &")
+    ()
+  }
+
+  private def awaitOn(container: FixedHostPortGenericContainer, port: Int, form: String, name: String): CIO[Unit] =
+    Eventually.converges(50, 100.millis)(() => CIO.blocking(cli(container, port, "pubsub", form)))(_.contains(name))(out =>
+      s"$name did not appear in $form on $port: $out"
+    )
+
+  private def onCluster[A](body: (FixedHostPortGenericContainer, Client[CIO, String]) => CIO[A]): Future[A] =
+    withContainers { container =>
+      formCluster(container).flatMap(_ => connectAndUse(config)(client => body(container, client))).unsafeRun
+    }
+
+  test("PUBSUB CHANNELS returns a channel whose only subscriber sits on a master the client never picked") {
+    onCluster { (container, client) =>
+      ports.foreach(p => subscribeOn(container, p, "subscribe", s"only-$p"))
+      val expected = ports.map(p => s"only-$p").toSet
+      for {
+        _        <- ports.foldLeft(CIO.value(()))((acc, p) => acc.flatMap(_ => awaitOn(container, p, "channels", s"only-$p")))
+        channels <- client.pubsubChannels()
+      } yield assert(expected.subsetOf(channels.toSet), s"swept channels $channels missed ${expected -- channels.toSet}")
+    }
+  }
+
+  test("PUBSUB CHANNELS reports a channel held on two masters once, rather than once per master") {
+    onCluster { (container, client) =>
+      subscribeOn(container, ports(0), "subscribe", "twice")
+      subscribeOn(container, ports(1), "subscribe", "twice")
+      for {
+        _        <- awaitOn(container, ports(0), "channels", "twice")
+        _        <- awaitOn(container, ports(1), "channels", "twice")
+        channels <- client.pubsubChannels()
+      } yield assertEquals(channels.count(_ == "twice"), 1, s"expected one entry for a channel held on two masters, got $channels")
+    }
+  }
+
+  test("PUBSUB NUMSUB sums a channel's subscribers across masters instead of reporting one master's count") {
+    onCluster { (container, client) =>
+      subscribeOn(container, ports(0), "subscribe", "summed")
+      subscribeOn(container, ports(1), "subscribe", "summed")
+      for {
+        _      <- awaitOn(container, ports(0), "channels", "summed")
+        _      <- awaitOn(container, ports(1), "channels", "summed")
+        counts <- client.pubsubNumSub("summed")
+      } yield assertEquals(counts.get("summed"), Some(2L))
+    }
+  }
+
+  test("PUBSUB SHARDCHANNELS concatenates the shard channels of every master, one per shard") {
+    onCluster { (container, client) =>
+      val oneChannelPerShard                  = Vector("orders", "delta", "epsilon")
+      oneChannelPerShard.foreach(channel => subscribeOn(container, ownerOfChannel(container, channel), "ssubscribe", channel))
+      val sweptAll: Vector[String] => Boolean = found => oneChannelPerShard.forall(found.contains)
+      Eventually.converges(50, 200.millis)(() => client.pubsubShardChannels())(sweptAll)(found =>
+        s"swept shard channels $found missed ${oneChannelPerShard.filterNot(found.contains)}"
+      )
+    }
+  }
+
+  test("PUBSUB SHARDNUMSUB attributes each shard channel's subscribers to it, across all three owners") {
+    onCluster { (container, client) =>
+      // one channel per slot range, distinct counts: no single master's reply can satisfy this
+      val expected = Map("sn-d" -> 1L, "sn-a" -> 2L, "sn-c" -> 3L)
+      expected.foreach { case (channel, subscribers) =>
+        val owner = ownerOfChannel(container, channel)
+        (1L to subscribers).foreach(_ => subscribeOn(container, owner, "ssubscribe", channel))
+      }
+      Eventually.converges(50, 200.millis)(() => client.pubsubShardNumSub(expected.keys.toSeq*))(_ == expected)(counts =>
+        s"expected $expected, got $counts"
+      )
+    }
+  }
+
+  test("PUBSUB NUMPAT sums the distinct patterns of every master") {
+    onCluster { (container, client) =>
+      subscribeOn(container, ports(0), "psubscribe", "pat-a.*")
+      subscribeOn(container, ports(1), "psubscribe", "pat-b.*")
+      Eventually.converges(50, 200.millis)(() => client.pubsubNumPat)(_ >= 2L)(total => s"expected both masters' patterns to be counted, got $total")
+    }
+  }
+
+  test("MEMORY PURGE runs on every master, not just the one the client picked") {
+    onCluster { (container, client) =>
+      ports.foreach(p => cli(container, p, "config", "resetstat"))
+      client.memoryPurge.map { _ =>
+        val unpurged = ports.filterNot(p => cli(container, p, "info", "commandstats").contains("cmdstat_memory|purge:calls="))
+        assert(unpurged.isEmpty, s"masters that never saw MEMORY PURGE: $unpurged")
+      }
+    }
+  }
+
+  test("a Pipeline rejects PUBSUB introspection, since a broadcast cannot be batched onto one node") {
+    onCluster { (_, client) =>
+      client
+        .pipeline((Commands.pubsubNumPat, Commands.get[String, String]("unused")))
+        .fold(
+          results => CIO.value(fail(s"expected the pipeline to be rejected, got $results")),
+          {
+            case _: InvalidArgument => CIO.value(())
+            case other              => CIO.value(fail(s"expected InvalidArgument, got $other"))
+          }
+        )
+    }
+  }
+
+  private def ownerOfChannel(container: FixedHostPortGenericContainer, channel: String): Int = {
+    val slot = cli(container, basePort, "cluster", "keyslot", channel).trim.toInt
+    clusterNodes(container, basePort).find(node => node.isMaster && node.owns(slot)).map(_.port).getOrElse(fail(s"no master owns slot $slot"))
+  }
+}
+
+class RedisClusterMultiMasterSuite extends ClusterMultiMasterSuite(Images.redis, "redis-server", 7200)
+
+class ValkeyClusterMultiMasterSuite extends ClusterMultiMasterSuite(Images.valkey, "valkey-server", 7210)

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/MultiNodeCluster.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/MultiNodeCluster.scala
@@ -1,0 +1,122 @@
+package sage.integration.cluster
+
+import scala.concurrent.duration.*
+
+import com.dimafeng.testcontainers.FixedHostPortGenericContainer
+import kyo.compat.*
+
+import sage.integration.Eventually
+
+/**
+  * One `CLUSTER NODES` row. The wire format is positional — `<id> <ip:port@cport> <flags> <master-id> …` with the owned slot ranges from
+  * field 8 on — so it is parsed once here rather than indexed at each use site.
+  */
+final case class ClusterNode(id: String, port: Int, flags: Set[String], masterId: String, slots: Vector[Range]) {
+  def isMaster: Boolean        = flags.contains("master")
+  def isReplica: Boolean       = flags.contains("slave")
+  def isMyself: Boolean        = flags.contains("myself")
+  def owns(slot: Int): Boolean = slots.exists(_.contains(slot))
+  def ownedSlotCount: Int      = slots.map(_.size).sum
+}
+
+/**
+  * Boots several cluster nodes in one container and forms them into a cluster.
+  *
+  * A cluster node announces a single address used for both gossip and clients, so the testcontainers-mapped random ports the single-node
+  * suites use cannot work here: gossip needs an address the nodes reach each other on. The escape is a fixed 1:1 host-port mapping plus
+  * `cluster-announce-ip 127.0.0.1`, so `127.0.0.1:<port>` resolves to the same node inside the container (gossip) and from the host (the
+  * test). The cost is fixed host ports, which must be free on the host and must not overlap between suites.
+  */
+trait MultiNodeCluster {
+
+  protected def image: String
+  protected def serverBinary: String
+  protected def ports: Seq[Int]
+
+  /**
+    * Replicas per master for `--cluster create`; `None` makes every node a master.
+    */
+  protected def replicasPerMaster: Option[Int] = None
+
+  /**
+    * Server flags this suite needs on top of the shared ones.
+    */
+  protected def extraServerFlags: Vector[String] = Vector.empty
+
+  // each node needs its own cluster-config-file (they otherwise collide on nodes.conf); a low node-timeout keeps a failover election short
+  final protected def clusterContainerDef: FixedHostPortGenericContainer.Def = {
+    val starts = ports
+      .map(p =>
+        (Vector(
+          serverBinary,
+          s"--port $p",
+          "--cluster-enabled yes",
+          s"--cluster-config-file nodes-$p.conf",
+          "--cluster-node-timeout 2000",
+          "--cluster-announce-ip 127.0.0.1"
+        ) ++ extraServerFlags ++ Vector("--save ''", "--appendonly no", "--protected-mode no", "--daemonize yes")).mkString(" ")
+      )
+      .mkString("; ")
+    FixedHostPortGenericContainer.Def(image, command = Seq("sh", "-c", s"$starts; tail -f /dev/null"), portBindings = ports.map(p => (p, p)).toSeq)
+  }
+
+  final protected def exec(container: FixedHostPortGenericContainer, args: String*): String = {
+    val result = container.execInContainer(args*)
+    result.getStdout + result.getStderr
+  }
+
+  final protected def cli(container: FixedHostPortGenericContainer, port: Int, args: String*): String =
+    exec(container, ("redis-cli" +: "-p" +: port.toString +: args)*)
+
+  /**
+    * The cluster as `port` currently sees it, one entry per node.
+    */
+  final protected def clusterNodes(container: FixedHostPortGenericContainer, port: Int): Vector[ClusterNode] =
+    cli(container, port, "cluster", "nodes").linesIterator.map(_.trim).filter(_.nonEmpty).flatMap(parseNode).toVector
+
+  // a replica owns no slots, so its row stops at the link-state field and the slot tokens are absent
+  private def parseNode(line: String): Option[ClusterNode] = {
+    val fields = line.split("\\s+")
+    Option.when(fields.length >= 8)(
+      ClusterNode(
+        id = fields(0),
+        port = fields(1).split("@")(0).split(":").last.toInt,
+        flags = fields(2).split(",").toSet,
+        masterId = fields(3),
+        // a `[slot-<-nodeid]` marker is an in-flight migration, not an owned slot
+        slots = fields.drop(8).filterNot(_.startsWith("[")).toVector.flatMap(slotRange)
+      )
+    )
+  }
+
+  private def slotRange(token: String): Option[Range] =
+    token.split("-") match {
+      case Array(only)     => only.toIntOption.map(slot => slot to slot)
+      case Array(from, to) => from.toIntOption.zip(to.toIntOption).map((low, high) => low to high)
+      case _               => None
+    }
+
+  final protected def awaitPortsUp(container: FixedHostPortGenericContainer, attempts: Int): CIO[Unit] =
+    Eventually.converges(attempts, 300.millis)(() => CIO.blocking(ports.forall(p => cli(container, p, "ping").contains("PONG"))))(identity)(_ =>
+      "cluster nodes did not start"
+    )
+
+  final protected def awaitClusterOk(container: FixedHostPortGenericContainer, attempts: Int): CIO[Unit] =
+    Eventually.converges(attempts, 500.millis)(() => CIO.blocking(clusterIsOk(container)))(identity)(_ => "cluster did not converge")
+
+  private def clusterIsOk(container: FixedHostPortGenericContainer): Boolean =
+    cli(container, ports.head, "cluster", "info").contains("cluster_state:ok")
+
+  // idempotent, so a suite sharing one container across tests forms the cluster on the first test only
+  final protected def formCluster(container: FixedHostPortGenericContainer, attempts: Int = 60): CIO[Unit] =
+    awaitPortsUp(container, attempts).flatMap { _ =>
+      CIO.blocking(clusterIsOk(container)).flatMap { ok =>
+        if (ok) CIO.value(())
+        else {
+          val replicas = replicasPerMaster.toVector.flatMap(n => Vector("--cluster-replicas", n.toString))
+          val create   = Vector("redis-cli", "--cluster", "create") ++ ports.map(p => s"127.0.0.1:$p") ++ replicas ++ Vector("--cluster-yes")
+          CIO.blocking(exec(container, create*)).flatMap(_ => awaitClusterOk(container, attempts))
+        }
+      }
+    }
+}

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -1080,27 +1080,30 @@ trait CommandRunner[F[_], K](using KeyCodec[K]) {
   final def sPublish[V: ValueCodec](channel: String, message: V): F[Long] = run(Pubsub.sPublish(channel, message))
 
   /**
-    * Lists currently-active classic channels with at least one subscriber, optionally filtered by glob `pattern`.
+    * Lists currently-active classic channels with at least one subscriber, optionally filtered by glob `pattern`. A server reports only the
+    * subscribers attached to it, so a cluster sweeps every master and appends the lists, dropping repeats.
     */
   final def pubsubChannels(pattern: Option[String] = None): F[Vector[String]] = run(Pubsub.pubsubChannels(pattern))
 
   /**
-    * Lists currently-active Shard Channels, optionally filtered by glob `pattern`.
+    * Lists currently-active Shard Channels, optionally filtered by glob `pattern`. Swept across masters like [[pubsubChannels]].
     */
   final def pubsubShardChannels(pattern: Option[String] = None): F[Vector[String]] = run(Pubsub.pubsubShardChannels(pattern))
 
   /**
-    * Returns the subscriber count of each given classic channel.
+    * Returns the subscriber count of each given classic channel, summed across every master in a cluster. The sweep does not reach replicas,
+    * so a subscriber attached to one is not counted.
     */
   final def pubsubNumSub(channels: String*): F[Map[String, Long]] = run(Pubsub.pubsubNumSub(channels*))
 
   /**
-    * Returns the subscriber count of each given Shard Channel.
+    * Returns the subscriber count of each given Shard Channel, summed across masters like [[pubsubNumSub]].
     */
   final def pubsubShardNumSub(channels: String*): F[Map[String, Long]] = run(Pubsub.pubsubShardNumSub(channels*))
 
   /**
-    * Returns the number of active pattern subscriptions across all clients.
+    * Returns the number of active pattern subscriptions, summed across every master in a cluster. The reply is a count rather than the
+    * patterns, so one pattern held on two masters is counted twice.
     */
   final def pubsubNumPat: F[Long] = run(Pubsub.pubsubNumPat)
 
@@ -1822,7 +1825,8 @@ trait CommandRunner[F[_], K](using KeyCodec[K]) {
   final def memoryUsage(key: K, samples: Option[Long] = None): F[Option[Long]] = run(Server.memoryUsage(key, samples))
 
   /**
-    * Asks the allocator to release memory back to the OS.
+    * Asks the allocator to release memory back to the OS. The effect is per-node, so a cluster asks every slot-owning master; a swept
+    * command cannot ride in a Pipeline.
     */
   final def memoryPurge: F[Unit] = run(Server.memoryPurge)
 

--- a/sage-core/src/main/scala/sage/commands/Command.scala
+++ b/sage-core/src/main/scala/sage/commands/Command.scala
@@ -34,9 +34,10 @@ enum BroadcastReduce {
   * change. Time-varying reads (`TTL`, `OBJECT IDLETIME`) and non-deterministic ones (`SRANDMEMBER`) are read-only but **not** cacheable —
   * they change with no key write, so no invalidation would ever fire. Both are intrinsic metadata set by the builders.
   *
-  * `allMasters` marks a keyless command whose effect is per-node and not replicated across shards, so a cluster must run it on every
-  * slot-owning master rather than one (`SCRIPT LOAD`, `FUNCTION LOAD` and their `FLUSH`/`DELETE`/`RESTORE` mutations, and `FLUSHALL`/
-  * `FLUSHDB`). Inert on a standalone server.
+  * `allMasters` marks a keyless command whose effect or answer is per-node and not shared across shards, so a cluster must run it on every
+  * slot-owning master rather than one (`SCRIPT LOAD`, `FUNCTION LOAD` and their `FLUSH`/`DELETE`/`RESTORE` mutations, `FLUSHALL`/`FLUSHDB`,
+  * `MEMORY PURGE`, and the `PUBSUB` introspection forms, which report only the subscribers attached to the node answering). Inert on a
+  * standalone server.
   *
   * `cursorBound` marks a command whose reply carries a continuation cursor valid only on the node that issued it (`SCAN`/`HSCAN`/`SSCAN`/
   * `ZSCAN`). Such a read is excluded from replica round-robin routing: iterating its pages across different replicas would feed a cursor to
@@ -44,8 +45,8 @@ enum BroadcastReduce {
   *
   * `broadcast` chooses how an `allMasters` command's per-node replies fold into one: `First` keeps one node's identical acknowledgement,
   * `Concat` appends each node's array slice (`KEYS`, since no single node sees the whole keyspace), `Fold` reduces pairwise (a durability
-  * barrier down to its weakest shard). The broadcast always targets masters regardless of the `ReadFrom` policy (a single replica would only
-  * see one shard's slice). Inert on a standalone server.
+  * barrier down to its weakest shard, a per-channel subscriber sum, a channel list appended and deduplicated). The broadcast always targets
+  * masters regardless of the `ReadFrom` policy (a single replica would only see one shard's slice). Inert on a standalone server.
   *
   * `requiresClusterWideTxResult` marks a command whose result is correct only when aggregated across every master, so a cluster `MULTI`/
   * `EXEC` — pinned to a single node — cannot produce it and rejects it before the wire. Only `DBSIZE` sets it: its contract is the cluster-wide

--- a/sage-core/src/main/scala/sage/commands/Merge.scala
+++ b/sage-core/src/main/scala/sage/commands/Merge.scala
@@ -1,0 +1,69 @@
+package sage.commands
+
+import scala.collection.mutable
+
+import sage.protocol.Frame
+
+/**
+  * Shape-generic pairwise combiners for [[BroadcastReduce.Fold]], folding two masters' replies into one. Each passes a reply that does not
+  * fit the expected shape straight through, in either operand position, so the command's own decoder reports it rather than this merge
+  * hiding it behind a well-formed sibling. A combiner that needs command-specific validation stays with its command instead, since it can
+  * reject what no downstream decoder would catch (`SCRIPT EXISTS` compares arrays that must describe the same SHAs).
+  */
+private[commands] object Merge {
+
+  val sum: (Frame, Frame) => Frame = integers((x, y) => math.addExact(x, y))
+
+  val min: (Frame, Frame) => Frame = integers((x, y) => math.min(x, y))
+
+  /**
+    * Appends two arrays, dropping repeats: a classic channel can hold subscribers on several masters, so more than one reports it.
+    */
+  val distinctChannels: (Frame, Frame) => Frame = (a, b) =>
+    (a, b) match {
+      case (Frame.Array(x), Frame.Array(y)) => Frame.Array((x ++ y).distinct)
+      case (Frame.Array(_), bad)            => bad
+      case (bad, _)                         => bad
+    }
+
+  /**
+    * Sums a flat `[channel, count, …]` reply per channel, keeping each channel's first-seen position. Appending instead would emit a channel
+    * once per master, and the `PUBSUB NUMSUB` decoder builds a `Map`, so every count but the last would be dropped.
+    */
+  val sumByChannel: (Frame, Frame) => Frame = (a, b) =>
+    (channelCounts(a), channelCounts(b)) match {
+      case (Some(x), Some(y)) =>
+        val totals = mutable.LinkedHashMap.empty[Frame.BulkString, Long]
+        (x ++ y).foreach { case (channel, count) => totals.update(channel, math.addExact(totals.getOrElse(channel, 0L), count)) }
+        Frame.Array(totals.iterator.flatMap { case (channel, total) => Vector(channel, Frame.Integer(total)) }.toVector)
+      case (None, _)          => a
+      case _                  => b
+    }
+
+  /**
+    * The channel/count pairs of a flat `[channel, count, …]` reply, or `None` when it is not that shape. Shared with the `PUBSUB NUMSUB`
+    * decoder so the merge and the decode cannot disagree about the reply's shape.
+    */
+  def channelCounts(frame: Frame): Option[Vector[(Frame.BulkString, Long)]] =
+    frame match {
+      case Frame.Array(elements) if elements.length % 2 == 0 =>
+        val builder = Vector.newBuilder[(Frame.BulkString, Long)]
+        var i       = 0
+        while (i < elements.length) {
+          (elements(i), elements(i + 1)) match {
+            case (channel: Frame.BulkString, Frame.Integer(count)) => builder += ((channel, count))
+            case _                                                 => return None
+          }
+          i += 2
+        }
+        Some(builder.result())
+      case _ => None
+    }
+
+  private def integers(combine: (Long, Long) => Long): (Frame, Frame) => Frame = (a, b) =>
+    (a, b) match {
+      case (Frame.Integer(x), Frame.Integer(y)) => Frame.Integer(combine(x, y))
+      case (Frame.Integer(_), bad)              => bad
+      case (bad, _)                             => bad
+    }
+}

--- a/sage-core/src/main/scala/sage/commands/Pubsub.scala
+++ b/sage-core/src/main/scala/sage/commands/Pubsub.scala
@@ -20,19 +20,31 @@ private[sage] object Pubsub {
     Command("SPUBLISH", Command.FirstKey, Vector(Bytes.utf8(channel), codec.encode(message)), Decode.long)
 
   def pubsubChannels(pattern: Option[String] = None): Command[Vector[String]] =
-    Command("PUBSUB", Command.NoKeys, Bytes.utf8("CHANNELS") +: pattern.map(Bytes.utf8).toVector, decodeStrings)
+    introspect(Bytes.utf8("CHANNELS") +: pattern.map(Bytes.utf8).toVector, decodeStrings, Merge.distinctChannels)
 
   def pubsubShardChannels(pattern: Option[String] = None): Command[Vector[String]] =
-    Command("PUBSUB", Command.NoKeys, Bytes.utf8("SHARDCHANNELS") +: pattern.map(Bytes.utf8).toVector, decodeStrings)
+    introspect(Bytes.utf8("SHARDCHANNELS") +: pattern.map(Bytes.utf8).toVector, decodeStrings, Merge.distinctChannels)
 
   def pubsubNumSub(channels: String*): Command[Map[String, Long]] =
-    Command("PUBSUB", Command.NoKeys, Bytes.utf8("NUMSUB") +: channels.toVector.map(Bytes.utf8), decodeNumSub)
+    introspect(Bytes.utf8("NUMSUB") +: channels.toVector.map(Bytes.utf8), decodeNumSub, Merge.sumByChannel)
 
   def pubsubShardNumSub(channels: String*): Command[Map[String, Long]] =
-    Command("PUBSUB", Command.NoKeys, Bytes.utf8("SHARDNUMSUB") +: channels.toVector.map(Bytes.utf8), decodeNumSub)
+    introspect(Bytes.utf8("SHARDNUMSUB") +: channels.toVector.map(Bytes.utf8), decodeNumSub, Merge.sumByChannel)
 
   val pubsubNumPat: Command[Long] =
-    Command("PUBSUB", Command.NoKeys, Vector(Bytes.utf8("NUMPAT")), Decode.long)
+    introspect(Vector(Bytes.utf8("NUMPAT")), Decode.long, Merge.sum)
+
+  /**
+    * A `PUBSUB` introspection form. A node answers only for the subscribers attached to it, so one master's reply describes one master, and
+    * a cluster must sweep every slot-owning master and merge. The sweep reaches masters only, so a subscriber attached to a replica is not
+    * counted; Sage pins its own subscription connections to a master, so this shows up only for subscribers created outside Sage.
+    */
+  private def introspect[Out](
+    args: Vector[Bytes],
+    decode: Frame => Either[DecodeError, Out],
+    merge: (Frame, Frame) => Frame
+  ): Command[Out] =
+    Command("PUBSUB", Command.NoKeys, args, decode, allMasters = true, broadcast = BroadcastReduce.Fold(merge))
 
   def subscribe(channels: Vector[String]): Bytes    = RespWriter.writeCommand("SUBSCRIBE", channels.map(Bytes.utf8))
   def unsubscribe(channels: Vector[String]): Bytes  = RespWriter.writeCommand("UNSUBSCRIBE", channels.map(Bytes.utf8))
@@ -130,21 +142,9 @@ private[sage] object Pubsub {
       case other                 => Left(DecodeError("array", Frame.describe(other)))
     }
 
-  // NUMSUB replies a flat [channel, count, channel, count, …] array
   private def decodeNumSub(frame: Frame): Either[DecodeError, Map[String, Long]] =
-    frame match {
-      case Frame.Array(elements) if elements.length % 2 == 0 =>
-        val builder = Map.newBuilder[String, Long]
-        builder.sizeHint(elements.length / 2)
-        var i       = 0
-        while (i < elements.length) {
-          (elements(i), elements(i + 1)) match {
-            case (Frame.BulkString(ch), Frame.Integer(count)) => builder += ch.asUtf8String -> count
-            case (a, b)                                       => return Left(DecodeError("channel/count pair", s"${Frame.describe(a)}, ${Frame.describe(b)}"))
-          }
-          i += 2
-        }
-        Right(builder.result())
-      case other => Left(DecodeError("array of channel/count pairs", Frame.describe(other)))
-    }
+    Merge
+      .channelCounts(frame)
+      .map(_.iterator.map { case (channel, count) => channel.value.asUtf8String -> count }.toMap)
+      .toRight(DecodeError("array of channel/count pairs", Frame.describe(frame)))
 }

--- a/sage-core/src/main/scala/sage/commands/Server.scala
+++ b/sage-core/src/main/scala/sage/commands/Server.scala
@@ -140,13 +140,6 @@ private[sage] object Server {
   def info(sections: String*): Command[String] =
     Command("INFO", Command.NoKeys, sections.iterator.map(Bytes.utf8).toVector, Decode.text)
 
-  private val dbSizeSum: (Frame, Frame) => Frame = (a, b) =>
-    (a, b) match {
-      case (Frame.Integer(x), Frame.Integer(y)) => Frame.Integer(math.addExact(x, y))
-      case (Frame.Integer(_), bad)              => bad
-      case (bad, _)                             => bad
-    }
-
   val dbSize: Command[Long] =
     Command(
       "DBSIZE",
@@ -154,7 +147,7 @@ private[sage] object Server {
       Vector.empty,
       Decode.long,
       allMasters = true,
-      broadcast = BroadcastReduce.Fold(dbSizeSum),
+      broadcast = BroadcastReduce.Fold(Merge.sum),
       requiresClusterWideTxResult = true
     )
 
@@ -206,13 +199,6 @@ private[sage] object Server {
   def flushDb(mode: Option[FlushMode] = None): Command[Unit]  =
     Command("FLUSHDB", Command.NoKeys, FlushMode.args(mode), Decode.ok, allMasters = true)
 
-  private val waitMinReplicas: (Frame, Frame) => Frame = (a, b) =>
-    (a, b) match {
-      case (Frame.Integer(x), Frame.Integer(y)) => Frame.Integer(math.min(x, y))
-      case (Frame.Integer(_), bad)              => bad
-      case (bad, _)                             => bad
-    }
-
   private val waitAofMin: (Frame, Frame) => Frame = (a, b) =>
     (a, b) match {
       case (Frame.Array(Vector(Frame.Integer(l1), Frame.Integer(r1))), Frame.Array(Vector(Frame.Integer(l2), Frame.Integer(r2)))) =>
@@ -233,7 +219,7 @@ private[sage] object Server {
       Vector(Bytes.utf8(numReplicas.toString), Bytes.utf8(waitTimeoutMillis(timeout).toString)),
       Decode.long,
       allMasters = true,
-      broadcast = BroadcastReduce.Fold(waitMinReplicas)
+      broadcast = BroadcastReduce.Fold(Merge.min)
     )
 
   def waitAof(numLocal: Long, numReplicas: Long, timeout: FiniteDuration): Command[(Long, Long)] =
@@ -257,7 +243,7 @@ private[sage] object Server {
       Decode.optionalLong
     )
 
-  val memoryPurge: Command[Unit] = Command("MEMORY", Command.NoKeys, Vector(Purge), Decode.ok)
+  val memoryPurge: Command[Unit] = Command("MEMORY", Command.NoKeys, Vector(Purge), Decode.ok, allMasters = true)
 
   def slowLogGet(count: Option[Long] = None): Command[Vector[SlowLogEntry]] =
     Command("SLOWLOG", Command.NoKeys, Get +: count.map(n => Bytes.utf8(n.toString)).toVector, Decode.vector(decodeSlowLog))

--- a/sage-core/src/test/scala/sage/commands/PubsubSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/PubsubSpec.scala
@@ -1,0 +1,105 @@
+package sage.commands
+
+import sage.protocol.Frame
+import sage.protocol.Frames.bulk
+
+class PubsubSpec extends munit.FunSuite with BroadcastFolds {
+
+  private val introspection = Vector(
+    "PUBSUB CHANNELS"      -> Pubsub.pubsubChannels(),
+    "PUBSUB SHARDCHANNELS" -> Pubsub.pubsubShardChannels(),
+    "PUBSUB NUMSUB"        -> Pubsub.pubsubNumSub("news"),
+    "PUBSUB SHARDNUMSUB"   -> Pubsub.pubsubShardNumSub("news"),
+    "PUBSUB NUMPAT"        -> Pubsub.pubsubNumPat
+  )
+
+  test("every PUBSUB introspection form broadcasts per master, since a node answers only for the subscribers attached to it") {
+    introspection.foreach { case (name, command) =>
+      assert(command.allMasters, s"$name must sweep every slot-owning master")
+      assert(command.rawFrame.allMasters, s"$name must keep allMasters through rawFrame")
+      command.broadcast match {
+        case BroadcastReduce.Fold(_) => ()
+        case other                   => fail(s"$name must merge with a Fold, got $other")
+      }
+    }
+  }
+
+  test("PUBSUB introspection stays transaction-legal with node-local semantics, as KEYS does") {
+    introspection.foreach { case (name, command) =>
+      assert(!command.requiresClusterWideTxResult, s"$name must not be rejected inside a transaction")
+    }
+  }
+
+  test("PUBLISH and SPUBLISH stay single-node: the cluster bus fans PUBLISH out, and SPUBLISH routes by its channel's slot") {
+    assert(!Pubsub.publish("news", "hello").allMasters)
+    assert(!Pubsub.sPublish("orders", "placed").allMasters)
+    assertEquals(Pubsub.sPublish("orders", "placed").keyIndices, Command.FirstKey)
+  }
+
+  test("CHANNELS merges each master's slice and reports a channel held on two masters once") {
+    val merge = fold(Pubsub.pubsubChannels())
+    val first = Frame.Array(Vector(bulk("news"), bulk("sport")))
+    val other = Frame.Array(Vector(bulk("news"), bulk("weather")))
+    assertEquals(Reply.run(Pubsub.pubsubChannels(), merge(first, other)), Right(Vector("news", "sport", "weather")))
+  }
+
+  test("CHANNELS merges an empty master in either position without losing the other's slice") {
+    val merge    = fold(Pubsub.pubsubChannels())
+    val occupied = Frame.Array(Vector(bulk("news")))
+    val bare     = Frame.Array(Vector.empty)
+    assertEquals(Reply.run(Pubsub.pubsubChannels(), merge(occupied, bare)), Right(Vector("news")))
+    assertEquals(Reply.run(Pubsub.pubsubChannels(), merge(bare, occupied)), Right(Vector("news")))
+  }
+
+  test("the CHANNELS merge passes a malformed reply through in either operand position, so it never hides behind a valid one") {
+    val merge = fold(Pubsub.pubsubChannels())
+    val valid = Frame.Array(Vector(bulk("news")))
+    val bad   = Frame.SimpleString("nonsense")
+    assertEquals(merge(valid, bad), bad)
+    assertEquals(merge(bad, valid), bad)
+    assert(Reply.run(Pubsub.pubsubChannels(), merge(valid, bad)).isLeft)
+  }
+
+  test("NUMSUB sums a channel's subscribers across masters instead of letting the decoder's Map keep only the last count") {
+    val merge = fold(Pubsub.pubsubNumSub("news", "sport"))
+    val first = Frame.Array(Vector(bulk("news"), Frame.Integer(1L), bulk("sport"), Frame.Integer(0L)))
+    val other = Frame.Array(Vector(bulk("news"), Frame.Integer(2L), bulk("sport"), Frame.Integer(5L)))
+    assertEquals(Reply.run(Pubsub.pubsubNumSub("news", "sport"), merge(first, other)), Right(Map("news" -> 3L, "sport" -> 5L)))
+  }
+
+  test("the NUMSUB merge keeps each channel's first-seen position and admits a master that reports a channel the other does not") {
+    val merge  = fold(Pubsub.pubsubNumSub("news", "sport"))
+    val first  = Frame.Array(Vector(bulk("news"), Frame.Integer(1L)))
+    val other  = Frame.Array(Vector(bulk("sport"), Frame.Integer(4L), bulk("news"), Frame.Integer(2L)))
+    val merged = merge(first, other)
+    assertEquals(Reply.run(Pubsub.pubsubNumSub("news", "sport"), merged), Right(Map("news" -> 3L, "sport" -> 4L)))
+    assertEquals(merged, Frame.Array(Vector(bulk("news"), Frame.Integer(3L), bulk("sport"), Frame.Integer(4L))))
+  }
+
+  test("SHARDNUMSUB sums per channel too, so a shard channel keeps its owner's count when the other masters report zero") {
+    val merge = fold(Pubsub.pubsubShardNumSub("orders"))
+    val owner = Frame.Array(Vector(bulk("orders"), Frame.Integer(3L)))
+    val bare  = Frame.Array(Vector(bulk("orders"), Frame.Integer(0L)))
+    assertEquals(Reply.run(Pubsub.pubsubShardNumSub("orders"), merge(bare, owner)), Right(Map("orders" -> 3L)))
+  }
+
+  test("the NUMSUB merge passes an odd-length or mistyped reply through in either operand position") {
+    val merge = fold(Pubsub.pubsubNumSub("news"))
+    val valid = Frame.Array(Vector(bulk("news"), Frame.Integer(1L)))
+    val odd   = Frame.Array(Vector(bulk("news")))
+    val typed = Frame.Array(Vector(bulk("news"), bulk("1")))
+    assertEquals(merge(valid, odd), odd)
+    assertEquals(merge(odd, valid), odd)
+    assertEquals(merge(valid, typed), typed)
+    assert(Reply.run(Pubsub.pubsubNumSub("news"), merge(valid, odd)).isLeft)
+  }
+
+  test("NUMPAT sums each master's pattern count, with checked overflow and malformed passthrough") {
+    val merge = fold(Pubsub.pubsubNumPat)
+    assertEquals(Reply.run(Pubsub.pubsubNumPat, merge(Frame.Integer(2L), Frame.Integer(3L))), Right(5L))
+    val bad   = Frame.SimpleString("nonsense")
+    assertEquals(merge(Frame.Integer(2L), bad), bad)
+    assertEquals(merge(bad, Frame.Integer(2L)), bad)
+    intercept[ArithmeticException](merge(Frame.Integer(Long.MaxValue), Frame.Integer(1L)))
+  }
+}

--- a/sage-core/src/test/scala/sage/commands/ServerSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ServerSpec.scala
@@ -149,6 +149,17 @@ class ServerSpec extends munit.FunSuite with BroadcastFolds {
     assert(Reply.run(Server.dbSize, sum(Frame.Integer(10L), badInt)).isLeft)
   }
 
+  test("MEMORY PURGE broadcasts per master, since purging one arbitrary master leaves every other one unpurged") {
+    assert(Server.memoryPurge.allMasters)
+    assert(Server.memoryPurge.rawFrame.allMasters)
+    assertEquals(Server.memoryPurge.broadcast, BroadcastReduce.First, "every master replies OK, so the first reply stands for all of them")
+    assert(!Server.memoryPurge.requiresClusterWideTxResult)
+  }
+
+  test("MEMORY USAGE stays keyed and node-local, so it is not swept along with PURGE") {
+    assert(!Server.memoryUsage("k").allMasters)
+  }
+
   test("MEMORY USAGE decodes a present count and a missing key as None, and is keyed") {
     assertEquals(Reply.run(Server.memoryUsage("k"), Frame.Integer(64L)), Right(Some(64L)))
     assertEquals(Reply.run(Server.memoryUsage("k"), Frame.Null), Right(None))


### PR DESCRIPTION
Closes #224.

## The bug

A server answers `PUBSUB` introspection only for the subscribers attached to *it*, and `MEMORY PURGE` only purges the node it reaches. All six were plain keyless commands, so a cluster sent them to whichever master `pickNode` returned — `masterPool.firstLiveNode` (`ClusterLive.scala:711`), a `collectFirst` over a pool that fills lazily and is pruned on every topology refresh.

Sage pins its own classic subscription connection through that same `pickNode`, but at first subscribe rather than at read time, so the two disagree in ordinary use and introspection could report an empty channel list while the subscription was live.

Reproduced on a three-master cluster, both backends, one subscriber on the first node:

```
PUBSUB CHANNELS        A -> ["news"]   B -> []   C -> []
PUBSUB NUMSUB news     A -> 1          B -> 0    C -> 0
PUBSUB SHARDCHANNELS   only the slot owner reports the channel
```

## The fix

All six now sweep every master. `MEMORY PURGE` keeps the default `First` reduce, as `FLUSHALL` does; channel lists concatenate and deduplicate; counts sum per channel.

`NUMSUB` cannot use `Concat` — its reply is a flat `[channel, count, …]` array, so appending yields duplicate keys and the decoder builds a `Map`, silently dropping every node's count but the last. The dedupe and sums are `Fold`s rather than new `BroadcastReduce` cases, since `BroadcastReduce` is exported public API.

Deliberate limits, documented rather than fixed: the sweep reaches masters only (a subscriber on a replica is uncounted); `NUMPAT` returns a count, not the patterns, so one pattern on two masters counts twice; these stay legal in a `Transaction` with node-local semantics, as `KEYS` does. Pipelining any of them in cluster mode now fails with `InvalidArgument`, the same rejection `KEYS` already carries.

## Tests

`ClusterSuite` forms a single-node cluster, so it structurally cannot catch this. `ClusterMultiMasterSuite` is a new three-master harness that attaches subscribers to chosen nodes with `redis-cli`, so no assertion depends on which master Sage would pin.

**Six of its seven tests fail without the routing change**, verified by reverting each flag:

```
==> X PUBSUB CHANNELS ...    swept channels Vector(only-7200) missed Set(only-7201, only-7202)
==> X PUBSUB SHARDCHANNELS   swept shard channels Vector(orders) missed Vector(delta, epsilon)
==> X PUBSUB NUMPAT ...      got 1
==> X MEMORY PURGE ...       masters that never saw MEMORY PURGE: Vector(7201, 7202)
```

`MEMORY PURGE` is verified, not just asserted: the test resets `commandstats` on every node and checks each recorded a `cmdstat_memory|purge` call. Plus 11 unit tests over the routing metadata and each merge, including malformed-reply passthrough in either operand position.

Also carried along: shape-generic combiners move to one `Merge` object shared with `dbSize`/`waitReplicas`, the `NUMSUB` decoder reuses the channel/count parser the merge needed, and the container plumbing the two multi-node suites share moves to `MultiNodeCluster` (the failover suite loses 76 lines).

## Not included

The public per-node targeting API the original issue also proposed — ruled a non-goal, with the internal `ScanTarget`/`runOn` seam still there if demand appears. Making `pickNode` deterministic is left out too; it changes subscription pinning independently of this bug.
