### PR TITLE
Accept a null endpoint in CLUSTER SLOTS

### DIFF
--- a/sage-core/src/main/scala/sage/commands/Cluster.scala
+++ b/sage-core/src/main/scala/sage/commands/Cluster.scala
@@ -32,7 +32,7 @@ private[sage] object Cluster {
     frame match {
       case Frame.Array(elements) if elements.length >= 2 =>
         for {
-          host <- stringOf(elements(0))
+          host <- endpointOf(elements(0))
           port <- intOf(elements(1))
         } yield Node(host, port)
       case other                                         => Left(DecodeError("node array [ip, port, id, ...]", Frame.describe(other)))
@@ -55,10 +55,12 @@ private[sage] object Cluster {
       case other                => Left(DecodeError("integer", Frame.describe(other)))
     }
 
-  private def stringOf(frame: Frame): Either[DecodeError, String] =
+  // a null endpoint means "the node you queried", which the empty host already denotes downstream
+  private def endpointOf(frame: Frame): Either[DecodeError, String] =
     frame match {
       case Frame.BulkString(bytes)  => Right(bytes.asUtf8String)
       case Frame.SimpleString(text) => Right(text)
-      case other                    => Left(DecodeError("string", Frame.describe(other)))
+      case Frame.Null               => Right("")
+      case other                    => Left(DecodeError("string or null endpoint", Frame.describe(other)))
     }
 }

--- a/sage-core/src/test/scala/sage/commands/ClusterSpec.scala
+++ b/sage-core/src/test/scala/sage/commands/ClusterSpec.scala
@@ -66,6 +66,17 @@ class ClusterSpec extends munit.FunSuite {
     assert(run(reply).isLeft)
   }
 
+  test("a null endpoint decodes to the empty host the caller substitutes itself into") {
+    val master = Frame.Array(Vector(Frame.Null, int(6379), bulk("m1")))
+    val reply  = Frame.Array(Vector(Frame.Array(Vector(int(0), int(10), master))))
+    assertEquals(run(reply).map(_.map(_.master)), Right(Vector(Node("", 6379))))
+  }
+
+  test("a `?` endpoint stays literal: it means an unknown node, not the queried one") {
+    val reply = Frame.Array(Vector(Frame.Array(Vector(int(0), int(10), node("?", 6379, "m1")))))
+    assertEquals(run(reply).map(_.map(_.master)), Right(Vector(Node("?", 6379))))
+  }
+
   test("a non-array reply fails") {
     assert(run(Frame.SimpleString("OK")).isLeft)
   }


### PR DESCRIPTION
## What

A node running with `cluster-preferred-endpoint-type unknown-endpoint` reports a **null** preferred endpoint in `CLUSTER SLOTS` (`cluster.c`, `addNodeToNodeReply` → `addReplyNull`). The spec says the client should then use the address it reached the node through, with the returned port. It exists for clusters behind a load balancer whose address the nodes don't know.

`decodeNode` required a string, so the null failed to decode. Since the topology reply is deliberately all-or-nothing, one null endpoint failed the entire `CLUSTER SLOTS` decode and the cluster could not be connected to at all.

## How

`Frame.Null` decodes to the empty host. That sentinel already means "the node I queried" everywhere downstream: `ClusterLive.resolve` swaps it for the queried node's address for masters and replicas alike, and `Redirect.parse` already produces it for a hostless `MOVED 3999 :6381`. No changes needed below the decoder.

`?` deliberately stays literal. The spec is explicit that it means an unknown node, *not* the one serving the current command, so folding it into the same sentinel would route to the wrong place. A test pins the asymmetry.

## Tests

Two cases in `ClusterSpec`: `[null, port, node-id]` decodes to the empty host, and `?` stays literal. `core/test` passes at 767.