### PR TITLE
Upgrade to kyo 1.0.0-RC6 and vendor the removed cats-effect binding

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val otelVersion           = "1.64.0"
 val circeVersion          = "0.14.16" // test-only: verifies ValueCodec.emap with a real JSON library
 
 // backend effect libraries, declared explicitly so Scala Steward keeps them current
-val kyoVersion        = "1.0.0-RC5"
+val kyoVersion        = "1.0.0-RC6"
 val zioVersion        = "2.1.26"
 val catsEffectVersion = "3.7.0"
 val fs2Version        = "3.13.0"
@@ -25,9 +25,14 @@ val lettuceVersion    = "7.6.0.RELEASE"
 val rediscalaVersion  = "2.1.0"
 val jedisVersion      = "6.0.0"
 
-// The Pekko backend uses the Future compatibility cell (kyo-compat-future) with Pekko Streams. A separate axis name prevents it from being
-// deduplicated with the implicit Future anchor. jvmSettings removes the nonexistent kyo-compat-pekko dependency injected by the plugin.
-val PekkoLib = CompatBackendAxis("pekko", "Pekko", "-pekko", Set("jvm"))
+// The Pekko backend uses the Future compatibility cell (`kyo-compat-future`) with Pekko Streams. A separate axis name prevents it from
+// being deduplicated with the implicit Future anchor. The explicit coordinates make its rows resolve `kyo-compat-future`; the plugin
+// would otherwise inject a nonexistent `kyo-compat-pekko` dependency.
+val PekkoLib = CompatBackendAxis.external("pekko", "Pekko", "-pekko", Set("jvm"), "io.getkyo", "kyo-compat-future", kyoVersion)
+
+// Kyo no longer ships a Cats Effect binding, so the `ce` axis binds locally to the vendored `sage-compat-ce` module. The name and
+// suffixes match the removed built-in, which keeps cell ids and artifact names unchanged.
+val CeLib = CompatBackendAxis.local("ce", "Ce", "-ce", Set("jvm"))
 
 inThisBuild(
   List(
@@ -61,8 +66,10 @@ addCommandAlias(
     "clientFuture/Test/compile integrationTestsFuture/Test/compile integrationTestsPekko/Test/compile " +
     s"benchmarksZio/compile benchmarksCe/compile benchmarksOx/compile benchmarksPekko/compile benchmarksKyo$scala3NextSuffix/compile " +
     "examplesZio/Compile/compile examplesCe/Compile/compile examplesOx/Compile/compile examplesPekko/Compile/compile " +
-    s"examplesKyo$scala3NextSuffix/Compile/compile examplesFuture/Compile/compile"
+    s"examplesKyo$scala3NextSuffix/Compile/compile examplesFuture/Compile/compile " +
+    "ceConformanceCe/test"
 )
+addCommandAlias("conformanceCe", "ceConformanceCe/test")
 addCommandAlias("itZio", "integrationTestsZio/test")
 addCommandAlias("itCe", "integrationTestsCe/test")
 addCommandAlias("itOx", "integrationTestsOx/test")
@@ -73,7 +80,7 @@ addCommandAlias("exampleKyo", s"examplesKyo$scala3NextSuffix/run")
 
 addCommandAlias(
   "docAll",
-  s"all core/doc opentelemetry/doc clientZio/doc clientCe/doc clientOx/doc clientPekko/doc clientKyo$scala3NextSuffix/doc"
+  s"all core/doc opentelemetry/doc compatCe/doc clientZio/doc clientCe/doc clientOx/doc clientPekko/doc clientKyo$scala3NextSuffix/doc"
 )
 
 lazy val root = project
@@ -81,7 +88,10 @@ lazy val root = project
   .settings(publish / skip := true)
   // Exclude benchmarks from root aggregation because their JMH, testcontainers, and competitor-client dependencies are needed only for
   // on-demand benchmark runs. Use benchAll or benchmarks<Cell>/Jmh/run to run them directly.
-  .aggregate(core.projectRefs ++ client.projectRefs ++ opentelemetry.projectRefs ++ integrationTests.projectRefs ++ examples.projectRefs: _*)
+  .aggregate(
+    core.projectRefs ++ client.projectRefs ++ opentelemetry.projectRefs ++ integrationTests.projectRefs ++ examples.projectRefs ++
+      Seq[ProjectReference](compatCe): _*
+  )
 
 // Pure sans-IO core: RESP3 protocol, command model, codecs. Zero external dependencies.
 // Built for both Scala LTS (published) and Scala Next (compile-only, so the kyo client cell can depend on it).
@@ -121,6 +131,28 @@ lazy val opentelemetry = (projectMatrix in file("sage-opentelemetry"))
     process = identity[Project] _
   )
 
+// The Cats Effect binding of the `kyo.compat` package, vendored because Kyo removed it upstream; `sage-compat-ce/README.md` records the
+// provenance. The `ce` cells of every matrix bind to this project through `bindLocally`.
+lazy val compatCe = project
+  .in(file("sage-compat-ce"))
+  .settings(name := "sage-compat-ce")
+  .settings(commonSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "cats-effect" % catsEffectVersion,
+      "co.fs2"        %% "fs2-core"    % fs2Version
+    )
+  )
+
+// Run the conformance suite bundled inside `kyo-compat-plugin` against the vendored `ce` binding, so that a change to the upstream
+// `kyo.compat` contract is reported here as a test failure rather than as a compile error in a downstream module. The implicit Future
+// anchor row is unused.
+lazy val ceConformance = (projectMatrix in file("sage-compat-ce/.conformance"))
+  .settings(publish / skip := true)
+  .compatLibrary(CeLib)(VirtualAxis.jvm)(Seq(scala3Version))
+  .bindLocally(CeLib, compatCe)
+  .compatConformance()
+
 // Runtime written once against kyo-compat, cross-published per backend. JDK 21+.
 // The kyo cell builds with Scala Next; the others stay on LTS.
 lazy val client = (projectMatrix in file("sage-client"))
@@ -143,7 +175,6 @@ lazy val client = (projectMatrix in file("sage-client"))
       else if (m.endsWith("-ox")) Seq("com.softwaremill.ox" %% "core" % oxVersion)
       else if (m.endsWith("-pekko"))
         Seq(
-          "io.getkyo"        %% "kyo-compat-future" % kyoVersion,
           "org.apache.pekko" %% "pekko-stream"      % pekkoVersion,
           "org.apache.pekko" %% "pekko-actor-typed" % pekkoVersion
         )
@@ -152,7 +183,7 @@ lazy val client = (projectMatrix in file("sage-client"))
   )
   .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq(scala3NextVersion))
   .compatLibrary(ZioLib, CeLib, OxLib, PekkoLib)(VirtualAxis.jvm)(Seq(scala3Version))
-  .jvmSettings(stripBogusPekkoCompatDep)
+  .bindLocally(CeLib, compatCe)
 
 // Run the shared testcontainers suite for every backend to test each backend against real servers. Run command behavior, security, cluster,
 // master-replica, and rate-limit suites on one backend because those features use the same shared implementation in every backend.
@@ -184,7 +215,7 @@ lazy val integrationTests = (projectMatrix in file("integration-tests"))
   )
   .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq(scala3NextVersion))
   .compatLibrary(ZioLib, CeLib, OxLib, PekkoLib)(VirtualAxis.jvm)(Seq(scala3Version))
-  .jvmSettings(stripBogusPekkoCompatDep)
+  .bindLocally(CeLib, compatCe)
 
 // Build runnable, unpublished examples for ZIO, Cats Effect, Ox, Kyo, and Pekko in separate cells so each uses its native client artifact. The
 // root project compiles them in CI through testUnit. The Future cell compiles examples/shared. Run an example against a local server with a
@@ -199,7 +230,7 @@ lazy val examples = (projectMatrix in file("examples"))
   .settings(Compile / doc / sources := Seq.empty)
   .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq(scala3NextVersion))
   .compatLibrary(ZioLib, CeLib, OxLib, PekkoLib)(VirtualAxis.jvm)(Seq(scala3Version))
-  .jvmSettings(stripBogusPekkoCompatDep)
+  .bindLocally(CeLib, compatCe)
 
 // Runtime end-to-end benchmark harness (JMH), used only during development. Each backend has a separate cell. The ZIO cell includes
 // zio-redis, the Cats Effect cell includes redis4cats, and the Ox cell includes Lettuce, Rediscala, and Jedis. The Kyo and Pekko cells include
