### PR TITLE
Fire onClosed when the writer tears the transport down

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MultiplexedConnection.scala
@@ -256,19 +256,16 @@ final private[client] class MultiplexedConnection private (
     val lostLiveness = locked {
       if (conn eq current)
         state match {
-          case State.Live         =>
+          case State.Live                        =>
             transition(State.Reconnecting)
             scheduleReconnect(nextReconnectAttempt())
             events.emit(SageEvent.Connection.Disconnected(node))
             true
-          case State.Reconnecting =>
-            scheduleReconnect(0)
-            false
-          case State.Draining     =>
+          case State.Draining                    =>
             transition(State.Closed)
             stopWatchdog()
             false
-          case State.Closed       => false
+          case State.Reconnecting | State.Closed => false
         }
       else false
     }

--- a/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/SocketTransport.scala
@@ -178,8 +178,10 @@ final private[client] class SocketTransport private (
         case _: IOException => ()
       }
       if (locked(threadsStarted)) {
-        writer.interrupt()
-        if (Thread.currentThread() ne writer) writer.join()
+        if (Thread.currentThread() ne writer) {
+          writer.interrupt()
+          writer.join()
+        }
         // fence the reader before onClosed, else an in-flight reply races the consumer's pending drain (#94); interrupt frees a reader
         // parked on backpressure so the join cannot hang
         if (Thread.currentThread() ne reader) {

--- a/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/SocketTransportSpec.scala
@@ -137,6 +137,35 @@ class SocketTransportSpec extends munit.FunSuite {
     }
   }
 
+  test("a failing write fires onClosed even though the writer itself tears the transport down") {
+    @volatile var closedCount = 0
+    val inOnFrame             = new CountDownLatch(1)
+    val release               = new CountDownLatch(1)
+    withTransport(
+      onClosed = () => closedCount += 1,
+      onFrame = _ => {
+        inOnFrame.countDown()
+        release.await()
+      }
+    ) { (transport, peer) =>
+      try {
+        peer.getOutputStream.write("+PONG\r\n".getBytes(StandardCharsets.UTF_8))
+        peer.getOutputStream.flush()
+        assert(inOnFrame.await(5, TimeUnit.SECONDS), "reader should reach frame delivery")
+        peer.setSoLinger(true, 0)
+        peer.close()
+        var sent = 0
+        while (transport.writer.isAlive && sent < 200) {
+          transport.send(new RecordingItem(s"PING $sent\r\n"))
+          sent += 1
+          Thread.sleep(5)
+        }
+        awaitUntil(closedCount == 1, "onClosed after a writer-initiated teardown")
+      } finally release.countDown()
+      transport.close()
+    }
+  }
+
   test("a malformed frame poisons the connection") {
     @volatile var closedCount = 0
     withTransport(onClosed = () => closedCount += 1) { (transport, peer) =>

--- a/sage-core/src/main/scala/sage/protocol/RespParser.scala
+++ b/sage-core/src/main/scala/sage/protocol/RespParser.scala
@@ -71,7 +71,10 @@ final private[sage] class RespParser {
             if (highWater > MaxRetainedBuffer) quietDrains = 0
             else {
               quietDrains += 1
-              if (quietDrains >= ShrinkAfterDrains) buf = Array.emptyByteArray
+              if (quietDrains >= ShrinkAfterDrains) {
+                buf = Array.emptyByteArray
+                quietDrains = 0
+              }
             }
           }
           highWater = 0


### PR DESCRIPTION
`SocketTransport.terminate()` interrupted the writer unconditionally, then joined whichever I/O thread was not the caller:

```scala
writer.interrupt()
if (Thread.currentThread() ne writer) writer.join()
if (Thread.currentThread() ne reader) {
  reader.interrupt()
  reader.join()
}
drainQueue()
onClosed()
```

When the **writer** thread is the one running `terminate()`, `writer.interrupt()` sets the calling thread's own interrupt flag, so the `reader.join()` below throws `InterruptedException` immediately. Since `terminate()` runs from `writeLoop`'s `finally`, that exception escapes past `writeLoop`'s catch clauses and `drainQueue()` / `onClosed()` never run.

The writer is the terminating thread whenever `out.write` fails, which is the normal outcome when a peer resets the connection while we are writing. The reader-initiated path (peer EOF) is unaffected, since there `writer.interrupt()` targets a different thread, which is why no existing test caught this.

Without `onClosed`, `MultiplexedConnection.Conn.onClosed` never runs, so:

- commands already in `pending` never get their callbacks, and sage has no per-command timeout, so those fibers hang forever
- `onConnTerminated` never fires: state stays `Live`, `liveEpoch` stays set, and no reconnect is ever scheduled, so every later command fails `ConnectionLost(false)` for the life of the client instead of reconnecting
- the watchdog cannot recover it either. It sees the stranded `pending` head and calls `Conn.close()`, but `terminate()`'s CAS has already flipped, so it returns without firing `onClosed`, every tick, forever
- `ClientCache` is never flushed, so invalidations are lost while that generation keeps serving cached reads until entries expire

The fix guards the interrupt with the same `ne` check as the join. A thread already inside `terminate()` is unwinding on its own and needs no interrupt.

Two smaller fixes ride along:

- `MultiplexedConnection.onConnTerminated`'s `State.Reconnecting` branch called `scheduleReconnect(0)`, which resets `reconnectAttempt` to 0 and adds a second pending attempt. Entering `Reconnecting` always leaves an attempt scheduled, so that branch could only double-schedule and defeat the flap backoff. It is unreachable under the current invariant (`current` is only assigned at the `Live` edge, and a `Conn`'s `onClosed` fires once per transport), so it is folded in with `Closed`.
- `RespParser` released its oversized buffer without resetting `quietDrains`, so after the first shrink the counter stayed at the threshold and every later oversized buffer was released on its first quiet drain rather than after `ShrinkAfterDrains`.

## Testing

New `SocketTransportSpec` case: park the reader inside `onFrame` so it cannot claim the teardown, reset the peer with `setSoLinger(true, 0)`, then write until the writer unwinds. Verified it fails against the unfixed transport (`timed out waiting for: onClosed after a writer-initiated teardown`) and passes with the fix, with the suite's other 8 cases unaffected either way.

`sbt check` clean and `sbt testUnit` green across every backend (765 core, 366 clientZio, 209 each for ce/ox/pekko/kyo, 7 opentelemetry).
