### PR TITLE
Trim maintainer internals out of the docs

### DIFF
--- a/docs/client-side-caching.md
+++ b/docs/client-side-caching.md
@@ -39,7 +39,7 @@ Tune cache sizing and behavior through `clientCache` on [`SageConfig`](/configur
 
 ## Topology
 
-Caching works on every topology. On a standalone or master-replica client, cached reads run on the master, which holds the tracking-backed cache. On a cluster client, each slot-owning master owns its own cache, and a cached read is routed to the master owning the key's slot (never a replica, whatever the read policy). The same call therefore runs on all three topologies, serving a local hit only where caching is active.
+Caching works on every topology, with no change to your code. A cached read always runs against a master, never a replica whatever the read policy, since that is where the tracking-backed cache lives. In a cluster each slot-owning master keeps its own cache, and the read is routed to the master owning the key's slot.
 
 ## Limitations
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -41,7 +41,7 @@ Commands mirror the server's documented groups, and the methods are named one-fo
 - **Pub/Sub**, **Scripting**, **Functions**
 - **Server**, **Connection**, **ACL**
 
-The full surface lives on the client and on `Commands`; the API docs list every method with its signature.
+The full surface lives on the client and on `Commands`; the [API docs](https://javadoc.io/doc/com.github.ghostdogpr/sage-core_3/) list every method with its signature.
 
 ## Typed keys and values
 
@@ -59,7 +59,7 @@ There are two separate typeclasses, by design:
 - `KeyCodec[A]` for **key and hash-field** positions (identifiers into the keyspace or a hash).
 - `ValueCodec[A]` for **payloads**.
 
-They are deliberately unrelated, which keeps `given` resolution unambiguous and lets key positions carry the cluster-slot hashing that value positions do not need.
+They are deliberately unrelated: a key position needs cluster-slot hashing that a value position does not, and keeping them apart makes `given` resolution unambiguous.
 
 ### Non-String keys
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Everything about how a client connects is set on one value, `SageConfig`. The command surface never changes: the same `SageClient` talks to a standalone server, a cluster, or a master-replica deployment, and the only difference is configuration. Standalone, cluster, and master-replica are choices here, not different code.
+Everything about how a client connects is set on one value, `SageConfig`. The command surface never changes: the same `SageClient` talks to a standalone server, a cluster, or a master-replica deployment, and the only difference is configuration.
 
 ```scala
 val config = SageConfig(
@@ -21,7 +21,7 @@ val config = SageConfig(
 )
 ```
 
-The `database` is selected once at connection setup and fixed for the client's lifetime, re-applied on every reconnect. It is never changed by a runtime command, because that would move the keyspace under every fiber sharing the connection. Valkey 9+ also supports numbered databases in cluster mode; Redis Cluster and older Valkey versions reject a non-zero database during connection setup.
+The `database` is selected at connection setup and fixed for the client's lifetime. There is no runtime `SELECT`, because it would move the keyspace under every fiber sharing the connection.
 
 ## Cluster
 
@@ -37,7 +37,8 @@ val config = SageConfig(
 ```
 
 Seeds bootstrap discovery only. Once the topology is known, Sage routes to the nodes the cluster reports; any one seed answering is enough.
-Set `database` to a non-zero value for a Valkey 9+ cluster configured with a sufficiently large `cluster-databases` setting. Sage issues `SELECT` while establishing every node connection, including after reconnects and redirects. Servers without numbered cluster database support reject the connection.
+
+A non-zero `database` in cluster mode needs Valkey 9+ with a large enough `cluster-databases` setting. Redis Cluster and older Valkey versions reject the connection.
 
 ### Hash tags
 
@@ -46,30 +47,25 @@ in one slot, for example `user:{42}:profile` and `user:{42}:settings`. Transacti
 
 ### Supported cross-slot commands
 
-Ordinary `mGet`, `mSet`, `exists`, `del`, `unlink`, and `touch` calls may span cluster slots. Sage transparently groups their keys by exact slot and
-sends one subcommand per slot through the normal routing and redirect machinery. This also works when the command is an entry in a pipeline.
-For `mGet`, Sage restores values to request order, retaining missing and repeated positions. For `exists`, `del`, `unlink`, and `touch`, it
-sums the slot-specific counts; `mSet` succeeds only when every slot subgroup returns `OK`.
+`mGet`, `mSet`, `exists`, `del`, `unlink`, and `touch` may span slots. Sage groups their keys by slot, sends one subcommand per slot, and merges the
+replies back into one: `mGet` restores request order (keeping missing and repeated positions), `exists`, `del`, `unlink`, and `touch` sum their
+counts, and `mSet` succeeds only if every group returns `OK`. This works inside a pipeline too.
 
-Each slot-specific command is atomic, but the combined operation is not cluster-wide atomic. A cross-slot `mGet` is not a point-in-time
-snapshot, and a failing cross-slot `mSet`, `del`, or `unlink` may already have applied writes in successful slot groups. If any subgroup
-fails, the logical call fails as a whole. Use a common hash tag when the operation must be atomic. `mSetNx` is not split because doing so would
-break its all-or-nothing condition. All cross-slot commands remain rejected inside a transaction because `MULTI`/`EXEC` must stay pinned to
-one slot.
+Each slot's subcommand is atomic on its own, but the call as a whole is not. A cross-slot `mGet` is not a point-in-time snapshot, and a failing
+`mSet`, `del`, or `unlink` may already have written to the groups that succeeded. If any group fails, the whole call fails. Use a common hash tag
+when the operation must be atomic.
 
-While a slot is being migrated, the server answers a multi-key command whose keys briefly straddle the moving slot with `-TRYAGAIN`. The command
-did not run, so Sage retries it. The retry shares the same `maxRedirects` budget as `MOVED`/`ASK` follows, but where those are resent
-immediately, a `-TRYAGAIN` retry is paced by a short jittered delay. If the migration outlasts that budget, the original `-TRYAGAIN` surfaces as
-a `ServerError`. `-CLUSTERDOWN`, `-LOADING`, and `-MASTERDOWN` are retried the same way, with one exception; see
-[Refusals Sage retries for you](/error-handling#refusals-sage-retries-for-you).
+`mSetNx` is never split, since that would break its all-or-nothing condition, and no cross-slot command is allowed inside a transaction, which must
+stay pinned to one slot.
 
 ### Commands that run on every master
 
-A cluster replicates no script or function cache, and no node sees the whole keyspace. So `scriptLoad`, `scriptExists`, `scriptFlush`, the
-`function*` mutations, `flushAll`, `flushDb`, `keys`, `dbSize`, `waitReplicas`, and `waitAof` run on every slot-owning master, and their replies
-are folded into one. One master failing fails the whole call, with no partial result. A master that is only reconnecting, or refusing with `-LOADING`
-or `-TRYAGAIN`, is retried on the `maxRedirects` budget; a retried `waitReplicas` or `waitAof` waits again there. A `-CLUSTERDOWN` is not retried,
-since it may have moved the masters the call fanned out to.
+No node sees the whole keyspace, and a cluster replicates neither the script nor the function cache. So `scriptLoad`, `scriptExists`, `scriptFlush`,
+the `function*` mutations, `flushAll`, `flushDb`, `keys`, `dbSize`, `waitReplicas`, and `waitAof` run on every slot-owning master, and their replies
+are folded into one. There is no partial result: if one master fails, the call fails.
+
+This is also the one case where Sage does not retry a `-CLUSTERDOWN` for you; see
+[Refusals Sage retries for you](/error-handling#refusals-sage-retries-for-you).
 
 ### Topology refresh
 
@@ -89,9 +85,8 @@ val config = SageConfig(
 )
 ```
 
-There is no timer unless you set one. Each admitted tick costs one `CLUSTER SLOTS`, and a tick landing inside the `minRefreshInterval` window is
-skipped, so a short interval cannot outpace it. The first tick is initially eligible, since discovery at connect opens no window, though an
-event-driven refresh before it can still throttle it. `MasterReplicaConfig` has the same setting.
+There is no timer unless you set one. Each refresh costs one `CLUSTER SLOTS`, and ticks arriving within `minRefreshInterval` of the last refresh are
+skipped, so a short interval cannot flood the cluster. `MasterReplicaConfig` has the same setting.
 
 ## Master-replica
 
@@ -113,14 +108,11 @@ The number of endpoints decides where Sage may connect:
 | Several | only the supplied endpoints, each classified by its own `ROLE`. Addresses that `ROLE` advertises are ignored, and a replica is used once it reports `connected` |
 | One | the supplied endpoint and the master or replicas discovered from its `ROLE` reply |
 
-Use several endpoints for managed deployments whose stable primary and reader names differ from the per-node addresses Redis advertises. An
-unreachable supplied endpoint is omitted when the roles are resolved, allowing a partially available deployment to connect. It can be considered
-again when an existing reconnect or routing failure triggers a later role refresh. A supplied replica that is still synchronizing is likewise
-omitted until a later event-driven refresh sees its own `ROLE` state become `connected`.
+Use several endpoints for managed deployments whose stable primary and reader names differ from the per-node addresses Redis advertises.
 
-With `ReplicaPreferred`, a read that falls back to the master while no replica is known also schedules this throttled refresh. This lets an
-omitted reader return to service under otherwise healthy master-only traffic without any polling. Once one replica is known, a second one is
-only picked up by `topologyRefreshInterval`; see [Topology refresh](#topology-refresh).
+An endpoint that is unreachable, or a replica that is still synchronizing, is left out at connect time so a partially available deployment still
+connects. Sage picks it up again on its own once traffic reveals the topology has changed, with no polling. Adding a *second* replica is the case
+nothing signals, so set `topologyRefreshInterval` if you scale readers out; see [Topology refresh](#topology-refresh).
 
 ## Read routing
 
@@ -159,10 +151,10 @@ The remaining fields tune connection lifecycle, pooling, and observability. Each
 
 | Field | Tunes | Defaults |
 | --- | --- | --- |
-| `connectTimeout` | per socket connect/TLS step and per bootstrap command (`HELLO 3`, identification, optional `SELECT`/`CLIENT SETNAME`, cache setup) | `10.seconds` |
+| `connectTimeout` | each socket connect, TLS handshake, and connection-setup command | `10.seconds` |
 | `reconnect` (`BackoffConfig`) | exponential reconnect backoff with full jitter | `50.millis` to `5.seconds`, ×2 |
 | `watchdog` (`WatchdogConfig`) | idle-connection liveness ping (death detector) | ping every `60.seconds`, `30.seconds` timeout |
-| `closeTimeout` | how long `close` waits for in-flight commands on the multiplexed connection to drain (blocking commands and transactions on the dedicated pool are force-closed at once) | `5.seconds` |
+| `closeTimeout` | how long `close` waits for in-flight commands to drain (blocking commands and transactions are closed at once) | `5.seconds` |
 | `dedicatedPool` (`DedicatedPoolConfig`) | the pool behind blocking commands and transactions, per node | max `8`, acquire `5.seconds`, idle `30.seconds` |
 | `pubsub` (`PubSubConfig`) | per-subscription message buffer size | `128` |
 | `clientCache` (`CacheConfig`) | client-side caching on/off and size cap | enabled, `64 MB` |

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -18,7 +18,7 @@ Every Sage failure is a `SageException`, a single sealed hierarchy you can match
 | `TimedOut(message)` | A blocking command or transaction waited past `dedicatedPool.acquireTimeout` for a free pooled connection. Not a per-command timeout; bound a command's own duration with your backend's timeout combinator. |
 | `TransactionDiscarded(message)` | A transaction was discarded server-side (`EXECABORT`); nothing ran. |
 | `NotCacheable(message)` | `cached` was given a command that cannot be safely cached. |
-| `InvalidArgument(message)` | An argument the API can never accept: an invalid configuration or rate-limit policy, a blocking command in a pipeline or transaction, or a command a cluster client cannot serve as routed (an all-masters command in a cluster pipeline, a cluster-wide result in a single-node transaction, a hand-built command it cannot route by key). A programming error, rejected before any server call. |
+| `InvalidArgument(message)` | A programming error, rejected before any server call: an invalid configuration or rate-limit policy, a blocking command inside a pipeline or transaction, or a command a cluster client cannot route as written. |
 
 ## Branching on the failure
 
@@ -67,10 +67,10 @@ Retries are bounded and spaced by a short random delay, sharing the cluster's `m
 reaches you as a `ServerError`, code intact. A read tries its next [`ReadFrom`](/configuration#read-routing) candidate first, so a refusing replica
 costs one hop when the master or another replica can serve it.
 
-Commands that run on every master are the exception: a `-CLUSTERDOWN` there reaches you, because the failover may have moved the masters the call
-fanned out to. Retry it yourself, remembering that the fan-out is not atomic, so masters that already ran it run it again. Harmless for the read-only
-ones, `SCRIPT LOAD`, and the `FLUSH` family. `FUNCTION LOAD`, `FUNCTION DELETE`, and `FUNCTION RESTORE` answer `already exists` or `not found` unless
-you pass `replace = true`, or `RestorePolicy.Replace` or `RestorePolicy.Flush`.
+The exception is [commands that run on every master](/configuration#commands-that-run-on-every-master): a `-CLUSTERDOWN` there reaches you, because
+the failover may have moved the very masters the call fanned out to. Retry it yourself, keeping in mind that the fan-out is not atomic, so masters
+that already ran the command run it again. That is harmless for reads, `SCRIPT LOAD`, and the `FLUSH` family, but the `FUNCTION` mutations refuse a
+second run unless you pass `replace = true` (or `RestorePolicy.Replace` / `RestorePolicy.Flush`).
 
 ## How failures surface per backend
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,9 +6,9 @@ Implementing RESP3, the commands, and the codecs directly in Scala keeps the cor
 
 ## How does Sage perform?
 
-Fast, by design rather than by tuning. Ordinary commands from every fiber share one auto-pipelined connection per node: a writer drains the send queue and coalesces whatever is waiting into a single socket write, so concurrent commands collapse into one syscall and one round trip instead of one each. The I/O runs on virtual threads with plain blocking reads and writes, with no callbacks and no carrier pinning, and replies are matched to in-flight commands through a lock-free queue, so the reader and writer never contend. With no Java client underneath, the RESP3 parser and codecs decode straight to your types with full control over allocation.
+Fast by design rather than by tuning. Commands from every fiber share one auto-pipelined connection per node, so concurrent commands coalesce into a single socket write and one round trip instead of one each. The I/O runs on virtual threads with plain blocking reads and writes, and replies are matched to in-flight commands without the reader and writer contending. With no Java client underneath, the RESP3 parser and the codecs decode straight to your types.
 
-In practice Sage matches or beats the established Scala clients on concurrent workloads. Run [the benchmarks](https://github.com/ghostdogpr/sage/tree/main/benchmarks) yourself: they pit Sage against Lettuce, redis4cats, and zio-redis on a real server. No numbers are committed because competitor results drift with their versions, so measure fresh on your own hardware.
+In practice Sage matches or beats the established Scala clients on concurrent workloads. Run [the benchmarks](https://github.com/ghostdogpr/sage/tree/main/benchmarks) yourself against a real server. No numbers are committed, since results drift with every version, so measure on your own hardware.
 
 ## Which backend artifact should I use?
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -162,7 +162,7 @@ Two cases step off that connection automatically. Commands that hold per-connect
 
 ## A short tour
 
-The snippets below show the same operations on each backend: pick your tab. In Ox they return values directly; in ZIO, Cats Effect, Kyo, and Pekko they are steps in a for-comprehension over that ecosystem's effect type, where on Pekko that type is `scala.concurrent.Future` (each `for` needs an `ExecutionContext`, for example `system.executionContext`). Each assumes a `client` in scope and the usual imports for your effect type (plus `import scala.concurrent.duration.*` where a duration appears).
+The snippets below show the same operations on each backend: pick your tab. In Ox they return values directly; on the other backends they are steps in a for-comprehension over that ecosystem's effect type (`Future` on Pekko, which means each `for` needs an `ExecutionContext`). All of them assume a `client` in scope and the usual imports for your effect type.
 
 ### Commands
 
@@ -272,7 +272,7 @@ The distinction is covered in [Pipelines & transactions](/pipelines-transactions
 
 Subscribing yields a stream of messages in your ecosystem's native stream type: an Ox `Flow`, a ZIO `ZStream`, an fs2 `Stream`, a Kyo `Stream`, or a Pekko Streams `Source`. Ending the stream, or closing its scope, unsubscribes.
 
-These examples publish right after subscribing, so they use the variant that waits for the server to confirm the subscription first: `subscribeScoped` on ZIO, Kyo, and Ox, `subscribeResource` on Cats Effect, and on Pekko the `Future[Done]` that `subscribe` materializes. Plain `subscribe` registers lazily on each run and suits a long-lived consumer that is not racing its own publisher. See [Pub/Sub](/pubsub) for the details.
+These examples publish immediately after subscribing, so they use the variant that waits for the server to confirm the subscription first. [Pub/Sub](/pubsub) explains when you need it.
 
 ::: code-group
 
@@ -316,8 +316,7 @@ for {
 ```
 
 ```scala [Pekko]
-// Keep.both keeps the confirmation Future[Done] and the collected messages;
-// await it before publishing so the publish can't outrun the registration (best-effort in cluster)
+// Keep.both gives both the confirmation Future[Done] and the collected messages
 val (confirmed, collected) =
   client.subscribe[String]("news").take(3).toMat(Sink.seq)(Keep.both).run()
 val messages =

--- a/docs/json.md
+++ b/docs/json.md
@@ -1,10 +1,12 @@
 # JSON
 
-Sage supports the `JSON.*` command surface shipped by Redis 8, which has JSON built in (RedisJSON), and by the Valkey Bundle (the valkey-json module). Documents are stored server-side and addressed with JSONPath expressions. Sage takes no JSON-library dependency: a document is raw JSON text on the wire, and any structured typing is your own codec.
+Sage supports the `JSON.*` commands, which store documents server-side and address them with JSONPath expressions. You need a server that provides them: Redis 8 has JSON built in, and on Valkey they come from the valkey-json module (shipped in the `valkey/valkey-bundle` image, not in the stock `valkey` one).
+
+Sage takes no JSON-library dependency. A document is raw JSON text on the wire, and any structured typing comes from your own codec.
 
 ## Paths
 
-Every JSON command locates values with a `JsonPath`. Sage supports the JSONPath dialect (expressions beginning with `$`), and a path defaults to the document root `$`. Location commands always send an explicit path; `jsonGet` alone omits it when you pass none, to return the whole document unwrapped (see below).
+Every JSON command locates values with a `JsonPath`, using the JSONPath dialect (expressions beginning with `$`). A path defaults to the document root `$`.
 
 ```scala
 JsonPath.root          // $
@@ -118,8 +120,7 @@ client.jsonMSet(("{acct:9}:profile", JsonPath.root, "{}"), ("{acct:9}:prefs", Js
 
 The common surface behaves the same on both servers. A few points differ:
 
-- `jsonMerge` (RFC 7386 merge) is available on Redis only; the Valkey Bundle 9.1.0 does not ship `JSON.MERGE` yet. Sage exposes it, and it works against Redis.
-- The two servers frame the replies to `jsonType`, `jsonNumIncrBy`, and `jsonNumMultBy` differently on the wire. Sage decodes both into the same result type, so your code does not see the difference.
-- `jsonSet` into a missing intermediate path that cannot be created returns `false` on Redis but raises a server error on Valkey.
+- `jsonMerge` (RFC 7386 merge) works on Redis only. Valkey does not ship `JSON.MERGE` yet.
+- `jsonSet` into a missing intermediate path that cannot be created returns `false` on Redis but fails with a server error on Valkey.
 
-Redis 8 ships JSON built in, but the stock `valkey` image carries no modules, so the tests run against JSON-capable images: `redis:8.8.0` and `valkey/valkey-bundle` (which adds valkey-json).
+The two servers also frame a few replies differently on the wire, but Sage decodes both into the same result type, so your code does not see it.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -19,9 +19,7 @@ Register one or more `SageListener` on `SageConfig`, and each receives every `Sa
 | `Cache.Hit(command)` / `Cache.Miss(command)` | A `cached` read was served locally, or had to fetch from the server. |
 | `TopologyChanged(masters)` | The cluster's slot-owning master set changed (a failover, or scaling a shard in or out). |
 
-Events carry no command arguments or payloads, so secrets such as `AUTH` credentials and user values never reach a listener. Where an event carries `node`, it is `Some` for cluster and master-replica clients (the relevant node) and `None` for a standalone client.
-Repeated connection-establishment and topology-qualification failures for the same node produce one `ConnectFailed` until a pooled connection to that node succeeds.
-`ConnectFailed` concerns establishing a connection to a node; `ReconnectFailed` concerns restoring an already-established one.
+Events carry no command arguments or payloads, so secrets such as `AUTH` credentials and user values never reach a listener. Where an event carries `node`, it is `Some` for cluster and master-replica clients and `None` for a standalone client. A node that keeps failing to connect produces one `ConnectFailed`, not one per attempt.
 
 ### Registering a listener
 
@@ -53,19 +51,15 @@ val config = SageConfig(
 
 ### Delivery guarantees
 
-Listeners are invoked off the command path, so they cannot block or break command execution:
-
-- The callback must not block. A slow listener only delays event delivery.
-- A thrown exception is swallowed.
-- Events are shed once the internal dispatch queue fills, so delivery is lossy under load.
+Listeners are invoked off the command path, so a slow or throwing listener cannot block or break command execution. It only delays or loses events.
 
 ::: warning
-Delivery is best-effort: events are dropped once the dispatch queue fills, and a throwing listener is swallowed. Listeners suit metrics, sampling, and operational logging, not anything that must be a complete or lossless record.
+Delivery is best-effort: a thrown exception is swallowed, and events are dropped once the internal dispatch queue fills. Listeners suit metrics, sampling, and operational logging, not anything that must be a complete record.
 :::
 
 ## Distributed tracing
 
-A `SageListener` is the wrong tool for distributed tracing: by the time it runs on the dispatcher thread the caller's trace context is gone, so its spans would not nest under the in-flight request, and a dropped event would orphan a span. A `CommandTracer` instead runs synchronously on the command path, so each Redis span is a child of whatever span is active when the command is issued.
+Use a `CommandTracer` rather than a listener here: it runs synchronously on the command path, so each Redis span is a child of whatever span is active when the command is issued. A listener runs too late, off that path, and its spans would be orphaned.
 
 Set one on `SageConfig.tracer`. The `sage-opentelemetry` module provides an OpenTelemetry implementation:
 
@@ -83,13 +77,11 @@ val config = SageConfig(
 )
 ```
 
-It emits one `CLIENT` span per command, named for the command (`GET`, `SET`, ...), with `db.system=redis`, `db.operation.name`, `peer.service` (default `redis`, configurable), `component=redis-client`, and the server address (the configured endpoint for a standalone server, the routed node for a cluster or master/replica); a failure sets an error status carrying the exception. Only the command name is recorded, never arguments or keys, so secrets and user values stay out of your traces. Spans follow the ambient sampling decision.
+It emits one `CLIENT` span per command, named for the command (`GET`, `SET`, ...), carrying `db.system`, `db.operation.name`, `peer.service` (default `redis`, configurable), `component`, and the server address; a failure sets an error status with the exception. Only the command name is recorded, never arguments or keys, so secrets and user values stay out of your traces. Spans follow the ambient sampling decision.
 
-One span is emitted per command that reaches the server: an ordinary command, a blocking command, and each command in a pipeline (cluster redirects fold into the command's own span). A `cached` read served from the local cache reaches no server and produces no span; one that misses and fetches from the server is traced like any other command.
+One span is emitted per command that reaches the server, including each command in a pipeline (cluster redirects fold into the command's own span). A `cached` read served locally reaches no server and produces no span; one that misses is traced like any other command. In a `transaction`, the watch-phase reads are traced individually and the `MULTI`/`EXEC` body gets a single span named `MULTI`, which reflects the round trip rather than whether the transaction committed.
 
-In a `transaction`, each read during the watch phase and the `WATCH` itself are traced like ordinary commands, and the atomic `MULTI`/`EXEC` body gets a single span named `MULTI`. That span reflects the round trip, not whether the transaction committed, so a `WATCH` abort or an error inside `EXEC` still settles it successfully. Transaction commands are traced but emit no `CommandCompleted`, so the listener contract is unchanged.
-
-The tracer reads the active span from OpenTelemetry's thread-local current context (`Context.current()`) on the fiber that submits the command. The module depends only on the OpenTelemetry API, so an APM agent supplies the implementation: when the agent instruments your runtime and propagates its context across that runtime's threads, the Redis span nests under the active request span with no further wiring. This is the case for ZIO under the Datadog Java agent. Configuring the agent itself (for Datadog, enabling its OpenTelemetry support) is covered by the agent's own documentation.
+The tracer reads the active span from OpenTelemetry's thread-local current context (`Context.current()`) on the fiber that submits the command, and the module depends only on the OpenTelemetry API. So under an APM agent that instruments your runtime and propagates context across its threads, the Redis span nests under the active request span with no further wiring. That is the case for ZIO under the Datadog Java agent; configuring the agent itself is covered by its own documentation.
 
 ### Context on a fiber runtime without an agent
 

--- a/docs/pipelines-transactions.md
+++ b/docs/pipelines-transactions.md
@@ -4,11 +4,7 @@ Both group several commands together, but they answer different needs. A **pipel
 
 ## Pipelines
 
-A pipeline is an applicative composition of `Command` values, sent in one round-trip and decoded into a typed tuple. There is no atomicity: other clients' commands may interleave, and in a cluster the pipeline is split and routed per key, then reassembled in order.
-
-A supported cross-slot command (`MGET`, `MSET`, `EXISTS`, `DEL`, `UNLINK`, or `TOUCH`) inside a cluster pipeline is itself split once more by exact
-slot and merged back into its one logical pipeline position. Each slot-specific operation is atomic individually, not across the cluster;
-write subgroups may already have applied when another subgroup fails.
+A pipeline is a composition of `Command` values, sent in one round-trip and decoded into a typed tuple. There is no atomicity: other clients' commands may interleave, and in a cluster the pipeline is split and routed per key, then reassembled in order. [Cross-slot commands](/configuration#supported-cross-slot-commands) work inside a pipeline exactly as they do on their own.
 
 ::: code-group
 
@@ -124,7 +120,7 @@ A few rules follow from how Redis transactions work:
 - **A queueing-phase rejection discards the whole transaction**, so nothing runs.
 - **An execution-phase error leaves the other commands committed.** Redis does not roll back, so those errors surface per position, like a pipeline.
 - **In a cluster, every key in the transaction must hash to one slot** (use a [hash tag](/configuration#hash-tags) to force that). A pipeline has no such restriction for commands with documented cross-slot support.
-- **In a cluster, bound your retries.** A transaction never follows a redirect, because that would break atomicity, so the whole block is retried by the caller, exactly as a `WATCH` abort already requires. While a slot is migrating, a key that has already moved keeps answering `ASK` until the migration finalizes, and no retry can commit until then. Retry with backoff and a ceiling rather than in a tight loop.
+- **In a cluster, bound your retries.** A transaction never follows a redirect, since that would break atomicity, so you retry the whole block yourself, exactly as a `WATCH` abort already requires. While a slot is migrating no retry can commit until the migration finalizes, so retry with backoff and a ceiling rather than in a tight loop.
 
 ## Which to use
 

--- a/docs/pubsub.md
+++ b/docs/pubsub.md
@@ -48,8 +48,7 @@ for {
 ```
 
 ```scala [Pekko]
-// Keep.both keeps the confirmation Future[Done] alongside the collected messages;
-// await it before publishing so the publish can't outrun the registration (best-effort in cluster)
+// await the confirmation before publishing so the publish can't outrun the subscription
 val (confirmed, collected) =
   client.subscribe[String]("news").take(3).toMat(Sink.seq)(Keep.both).run()
 val messages =
@@ -72,7 +71,7 @@ The plain `subscribe` returns the stream immediately and registers the subscript
 - **Ox**: `subscribeScoped`, bound to the enclosing Ox scope.
 - **Pekko**: plain `subscribe` returns a `Source` whose materialized `Future[Done]` completes once registered; await it before publishing.
 
-The examples above use these. Confirmation closes the race on a standalone or master-replica server; in cluster mode it is best-effort, as on every backend. With the scoped and resource variants that scope owns the unsubscribe, so the subscription outlives the stream and is released when the scope closes; on Pekko, ending the `Source` (cancel, complete, or fail) unsubscribes.
+Confirmation closes the race on a standalone or master-replica server; in a cluster it is best-effort. With the scoped and resource variants the scope owns the unsubscribe, so the subscription outlives the stream and is released when the scope closes. On Pekko, ending the `Source` unsubscribes.
 :::
 
 ::: tip Connection isolation
@@ -81,9 +80,10 @@ All classic subscriptions share one **subscription connection**, created the fir
 
 ## Sharded channels (cluster)
 
-In a cluster, a **shard channel** keeps its traffic within the shard that owns the channel's slot: `sSubscribe` and `sPublish` target that owning node rather than broadcasting across the whole cluster. There is no pattern form, and a delivery surfaces as an ordinary message.
+In a cluster, a **shard channel** keeps its traffic within the shard that owns the channel's slot: `sSubscribe` and `sPublish` target that owning node rather than broadcasting across the whole cluster. There is no pattern form, and a delivery arrives as an ordinary message.
 
-```scala [ZIO]
+```scala
+// ZIO; the shape is the same on every backend
 ZIO.scoped {
   for {
     stream   <- client.sSubscribeScoped[String]("orders")
@@ -93,6 +93,6 @@ ZIO.scoped {
 }
 ```
 
-The shape is the same on every backend, using each one's native stream type exactly as classic pub/sub does. Sage holds one sharded subscription connection per owning node and re-homes the affected subscriptions automatically when a slot migrates or a node fails over.
+Sage holds one sharded subscription connection per owning node and re-homes the affected subscriptions automatically when a slot migrates or a node fails over.
 
 See [Configuration](/configuration) for how to connect to a cluster.

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -2,7 +2,7 @@
 
 A **rate limiter** caps how often something may happen: so many requests per second for an API key, a budget of login attempts per account, a fair-use quota per tenant. Sage ships one built in, so every client has it with no extra dependency.
 
-The limiter is **distributed**. Its state lives on the server, not in process memory, so the limit holds across every process pointed at the same server (they share the keyspace, not a connection). Each check runs its whole decide-and-consume cycle atomically on the server; in steady state that is a single round trip. The script is cached on the server, so only a cold server (or one after `SCRIPT FLUSH`) costs a second round trip to resend the script body. In a cluster that resend goes to the node owning the subject's key, like the check itself.
+The limiter is **distributed**. Its state lives on the server, not in process memory, so the limit holds across every process pointed at the same server. Each check decides and consumes atomically on the server, in a single round trip.
 
 `rateLimiter` binds a policy to the client. Each `tryAcquire` consumes tokens for a subject and returns a `Decision`.
 
@@ -48,8 +48,6 @@ RateLimit(permits = 100, per = 1.second, burst = 200) // 100/s sustained, bursti
 
 There is no blocking `acquire`: `tryAcquire` never waits. To retry, sleep for `retryAfter` at the call site and try again.
 
-Waits are reported at microsecond resolution, saturating at `RateLimiter.maximumReportedWait` if a server-clock rollback ever pushes one past what a `FiniteDuration` holds.
-
 ## Peek and reset
 
 - `peek(subject)` reports the current standing without consuming: `Allowed` while at least one token is available, otherwise `Denied` with the wait until one is. The bucket is still refilled by elapsed time, but no tokens are taken.
@@ -69,30 +67,23 @@ A subject can be any type with a `KeyCodec`. It is encoded and prefixed with a n
 client.rateLimiter[String](RateLimit.perSecond(100), namespace = "login")
 ```
 
-Give each policy that is active at the same time its own namespace. A namespace that does see its policy change, during a rolling deployment say, carries its buckets over safely: a bucket records the policy that created it, and on a change each subject keeps the lesser of its whole tokens and the new capacity, drops the fraction, and refills under the new settings. That stops overlapping old and new instances from handing out full buckets repeatedly. Idle full buckets expire quickly, so a subject first seen after the switch starts at the new capacity.
+Give each policy that is active at the same time its own namespace. Changing the policy on an existing namespace is safe during a rolling deployment: a bucket remembers the policy that created it, and on a change each subject carries over the lesser of its current tokens and the new capacity, so overlapping old and new instances cannot hand out full buckets repeatedly.
 
-## Valid policies
+## Invalid policies
 
-A policy and a `cost` must satisfy:
+A policy needs a positive `capacity` and `refillTokens` and a `refillPeriod` of at least a microsecond, and `cost` must be between `1` and `capacity`. Very large values are also rejected, since the server-side arithmetic has to stay exact.
 
-- `capacity` greater than 0, `refillTokens` greater than 0, `refillPeriod` at least one microsecond.
-- `capacity`, `refillTokens`, and `refillPeriod` in microseconds each within `2^53` (the range a server-side Lua number represents exactly).
-- `capacity` multiplied by `refillPeriod` in microseconds within `2^53`, so the refill arithmetic stays exact on the server.
-- `cost` in the range `1` to `capacity`.
-
-Violations are a programming error, not a runtime outcome. On the `rateLimiter` factory path (`tryAcquire`, `peek`) a bad policy or cost fails with a typed `SageException.InvalidArgument` through the effect before any server call. On the composable `command` path the server rejects the call with an error and never modifies the bucket.
+These are programming errors, not runtime outcomes: `tryAcquire` and `peek` fail with `SageException.InvalidArgument` before any server call.
 
 ## When the store is unreachable
 
-A check reaches the server, so it can fail when the server is unreachable. The failure surfaces through the effect `F` for the caller to handle, exactly like any other command. Sage applies no fallback of its own: decide at the call site whether an outage should admit the request (availability first) or reject it (protection first).
+A check reaches the server, so it fails like any other command when the server is unreachable, through the effect `F`. Sage applies no fallback of its own: decide at the call site whether an outage should admit the request (availability first) or reject it (protection first).
 
 ## Capacity planning
 
-Each check is one cached-script request and one constant-time atomic operation. It rewrites a small hash and refreshes its expiry, so it consumes write throughput even on a denial, and the server runs each script serially however many the client multiplexes.
+Each check is one script call and one constant-time atomic operation. It writes even on a denial, so a limiter on every application call adds real write throughput. One key exists per subject whose bucket is not full, expiring once that bucket would be full again, so live keys track the distinct subjects seen within one refill window: long windows over many subjects hold the most state.
 
-One key exists per subject whose bucket is not full, expiring when that bucket would refill completely. Active keys therefore track the distinct subjects seen within one refill window: long windows over high-cardinality subjects retain the most state.
-
-For a limiter on every application call: count its operations, memory, replication, and persistence traffic in the store's capacity test; keep denied callers from retrying in a tight loop; and give it a dedicated deployment or more cluster shards if it would take a material share of an existing store.
+If the limiter would take a material share of an existing store, give it its own deployment or more cluster shards, and keep denied callers from retrying in a tight loop.
 
 ## The composable command
 

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -1,6 +1,6 @@
 # Streams
 
-A Stream is an append-only log. Each entry has a Stream Entry ID (a millisecond timestamp and a per-millisecond sequence) and an ordered, duplicate-permitting list of field/value pairs. You read a Stream by range or by tailing, and you consume it cooperatively through Consumer Groups.
+A stream is an append-only log. Each entry has an ID (a millisecond timestamp plus a sequence number) and an ordered list of field/value pairs, where a field may repeat. You read a stream by range or by tailing it, and several workers can share one cooperatively through a consumer group.
 
 ## Appending and reading
 
@@ -29,11 +29,11 @@ for {
 
 :::
 
-Field and value types are codec-driven, exactly like [other commands](/commands): `xRange[K, F, V]` here decodes string fields and string values.
+Field and value types are codec-driven, exactly like [other commands](/commands): the two type parameters above name the field type and the value type.
 
 ## Consumer groups
 
-A Consumer Group lets several consumers split a Stream's entries between them without overlap. The group tracks a last-delivered ID and a Pending Entries List (PEL) of entries delivered but not yet acknowledged. `xReadGroup` with `GroupReadId.New` (the `>` token) delivers never-seen entries and records them as pending; `xAck` removes them from the PEL once handled.
+A consumer group lets several consumers split a stream's entries between them without overlap. The group tracks a last-delivered ID and a pending entries list (PEL) of entries delivered but not yet acknowledged. `xReadGroup` with `GroupReadId.New` (the `>` token) delivers never-seen entries and records them as pending; `xAck` removes them from the PEL once handled.
 
 ::: code-group
 
@@ -72,10 +72,12 @@ Each command position that admits a special ID token carries its own type, so an
 
 ## Tailing a group
 
-For a long-running worker, `xConsume` tails a group as a stream in your ecosystem's native type. It first drains this consumer's own pending history (at-least-once recovery after a restart), then blocks for new entries. Your handler runs per entry, and the entry is acknowledged only after the handler succeeds, so a failure leaves it in the PEL for another attempt. On Pekko, where a `Future` cannot be cancelled, the loop runs in the background and `xConsume` hands back a `RunningConsumer`: call `stop()` to halt it between entries and await its `completion`. Pekko tailing helpers require a finite block timeout; the default bounded poll keeps stop/cancel responsive.
+For a long-running worker, `xConsume` tails a group and runs your handler on each entry. It first replays this consumer's own pending entries (recovering whatever a previous run left unacknowledged), then blocks waiting for new ones. An entry is acknowledged only once the handler succeeds, so a failure leaves it in the PEL for another attempt.
+
+On Pekko, where a `Future` cannot be cancelled, the loop runs in the background and `xConsume` returns a `RunningConsumer`: call `stop()` to halt it between entries and await its `completion`.
 
 ::: tip At-least-once delivery
-Because an entry is acknowledged only after the handler succeeds, the same entry can be delivered again after a crash or a failed handler. Make your handler idempotent. `xConsume` also blocks while tailing, so it is the body of a long-running worker, not a one-shot read.
+The same entry can be delivered again after a crash or a failed handler, so make your handler idempotent. `xConsume` blocks while tailing: it is the body of a long-running worker, not a one-shot read.
 :::
 
 ::: code-group
@@ -116,4 +118,4 @@ val consumer = client.xConsume[String, String]("workers", "w1", "stream:orders")
 
 :::
 
-Beyond these, the full `X*` surface is available: trimming (`xTrim`), reverse range (`xRevRange`), blocking reads (`xRead`), claim and auto-claim (`xClaim`, `xAutoClaim`), pending inspection (`xPending`), and group management. See the API docs for the complete list.
+Beyond these, the full `X*` surface is available: trimming (`xTrim`), reverse range (`xRevRange`), blocking reads (`xRead`), claim and auto-claim (`xClaim`, `xAutoClaim`), pending inspection (`xPending`), and group management. See the [API docs](https://javadoc.io/doc/com.github.ghostdogpr/sage-core_3/) for the complete list.


### PR DESCRIPTION
A readability pass over `docs/`. The prose was already good, but several pages had drifted into design-note territory: internal mechanics a maintainer cares about but a user cannot act on. `configuration.md` and `rate-limiting.md` were the worst of it.

### Cut

Internals with no user-facing decision behind them:

- **configuration.md** — the `-TRYAGAIN` retry-pacing paragraph (jittered delay, `maxRedirects` budget sharing), which already lived in `error-handling.md`; the topology-refresh throttling walkthrough ("the first tick is initially eligible, since discovery at connect opens no window…"); the master-replica role-refresh mechanics, cut back to what actually needs configuring.
- **rate-limiting.md** — the `2^53` Lua-number bounds, `RateLimiter.maximumReportedWait` and server-clock rollback, script-caching round-trip detail, and the bucket-carryover algorithm. The rules stayed; the derivations went.
- **json.md** — the CI test image names were maintainer info. Rewritten as what a user needs: which server actually provides `JSON.*`.
- **streams.md** — the Pekko "finite block timeout / bounded poll" note.
- **observability.md** — a three-bullet delivery-guarantees list that the warning box directly below it restated.

### Fixed

- `streams.md` opened with capitalized invented terms ("Stream Entry ID", "Consumer Groups") and documented `xRange[K, F, V]` while the example showed two type parameters.
- Cross-slot behavior was explained in both `configuration.md` and `pipelines-transactions.md`; confirmed subscriptions in both `getting-started.md` and `pubsub.md`. Each is now one canonical section plus a link.
- The `-CLUSTERDOWN` fan-out exception is now cross-linked in both directions.
- Broke up the longest run-ons (the `InvalidArgument` table row, the tracing attribute paragraph), and linked the "API docs" mentions to the Scaladoc instead of leaving them as bare text.

### Kept deliberately

The "How it works" aside in `getting-started.md` and the fiber-runtime context-storage section in `observability.md`. Both are dense, but a user hits real problems without them.

Net 106 lines removed, 79 added. `vitepress build` passes.