### PR TITLE
Keep a pipeline's same-slot retries in submission order

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -1,6 +1,7 @@
 package sage.client.internal
 
 import java.util.Locale
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.util.concurrent.locks.ReentrantLock
 
@@ -757,16 +758,31 @@ final private[client] class ClusterLive(
     deferred: Vector[() => CommandSpan],
     plan: SplitPlan
   ): Unit = {
-    val n                         = p.commands.length
-    val collector                 =
+    val n                           = p.commands.length
+    val collector                   =
       new TxSupport.IndexedCollector[Either[SageException, Any]](n, results => complete(Success(results)))
-    val emits                     = Vector.tabulate(n) { i =>
-      val span = if (deferred.isEmpty) CommandSpan.noop else Events.startDeferred(deferred(i))
-      Events.trackCommand[Any](events, p.commands(i), (result: Try[Any]) => collector.set(i, TxSupport.toEither(result)), span)
+    // a position opens its gate as it settles; a retry waits out the gate of the one before it on its slot, so same-key writes cannot invert
+    val gates                       = Vector.fill(n)(new CountDownLatch(1))
+    val slotAt                      = p.commands.map(slotOf)
+    val emits                       = Vector.tabulate(n) { i =>
+      val span                     = if (deferred.isEmpty) CommandSpan.noop else Events.startDeferred(deferred(i))
+      val settle: Try[Any] => Unit = result => {
+        gates(i).countDown()
+        collector.set(i, TxSupport.toEither(result))
+      }
+      Events.trackCommand[Any](events, p.commands(i), settle, span)
+    }
+    def awaitTurn(index: Int): Unit = {
+      val previous = if (slotAt(index) < 0) -1 else slotAt.lastIndexOf(slotAt(index), index - 1)
+      if (previous >= 0) gates(previous).await()
     }
     // all-or-nothing: reroutes honor the same choice so a slot is never split across master and replica
-    val useReplica                = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
-    def reroute(index: Int): Unit = dispatch(p.commands(index), cluster.maxRedirects, emits(index), allowReplica = useReplica)
+    val useReplica                  = readFrom != ReadFrom.Master && p.commands.forall(ReadRouting.replicaEligible)
+    // on the caller thread, so the wait gets a thread of its own; a retry from a reply is already offloaded
+    def reroute(index: Int): Unit   = scheduler.offload {
+      awaitTurn(index)
+      dispatch(p.commands(index), cluster.maxRedirects, emits(index), allowReplica = useReplica)
+    }
 
     plan.rejected.foreach {
       case (index, Rejected.CrossSlot(slots)) =>
@@ -779,9 +795,17 @@ final private[client] class ClusterLive(
     if (plan.perNode.isEmpty) plan.keyless.foreach(reroute)
     plan.perNode.zipWithIndex.foreach { case (NodeGroup(node, positions), groupIndex) =>
       // sorted: keep each node's batch in submission order even when keyless positions are folded into the first group
-      sendBatch(node, if (groupIndex == 0) (positions ++ plan.keyless).sorted else positions, p, emits, reroute, useReplica)
+      sendBatch(node, if (groupIndex == 0) (positions ++ plan.keyless).sorted else positions, p, emits, reroute, awaitTurn, useReplica)
     }
   }
+
+  // the slot a retry orders on; -1 for a keyless or cross-slot position, which orders against nothing
+  private def slotOf(command: Command[?]): Int =
+    topologyRef.get().route(command) match {
+      case Route.ToNode(_, slot) => slot.value
+      case Route.Unowned(slot)   => slot.value
+      case _                     => -1
+    }
 
   private def sendBatch[Out, R](
     node: Node,
@@ -789,22 +813,23 @@ final private[client] class ClusterLive(
     p: Pipeline[Out, R],
     emits: Vector[Try[Any] => Unit],
     reroute: Int => Unit,
+    awaitTurn: Int => Unit,
     useReplica: Boolean
   ): Unit =
     // the batch attributes to the node it lands on (a replica when useReplica)
     if (useReplica) {
       val replicas = topologyRef.get().shards.collectFirst { case s if s.master == node => s.replicas }.getOrElse(Vector.empty)
       reads.pickOne(reads.candidatesFor(node, replicas), node) {
-        case Some(picked) => submitBatch(picked.node, picked.client, indices, p, emits, reroute, useReplica)
+        case Some(picked) => submitBatch(picked.node, picked.client, indices, p, emits, reroute, awaitTurn, useReplica)
         case None         => indices.foreach(reroute)
       }
     } else {
       val existing = masterPool.existing(node)
-      if (existing != null) submitBatch(node, existing, indices, p, emits, reroute, useReplica)
+      if (existing != null) submitBatch(node, existing, indices, p, emits, reroute, awaitTurn, useReplica)
       else
         scheduler.offload {
           val nc = masterPool.getOrEstablishOrNull(node)
-          submitBatch(node, nc, indices, p, emits, reroute, useReplica)
+          submitBatch(node, nc, indices, p, emits, reroute, awaitTurn, useReplica)
         }
     }
 
@@ -815,6 +840,7 @@ final private[client] class ClusterLive(
     p: Pipeline[Out, R],
     emits: Vector[Try[Any] => Unit],
     reroute: Int => Unit,
+    awaitTurn: Int => Unit,
     useReplica: Boolean
   ): Unit = {
     def settle(index: Int, result: Try[Any]): Unit = {
@@ -827,6 +853,7 @@ final private[client] class ClusterLive(
         // a fault's disposition can block on CLUSTER SLOTS, whose reply needs this very reader thread
         case Failure(error) =>
           scheduler.offload {
+            awaitTurn(index)
             Fault.categorize(error) match {
               // ASK keeps the slot's owner, so re-routing by topology bounces off the exporting node and burns a redirect; follow it straight
               // to the importing node with ASKING. MOVED and connection loss re-route normally.

--- a/sage-client/shared/src/test/scala/sage/client/internal/StaggeringScheduler.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/StaggeringScheduler.scala
@@ -1,0 +1,26 @@
+package sage.client.internal
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
+/**
+  * Delegates to [[Scheduler.real]], but holds the first zero-delay offload taken after `arm()` back by `delay`, so a path that offloads one
+  * task per position cannot pass by having the earliest one win the race.
+  */
+final class StaggeringScheduler(delay: FiniteDuration) extends Scheduler {
+
+  private val armed = new AtomicBoolean(false)
+
+  def arm(): Unit = armed.set(true)
+
+  def nowMillis: Long = Scheduler.real.nowMillis
+
+  def jitterMillis(boundExclusive: Long): Long = Scheduler.real.jitterMillis(boundExclusive)
+
+  def after(requested: FiniteDuration)(task: => Unit): Unit =
+    if (requested <= Duration.Zero && armed.compareAndSet(true, false)) Scheduler.real.after(delay)(task)
+    else Scheduler.real.after(requested)(task)
+
+  def every(interval: FiniteDuration)(task: => Unit): Scheduler.Cancelable = Scheduler.real.every(interval)(task)
+}

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -1,14 +1,23 @@
 package sage.client
 
 import scala.collection.mutable
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.*
 
 import kyo.compat.*
 
 import sage.Bytes
 import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, InvalidArgument, NotConnected, ServerError, UnsupportedServer}
-import sage.client.internal.{ClusterLive, CountingScheduler, FakeTransport, ManualScheduler, MultiplexedConnection, Replies, Scheduler}
+import sage.client.internal.{
+  ClusterLive,
+  CountingScheduler,
+  FakeTransport,
+  ManualScheduler,
+  MultiplexedConnection,
+  Replies,
+  Scheduler,
+  StaggeringScheduler
+}
 import sage.client.internal.Replies.bulk
 import sage.cluster.{Node, Slot}
 import sage.commands.{BroadcastReduce, Command, Connection, Json, JsonPath, Keys, Scripting, Server, Strings}
@@ -847,6 +856,35 @@ class ClusterClientSpec extends munit.FunSuite {
       assertEquals(result, (Some("from-b"), Some("from-b")))
       assertEquals(fixture.written(nodeA).count(_.contains("GET")), 1, "the refused master must see the batch once, never a retry")
     }
+  }
+
+  private def assertRedirectedWritesStayOrdered(kind: String): Future[Unit] = {
+    val staggering = new StaggeringScheduler(150.millis)
+    val slot       = Slot.of(Bytes.utf8("k")).value
+    val owner      = if (slot < mid) nodeA else nodeB
+    val target     = if (owner == nodeA) nodeB else nodeA
+    val behaviour  = (node: Node, text: String) =>
+      if (text.contains("CLUSTER")) Seq(splitCluster)
+      else if (node == owner) Seq.fill(text.split("\r\nSET\r\n", -1).length - 1)(Frame.SimpleError(s"$kind $slot ${target.host}:${target.port}"))
+      // an ASK follow-up reaches the target as [ASKING, SET]: one reply per command in the payload
+      else Seq.fill(text.split("\r\n(ASKING|SET)\r\n", -1).length - 1)(Frame.SimpleString("OK"))
+    val fixture    = new Fixture(behaviour, Vector(nodeA), scheduler = staggering)
+
+    staggering.arm()
+    fixture.live.pipeline((Strings.set("k", "v1"), Strings.set("k", "v2"))).unsafeRun.map { result =>
+      assertEquals(result, (true, true))
+      val writes = fixture.written(target).filter(_.contains("\r\nSET\r\n"))
+      assertEquals(writes.size, 2)
+      assert(writes.head.contains("v1") && writes.last.contains("v2"), s"the target saw the writes out of order: $writes")
+    }
+  }
+
+  test("two same-slot writes redirected by MOVED are reissued on the new owner in submission order") {
+    assertRedirectedWritesStayOrdered("MOVED")
+  }
+
+  test("two same-slot writes redirected by ASK are followed to the importing node in submission order") {
+    assertRedirectedWritesStayOrdered("ASK")
   }
 
   test("a CLUSTERDOWN retry re-dispatches on the mapping the refresh adopted, not the one that refused") {


### PR DESCRIPTION
A cluster pipeline batch answered with MOVED, ASK, or a self-clearing refusal (TRYAGAIN, CLUSTERDOWN, a connection lost before the batch landed) retried every failed position on its own virtual thread. Nothing ordered those retries, so `pipeline((set("k", "1"), set("k", "2")))` sent to a stale owner could reissue the second write first: both positions report success and the key ends up holding `1`. Redirects are normal during resharding and failover, so this is a silent lost update in ordinary operation.

## Fix

Each position gets a gate that its own emit opens as it settles, and a retry waits out the gate of the position before it on the same slot. Positions on other slots, and keyless ones, keep retrying concurrently, so a batch spread over many slots still recovers in parallel. Waits are acyclic (a position only ever waits on a lower index) and cost a parked virtual thread, which every retry already occupies.

This covers all the paths that reroute a position: a reply's fault disposition, an unowned slot at dispatch, and a batch that never left the client.

## Tests

Two tests, one per redirect kind, driven by a `StaggeringScheduler` that holds the first zero-delay offload back so passing cannot come down to which retry wins the race. Both fail on the current code with `the target saw the writes out of order`.

## Not covered

A supported cross-slot command (`MSET` spanning slots) is dispatched from `plan.rejected` before the per-node batches, so `pipeline((set("{a}k", "2"), mSet("{a}k" -> "1", "{b}k" -> "1")))` can already reverse those two writes with no fault involved. Ordering that needs a scattered command's subgroups interleaved into the batches, which is a separate change.