### PR TITLE
Cut the per-read cost of triggering a topology refresh

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -1163,19 +1163,23 @@ final private[client] class ClusterLive(
 
   // --- topology refresh (single-flight, throttled) -------------------------------------------------------------------------------------
 
-  private def triggerRefresh(): Unit = scheduler.offload(refresh(force = false))
+  private val refreshWork: () => Unit = () => runRefresh()
+
+  private def triggerRefresh(): Unit = refreshThrottle.trigger(refreshWork)
 
   private def startRefreshPoll(): Unit = refreshThrottle.startPolling(cluster.topologyRefreshInterval)(triggerRefresh())
 
+  // blocks until the topology is adopted: callers read `topologyRef` on the next line
+  private def refresh(force: Boolean): Unit = if (!closed) refreshThrottle(force)(runRefresh())
+
   // a refresh queued before close must not re-establish what the close tore down
-  private def refresh(force: Boolean): Unit =
-    if (!closed) refreshThrottle(force) {
+  private def runRefresh(): Unit =
+    if (!closed)
       querySlots(refreshCandidates()) match {
         case Some((from, shards)) => adopt(from, shards)
         // no candidate answered CLUSTER SLOTS: ownership is unknowable, so retire every cache
         case None                 => if (cachingEnabled) masterPool.foreachEstablished(_.flushCache())
       }
-    }
 
   private def refreshCandidates(): Vector[Node] = (masterPool.candidatesByLiveness ++ seeds).distinct
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -142,45 +142,74 @@ final private[client] class MasterReplicaLive(
       case _: Role.Sentinel               => None
     }
 
-  // a throwaway connection (must not leave a pooled one behind): a connect/handshake failure propagates so bootstrapRoles surfaces it like a
-  // standalone connect; a node that handshakes but doesn't answer ROLE yields None
+  // ROLE rides the node's pooled connection when one is live, else a throwaway one that must not leave a pooled connection behind
   private def probeRole(node: Node): Option[Role] = {
-    val nc =
-      try
-        NodeClient.connect(
-          nodeFactory(node),
-          scheduler,
-          bootstrap,
-          config.reconnect,
-          config.watchdog,
-          config.connectTimeout,
-          config.closeTimeout,
-          config.dedicatedPool,
-          node = node,
-          events = Events.disabled
-        )
-      catch {
-        case NonFatal(error) =>
-          reportProbeFailure(node, error)
-          throw error
-      }
-    try
-      Bootstrap.awaitReply[Role](config.connectTimeout.toMillis)(callback => nc.submit(Server.role, asking = false, callback)) match {
-        case Some(Success(role))  => Some(role)
-        case Some(Failure(error)) =>
-          reportProbeFailure(node, error)
-          None
-        case None                 =>
-          reportProbeFailure(node, TimedOut(s"ROLE timed out after ${config.connectTimeout.toMillis}ms"))
-          None
-      }
+    val pooled = pooledFor(node)
+    if (pooled != null) {
+      val reply = askRole(pooled)
+      if (!lostConnection(reply)) return interpretRole(node, reply)
+    }
+    val nc     = connectForProbe(node)
+    try interpretRole(node, askRole(nc))
     finally nc.close()
   }
+
+  private def pooledFor(node: Node): NodeClient = {
+    val master = masterPool.existing(node)
+    val nc     = if (master != null) master else replicaPool.existing(node)
+    if (nc != null && nc.isLive) nc else null
+  }
+
+  private def askRole(nc: NodeClient): Option[Try[Role]] =
+    Bootstrap.awaitReply[Role](config.connectTimeout.toMillis)(callback => nc.submit(Server.role, asking = false, callback))
+
+  private def interpretRole(node: Node, reply: Option[Try[Role]]): Option[Role] =
+    reply match {
+      case Some(Success(role))  => Some(role)
+      case Some(Failure(error)) =>
+        reportProbeFailure(node, error)
+        None
+      case None                 =>
+        reportProbeFailure(node, TimedOut(s"ROLE timed out after ${config.connectTimeout.toMillis}ms"))
+        None
+    }
+
+  private def lostConnection(reply: Option[Try[Role]]): Boolean =
+    reply match {
+      case Some(Failure(error)) =>
+        Fault.categorize(error) match {
+          case Fault.Lost(_) => true
+          case _             => false
+        }
+      case _                    => false
+    }
+
+  private def connectForProbe(node: Node): NodeClient =
+    try
+      NodeClient.connect(
+        nodeFactory(node),
+        scheduler,
+        bootstrap,
+        config.reconnect,
+        config.watchdog,
+        config.connectTimeout,
+        config.closeTimeout,
+        config.dedicatedPool,
+        node = node,
+        events = Events.disabled
+      )
+    catch {
+      case NonFatal(error) =>
+        reportProbeFailure(node, error)
+        throw error
+    }
 
   private def reportProbeFailure(node: Node, error: Throwable): Unit =
     events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))
 