@@ -230,7 +261,7 @@ lazy val benchmarks = (projectMatrix in file("benchmarks"))
   )
   .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq(scala3NextVersion))
   .compatLibrary(ZioLib, CeLib, OxLib, PekkoLib)(VirtualAxis.jvm)(Seq(scala3Version))
-  .jvmSettings(stripBogusPekkoCompatDep)
+  .bindLocally(CeLib, compatCe)
 
 // The runtime benchmark harness: runs every backend cell's JMH suite against its own self-provisioned Redis (the future anchor cell is skipped),
 // each writing JMH JSON to benchmarks/results/<cell>.json. benchmarks/merge-results.sh merges them into one all.json covering every client
@@ -264,7 +295,3 @@ lazy val commonSettings = Def.settings(
 // Only for container-free cells: integration suites each boot their own container, so running them in
 // parallel would multiply peak load and invite timing races
 lazy val parallelUnitTests = Def.settings(Test / testForkedParallel := true)
-
-// compatLibrary auto-injects a nonexistent kyo-compat-pekko for the custom axis; drop it (via jvmSettings, after the plugin's per-row settings).
-lazy val stripBogusPekkoCompatDep: Setting[?] =
-  libraryDependencies := libraryDependencies.value.filterNot(m => m.organization == "io.getkyo" && m.name.startsWith("kyo-compat-pekko"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.getkyo"          % "kyo-compat-plugin" % "1.0.0-RC5")
+addSbtPlugin("io.getkyo"          % "kyo-compat-plugin" % "1.0.0-RC6")
 addSbtPlugin("com.eed3si9n"       % "sbt-projectmatrix" % "0.11.0")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"     % "0.13.1")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"      % "2.6.2")

--- a/sage-compat-ce/README.md
+++ b/sage-compat-ce/README.md
@@ -1,0 +1,26 @@
+# sage-compat-ce
+
+This module is the Cats Effect binding of the [kyo-compat](https://github.com/getkyo/kyo/tree/main/kyo-compat) surface: it implements
+the full `kyo.compat` package on `cats.effect.IO` and fs2. Sage's runtime is written once against that surface, and the `-ce` cells of
+`sage-client` and every downstream module compile and run against this binding.
+
+## Provenance
+
+Kyo removed its Cats Effect integrations in 1.0.0-RC6 ([kyo#1779](https://github.com/getkyo/kyo/pull/1779)) and invited the community to
+maintain them externally ([kyo#1840](https://github.com/getkyo/kyo/pull/1840)). This module vendors the binding from its last upstream
+state, commit [`eae31e1d`](https://github.com/getkyo/kyo/tree/eae31e1d39d4b8ff2df168272e60b38d9e9dd502/kyo-compat/bindings/ce), whose
+sources match the published `io.getkyo:kyo-compat-ce_3:1.0.0-RC5` exactly. The vendored copy differs textually from that state: the
+`shared` and `jvm` source trees are merged because Sage is JVM-only, the code is reformatted to this repository's brace-based style, and
+several pieces of documentation are corrected or completed. The conformance suite described below verifies that it stays equivalent to
+upstream in API and behavior.
+
+Kyo is licensed under [Apache 2.0](https://github.com/getkyo/kyo/blob/main/LICENSE), the same license as Sage.
+
+## Keeping it in sync
+
+The binding's only dependencies are Cats Effect and fs2, so upgrading Kyo does not affect this module directly. What can change is the
+`kyo.compat` contract itself: a Kyo release may add operations to the surface or adjust the semantics the bindings must implement. The
+cross-binding conformance suite catches that. The suite is bundled inside `kyo-compat-plugin`, the `ceConformance` matrix compiles and
+runs it against this module, and CI runs it as part of `testUnit` (`sbt conformanceCe` runs it alone). A failure there identifies which
+operations are missing or which semantics changed; port the corresponding update from another binding, for example
+[bindings/future](https://github.com/getkyo/kyo/tree/main/kyo-compat/bindings/future), translating the primitives to Cats Effect.

--- a/sage-compat-ce/src/main/scala/kyo/compat/CAtomicBoolean.scala
+++ b/sage-compat-ce/src/main/scala/kyo/compat/CAtomicBoolean.scala
@@ -1,0 +1,56 @@
+package kyo.compat
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+
+/**
+  * Underlying carrier is `cats.effect.kernel.Ref[IO, Boolean]`. Cats Effect has no `Frame` / `Trace` to propagate. `lift` and `lower` are
+  * identity since the carrier is already a native CE ref. `compareAndSet` is composed via `Ref.modify` since CE has no native CAS
+  * primitive.
+  */
+opaque type CAtomicBoolean = Ref[IO, Boolean]
+
+object CAtomicBoolean {
+
+  /**
+    * Allocates a fresh atomic boolean initialized to `v`.
+    */
+  inline def init(inline v: Boolean): CIO[CAtomicBoolean] =
+    CIO.lift(Ref.of[IO, Boolean](v))
+
+  /**
+    * Wraps a native `cats.effect.kernel.Ref[IO, Boolean]` as a `CAtomicBoolean`. The conversion is the identity on the carrier.
+    */
+  inline def lift(inline u: Ref[IO, Boolean]): CAtomicBoolean = u
+
+  extension (inline self: CAtomicBoolean) {
+
+    /**
+      * Unwraps to the native `cats.effect.kernel.Ref[IO, Boolean]`. The conversion is the identity on the carrier.
+      */
+    inline def lower: Ref[IO, Boolean] = self
+
+    /**
+      * Reads the current value.
+      */
+    inline def get: CIO[Boolean] = CIO.lift(self.get)
+
+    /**
+      * Atomically sets the value to `v`.
+      */
+    inline def set(inline v: Boolean): CIO[Unit] = CIO.lift(self.set(v))
+
+    /**
+      * Atomically sets the value to `v` and returns the previous value.
+      */
+    inline def getAndSet(inline v: Boolean): CIO[Boolean] = CIO.lift(self.getAndSet(v))
+
+    /**
+      * Atomic compare-and-set: replaces `expected` with `updated` iff the current value equals `expected`.
+      */
+    inline def compareAndSet(inline expected: Boolean, inline updated: Boolean): CIO[Boolean] =
+      CIO.lift(self.modify(cur => if (cur == expected) (updated, true) else (cur, false)))
+
+  }
+
+}

--- a/sage-compat-ce/src/main/scala/kyo/compat/CAtomicInt.scala
+++ b/sage-compat-ce/src/main/scala/kyo/compat/CAtomicInt.scala
@@ -1,0 +1,86 @@
+package kyo.compat
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+
+/**
+  * Underlying carrier is `cats.effect.kernel.Ref[IO, Int]`. Cats Effect has no `Frame` / `Trace` to propagate. `lift` and `lower` are
+  * identity since the carrier is already a native CE ref. CE has no specialised atomic-int; arithmetic operations compose via `Ref[Int]`
+  * updates, and `compareAndSet` is composed via `Ref.modify` since CE has no native CAS primitive.
+  */
+opaque type CAtomicInt = Ref[IO, Int]
+
+object CAtomicInt {
+
+  /**
+    * Allocates a fresh atomic int initialized to `v`.
+    */
+  inline def init(inline v: Int): CIO[CAtomicInt] =
+    CIO.lift(Ref.of[IO, Int](v))
+
+  /**
+    * Wraps a native `cats.effect.kernel.Ref[IO, Int]` as a `CAtomicInt`. The conversion is the identity on the carrier.
+    */
+  inline def lift(inline u: Ref[IO, Int]): CAtomicInt = u
+
+  extension (inline self: CAtomicInt) {
+
+    /**
+      * Unwraps to the native `cats.effect.kernel.Ref[IO, Int]`. The conversion is the identity on the carrier.
+      */
+    inline def lower: Ref[IO, Int] = self
+
+    /**
+      * Reads the current value.
+      */
+    inline def get: CIO[Int] = CIO.lift(self.get)
+
+    /**
+      * Atomically sets the value to `v`.
+      */
+    inline def set(inline v: Int): CIO[Unit] = CIO.lift(self.set(v))
+
+    /**
+      * Atomically sets the value to `v` and returns the previous value.
+      */
+    inline def getAndSet(inline v: Int): CIO[Int] = CIO.lift(self.getAndSet(v))
+
+    /**
+      * Atomically increments by 1 and returns the new value.
+      */
+    inline def incrementAndGet: CIO[Int] = CIO.lift(self.updateAndGet(_ + 1))
+
+    /**
+      * Atomically increments by 1 and returns the previous value.
+      */
+    inline def getAndIncrement: CIO[Int] = CIO.lift(self.getAndUpdate(_ + 1))
+
+    /**
+      * Atomically decrements by 1 and returns the new value.
+      */
+    inline def decrementAndGet: CIO[Int] = CIO.lift(self.updateAndGet(_ - 1))
+
+    /**
+      * Atomically decrements by 1 and returns the previous value.
+      */
+    inline def getAndDecrement: CIO[Int] = CIO.lift(self.getAndUpdate(_ - 1))
+
+    /**
+      * Atomically adds `delta` and returns the new value.
+      */
+    inline def addAndGet(inline delta: Int): CIO[Int] = CIO.lift(self.updateAndGet(_ + delta))
+
+    /**
+      * Atomically adds `delta` and returns the previous value.
+      */
+    inline def getAndAdd(inline delta: Int): CIO[Int] = CIO.lift(self.getAndUpdate(_ + delta))
+
+    /**
+      * Atomic compare-and-set: replaces `expected` with `updated` iff the current value equals `expected`.
+      */
+    inline def compareAndSet(inline expected: Int, inline updated: Int): CIO[Boolean] =
+      CIO.lift(self.modify(cur => if (cur == expected) (updated, true) else (cur, false)))
+
+  }
+
+}

--- a/sage-compat-ce/src/main/scala/kyo/compat/CAtomicLong.scala
+++ b/sage-compat-ce/src/main/scala/kyo/compat/CAtomicLong.scala
@@ -1,0 +1,86 @@
+package kyo.compat
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+
+/**
+  * Underlying carrier is `cats.effect.kernel.Ref[IO, Long]`. Cats Effect has no `Frame` / `Trace` to propagate. `lift` and `lower` are
+  * identity since the carrier is already a native CE ref. CE has no specialised atomic-long; arithmetic operations compose via `Ref[Long]`
+  * updates, and `compareAndSet` is composed via `Ref.modify` since CE has no native CAS primitive.
+  */
+opaque type CAtomicLong = Ref[IO, Long]
+
+object CAtomicLong {
+
+  /**
+    * Allocates a fresh atomic long initialized to `v`.
+    */
+  inline def init(inline v: Long): CIO[CAtomicLong] =
+    CIO.lift(Ref.of[IO, Long](v))
+
+  /**
+    * Wraps a native `cats.effect.kernel.Ref[IO, Long]` as a `CAtomicLong`. The conversion is the identity on the carrier.
+    */
+  inline def lift(inline u: Ref[IO, Long]): CAtomicLong = u
+
+  extension (inline self: CAtomicLong) {
+
+    /**
+      * Unwraps to the native `cats.effect.kernel.Ref[IO, Long]`. The conversion is the identity on the carrier.
+      */
+    inline def lower: Ref[IO, Long] = self
+
+    /**
+      * Reads the current value.
+      */
+    inline def get: CIO[Long] = CIO.lift(self.get)
+
+    /**
+      * Atomically sets the value to `v`.
+      */
+    inline def set(inline v: Long): CIO[Unit] = CIO.lift(self.set(v))
+
+    /**
+      * Atomically sets the value to `v` and returns the previous value.
+      */
+    inline def getAndSet(inline v: Long): CIO[Long] = CIO.lift(self.getAndSet(v))
+
+    /**
+      * Atomically increments by 1 and returns the new value.
+      */
+    inline def incrementAndGet: CIO[Long] = CIO.lift(self.updateAndGet(_ + 1L))
+
+    /**
+      * Atomically increments by 1 and returns the previous value.
+      */
+    inline def getAndIncrement: CIO[Long] = CIO.lift(self.getAndUpdate(_ + 1L))
+
+    /**
+      * Atomically decrements by 1 and returns the new value.
+      */
+    inline def decrementAndGet: CIO[Long] = CIO.lift(self.updateAndGet(_ - 1L))
+
+    /**
+      * Atomically decrements by 1 and returns the previous value.
+      */
+    inline def getAndDecrement: CIO[Long] = CIO.lift(self.getAndUpdate(_ - 1L))
+
+    /**
+      * Atomically adds `delta` and returns the new value.
+      */
+    inline def addAndGet(inline delta: Long): CIO[Long] = CIO.lift(self.updateAndGet(_ + delta))
+
+    /**
+      * Atomically adds `delta` and returns the previous value.
+      */
+    inline def getAndAdd(inline delta: Long): CIO[Long] = CIO.lift(self.getAndUpdate(_ + delta))
+
+    /**
+      * Atomic compare-and-set: replaces `expected` with `updated` iff the current value equals `expected`.
+      */
+    inline def compareAndSet(inline expected: Long, inline updated: Long): CIO[Boolean] =
+      CIO.lift(self.modify(cur => if (cur == expected) (updated, true) else (cur, false)))
+
+  }
+
+}

--- a/sage-compat-ce/src/main/scala/kyo/compat/CAtomicRef.scala
+++ b/sage-compat-ce/src/main/scala/kyo/compat/CAtomicRef.scala
@@ -1,0 +1,69 @@
+package kyo.compat
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+
+/**
+  * Underlying carrier is `cats.effect.kernel.Ref[IO, A]`. Cats Effect has no `Frame` / `Trace` to propagate. `lift` and `lower` are
+  * identity since the carrier is already a native CE ref. `compareAndSet` is composed via `Ref.modify` since CE has no native CAS
+  * primitive.
+  */
+opaque type CAtomicRef[A] = Ref[IO, A]
+
+object CAtomicRef {
+
+  /**
+    * Allocates a fresh atomic reference initialized to `a`.
+    */
+  inline def init[A](inline a: A): CIO[CAtomicRef[A]] =
+    CIO.lift(Ref.of[IO, A](a))
+
+  /**
+    * Wraps a native `cats.effect.kernel.Ref[IO, A]` as a `CAtomicRef`. The conversion is the identity on the carrier.
+    */
+  inline def lift[A](inline u: Ref[IO, A]): CAtomicRef[A] = u
+
+  extension [A](inline self: CAtomicRef[A]) {
+
+    /**
+      * Unwraps to the native `cats.effect.kernel.Ref[IO, A]`. The conversion is the identity on the carrier.
+      */
+    inline def lower: Ref[IO, A] = self
+
+    /**
+      * Reads the current value.
+      */
+    inline def get: CIO[A] = CIO.lift(self.get)
+
+    /**
+      * Atomically sets the value to `a`.
+      */
+    inline def set(inline a: A): CIO[Unit] = CIO.lift(self.set(a))
+
+    /**
+      * Atomically sets the value to `a` and returns the previous value.
+      */
+    inline def getAndSet(inline a: A): CIO[A] = CIO.lift(self.getAndSet(a))
+
+    /**
+      * Atomically applies `f` to the current value and returns the new value.
+      */
+    inline def updateAndGet(inline f: A => A): CIO[A] = CIO.lift(self.updateAndGet(f))
+
+    /**
+      * Atomically applies `f` to the current value and returns the previous value.
+      */
+    inline def getAndUpdate(inline f: A => A): CIO[A] = CIO.lift(self.getAndUpdate(f))
+
+    /**
+      * Atomic compare-and-set: replaces `expected` with `updated` iff the current value equals `expected`.
+      */
+    inline def compareAndSet(inline expected: A, inline updated: A): CIO[Boolean] =
+      CIO.lift(self.modify { cur =>
+        given CanEqual[A, A] = CanEqual.derived
+        if (cur == expected) (updated, true) else (cur, false)
+      })
+
+  }
+
+}

--- a/sage-compat-ce/src/main/scala/kyo/compat/CChannel.scala
+++ b/sage-compat-ce/src/main/scala/kyo/compat/CChannel.scala
@@ -1,0 +1,51 @@
+package kyo.compat
+
+import cats.effect.IO
+import cats.effect.std.Queue
+
+/**
+  * Underlying carrier is `cats.effect.std.Queue[IO, A]`, a bounded FIFO async queue. Cats Effect has no `Frame` / `Trace` to propagate.
+  * `lift` and `lower` are identity since the carrier is already a native CE queue. CE `Queue` has no shutdown semantic, so `close` is not
+  * exposed on the compat surface.
+  */
+opaque type CChannel[A] = Queue[IO, A]
+
+object CChannel {
+
+  /**
+    * Allocates a bounded FIFO channel of the given capacity. `capacity` must be nonnegative; a capacity of 0 creates a synchronous
+    * channel, where each `put` suspends until a matching `take`.
+    */
+  inline def init[A](inline capacity: Int): CIO[CChannel[A]] =
+    CIO.lift(Queue.bounded[IO, A](capacity))
+
+  /**
+    * Wraps a native `cats.effect.std.Queue` as a `CChannel`. The conversion is the identity on the carrier.
+    */
+  inline def lift[A](inline u: Queue[IO, A]): CChannel[A] = u
+
+  extension [A](inline self: CChannel[A]) {
+
+    /**
+      * Unwraps to the native `cats.effect.std.Queue`. The conversion is the identity on the carrier.
+      */
+    inline def lower: Queue[IO, A] = self
+
+    /**
+      * Enqueues `v`; suspends when the channel is full.
+      */
+    inline def put(inline v: A): CIO[Unit] = CIO.lift(self.offer(v))
+
+    /**
+      * Dequeues the next element; suspends when the channel is empty.
+      */
+    inline def take: CIO[A] = CIO.lift(self.take)
+
+    /**
+      * Dequeues without suspending: returns `Some(a)` if an element is available and `None` otherwise.
+      */
+    inline def poll: CIO[Option[A]] = CIO.lift(self.tryTake)
+
+  }
+
+}

--- a/sage-compat-ce/src/main/scala/kyo/compat/CChunk.scala
+++ b/sage-compat-ce/src/main/scala/kyo/compat/CChunk.scala
@@ -1,0 +1,56 @@
+package kyo.compat
+
+/**
+  * Underlying carrier is `Vector[A]`. Cats Effect has no native bulk-collection type, so `CChunk` reuses the standard-library `Vector`.
+  * `lift` and `lower` are identity since the carrier is already a `Vector`. The portable accessor surface (`toSeq`, `toIndexedSeq`,
+  * `apply`, `size`, `iterator`, `isEmpty`) is exposed on every backend.
+  */
+opaque type CChunk[+A] = Vector[A]
+
+object CChunk {
+
+  /**
+    * Wraps a `Vector` as a `CChunk`. The conversion is the identity on the carrier.
+    */
+  inline def lift[A](inline c: Vector[A]): CChunk[A] = c
+
+  extension [A](inline self: CChunk[A]) {
+
+    /**
+      * Unwraps to the native `Vector`. The conversion is the identity on the carrier.
+      */
+    inline def lower: Vector[A] = self
+
+    /**
+      * Views the chunk as a `Seq[A]`.
+      */
+    inline def toSeq: Seq[A] = self
+
+    /**
+      * Views the chunk as an `IndexedSeq[A]`.
+      */
+    inline def toIndexedSeq: IndexedSeq[A] = self
+
+    /**
+      * Returns the element at index `i`.
+      */
+    inline def apply(inline i: Int): A = self(i)
+
+    /**
+      * Returns the number of elements.
+      */
+    inline def size: Int = self.size
+
+    /**
+      * Returns an iterator over the chunk's elements.
+      */
+    inline def iterator: Iterator[A] = self.iterator
+
+    /**
+      * Returns `true` if the chunk has no elements.
+      */
+    inline def isEmpty: Boolean = self.isEmpty
+
+  }
+
+}

--- a/sage-compat-ce/src/main/scala/kyo/compat/CFiber.scala
+++ b/sage-compat-ce/src/main/scala/kyo/compat/CFiber.scala
@@ -1,0 +1,65 @@
+package kyo.compat
+
+import java.util.concurrent.CancellationException
+
+import cats.effect.FiberIO
+import cats.effect.IO
+
+/**
+  * Underlying carrier is `cats.effect.FiberIO[A]`. Cats Effect has no `Frame` / `Trace` to propagate. `lift` and `lower` are identity since
+  * the carrier is already a native CE fiber. `init` uses `.start`, so the fork has no parent scope and the caller is responsible for its
+  * lifetime. `onComplete` starts a listener fiber and translates `Outcome.Canceled` into `Failure(CancellationException)` before invoking
+  * `cb`.
+  */
+
+opaque type CFiber[+A] = FiberIO[? <: A]
+
+object CFiber {
+
+  /**
+    * Forks `c` as a new fiber and returns a handle; the fork has no parent scope.
+    */
+  inline def init[A](inline c: CIO[A]): CIO[CFiber[A]] =
+    CIO.lift(c.lower.start)
+
+  /**
+    * Wraps a native `cats.effect.FiberIO` as a `CFiber`. The conversion is the identity on the carrier.
+    */
+  inline def lift[A](inline u: FiberIO[A]): CFiber[A] = u
+
+  extension [A](self: CFiber[A]) {
+
+    /**
+      * Unwraps to the native `cats.effect.FiberIO`. The conversion is the identity on the carrier.
+      */
+    inline def lower: FiberIO[? <: A] = self
+
+    /**
+      * Joins the fiber and returns its result; cancellation surfaces as `CancellationException`.
+      */
+    inline def get: CIO[A] =
+      CIO.lift(
+        self.join.flatMap {
+          case cats.effect.Outcome.Succeeded(ioa) => ioa
+          case cats.effect.Outcome.Errored(t)     => IO.raiseError(t)
+          case cats.effect.Outcome.Canceled()     => IO.raiseError(new CancellationException("CFiber.interrupt"))
+        }
+      )
+
+    /**
+      * Registers `cb` to fire when the fiber completes; success and failure are reified as `scala.util.Try`, and `Outcome.Canceled` is
+      * translated to `Failure(CancellationException)` before the callback runs.
+      */
+    inline def onComplete(cb: scala.util.Try[A] => CIO[Unit]): CIO[Unit] =
+      CIO.lift(
+        self.join
+          .flatMap {
+            case cats.effect.Outcome.Succeeded(ioa) => ioa.flatMap(a => cb(scala.util.Success(a)).lower)
+            case cats.effect.Outcome.Errored(t)     => cb(scala.util.Failure(t)).lower
+            case cats.effect.Outcome.Canceled()     => cb(scala.util.Failure(new CancellationException("CFiber.interrupt"))).lower
+          }
+          .start
+          .void
+      )
+  }
+}

--- a/sage-compat-ce/src/main/scala/kyo/compat/CIO.scala
+++ b/sage-compat-ce/src/main/scala/kyo/compat/CIO.scala
@@ -1,0 +1,398 @@
+package kyo.compat
+
+import scala.annotation.nowarn
+import scala.concurrent.Future as ScalaFuture
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.NANOSECONDS
+
+import cats.effect.IO
+import cats.syntax.parallel.*
+
+/**
+  * Underlying carrier is `cats.effect.IO[A]`. Cats Effect has no `Frame` / `Trace` to propagate. `lift` and `lower` are identity since the
+  * carrier is already a native `IO`. `CIO.acquireReleaseWith` is `IO.bracket`; release errors propagate through the `IO` error channel.
+  * `CIO.cede` is `IO.cede`; `CIO.blocking { thunk }` is `IO.blocking`.
+  */
+opaque type CIO[+A] = IO[A]
+
+object CIO {
+
+  /**
+    * Wraps an already-constructed `IO` as a `CIO`. The conversion is the identity on the carrier.
+    */
+  inline def lift[A](inline io: IO[A]): CIO[A] = io
+
+  /**
+    * Suspends side-effecting code that produces an `IO`, deferring its construction to effect-evaluation time.
+    */
+  inline def deferLift[A](inline io: => IO[A]): CIO[A] = lift(IO.defer(io))
+
+  /**
+    * Creates a `CIO` that succeeds with the given value.
+    */
+  inline def value[A](inline a: A): CIO[A] = lift(IO.pure(a))
+
+  /**
+    * Returns a `CIO` that succeeds with the unit value.
+    */
+  inline def unit: CIO[Unit] = lift(IO.unit)
+
+  /**
+    * Suspends a side-effecting thunk that produces a plain value, deferring its execution to effect-evaluation time.
+    */
+  inline def defer[A](inline thunk: => A): CIO[A] =
+    lift(IO.delay(thunk))
+
+  /**
+    * Creates a `CIO` that fails with `e`.
+    */
+  inline def fail(inline e: Throwable): CIO[Nothing] =
+    lift(IO.raiseError(e))
+
+  /**
+    * Lifts a `Try[A]`: `Success` succeeds with the value, `Failure` fails with the throwable.
+    */
+  inline def get[A](inline t: scala.util.Try[A]): CIO[A] =
+    lift(IO.fromTry(t))
+
+  /**
+    * Lifts a `scala.concurrent.Future[A]`; observes the future's eventual completion. Cancellation does not propagate back.
+    */
+  inline def fromScalaFuture[A](inline f: ScalaFuture[A]): CIO[A] =
+    // Use `IO.fromFutureCancelable` with a no-op cancel token: a Scala `Future` cannot be canceled, but the resulting `IO` must still be
+    // cancelable so that `CIO.timeout` and `CIO.race` can drop it. `IO.fromFuture` is uncancelable, and canceling a pending
+    // `fromScalaFuture` built on it deadlocks the surrounding operation.
+    lift(IO.fromFutureCancelable(IO.pure(f -> IO.unit)))
+
+  /**
+    * Pairs acquisition with release that runs on success, failure, and interrupt of `use`; release errors propagate through the `IO`
+    * error channel (`IO.bracket`).
+    */
+  inline def acquireReleaseWith[A, B](
+    inline acquire: CIO[A]
+  )(
+    inline release: A => CIO[Unit]
+  )(
+    inline use: A => CIO[B]
+  ): CIO[B] =
+    lift(IO.bracketFull(_ => acquire.lower)(use(_).lower)((a, _) => release(a).lower))
+
+  /**
+    * Runs `c` and guarantees `cleanup` executes on every exit path.
+    */
+  inline def ensure[A](
+    inline cleanup: CIO[Unit]
+  )(
+    inline c: CIO[A]
+  ): CIO[A] =
+    acquireReleaseWith(CIO.defer(()))(_ => cleanup)(_ => c)
+
+  /**
+    * Returns a `CIO` that never completes.
+    */
+  inline def never: CIO[Nothing] =
+    lift(IO.never)
+
+  extension [A](inline self: CIO[A]) {
+
+    /**
+      * Unwraps to the native `IO`. The conversion is the identity on the carrier.
+      */
+    inline def lower: IO[A] = self
+
+    /**
+      * Runs `handler` on failure to produce a recovery `CIO`.
+      */
+    inline def recover[A2 >: A](inline handler: Throwable => CIO[A2]): CIO[A2] =
+      lift(self.lower.handleErrorWith(t => handler(t).lower))
+
+    /**
+      * Collapses success and failure into a single `CIO[B]` via the respective handlers.
+      */
+    inline def fold[B](
+      inline onSuccess: A => CIO[B],
+      inline onFail: Throwable => CIO[B]
+    ): CIO[B] =
+      lift(
+        self.lower.redeemWith(
+          t => onFail(t).lower,
+          a => onSuccess(a).lower
+        )
+      )
+
+    /**
+      * Reifies failure as `Try`; the resulting `CIO` always succeeds.
+      */
+    inline def liftToTry: CIO[scala.util.Try[A]] =
+      lift(self.lower.attempt.map {
+        case Right(a) => scala.util.Success(a)
+        case Left(t)  => scala.util.Failure(t)
+      })
+
+    /**
+      * Discards the success value; failure propagates.
+      */
+    inline def unit: CIO[Unit] =
+      lift(self.lower.void)
+
+    /**
+      * Falls back to `that` on any failure of `self`.
+      */
+    inline def orElse[A2 >: A](inline that: CIO[A2]): CIO[A2] =
+      lift(self.lower.handleErrorWith(_ => that.lower))
+
+    /**
+      * Rewrites the error value through `f`.
+      */
+    @nowarn("msg=anonymous")
+    inline def mapError(inline f: Throwable => Throwable): CIO[A] =
+      lift(self.lower.adaptError { case t =>
+        f(t)
+      })
+
+    /**
+      * Transforms the success value with a pure function.
+      */
+    inline def map[B](inline f: A => B): CIO[B] =
+      lift(self.lower.map(f))
+
+    /**
+      * Chains another `CIO` whose construction depends on the success value.
+      */
+    inline def flatMap[B](inline f: A => CIO[B]): CIO[B] =
+      lift(self.lower.flatMap(a => f(a).lower))
+
+    /**
+      * Materializes this `CIO` into a `scala.concurrent.Future[A]` using CE's default `IORuntime`.
+      */
+    inline def unsafeRun: scala.concurrent.Future[A] =
+      self.lower.unsafeToFuture()(using cats.effect.unsafe.IORuntime.global)
+  }
+
+  /**
+    * Suspends the calling computation for `d`.
+    */
+  inline def sleep(inline d: FiniteDuration): CIO[Unit] =
+    lift(IO.sleep(d))
+
+  /**
+    * Reads the current wall-clock instant.
+    */
+  inline def now: CIO[java.time.Instant] =
+    lift(IO.realTime.map(d => java.time.Instant.ofEpochMilli(d.toMillis)))
+
+  /**
+    * Reads a monotonic timestamp expressed as a `FiniteDuration` since a backend-defined origin, suitable for measuring intervals.
+    */
+  inline def nowMonotonic: CIO[FiniteDuration] =
+    lift(IO.monotonic.map(d => FiniteDuration(d.toNanos, NANOSECONDS)))
+
+  /**
+    * Runs `c` with a deadline; resolves to `None` if `d` elapses first.
+    */
+  inline def timeout[A](inline d: FiniteDuration)(inline c: CIO[A]): CIO[Option[A]] =
+    lift(c.lower.map(Option(_)).timeoutTo(d, IO.none[A]))
+
+  /**
+    * Runs `c` with a deadline; fails with `e` if `d` elapses first.
+    */
+  inline def timeoutWithError[A](inline d: FiniteDuration)(inline e: Throwable)(inline c: CIO[A]): CIO[A] =
+    lift(c.lower.timeoutTo(d, IO.raiseError(e)))
+
+  /**
+    * Sleeps for `d` and then runs `c`.
+    */
+  inline def delay[A](inline d: FiniteDuration)(inline c: CIO[A]): CIO[A] =
+    lift(c.lower.delayBy(d))
+
+  /**
+    * Runs `a` and `b` in parallel. Returns the value or raises the error of the first fiber to complete, canceling the other. A canceled
+    * fiber is never selected: if one side is canceled, the result of the other side is awaited.
+    */
+  // `IO.race` returns `Either[A, B]`; `.merge` narrows since both legs share type A.
+  inline def race[A](
+    inline a: CIO[A],
+    inline b: CIO[A]
+  ): CIO[A] =
+    lift(IO.race(a.lower, b.lower).map(_.merge))
+
+  /**
+    * Parallel map. `concurrency` caps the number of in-flight elements, is unbounded by default, and must be positive when bounded.
+    */
+  inline def foreach[A, B](
+    inline coll: Iterable[A],
+    inline concurrency: Int = Int.MaxValue
+  )(f: A => CIO[B]): CIO[CChunk[B]] =
+    lift {
+      val list = coll.toList
+      val io   =
+        if (concurrency == Int.MaxValue) list.parTraverse(a => f(a).lower)
+        else IO.parTraverseN(concurrency)(list)(a => f(a).lower)
+      io.map(lst => CChunk.lift(lst.toVector))
+    }
+
+  /**
+    * Parallel map that passes the element index to `f`; same concurrency semantics as `foreach`.
+    */
+  inline def foreachIndexed[A, B](
+    inline coll: Iterable[A],
+    inline concurrency: Int = Int.MaxValue
+  )(f: (Int, A) => CIO[B]): CIO[CChunk[B]] =
+    lift {
+      val list = coll.toList.zipWithIndex
+      val io   =
+        if (concurrency == Int.MaxValue) list.parTraverse { case (a, i) => f(i, a).lower }
+        else IO.parTraverseN(concurrency)(list) { case (a, i) => f(i, a).lower }
+      io.map(lst => CChunk.lift(lst.toVector))
+    }
+
+  /**
+    * Runs `f` for its effects on each element and discards the results; same concurrency semantics as `foreach`.
+    */
+  inline def foreachDiscard[A](
+    inline coll: Iterable[A],
+    inline concurrency: Int = Int.MaxValue
+  )(f: A => CIO[Any]): CIO[Unit] =
+    lift {
+      val list = coll.toList
+      if (concurrency == Int.MaxValue) list.parTraverse_(a => f(a).lower)
+      else IO.parTraverseN_(concurrency)(list)(a => f(a).lower)
+    }
+
+  /**
+    * Filters the collection with an effectful predicate; same concurrency semantics as `foreach`.
+    */
+  @nowarn("msg=anonymous")
+  inline def filter[A](
+    inline coll: Iterable[A],
+    inline concurrency: Int = Int.MaxValue
+  )(p: A => CIO[Boolean]): CIO[CChunk[A]] =
+    lift {
+      val list = coll.toList
+      if (concurrency == Int.MaxValue) list.parFilterA(a => p(a).lower).map(lst => CChunk.lift(lst.toVector))
+      else
+        IO.parTraverseN(concurrency)(list)(a => p(a).lower.map(b => a -> b))
+          .map(pairs => CChunk.lift(pairs.collect { case (a, true) => a }.toVector))
+    }
+
+  /**
+    * Sequences an `Iterable[CIO[A]]`; same concurrency semantics as `foreach`.
+    */
+  inline def collectAll[A](
+    inline coll: Iterable[CIO[A]],
+    inline concurrency: Int = Int.MaxValue
+  ): CIO[CChunk[A]] =
+    lift {
+      val list = coll.toList.map(_.lower)
+      if (concurrency == Int.MaxValue) list.parSequence.map(lst => CChunk.lift(lst.toVector))
+      else IO.parSequenceN(concurrency)(list).map(lst => CChunk.lift(lst.toVector))
+    }
+
+  /**
+    * Sequences and discards the results; same concurrency semantics as `foreach`.
+    */
+  inline def collectAllDiscard(
+    inline coll: Iterable[CIO[Any]],
+    inline concurrency: Int = Int.MaxValue
+  ): CIO[Unit] =
+    lift {
+      val list = coll.toList.map(_.lower)
+      if (concurrency == Int.MaxValue) list.parSequence_
+      else IO.parSequenceN_(concurrency)(list)
+    }
+
+  /**
+    * Bridges a one-shot completion callback into `CIO`; `register` receives a `Try[A] => Unit`.
+    */
+  inline def async[A](inline register: ((scala.util.Try[A] => Unit) => Unit)): CIO[A] =
+    lift(IO.async_[A] { k =>
+      val cb: scala.util.Try[A] => Unit = {
+        case scala.util.Success(a) => k(Right(a))
+        case scala.util.Failure(e) => k(Left(e))
+      }
+      register(cb)
+    })
+
+  /**
+    * Runs the thunk on CE's blocking pool (`IO.blocking`).
+    */
+  inline def blocking[A](inline thunk: => A): CIO[A] =
+    lift(IO.blocking(thunk))
+
+  /**
+    * Yields the current fiber (`IO.cede`).
+    */
+  inline def cede: CIO[Unit] =
+    lift(IO.cede)
+
+  /**
+    * Runs two computations in parallel and returns their results as a tuple.
+    */
+  // Arity 2 uses `IO.both`; arities 3 to 7 use `parTupled` from `cats.syntax.parallel.*`.
+  inline def zip[A1, A2](
+    inline a1: CIO[A1],
+    inline a2: CIO[A2]
+  ): CIO[(A1, A2)] =
+    lift(IO.both(a1.lower, a2.lower))
+
+  /**
+    * Runs three computations in parallel and returns their results as a tuple.
+    */
+  inline def zip[A1, A2, A3](
+    inline a1: CIO[A1],
+    inline a2: CIO[A2],
+    inline a3: CIO[A3]
+  ): CIO[(A1, A2, A3)] =
+    lift((a1.lower, a2.lower, a3.lower).parTupled)
+
+  /**
+    * Runs four computations in parallel and returns their results as a tuple.
+    */
+  inline def zip[A1, A2, A3, A4](
+    inline a1: CIO[A1],
+    inline a2: CIO[A2],
+    inline a3: CIO[A3],
+    inline a4: CIO[A4]
+  ): CIO[(A1, A2, A3, A4)] =
+    lift((a1.lower, a2.lower, a3.lower, a4.lower).parTupled)
+
+  /**
+    * Runs five computations in parallel and returns their results as a tuple.
+    */
+  inline def zip[A1, A2, A3, A4, A5](
+    inline a1: CIO[A1],
+    inline a2: CIO[A2],
+    inline a3: CIO[A3],
+    inline a4: CIO[A4],
+    inline a5: CIO[A5]
+  ): CIO[(A1, A2, A3, A4, A5)] =
+    lift((a1.lower, a2.lower, a3.lower, a4.lower, a5.lower).parTupled)
+
+  /**
+    * Runs six computations in parallel and returns their results as a tuple.
+    */
+  inline def zip[A1, A2, A3, A4, A5, A6](
+    inline a1: CIO[A1],
+    inline a2: CIO[A2],
+    inline a3: CIO[A3],
+    inline a4: CIO[A4],
+    inline a5: CIO[A5],
+    inline a6: CIO[A6]
+  ): CIO[(A1, A2, A3, A4, A5, A6)] =
+    lift((a1.lower, a2.lower, a3.lower, a4.lower, a5.lower, a6.lower).parTupled)
+
+  /**
+    * Runs seven computations in parallel and returns their results as a tuple.
+    */
+  inline def zip[A1, A2, A3, A4, A5, A6, A7](
+    inline a1: CIO[A1],
+    inline a2: CIO[A2],
+    inline a3: CIO[A3],
+    inline a4: CIO[A4],
+    inline a5: CIO[A5],
+    inline a6: CIO[A6],
+    inline a7: CIO[A7]
+  ): CIO[(A1, A2, A3, A4, A5, A6, A7)] =
+    lift((a1.lower, a2.lower, a3.lower, a4.lower, a5.lower, a6.lower, a7.lower).parTupled)
+
+}

--- a/sage-compat-ce/src/main/scala/kyo/compat/CLatch.scala
+++ b/sage-compat-ce/src/main/scala/kyo/compat/CLatch.scala
@@ -1,0 +1,49 @@
+package kyo.compat
+
+import cats.effect.IO
+import cats.effect.std.CountDownLatch
+
+/**
+  * Underlying carrier is `cats.effect.std.CountDownLatch[IO]`, a one-shot count-down latch. Cats Effect has no `Frame` / `Trace` to
+  * propagate. `lift` and `lower` are identity since the carrier is already a native CE latch. `init(n)` with `n <= 0` is normalized to
+  * "already released" by allocating `CountDownLatch[IO](1)` and pre-releasing it, since CE requires `n >= 1`.
+  */
+opaque type CLatch = CountDownLatch[IO]
+
+object CLatch {
+
+  /**
+    * Allocates a latch with counter `n`; `n <= 0` is normalized to "already released".
+    */
+  inline def init(inline n: Int): CIO[CLatch] =
+    CIO.lift(initImpl(n))
+
+  /**
+    * Wraps a native `cats.effect.std.CountDownLatch` as a `CLatch`. The conversion is the identity on the carrier.
+    */
+  inline def lift(inline u: CountDownLatch[IO]): CLatch = u
+
+  private inline def initImpl(inline n: Int): IO[CountDownLatch[IO]] =
+    if (n <= 0) CountDownLatch[IO](1).flatMap(l => l.release.as(l))
+    else CountDownLatch[IO](n)
+
+  extension (inline self: CLatch) {
+
+    /**
+      * Unwraps to the native `cats.effect.std.CountDownLatch`. The conversion is the identity on the carrier.
+      */
+    inline def lower: CountDownLatch[IO] = self
+
+    /**
+      * Suspends until the counter reaches zero.
+      */
+    inline def await: CIO[Unit] = CIO.lift(self.await)
+
+    /**
+      * Decrements the counter by one; unblocks all `await`s when it reaches zero.
+      */
+    inline def release: CIO[Unit] = CIO.lift(self.release)
+
+  }
+
+}

--- a/sage-compat-ce/src/main/scala/kyo/compat/CLocal.scala
+++ b/sage-compat-ce/src/main/scala/kyo/compat/CLocal.scala
@@ -1,0 +1,53 @@
+package kyo.compat
+
+import cats.effect.IOLocal
+
+/**
+  * Underlying carrier is `cats.effect.IOLocal[A]`, a fiber-scoped value. Cats Effect has no `Frame` / `Trace` to propagate. `lift` and
+  * `lower` are identity since the carrier is already a native CE local. `init` allocates a fresh `IOLocal` inside `IO`, so the allocation
+  * is deferred to effect-evaluation time. `let` and `update` use `IO.bracket` to install the new value and revert the prior one on every
+  * exit path.
+  */
+opaque type CLocal[A] = IOLocal[A]
+
+object CLocal {
+
+  /**
+    * Allocates a fresh fiber-local seeded with `default`.
+    */
+  inline def init[A](inline default: A): CIO[CLocal[A]] =
+    CIO.lift(IOLocal[A](default))
+
+  /**
+    * Wraps a native `cats.effect.IOLocal` as a `CLocal`. The conversion is the identity on the carrier.
+    */
+  inline def lift[A](inline u: IOLocal[A]): CLocal[A] = u
+
+  extension [A](inline self: CLocal[A]) {
+
+    /**
+      * Unwraps to the native `cats.effect.IOLocal`. The conversion is the identity on the carrier.
+      */
+    inline def lower: IOLocal[A] = self
+
+    /**
+      * Reads the current fiber's value.
+      */
+    inline def get: CIO[A] = CIO.lift(self.get)
+
+    /**
+      * Installs `v` for the duration of `c`, then reverts.
+      */
+    inline def let[B](inline v: A)(inline c: CIO[B]): CIO[B] =
+      CIO.lift(self.getAndSet(v).bracket(_ => c.lower)(prior => self.set(prior)))
+
+    /**
+      * Reads the current value, applies `f`, installs the result for the duration of `c`, then reverts.
+      */
+    inline def update[B](inline f: A => A)(inline c: CIO[B]): CIO[B] =
+      CIO.lift(self.get.flatMap { cur =>
+        self.set(f(cur)).bracket(_ => c.lower)(_ => self.set(cur))
+      })
+
+  }
+}

--- a/sage-compat-ce/src/main/scala/kyo/compat/CMeter.scala
+++ b/sage-compat-ce/src/main/scala/kyo/compat/CMeter.scala
@@ -1,0 +1,56 @@
+package kyo.compat
+
+import cats.effect.IO
+import cats.effect.std.Semaphore
+
+/**
+  * Underlying carrier is `cats.effect.std.Semaphore[IO]`, a counting semaphore. Cats Effect has no `Frame` / `Trace` to propagate. `lift`
+  * and `lower` are identity since the carrier is already a native CE semaphore. Permit counts are `Long` on the CE side; the compat surface
+  * converts to/from `Int` on `init` and `availablePermits`. `tryRun` uses `tryPermit` (`Resource[IO, Boolean]`).
+  */
+opaque type CMeter = Semaphore[IO]
+
+object CMeter {
+
+  /**
+    * Allocates a counting semaphore with `permits` permits. `permits` must be nonnegative.
+    */
+  inline def init(inline permits: Int): CIO[CMeter] =
+    CIO.lift(Semaphore[IO](permits.toLong))
+
+  /**
+    * Wraps a native `cats.effect.std.Semaphore` as a `CMeter`. The conversion is the identity on the carrier.
+    */
+  inline def lift(inline u: Semaphore[IO]): CMeter = u
+
+  extension (inline self: CMeter) {
+
+    /**
+      * Unwraps to the native `cats.effect.std.Semaphore`. The conversion is the identity on the carrier.
+      */
+    inline def lower: Semaphore[IO] = self
+
+    /**
+      * Acquires one permit, runs `c`, and releases on completion (success or failure).
+      */
+    inline def run[A](inline c: CIO[A]): CIO[A] =
+      CIO.lift(self.permit.use(_ => c.lower))
+
+    /**
+      * Attempts to acquire a permit without blocking; runs `c` if successful, otherwise returns `None`.
+      */
+    inline def tryRun[A](inline c: CIO[A]): CIO[Option[A]] =
+      CIO.lift(self.tryPermit.use {
+        case true  => c.lower.map(Some(_))
+        case false => IO.none[A]
+      })
+
+    /**
+      * Returns the current count of available permits.
+      */
+    inline def availablePermits: CIO[Int] =
+      CIO.lift(self.available.map(_.toInt))
+
+  }
+
+}

--- a/sage-compat-ce/src/main/scala/kyo/compat/CPromise.scala
+++ b/sage-compat-ce/src/main/scala/kyo/compat/CPromise.scala
@@ -1,0 +1,73 @@
+package kyo.compat
+
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import cats.effect.Deferred
+import cats.effect.IO
+
+/**
+  * Underlying carrier is `cats.effect.Deferred[IO, Try[A]]`. Cats Effect has no `Frame` / `Trace` to propagate. `Deferred` is a
+  * single-assignment cell of a plain value — it has no error channel (`complete` takes an `A`, `get` returns an `A`). A `CPromise` must
+  * carry failures, so the cell stores a `Try[A]` and failure is encoded as `Failure(t)`. `succeed` and `fail` return `true` on first
+  * completion and `false` on subsequent attempts (first-wins). `poll` returns the stored `Try` directly.
+  */
+opaque type CPromise[A] = Deferred[IO, Try[A]]
+
+object CPromise {
+
+  /**
+    * Allocates a fresh single-shot promise.
+    */
+  inline def init[A]: CIO[CPromise[A]] =
+    CIO.lift(Deferred[IO, Try[A]])
+
+  /**
+    * Wraps a native `cats.effect.Deferred` as a `CPromise`. The conversion is the identity on the carrier.
+    */
+  inline def lift[A](inline u: Deferred[IO, Try[A]]): CPromise[A] = u
+
+  extension [A](inline self: CPromise[A]) {
+
+    /**
+      * Unwraps to the native `cats.effect.Deferred`. The conversion is the identity on the carrier.
+      */
+    inline def lower: Deferred[IO, Try[A]] = self
+
+    /**
+      * Attempts to complete the promise with `a`; returns `true` if this is the first completion.
+      */
+    inline def succeed(inline a: A): CIO[Boolean] =
+      CIO.lift(self.complete(Success(a)))
+
+    /**
+      * Attempts to complete the promise with failure `e`; returns `true` if this is the first completion.
+      */
+    inline def fail(inline e: Throwable): CIO[Boolean] =
+      CIO.lift(self.complete(Failure(e)))
+
+    /**
+      * Suspends until the promise is completed and returns its value.
+      */
+    inline def get: CIO[A] =
+      CIO.lift(self.get.flatMap {
+        case Success(a) => IO.pure(a)
+        case Failure(e) => IO.raiseError(e)
+      })
+
+    /**
+      * Returns the current state without blocking: `None` if pending, `Some(Try)` if completed.
+      */
+    inline def poll: CIO[Option[Try[A]]] =
+      CIO.lift(self.tryGet)
+
+    /**
+      * Returns `true` if the promise has been completed.
+      */
+    inline def done: CIO[Boolean] =
+      CIO.lift(self.tryGet.map(_.isDefined))
+
+  }
+
+}

--- a/sage-compat-ce/src/main/scala/kyo/compat/CStream.scala
+++ b/sage-compat-ce/src/main/scala/kyo/compat/CStream.scala
@@ -1,0 +1,149 @@
+package kyo.compat
+
+import cats.effect.IO
+import fs2.Stream
+
+/**
+  * Underlying carrier is `fs2.Stream[cats.effect.IO, A]`. Operations delegate to the native `fs2.Stream` methods directly. The fs2 error
+  * channel is the throwable raised inside the underlying `IO`; matches `CStream`'s `Throwable` shape. `lift` and `lower` are identity since
+  * the carrier is already an `fs2.Stream`. Method names mirror `kyo.Stream`
+  * (`mapPure`/`filterPure`/`takeWhilePure`/`collectPure`/`foldPure`/`discard`); the pure/effectful split tracks the Kyo convention.
+  */
+opaque type CStream[+A] = Stream[IO, A]
+
+object CStream {
+
+  /**
+    * Returns the empty stream.
+    */
+  inline def empty[A]: CStream[A] = Stream.empty.covary[IO]
+
+  /**
+    * Creates a stream emitting the elements produced by the effectful sequence.
+    */
+  inline def init[A](inline c: CIO[Seq[A]]): CStream[A] =
+    Stream.eval(c.lower).flatMap(Stream.emits)
+
+  /**
+    * Creates a stream emitting the elements of the given sequence.
+    */
+  inline def init[A](inline seq: Seq[A]): CStream[A] =
+    Stream.emits(seq)
+
+  /**
+    * Creates a stream emitting the integers from `start` until `end` (exclusive) in steps of 1.
+    */
+  inline def range(inline start: Int, inline end: Int): CStream[Int] =
+    Stream.range(start, end).covary[IO]
+
+  /**
+    * Creates a stream by iteratively unfolding `acc` through `f`; emission stops when `f` yields `None`.
+    */
+  inline def unfold[S, A](inline acc: S)(inline f: S => CIO[Option[(A, S)]]): CStream[A] =
+    Stream.unfoldEval(acc)(s => f(s).lower)
+
+  /**
+    * Wraps a native `fs2.Stream` as a `CStream`. The conversion is the identity on the carrier.
+    */
+  inline def lift[A](inline native: Stream[IO, A]): CStream[A] = native
+
+  extension [A](inline self: CStream[A]) {
+
+    /**
+      * Unwraps to the native `fs2.Stream`. The conversion is the identity on the carrier.
+      */
+    inline def lower: Stream[IO, A] = self
+
+    /**
+      * Concatenates `other` after `self`.
+      */
+    inline def concat[A2 >: A](inline other: CStream[A2]): CStream[A2] =
+      self ++ other.lower
+
+    /**
+      * Maps each element with a pure function.
+      */
+    inline def mapPure[B](inline f: A => B): CStream[B] =
+      self.map(f)
+
+    /**
+      * Maps each element with an effectful function.
+      */
+    inline def map[B](inline f: A => CIO[B]): CStream[B] =
+      self.evalMap(a => f(a).lower)
+
+    /**
+      * Flat-maps each element to another stream and concatenates the results.
+      */
+    inline def flatMap[B](inline f: A => CStream[B]): CStream[B] =
+      self.flatMap(a => f(a).lower)
+
+    /**
+      * Runs `f` for its effect on each element, passing the element through unchanged.
+      */
+    inline def tap(inline f: A => CIO[Any]): CStream[A] =
+      self.evalTap(a => f(a).lower.void)
+
+    /**
+      * Takes the first `n` elements.
+      */
+    inline def take(inline n: Int): CStream[A] =
+      self.take(n.toLong)
+
+    /**
+      * Drops the first `n` elements.
+      */
+    inline def drop(inline n: Int): CStream[A] =
+      self.drop(n.toLong)
+
+    /**
+      * Takes elements while `p` holds.
+      */
+    inline def takeWhilePure(inline p: A => Boolean): CStream[A] =
+      self.takeWhile(p)
+
+    /**
+      * Keeps elements matching the pure predicate.
+      */
+    inline def filterPure(inline p: A => Boolean): CStream[A] =
+      self.filter(p)
+
+    /**
+      * Keeps elements matching the effectful predicate.
+      */
+    inline def filter(inline p: A => CIO[Boolean]): CStream[A] =
+      self.evalFilter(a => p(a).lower)
+
+    /**
+      * Maps and filters in one pass via a pure partial mapping.
+      */
+    inline def collectPure[B](inline f: A => Option[B]): CStream[B] =
+      self.collect(Function.unlift(f))
+
+    /**
+      * Runs the stream and collects all emitted elements into a `CChunk`.
+      */
+    inline def run: CIO[CChunk[A]] =
+      CIO.lift(self.compile.toVector.map(CChunk.lift(_)))
+
+    /**
+      * Folds the stream with a pure accumulator.
+      */
+    inline def foldPure[B](inline acc: B)(inline f: (B, A) => B): CIO[B] =
+      CIO.lift(self.compile.fold(acc)(f))
+
+    /**
+      * Runs `f` for its effect on each element, discarding results.
+      */
+    inline def foreach(inline f: A => CIO[Unit]): CIO[Unit] =
+      CIO.lift(self.foreach(a => f(a).lower).compile.drain)
+
+    /**
+      * Runs the stream and discards all emitted elements.
+      */
+    inline def discard: CIO[Unit] =
+      CIO.lift(self.compile.drain)
+
+  }
+
+}

--- a/sage-compat-ce/src/main/scala/kyo/compat/FromCompletionStage.scala
+++ b/sage-compat-ce/src/main/scala/kyo/compat/FromCompletionStage.scala
@@ -1,0 +1,28 @@
+package kyo.compat
+
+import java.util.concurrent.CompletionStage
+
+import cats.effect.IO
+
+/**
+  * Lifts a `CompletionStage[A]` into `CIO[A]` via `IO.fromCompletionStage`; this integration is JVM-only. Failures propagate through the
+  * `IO` error channel, and `CIO` interruption propagates to the source via `cf.cancel(true)`.
+  */
+object CompatFromCompletionStage {
+
+  /**
+    * Lifts `cs` into a `CIO[A]` that observes its eventual completion; `CIO` interruption propagates to `cs` via `cf.cancel(true)`.
+    */
+  inline def fromCompletionStage[A](inline cs: CompletionStage[A]): CIO[A] =
+    CIO.lift(IO.fromCompletionStage(IO.delay(cs)))
+
+}
+
+extension (inline c: CIO.type) {
+
+  /**
+    * Lifts `cs` into a `CIO[A]` that observes its eventual completion; `CIO` interruption propagates to `cs` via `cf.cancel(true)`.
+    */
+  inline def fromCompletionStage[A](inline cs: CompletionStage[A]): CIO[A] =
+    CompatFromCompletionStage.fromCompletionStage(cs)
+}


### PR DESCRIPTION
kyo 1.0.0-RC6 removed its cats-effect integrations (getkyo/kyo#1779) and opened kyo-compat to external backends (getkyo/kyo#1840). This keeps sage's cats-effect backend fully intact, with identical artifact names and project ids.

## Changes

- **New `sage-compat-ce` module** (published): the `kyo.compat` Cats Effect binding vendored from its last upstream state (the sources of `kyo-compat-ce` 1.0.0-RC5). The vendored copy is API- and behavior-equivalent rather than textually identical: the `shared`/`jvm` trees are merged, the code is converted to this repo's brace style, and documentation is corrected or completed where the review found gaps (`CIO.race` semantics, allocation and concurrency constraints). Provenance and Apache 2.0 attribution in its README. Depends only on Cats Effect and fs2, so no kyo release can break it at runtime.
- **`CeLib` redefined** as `CompatBackendAxis.local("ce", ...)` and bound to the module with `bindLocally` on all four matrices. Same name and suffixes as the removed built-in, so `sage-client-ce`, `clientCe`, `itCe`, etc. are unchanged; the published POM now depends on `sage-compat-ce` instead of `io.getkyo:kyo-compat-ce`.
- **Conformance harness**: a `ceConformance` matrix runs the cross-binding conformance suite bundled inside `kyo-compat-plugin` against the vendored binding (`conformanceCe` alias, wired into `testUnit`). When a future kyo release grows the `kyo.compat` contract, CI fails here instead of as a downstream compile error. All 346 tests pass (3 pending are the documented upstream `kyo.Stream` divergences, pending on every binding).
- **Pekko axis** now uses `CompatBackendAxis.external` pointing at `kyo-compat-future`, replacing the strip-the-injected-dep hack.

## Notes

- kyo-core RC6 requires JDK 25 at runtime (kyo cell tests); CI is already on temurin 25.
- getkyo/kyo#1730 (Ox `acquireReleaseWith` release on interruption) needs no change here — it fixes a latent leak for sage-on-Ox blocking-command leases, and its regression tests are part of the conformance suite the vendored binding passes.
- Vendored scaladoc keeps upstream's vocabulary (e.g. "carrier") and structure (parallel `CAtomicInt`/`CAtomicLong`, `FromCompletionStage` delegation) to keep future syncs against other kyo-compat bindings mechanical; prose written for this PR follows AGENTS.md.

## Verification

`testUnit` green across all cells (including the conformance run), `itCe` green against Redis and Valkey containers, `check` and the `docAll` scaladoc gate pass. Rebased on main after #240 and restyled per the new documentation guidance.