### PR TITLE
Do not probe roles after the client is closed

### DIFF
--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -183,7 +183,9 @@ final private[client] class MasterReplicaLive(
       case _                    => false
     }
 
-  private def connectForProbe(node: Node): NodeClient =
+  private def connectForProbe(node: Node): NodeClient = {
+    // a refresh can outlive the start of close, and a closed client must not open a new socket
+    if (closed) throw NotConnected()
     try
       NodeClient.connect(
         nodeFactory(node),
@@ -202,6 +204,7 @@ final private[client] class MasterReplicaLive(
         reportProbeFailure(node, error)
         throw error
     }
+  }
 
   private def reportProbeFailure(node: Node, error: Throwable): Unit =
     events.emit(SageEvent.Connection.ConnectFailed(Some(node), error))

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -177,15 +177,16 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     val settledDials = fixture.dialled.size
     val settledRoles = fixture.roleRequestCount(primary)
 
-    var i = 0
+    var i       = 0
     while (i < 20) {
       assertEquals(fixture.read(), 1L)
       i += 1
     }
     fixture.awaitTrue(fixture.roleRequestCount(primary) > settledRoles, "later reads stopped re-discovering")
+    val dialled = fixture.dialled
     fixture.close()
 
-    assertEquals(fixture.dialled.size, settledDials, s"a refresh dialled a node it was already connected to: ${fixture.dialled}")
+    assertEquals(dialled.size, settledDials, s"a refresh dialled a node it was already connected to: $dialled")
   }
 
   test("a read whose connection dies mid-flight falls through to the next candidate") {


### PR DESCRIPTION
The unit test `MasterReplicaTopologySpec` fails intermittently in "a role refresh asks ROLE over the established connection instead of opening a second socket". It expects two dials of the primary and sometimes observes three. [This run](https://github.com/ghostdogpr/sage/actions/runs/30967042619/job/92183153610) is one example.

## Cause

The third dial happens after `close()` returns, so the refreshes that the test measures are not responsible for it.

With `minRefreshInterval = Duration.Zero`, every replica-preferred read that has no known replica triggers a role refresh. `rediscover` checks `closed` when it starts, so a refresh that has already passed that check runs alongside `closeAll`. By the time it reaches `probeRole`, `masterPool.close()` may have cleared the established connections. `pooledFor` then returns `null` and `probeRole` falls back to `connectForProbe`, which opens a throwaway socket for a client that is already closed.

## Changes

`connectForProbe` now fails when the client is closed. Discovery already handles a probe that throws by treating the address as unreachable, so the refresh installs no topology and emits no event. The cluster runtime is protected here because it probes through `NodePool.getOrEstablish`, which fails once the pool is closed. The master-replica probe opens its socket outside the pools and had no equivalent check.

The test reads `dialled` before `close()`, which is what the other two tests in the file that inspect dials do. Its assertion describes refresh behavior, and the behavior after close has its own test that drives the scheduler directly.

## Remaining race

The check reduces the window without removing it, because `closed` can change between the check and the dial. Closing the window completely would require holding a lock across the connect attempt, which would allow a slow probe to delay `close` by up to `connectTimeout`, or opening the socket and closing it immediately afterwards. The probe socket is already closed in a `finally` block, so the remaining exposure is a single short-lived connection. The test no longer depends on this timing.

## Verification

`sbt check` and `sbt testUnit` pass. The affected spec passed 16 consecutive runs.