-  private def triggerRefresh(): Unit = refreshThrottle.trigger(rediscover())
+  private val rediscoverWork: () => Unit = () => rediscover()
+
+  private def triggerRefresh(): Unit = refreshThrottle.trigger(rediscoverWork)
 
   private def startRefreshPoll(): Unit = refreshThrottle.startPolling(masterReplica.topologyRefreshInterval)(triggerRefresh())
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/RefreshThrottle.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/RefreshThrottle.scala
@@ -13,22 +13,25 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
   */
 final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: Long) {
 
-  private val lock          = new ReentrantLock()
-  private val done          = lock.newCondition()
-  private var refreshing    = false
-  private var lastRefreshMs = scheduler.nowMillis - minRefreshMs
-  private var ticker        = null: Scheduler.Cancelable
-  private var stopped       = false
+  private val lock                    = new ReentrantLock()
+  private val done                    = lock.newCondition()
+  // volatile so `throttled` can answer without the lock; every mutation still happens under it
+  @volatile private var refreshing    = false
+  @volatile private var lastRefreshMs = scheduler.nowMillis - minRefreshMs
+  private var ticker                  = null: Scheduler.Cancelable
+  private var stopped                 = false
 
   def apply(force: Boolean)(work: => Unit): Unit =
     if (claim(force, wait = true)) run(work)
 
   /**
     * Schedules a non-forced refresh only when this call claims the throttle. Unlike [[apply]], callers never wait for an in-flight refresh.
+    * Called per read while routing can reach no replica, so the throttled path must stay lock-free and `work` pre-built: a by-name
+    * argument would re-allocate a closure per read even when it never runs.
     */
-  def trigger(work: => Unit): Unit =
+  def trigger(work: () => Unit): Unit =
     if (claim(force = false, wait = false))
-      try scheduler.after(Duration.Zero)(run(work))
+      try scheduler.after(Duration.Zero)(run(work()))
       catch {
         case error: Throwable =>
           finish()
@@ -66,6 +69,7 @@ final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: 
   }
 
   private def claim(force: Boolean, wait: Boolean): Boolean = {
+    if (!force && !wait && throttled) return false
     lock.lock()
     try
       if (refreshing && wait) {
@@ -79,6 +83,8 @@ final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: 
     finally lock.unlock()
   }
 
+  private def throttled: Boolean = refreshing || scheduler.nowMillis - lastRefreshMs < minRefreshMs
+
   private def run(work: => Unit): Unit =
     try work
     finally finish()
@@ -86,8 +92,9 @@ final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: 
   private def finish(): Unit = {
     lock.lock()
     try {
-      refreshing = false
+      // stamp before clearing: by the volatile write ordering, a lock-free `throttled` seeing `refreshing == false` sees this window too
       lastRefreshMs = scheduler.nowMillis
+      refreshing = false
       done.signalAll()
     } finally lock.unlock()
   }

--- a/sage-client/shared/src/test/scala/sage/client/internal/RefreshThrottleSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/RefreshThrottleSpec.scala
@@ -1,6 +1,9 @@
 package sage.client.internal
 
 import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.duration.*
 
 class RefreshThrottleSpec extends munit.FunSuite {
 
@@ -11,7 +14,7 @@ class RefreshThrottleSpec extends munit.FunSuite {
     val release   = new CountDownLatch(1)
     val finished  = new CountDownLatch(1)
 
-    throttle.trigger {
+    throttle.trigger { () =>
       started.countDown()
       release.await()
       finished.countDown()
@@ -20,7 +23,7 @@ class RefreshThrottleSpec extends munit.FunSuite {
 
     var i = 0
     while (i < 1000) {
-      throttle.trigger(fail("an in-flight trigger must not evaluate later work"))
+      throttle.trigger(() => fail("an in-flight trigger must not run later work"))
       i += 1
     }
     assertEquals(scheduler.zeroDelays.get(), 1, "an in-flight refresh should own the only scheduler offload")
@@ -39,5 +42,42 @@ class RefreshThrottleSpec extends munit.FunSuite {
     assert(finished.await(2, TimeUnit.SECONDS), "the triggered refresh did not finish")
     assert(blockingDone.await(2, TimeUnit.SECONDS), "the blocking caller did not resume")
     waiter.join()
+  }
+
+  test("the window closes as soon as a refresh finishes and reopens once it elapses") {
+    val scheduler = new ManualScheduler
+    val throttle  = new RefreshThrottle(scheduler, minRefreshMs = 1000L)
+    val runs      = new AtomicInteger(0)
+    val work      = () => runs.incrementAndGet(): Unit
+
+    throttle.trigger(work)
+    scheduler.advance(Duration.Zero)
+    assertEquals(runs.get(), 1, "the first trigger did not run")
+
+    throttle.trigger(work)
+    scheduler.advance(500.millis)
+    assertEquals(runs.get(), 1, "a trigger inside the refresh window ran its work")
+
+    scheduler.advance(600.millis)
+    throttle.trigger(work)
+    scheduler.advance(Duration.Zero)
+    assertEquals(runs.get(), 2, "the window did not reopen once minRefreshInterval elapsed")
+  }
+
+  test("a trigger inside the refresh window offloads nothing") {
+    val scheduler = new CountingScheduler
+    val throttle  = new RefreshThrottle(scheduler, minRefreshMs = 60000L)
+    val ran       = new CountDownLatch(1)
+
+    throttle.trigger(() => ran.countDown())
+    assert(ran.await(2, TimeUnit.SECONDS), "the first trigger did not run")
+
+    val offloads = scheduler.zeroDelays.get()
+    var i        = 0
+    while (i < 1000) {
+      throttle.trigger(() => fail("a throttled trigger must not run work"))
+      i += 1
+    }
+    assertEquals(scheduler.zeroDelays.get(), offloads, "a throttled trigger offloaded")
   }
 }

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -263,6 +263,22 @@ class ClusterClientSpec extends munit.FunSuite {
     }
   }
 
+  test("a replica-preferred read on a shard with no replica offloads no refresh once the window is closed") {
+    val counting  = new CountingScheduler
+    val behaviour =
+      (node: Node, text: String) => if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA)) else Seq(bulk(node.host))
+    val fixture   = new Fixture(behaviour, Vector(nodeA), readFrom = ReadFrom.ReplicaPreferred, scheduler = counting)
+    val get       = fixture.live.run(Strings.get[String, String]("foo"))
+
+    get.unsafeRun.flatMap { _ =>
+      val before = counting.zeroDelays.get()
+      get.unsafeRun.flatMap(_ => get.unsafeRun).map { result =>
+        assertEquals(result, Some(nodeA.host))
+        assertEquals(counting.zeroDelays.get(), before, "a throttled replica-preferred read must not offload a refresh")
+      }
+    }
+  }
+
   test("a pipeline to an established node dispatches inline, with no zero-delay scheduler hop") {
     val counting  = new CountingScheduler
     val behaviour = (_: Node, text: String) =>

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -164,6 +164,30 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     assert(!dialled.contains(advertisedReplica), s"advertised address must not be dialled: $dialled")
   }
 
+  test("a role refresh asks ROLE over the established connection instead of opening a second socket") {
+    val fixture = new Fixture(
+      seeds = Vector(primary),
+      initialRoles = Map(primary -> masterRole()),
+      minRefreshInterval = Duration.Zero
+    )
+    fixture.live.bootstrapRoles()
+
+    assertEquals(fixture.read(), 1L)
+    fixture.awaitTrue(fixture.roleRequestCount(primary) >= 2, "the first read did not trigger a re-discovery")
+    val settledDials = fixture.dialled.size
+    val settledRoles = fixture.roleRequestCount(primary)
+
+    var i = 0
+    while (i < 20) {
+      assertEquals(fixture.read(), 1L)
+      i += 1
+    }
+    fixture.awaitTrue(fixture.roleRequestCount(primary) > settledRoles, "later reads stopped re-discovering")
+    fixture.close()
+
+    assertEquals(fixture.dialled.size, settledDials, s"a refresh dialled a node it was already connected to: ${fixture.dialled}")
+  }
+
   test("a read whose connection dies mid-flight falls through to the next candidate") {
     val fixture = new Fixture(
       seeds = Vector(primary),


### PR DESCRIPTION
## Problem

Routing re-runs discovery whenever a read policy can reach no replica: `ReplicaPreferred` with an empty replica set (`ReadRouting.scala:84`), or any policy whose candidate order is exhausted (`ReadRouting.scala:115`). The trigger is load-bearing, since `topologyRefreshInterval` is `None` by default and this is the only way a client adopts a replica that appears after connect. But it fires per read, and everything behind it was priced as if it fired rarely. Any master with no attached replica, or any cluster shard with none, pays this on the command hot path.

## What changed

1. **`RefreshThrottle` took a lock before it could tell it was throttled.** `refreshing` and `lastRefreshMs` are now `@volatile` and `claim` settles the throttled case on those reads alone; only real claims and blocking callers take the lock, so single-flight is unchanged. `finish` stamps the window before clearing the flag, so a lock-free reader that sees a cleared flag also sees the current window. `trigger` takes a pre-built `() => Unit` instead of a by-name argument that allocated a closure per read.
2. **`ClusterLive.triggerRefresh` offloaded before claiming**, so a read on a replica-less shard spawned a virtual thread that immediately found nothing to do. It now claims first. The blocking `refresh(force)` is untouched: `onUnowned` depends on it completing before it reads `topologyRef`.
3. **`MasterReplicaLive.probeRole` opened a throwaway socket for every `ROLE`**, including for nodes already holding a live pooled connection, costing a second socket plus the bootstrap's sequential round trips. `ROLE` now rides the pooled connection when one is live, as `querySlotsVia` already does for `CLUSTER SLOTS`. An unknown node still gets a throwaway connection that leaves no pooled one behind, and a connection lost mid-probe falls through to a fresh socket.

## Verification

Each new test fails without its fix: reverting the cluster ordering trips the offload assertion, and reverting the pooled probe produces 12 redundant dials against zero. Green across `clientZio` (372), `clientCe` (211), and the master-replica (14) and cluster (36) integration suites on both Redis and Valkey, including the failover, demotion, replica-down and stale-replica cases. `scalafmtCheckAll` clean.
