### PR TITLE
Distributed Locks

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -32,6 +32,7 @@ export default defineConfig({
           { text: 'JSON', link: '/json' },
           { text: 'Client-side caching', link: '/client-side-caching' },
           { text: 'Rate limiting', link: '/rate-limiting' },
+          { text: 'Distributed locks', link: '/distributed-locks' },
           { text: 'Configuration', link: '/configuration' },
           { text: 'Error handling', link: '/error-handling' },
           { text: 'Observability', link: '/observability' },

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,7 +156,7 @@ The remaining fields control connection lifetime, pooling, and observability. Ea
 | `reconnect` (`BackoffConfig`) | exponential reconnect backoff with full jitter | `50.millis` to `5.seconds`, ×2 |
 | `watchdog` (`WatchdogConfig`) | connection liveness checks for pending commands and idle connections | ping every `60.seconds`, `30.seconds` timeout |
 | `closeTimeout` | how long `close` waits for in-flight commands to finish (blocking commands and transactions are closed at once) | `5.seconds` |
-| `dedicatedPool` (`DedicatedPoolConfig`) | the pool behind blocking commands and transactions, per node | max `8`, acquire `5.seconds`, idle `30.seconds` |
+| `dedicatedPool` (`DedicatedPoolConfig`) | the pool behind blocking commands, transactions, and lock replication checks, per node | max `8`, acquire `5.seconds`, idle `30.seconds` |
 | `pubsub` (`PubSubConfig`) | per-subscription message buffer size | `128` |
 | `clientCache` (`CacheConfig`) | whether client-side caching is enabled and its size limit | enabled, `64 MB` |
 | `clientName` | `CLIENT SETNAME`, shown in `CLIENT LIST` / `CLIENT INFO` | none |
@@ -164,6 +164,8 @@ The remaining fields control connection lifetime, pooling, and observability. Ea
 | `tracer` | [distributed-tracing](/observability#distributed-tracing) spans on the command path (`CommandTracer`) | none |
 
 `dedicatedPool.maxConnections` applies to each node. A blocking command runs on the node that holds its keys, so every node has a separate pool. Connections open on demand, and Sage removes idle connections. When setting the limit, account for both the node count and the server's `maxclients` setting.
+
+Each lock write and its replication check have a budget of at most one second, including pool acquisition. The pool wait ends at the earlier of `dedicatedPool.acquireTimeout` and the remaining lock budget. See [Distributed locks](/distributed-locks) for contention and timeout behavior.
 
 For example, a cluster client with a shorter connect timeout, a larger blocking-command pool, a more frequent watchdog, and a name:
 

--- a/docs/distributed-locks.md
+++ b/docs/distributed-locks.md
@@ -39,14 +39,20 @@ All processes protecting the same resource must use the same deployment, namespa
 
 The same code works with standalone, master-replica, and cluster clients, including clients configured for replica reads.
 
+In master-replica and cluster mode, acquisition and renewal require acknowledgement from at least as many replicas as the client discovered for the granting master, including any additional replicas that master now reports. Sage allows up to one second for each write and its replication check, bounded by the remaining acquisition wait or lease. This includes waiting for a dedicated connection and receiving replies. A disconnected replica or one still synchronizing can prevent acquisition or cause a running lock to be lost. Failed confirmation requests a topology refresh so later attempts can account for removed replicas.
+
+These checks require permission to run `ROLE` and `WAIT`. Each write and its confirmation briefly borrow a dedicated connection, which is returned when confirmation finishes. Masters without replicas continue to work. Standalone clients do not check replication.
+
+Lock checks share `dedicatedPool` with blocking commands and transactions. A full pool can prevent acquisition or renewal, even for different lock keys. Increasing `dedicatedPool.maxConnections` allows more of these operations to run concurrently.
+
 ## Failure and cancellation
 
-If Sage loses ownership or cannot renew the lock, the operation fails with `SageException.LockLost` and attempts to cancel the body. Release must also be confirmed before Sage reports success. Server and connection errors propagate through your backend's normal failure channel. Cleanup preserves an existing body failure or cancellation.
+If replicas do not acknowledge acquisition in time, Sage raises `SageException.TimedOut` without starting the body. Acquisition can also raise `SageException.LockLost` if the granting master changes role or the lease expires before the body starts. If Sage loses ownership or cannot confirm renewal, the operation fails with `SageException.LockLost` and attempts to cancel the body. Successful completion requires the master to acknowledge release. Server and connection errors propagate through your backend's normal failure channel. Cleanup preserves an existing body failure or cancellation.
 
 Cancellation is cooperative and cannot undo completed work. Uninterruptible work can delay completion. Pekko uses `Future`, so its body may continue after lock loss even though Sage stops renewing the lock. A timed-out or cancelled acquisition can leave the lock held until its lease expires.
 
 ## Limits
 
-Exclusivity depends on the lease remaining valid and the server retaining the lock. A long process pause, failover, or an evicted lock key can allow overlapping work. Prevent eviction or deletion of active lock keys.
+Exclusivity depends on the lease remaining valid and the server retaining the lock. Replica acknowledgement reduces the risk of losing a lock during failover, but does not make Redis or Valkey strongly consistent. A long process pause, failover, or an evicted lock key can still allow overlapping work. Prevent eviction or deletion of active lock keys.
 
 Sage does not provide fencing tokens or exactly-once execution. If correctness must survive those failures, the system receiving the changes must enforce ownership or provide transactional protection. See [Redis's distributed lock documentation](https://redis.io/docs/latest/develop/clients/patterns/distributed-locks/) for the failure assumptions.

--- a/docs/distributed-locks.md
+++ b/docs/distributed-locks.md
@@ -1,0 +1,52 @@
+# Distributed locks
+
+`client.lock` coordinates work on the same resource across processes using Redis or Valkey. Sage acquires the lock before running your body, renews it while the body runs, and releases it when the body finishes.
+
+```scala
+import scala.concurrent.duration.*
+import sage.*
+import sage.backend.*
+
+val locks = client.lock[String]()
+
+locks.withLock("account:42", waitTimeout = 2.seconds) {
+  updateAccount()
+}
+```
+
+The body returns your backend's native effect. With Ox, it is a direct-style block. Construct the operation inside the block: an already-started `Future` may run before acquisition. Keep all protected work inside the returned effect, including any child tasks it starts.
+
+## Waiting for a lock
+
+- `withLock(key, waitTimeout)(body)` waits for the lock and returns the body's result. Retries back off under contention to reduce server traffic. If acquisition times out, it raises `SageException.TimedOut`.
+- `tryWithLock(key)(body)` attempts acquisition once. It returns `None` when busy, without evaluating the body, or `Some(result)` after successful execution and release. It still waits for a server reply.
+
+`waitTimeout` must be positive. It covers acquisition, including server replies and retry delays, but does not limit the body's runtime. Cleanup can add up to one second before a timeout returns.
+
+Sage never retries the body. Locks do not guarantee acquisition order. Acquiring the same key inside its own lock scope contends with the outer scope.
+
+## Lease and namespace
+
+The lease defaults to 30 seconds and must be at least 30 milliseconds. Sage renews it automatically, so the body can run longer than one lease.
+
+```scala
+val locks = client.lock[String](leaseDuration = 10.seconds, namespace = "account-updates")
+```
+
+Choose a lease comfortably longer than expected network latency and process pauses. A longer lease delays recovery after a holder crashes. Invalid lease or wait durations raise `SageException.InvalidArgument`.
+
+All processes protecting the same resource must use the same deployment, namespace, and compatible key encoding. Keys support any `KeyCodec`. The default namespace is `lock`; reserve it for locks and give other application data separate namespaces.
+
+The same code works with standalone, master-replica, and cluster clients, including clients configured for replica reads.
+
+## Failure and cancellation
+
+If Sage loses ownership or cannot renew the lock, the operation fails with `SageException.LockLost` and attempts to cancel the body. Release must also be confirmed before Sage reports success. Server and connection errors propagate through your backend's normal failure channel. Cleanup preserves an existing body failure or cancellation.
+
+Cancellation is cooperative and cannot undo completed work. Uninterruptible work can delay completion. Pekko uses `Future`, so its body may continue after lock loss even though Sage stops renewing the lock. A timed-out or cancelled acquisition can leave the lock held until its lease expires.
+
+## Limits
+
+Exclusivity depends on the lease remaining valid and the server retaining the lock. A long process pause, failover, or an evicted lock key can allow overlapping work. Prevent eviction or deletion of active lock keys.
+
+Sage does not provide fencing tokens or exactly-once execution. If correctness must survive those failures, the system receiving the changes must enforce ownership or provide transactional protection. See [Redis's distributed lock documentation](https://redis.io/docs/latest/develop/clients/patterns/distributed-locks/) for the failure assumptions.

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -15,10 +15,13 @@ Every Sage failure is a `SageException` in a sealed hierarchy that you can match
 | `UnsupportedServer(message)` | The server rejected `HELLO 3` (it predates RESP3, or is a RESP2-only proxy). |
 | `TlsError(message)` | TLS could not be established (rejected certificate or unusable trust material). |
 | `CrossSlot(message)` | An unsupported multi-key command or a transaction touched keys in more than one cluster slot. `MGET`, `MSET`, `EXISTS`, `DEL`, `UNLINK`, and `TOUCH` are transparently split outside transactions. |
-| `TimedOut(message)` | A blocking command or transaction waited past `dedicatedPool.acquireTimeout` for a free pooled connection. Not a per-command timeout; bound a command's own duration with your backend's timeout combinator. |
+| `TimedOut(message)` | A pooled connection wait exceeded `dedicatedPool.acquireTimeout`, a topology probe exceeded `connectTimeout`, or distributed lock acquisition exceeded its wait or lease budget. |
+| `LockLost(message)` | A distributed lock expired, changed owner, or could not confirm renewal or release within its deadline. Sage attempts to cancel the protected body. Cancellation depends on the backend and cannot undo completed work. |
 | `TransactionDiscarded(message)` | A transaction was discarded server-side (`EXECABORT`); nothing ran. |
 | `NotCacheable(message)` | `cached` was given a command that cannot be safely cached. |
 | `InvalidArgument(message)` | A programming error, rejected before any server call: an invalid configuration or rate-limit policy, a blocking command inside a pipeline or transaction, or a command a cluster client cannot route as written. |
+
+Regular commands have no per-command timeout. Use your backend's timeout combinator to bound their duration. See [Distributed locks](/distributed-locks) for lock deadlines and cancellation behavior.
 
 ## Branching on the failure
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -15,8 +15,8 @@ Every Sage failure is a `SageException` in a sealed hierarchy that you can match
 | `UnsupportedServer(message)` | The server rejected `HELLO 3` (it predates RESP3, or is a RESP2-only proxy). |
 | `TlsError(message)` | TLS could not be established (rejected certificate or unusable trust material). |
 | `CrossSlot(message)` | An unsupported multi-key command or a transaction touched keys in more than one cluster slot. `MGET`, `MSET`, `EXISTS`, `DEL`, `UNLINK`, and `TOUCH` are transparently split outside transactions. |
-| `TimedOut(message)` | A pooled connection wait exceeded `dedicatedPool.acquireTimeout`, a topology probe exceeded `connectTimeout`, or distributed lock acquisition exceeded its wait or lease budget. |
-| `LockLost(message)` | A distributed lock expired, changed owner, or could not confirm renewal or release within its deadline. Sage attempts to cancel the protected body. Cancellation depends on the backend and cannot undo completed work. |
+| `TimedOut(message)` | A pooled connection wait exceeded `dedicatedPool.acquireTimeout`, a topology probe exceeded `connectTimeout`, or distributed lock acquisition exceeded its wait, lease, or replica confirmation budget. |
+| `LockLost(message)` | A distributed lock expired, changed owner, or could not confirm renewal or release within its deadline. Acquisition can raise this before the body starts if the granting master changes role or the lease expires. Sage attempts to cancel a running body. Cancellation depends on the backend and cannot undo completed work. |
 | `TransactionDiscarded(message)` | A transaction was discarded server-side (`EXECABORT`); nothing ran. |
 | `NotCacheable(message)` | `cached` was given a command that cannot be safely cached. |
 | `InvalidArgument(message)` | A programming error, rejected before any server call: an invalid configuration or rate-limit policy, a blocking command inside a pipeline or transaction, or a command a cluster client cannot route as written. |

--- a/examples/ce/src/main/scala/sage/examples/ce/LockExample.scala
+++ b/examples/ce/src/main/scala/sage/examples/ce/LockExample.scala
@@ -1,0 +1,26 @@
+package sage.examples.ce
+
+import scala.concurrent.duration.*
+
+import cats.effect.IO
+
+import sage.backend.*
+
+/**
+  * Serializes a counter update across processes that use the same lock namespace and key.
+  */
+object LockExample {
+  def run(client: SageClient): IO[Unit] = {
+    val locks = client.lock[String](namespace = "example-locks")
+    for {
+      next <- locks.withLock("counter", waitTimeout = 2.seconds) {
+                for {
+                  current <- client.get[Int]("example:locked-counter")
+                  next     = current.getOrElse(0) + 1
+                  _       <- client.set("example:locked-counter", next)
+                } yield next
+              }
+      _    <- IO.println(s"Updated counter to $next")
+    } yield ()
+  }
+}

--- a/examples/ce/src/main/scala/sage/examples/ce/Tour.scala
+++ b/examples/ce/src/main/scala/sage/examples/ce/Tour.scala
@@ -21,6 +21,7 @@ object Tour extends IOApp.Simple {
         PubSubExample.run(client) *>
         CachedReadsExample.run(client) *>
         RateLimiterExample.run(client) *>
+        LockExample.run(client) *>
         StreamsExample.run(client)
     }
 }

--- a/examples/kyo/src/main/scala/sage/examples/kyo/LockExample.scala
+++ b/examples/kyo/src/main/scala/sage/examples/kyo/LockExample.scala
@@ -1,0 +1,26 @@
+package sage.examples.kyo
+
+import scala.concurrent.duration.*
+
+import kyo.*
+
+import sage.backend.*
+
+/**
+  * Serializes a counter update across processes that use the same lock namespace and key.
+  */
+object LockExample {
+  def run(client: SageClient): Unit < (Abort[Throwable] & Async) = {
+    val locks = client.lock[String](namespace = "example-locks")
+    for {
+      next <- locks.withLock("counter", waitTimeout = 2.seconds) {
+                for {
+                  current <- client.get[Int]("example:locked-counter")
+                  next     = current.getOrElse(0) + 1
+                  _       <- client.set("example:locked-counter", next)
+                } yield next
+              }
+      _    <- Console.printLine(s"Updated counter to $next")
+    } yield ()
+  }
+}

--- a/examples/kyo/src/main/scala/sage/examples/kyo/Tour.scala
+++ b/examples/kyo/src/main/scala/sage/examples/kyo/Tour.scala
@@ -23,6 +23,7 @@ object Tour extends KyoApp {
         _      <- PubSubExample.run(client)
         _      <- CachedReadsExample.run(client)
         _      <- RateLimiterExample.run(client)
+        _      <- LockExample.run(client)
         _      <- StreamsExample.run(client)
       } yield ()
     }

--- a/examples/ox/src/main/scala/sage/examples/ox/LockExample.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/LockExample.scala
@@ -1,0 +1,23 @@
+package sage.examples.ox
+
+import scala.concurrent.duration.*
+
+import ox.Ox
+
+import sage.backend.*
+
+/**
+  * Serializes a counter update across processes that use the same lock namespace and key.
+  */
+object LockExample {
+  def run(client: SageClient)(using Ox): Unit = {
+    val locks = client.lock[String](namespace = "example-locks")
+    val next  = locks.withLock("counter", waitTimeout = 2.seconds) {
+      val current = client.get[Int]("example:locked-counter")
+      val next    = current.getOrElse(0) + 1
+      client.set("example:locked-counter", next)
+      next
+    }
+    println(s"Updated counter to $next")
+  }
+}

--- a/examples/ox/src/main/scala/sage/examples/ox/Tour.scala
+++ b/examples/ox/src/main/scala/sage/examples/ox/Tour.scala
@@ -19,6 +19,7 @@ import sage.backend.*
     PubSubExample.run(client)
     CachedReadsExample.run(client)
     RateLimiterExample.run(client)
+    LockExample.run(client)
     StreamsExample.run(client)
   }
 }

--- a/examples/pekko/src/main/scala/sage/examples/pekko/LockExample.scala
+++ b/examples/pekko/src/main/scala/sage/examples/pekko/LockExample.scala
@@ -1,0 +1,25 @@
+package sage.examples.pekko
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.*
+
+import sage.backend.*
+
+/**
+  * Serializes a counter update across processes that use the same lock namespace and key.
+  */
+object LockExample {
+  def run(client: SageClient)(using ExecutionContext): Future[Unit] = {
+    val locks = client.lock[String](namespace = "example-locks")
+    for {
+      next <- locks.withLock("counter", waitTimeout = 2.seconds) {
+                for {
+                  current <- client.get[Int]("example:locked-counter")
+                  next     = current.getOrElse(0) + 1
+                  _       <- client.set("example:locked-counter", next)
+                } yield next
+              }
+      _     = println(s"Updated counter to $next")
+    } yield ()
+  }
+}

--- a/examples/pekko/src/main/scala/sage/examples/pekko/Tour.scala
+++ b/examples/pekko/src/main/scala/sage/examples/pekko/Tour.scala
@@ -31,6 +31,7 @@ object Tour {
           _ <- PubSubExample.run(client)
           _ <- CachedReadsExample.run(client)
           _ <- RateLimiterExample.run(client)
+          _ <- LockExample.run(client)
           _ <- StreamsExample.run(client)
         } yield ()
       }

--- a/examples/zio/src/main/scala/sage/examples/zio/LockExample.scala
+++ b/examples/zio/src/main/scala/sage/examples/zio/LockExample.scala
@@ -1,0 +1,26 @@
+package sage.examples.zio
+
+import scala.concurrent.duration.*
+
+import zio.*
+
+import sage.backend.*
+
+/**
+  * Serializes a counter update across processes that use the same lock namespace and key.
+  */
+object LockExample {
+  val run: ZIO[SageClient, Throwable, Unit] = ZIO.serviceWithZIO[SageClient] { client =>
+    val locks = client.lock[String](namespace = "example-locks")
+    for {
+      next <- locks.withLock("counter", waitTimeout = 2.seconds) {
+                for {
+                  current <- client.get[Int]("example:locked-counter")
+                  next     = current.getOrElse(0) + 1
+                  _       <- client.set("example:locked-counter", next)
+                } yield next
+              }
+      _    <- Console.printLine(s"Updated counter to $next")
+    } yield ()
+  }
+}

--- a/examples/zio/src/main/scala/sage/examples/zio/Tour.scala
+++ b/examples/zio/src/main/scala/sage/examples/zio/Tour.scala
@@ -20,5 +20,6 @@ object Tour extends ZIOAppDefault {
       PubSubExample.run *>
       CachedReadsExample.run *>
       RateLimiterExample.run *>
+      LockExample.run *>
       StreamsExample.run).provide(SageClient.layer(config))
 }

--- a/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
+++ b/integration-tests/ce/src/test/scala/sage/integration/CeSmokeSuite.scala
@@ -14,6 +14,26 @@ class CeSmokeSuite extends ServerSuite(Images.redis) {
   private def withNativeClient(body: SageClient => IO[Unit]): Unit =
     withContainers(server => SageClient.resource(configOf(server)).use(body).unsafeRunSync())
 
+  test("a distributed lock scopes native effects and skips contended bodies") {
+    withNativeClient { client =>
+      val locks     = client.lock[String]()
+      var evaluated = false
+      for {
+        busy     <- locks.withLock("native-lock", 2.seconds) {
+                      locks.tryWithLock("native-lock") {
+                        evaluated = true
+                        client.ping()
+                      }
+                    }
+        acquired <- locks.tryWithLock("native-lock")(client.ping())
+      } yield {
+        assertEquals(busy, None)
+        assertEquals(acquired, Some("PONG"))
+        assert(!evaluated)
+      }
+    }
+  }
+
   test("an end user connects and round-trips with native Cats Effect") {
     withNativeClient { client =>
       for {

--- a/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
+++ b/integration-tests/kyo/src/test/scala/sage/integration/KyoSmokeSuite.scala
@@ -21,6 +21,26 @@ class KyoSmokeSuite extends ServerSuite(Images.redis) {
       KyoApp.Unsafe.runAndBlock(timeout)(program).getOrThrow
     }
 
+  test("a distributed lock scopes native effects and skips contended bodies") {
+    withNativeClient { client =>
+      val locks     = client.lock[String]()
+      var evaluated = false
+      for {
+        busy     <- locks.withLock("native-lock", FiniteDuration(2L, TimeUnit.SECONDS)) {
+                      locks.tryWithLock("native-lock") {
+                        evaluated = true
+                        client.ping()
+                      }
+                    }
+        acquired <- locks.tryWithLock("native-lock")(client.ping())
+      } yield {
+        assertEquals(busy, None)
+        assertEquals(acquired, Some("PONG"))
+        assert(!evaluated)
+      }
+    }
+  }
+
   test("an end user connects and round-trips with native Kyo") {
     withNativeClient { client =>
       for {
@@ -30,6 +50,25 @@ class KyoSmokeSuite extends ServerSuite(Images.redis) {
       } yield {
         assertEquals(pong, "PONG")
         assertEquals(values.toList, (1 to 50).toList.map(i => Some(s"value-$i")))
+      }
+    }
+  }
+
+  test("a distributed lock preserves a native panic and releases ownership") {
+    withBoundedClient(3L.seconds) { client =>
+      val failure = new IllegalStateException("body panic")
+      val locks   = client.lock[String]()
+      for {
+        result   <- Abort.run[SageException](locks.tryWithLock[Int]("native-panic")(Abort.panic(failure)))
+        _         = result match {
+                      case Result.Panic(error) => assert(error eq failure)
+                      case other               => fail(s"expected the original panic, got $other")
+                    }
+        exists   <- client.exists("4:lock:native-panic")
+        acquired <- locks.tryWithLock("native-panic")(client.ping())
+      } yield {
+        assertEquals(exists, 0L)
+        assertEquals(acquired, Some("PONG"))
       }
     }
   }

--- a/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
+++ b/integration-tests/ox/src/test/scala/sage/integration/OxSmokeSuite.scala
@@ -12,6 +12,23 @@ class OxSmokeSuite extends ServerSuite(Images.redis) {
   private def withNativeClient(body: Ox ?=> SageClient => Unit): Unit =
     withContainers(server => supervised(body(SageClient.scoped(configOf(server)))))
 
+  test("a distributed lock scopes native effects and skips contended bodies") {
+    withNativeClient { client =>
+      val locks     = client.lock[String]()
+      var evaluated = false
+      val busy      = locks.withLock("native-lock", 2.seconds) {
+        locks.tryWithLock("native-lock") {
+          evaluated = true
+          client.ping()
+        }
+      }
+      val acquired  = locks.tryWithLock("native-lock")(client.ping())
+      assertEquals(busy, None)
+      assertEquals(acquired, Some("PONG"))
+      assert(!evaluated)
+    }
+  }
+
   test("an end user connects and round-trips with direct-style Ox") {
     withNativeClient { client =>
       assertEquals(client.ping(), "PONG")

--- a/integration-tests/pekko/src/test/scala/sage/integration/PekkoSmokeSuite.scala
+++ b/integration-tests/pekko/src/test/scala/sage/integration/PekkoSmokeSuite.scala
@@ -31,6 +31,26 @@ class PekkoSmokeSuite extends ServerSuite(Images.redis) {
       }
     }
 
+  test("a distributed lock scopes native effects and skips contended bodies") {
+    withNativeClient { (client, _, _) =>
+      val locks     = client.lock[String]()
+      var evaluated = false
+      for {
+        busy     <- locks.withLock("native-lock", 2.seconds) {
+                      locks.tryWithLock("native-lock") {
+                        evaluated = true
+                        client.ping()
+                      }
+                    }
+        acquired <- locks.tryWithLock("native-lock")(client.ping())
+      } yield {
+        assertEquals(busy, None)
+        assertEquals(acquired, Some("PONG"))
+        assert(!evaluated)
+      }
+    }
+  }
+
   test("an end user connects and round-trips with scala.concurrent.Future") {
     val values = withNativeClient { (client, _, _) =>
       for {

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterFailoverSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterFailoverSuite.scala
@@ -8,9 +8,11 @@ import com.dimafeng.testcontainers.FixedHostPortGenericContainer
 import com.dimafeng.testcontainers.munit.TestContainerForEach
 import kyo.compat.*
 
+import sage.Bytes
 import sage.client.{ClusterConfig, Endpoint, SageConfig, Topology}
 import sage.client.internal.Client
-import sage.commands.Commands
+import sage.cluster.Slot
+import sage.commands.{Commands, Connection}
 import sage.integration.{ContainerClient, Eventually, Images}
 
 /**
@@ -125,6 +127,54 @@ abstract class ClusterFailoverSuite(val image: String, val serverBinary: String)
       slots.toString,
       "--cluster-yes"
     )
+
+  private def replicationWaits(container: FixedHostPortGenericContainer, port: Int): Long =
+    cli(container, port, "info", "commandstats").linesIterator
+      .find(_.startsWith("cmdstat_wait:calls="))
+      .fold(0L)(_.stripPrefix("cmdstat_wait:calls=").takeWhile(_ != ',').toLong)
+
+  test("distributed locks confirm acquisition and renewal on each master's replica") {
+    withContainers { container =>
+      val config = SageConfig(topology = Topology.Cluster(Vector(Endpoint("127.0.0.1", ports.head))))
+      formCluster(container).flatMap { _ =>
+        connectAndUse(config) { client =>
+          val keys = Vector("orders", "delta", "epsilon").map(tag => s"replicated-lock:{$tag}")
+          CIO.blocking(clusterNodes(container, ports.head)).flatMap { nodes =>
+            val owners = keys.map(key => nodes.find(_.owns(Slot.of(Bytes.utf8(s"4:lock:$key")).value)).get)
+            assertEquals(owners.map(_.port).distinct.size, 3)
+            keys.zip(owners).foldLeft(CIO.unit) { case (previous, (key, owner)) =>
+              previous.flatMap { _ =>
+                val replica       = nodes.find(node => node.isReplica && node.masterId == owner.id).get
+                val replicaConfig = SageConfig(topology = Topology.Standalone(Endpoint("127.0.0.1", replica.port)))
+                connectAndUse(replicaConfig) { reader =>
+                  for {
+                    _           <- reader.run(Connection.readonly)
+                    // Initial replica synchronization can finish after the cluster starts accepting writes.
+                    _           <- Eventually.converges(100, 100.millis)(() => reader.run(Commands.role))(_.isConnectedReplica)(_ =>
+                                     "cluster replica did not connect"
+                                   )
+                    waitsBefore <- CIO.blocking(replicationWaits(container, owner.port))
+                    _           <- client.lock[String](3.seconds).withLock(key, 5.seconds) {
+                                     for {
+                                       before     <- reader.exists(s"4:lock:$key")
+                                       _          <- CIO.sleep(3200.millis)
+                                       after      <- reader.exists(s"4:lock:$key")
+                                       waitsAfter <- CIO.blocking(replicationWaits(container, owner.port))
+                                     } yield {
+                                       assertEquals(before, 1L)
+                                       assertEquals(after, 1L)
+                                       assert(waitsAfter >= waitsBefore + 2, "acquisition and renewal did not wait for replication")
+                                     }
+                                   }
+                  } yield ()
+                }
+              }
+            }
+          }
+        }
+      }.unsafeRun
+    }
+  }
 
   test("the client recovers reads after a master crashes and its replica is promoted") {
     withContainers { container =>

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterMultiMasterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterMultiMasterSuite.scala
@@ -52,6 +52,36 @@ abstract class ClusterMultiMasterSuite(val image: String, val serverBinary: Stri
       formCluster(container).flatMap(_ => connectAndUse(config)(client => body(container, client))).unsafeRun
     }
 
+  test("distributed locks acquire, renew, and release keys owned by different masters") {
+    onCluster { (container, first) =>
+      val keys = Vector("orders", "delta", "epsilon").map(tag => s"distributed:{$tag}")
+      assertEquals(keys.map(key => slotOwner(container, s"4:lock:$key")).toSet, ports.toSet)
+      connectAndUse(config) { second =>
+        CIO
+          .foreach(keys) { key =>
+            val holder    = first.lock[String](leaseDuration = 600.millis)
+            val contender = second.lock[String]()
+            for {
+              denied   <- holder.withLock(key, 2.seconds) {
+                            for {
+                              before <- contender.tryWithLock(key)(CIO.value(1))
+                              _      <- CIO.sleep(1500.millis)
+                              after  <- contender.tryWithLock(key)(CIO.value(2))
+                            } yield (before, after)
+                          }
+              acquired <- contender.tryWithLock(key)(CIO.value(42))
+              exists   <- first.exists(s"4:lock:$key")
+            } yield {
+              assertEquals(denied, (None, None))
+              assertEquals(acquired, Some(42))
+              assertEquals(exists, 0L)
+            }
+          }
+          .unit
+      }
+    }
+  }
+
   test("PUBSUB CHANNELS returns a channel whose only subscriber sits on a master the client never picked") {
     onCluster { (container, client) =>
       ports.foreach(p => subscribeOn(container, p, "subscribe", s"only-$p"))
@@ -90,7 +120,7 @@ abstract class ClusterMultiMasterSuite(val image: String, val serverBinary: Stri
   test("PUBSUB SHARDCHANNELS concatenates the shard channels of every master, one per shard") {
     onCluster { (container, client) =>
       val oneChannelPerShard                  = Vector("orders", "delta", "epsilon")
-      oneChannelPerShard.foreach(channel => subscribeOn(container, ownerOfChannel(container, channel), "ssubscribe", channel))
+      oneChannelPerShard.foreach(channel => subscribeOn(container, slotOwner(container, channel), "ssubscribe", channel))
       val sweptAll: Vector[String] => Boolean = found => oneChannelPerShard.forall(found.contains)
       Eventually.converges(50, 200.millis)(() => client.pubsubShardChannels())(sweptAll)(found =>
         s"swept shard channels $found missed ${oneChannelPerShard.filterNot(found.contains)}"
@@ -103,7 +133,7 @@ abstract class ClusterMultiMasterSuite(val image: String, val serverBinary: Stri
       // Use one channel per slot range and give each a distinct subscriber count. The expected result therefore requires replies from all masters.
       val expected = Map("sn-d" -> 1L, "sn-a" -> 2L, "sn-c" -> 3L)
       expected.foreach { case (channel, subscribers) =>
-        val owner = ownerOfChannel(container, channel)
+        val owner = slotOwner(container, channel)
         (1L to subscribers).foreach(_ => subscribeOn(container, owner, "ssubscribe", channel))
       }
       Eventually.converges(50, 200.millis)(() => client.pubsubShardNumSub(expected.keys.toSeq*))(_ == expected)(counts =>
@@ -144,8 +174,8 @@ abstract class ClusterMultiMasterSuite(val image: String, val serverBinary: Stri
     }
   }
 
-  private def ownerOfChannel(container: FixedHostPortGenericContainer, channel: String): Int = {
-    val slot = cli(container, basePort, "cluster", "keyslot", channel).trim.toInt
+  private def slotOwner(container: FixedHostPortGenericContainer, key: String): Int = {
+    val slot = cli(container, basePort, "cluster", "keyslot", key).trim.toInt
     clusterNodes(container, basePort).find(node => node.isMaster && node.owns(slot)).map(_.port).getOrElse(fail(s"no master owns slot $slot"))
   }
 }

--- a/integration-tests/shared/src/test/scala/sage/integration/locking/LockSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/locking/LockSuite.scala
@@ -1,0 +1,131 @@
+package sage.integration.locking
+
+import scala.concurrent.Future
+import scala.concurrent.duration.*
+
+import kyo.compat.*
+
+import sage.SageException.LockLost
+import sage.client.internal.Client
+import sage.integration.{Images, ServerSuite}
+
+abstract class LockSuite(image: String) extends ServerSuite(image) {
+  private def withClients[A](body: (Client[CIO, String], Client[CIO, String]) => CIO[A]): Future[A] =
+    withContainers { server =>
+      connectAndUse(configOf(server)) { first =>
+        connectAndUse(configOf(server))(second => body(first, second))
+      }.unsafeRun
+    }
+
+  test("independent clients contend on the same key and acquire after release") {
+    withClients { (first, second) =>
+      val a = first.lock[String]()
+      val b = second.lock[String]()
+      for {
+        denied   <- a.withLock("shared", 2.seconds) {
+                      b.tryWithLock("shared")(CIO.fail(new AssertionError("contended body ran")))
+                    }
+        acquired <- b.tryWithLock("shared")(CIO.value(42))
+        exists   <- first.exists("4:lock:shared")
+      } yield {
+        assertEquals(denied, None)
+        assertEquals(acquired, Some(42))
+        assertEquals(exists, 0L)
+      }
+    }
+  }
+
+  test("waiting scopes protect a read-modify-write operation across clients") {
+    withClients { (first, second) =>
+      first.set("counter", 0).flatMap { _ =>
+        CIO
+          .foreach(1 to 12) { i =>
+            val client = if (i % 2 == 0) first else second
+            client.lock[String]().withLock("counter", 5.seconds) {
+              client.get[Int]("counter").flatMap { current =>
+                CIO.sleep(5.millis).flatMap(_ => client.set("counter", current.get + 1))
+              }
+            }
+          }
+          .flatMap(_ => first.get[Int]("counter"))
+          .map(value => assertEquals(value, Some(12)))
+      }
+    }
+  }
+
+  test("automatic renewal excludes another client after the initial lease would have expired") {
+    withClients { (first, second) =>
+      first
+        .lock[String](leaseDuration = 600.millis)
+        .withLock("long", 2.seconds) {
+          CIO.sleep(1500.millis).flatMap { _ =>
+            second.lock[String]().tryWithLock("long")(CIO.value(42)).map(result => assertEquals(result, None))
+          }
+        }
+        .flatMap(_ => second.lock[String]().tryWithLock("long")(CIO.value(42)))
+        .map(result => assertEquals(result, Some(42)))
+    }
+  }
+
+  test("expired ownership cannot renew or remove a replacement owner's lock") {
+    withClients { (first, second) =>
+      first
+        .lock[String](leaseDuration = 300.millis)
+        .tryWithLock("replaced") {
+          second.set("4:lock:replaced", "new-owner").flatMap(_ => CIO.never)
+        }
+        .liftToTry
+        .flatMap { result =>
+          assert(result.failed.get.isInstanceOf[LockLost], result.toString)
+          second.get[String]("4:lock:replaced").map(value => assertEquals(value, Some("new-owner")))
+        }
+    }
+  }
+
+  test("body failure releases the lease and preserves the error") {
+    withClient { client =>
+      val failure = new IllegalStateException("body failed")
+      val lock    = client.lock[String]()
+      lock.withLock("failure", 2.seconds)(CIO.fail(failure)).liftToTry.flatMap { result =>
+        assert(result.failed.get eq failure)
+        lock.tryWithLock("failure")(CIO.value(42)).map(value => assertEquals(value, Some(42)))
+      }
+    }
+  }
+
+  test("script cache flush during a scope is recovered by renewal and release") {
+    withClient { client =>
+      client
+        .scriptFlush()
+        .flatMap { _ =>
+          client.lock[String](leaseDuration = 600.millis).withLock("flush", 2.seconds) {
+            client.scriptFlush().flatMap(_ => CIO.sleep(1.second)).flatMap(_ => client.scriptFlush())
+          }
+        }
+        .flatMap(_ => client.exists("4:lock:flush"))
+        .map(count => assertEquals(count, 0L))
+    }
+  }
+
+  test("different keys and namespaces remain independent, including through client.as") {
+    withClient { client =>
+      client
+        .lock[String](namespace = "one")
+        .tryWithLock("key") {
+          for {
+            differentKey       <- client.lock[String](namespace = "one").tryWithLock("other")(CIO.value(1))
+            differentNamespace <- client.lock[String](namespace = "two").tryWithLock("key")(CIO.value(2))
+            same               <- client.as[Array[Byte]].lock[Array[Byte]](namespace = "one").tryWithLock("key".getBytes("UTF-8"))(CIO.value(3))
+          } yield {
+            assertEquals(differentKey, Some(1))
+            assertEquals(differentNamespace, Some(2))
+            assertEquals(same, None)
+          }
+        }
+        .unit
+    }
+  }
+}
+
+class RedisLockSuite  extends LockSuite(Images.redis)
+class ValkeyLockSuite extends LockSuite(Images.valkey)

--- a/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
@@ -111,6 +111,43 @@ abstract class MasterReplicaSuiteBase(image: String, serverBinary: String) exten
   */
 abstract class MasterReplicaSuite(image: String, serverBinary: String) extends MasterReplicaSuiteBase(image, serverBinary) {
 
+  test("distributed locks acquire, renew, and release on the master with Replica reads") {
+    withContainers { server =>
+      val host = server.host
+      val pm   = server.mappedPort(masterPort)
+      val pr   = server.mappedPort(replicaPort)
+
+      val program =
+        connectAndUse(standalone(host, pr))(ensureReplicating(_, host, pr)).flatMap { _ =>
+          connectAndUse(masterReplica(host, pm, ReadFrom.Replica)) { client =>
+            connectAndUse(standalone(host, pm)) { master =>
+              val key       = "mr:distributed-lock"
+              val holder    = client.lock[String](leaseDuration = 600.millis)
+              val contender = master.lock[String]()
+              for {
+                fromReplica <- client.get[String](marker)
+                denied      <- holder.withLock(key, 2.seconds) {
+                                 for {
+                                   before <- contender.tryWithLock(key)(CIO.value(1))
+                                   _      <- CIO.sleep(1500.millis)
+                                   after  <- contender.tryWithLock(key)(CIO.value(2))
+                                 } yield (before, after)
+                               }
+                acquired    <- contender.tryWithLock(key)(CIO.value(42))
+                exists      <- master.exists(s"4:lock:$key")
+              } yield {
+                assertEquals(fromReplica, Some("from-replica"))
+                assertEquals(denied, (None, None))
+                assertEquals(acquired, Some(42))
+                assertEquals(exists, 0L)
+              }
+            }
+          }
+        }
+      program.unsafeRun
+    }
+  }
+
   test("reads honor the ReadFrom policy and writes always reach the master") {
     withContainers { server =>
       val host       = server.host

--- a/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
@@ -8,7 +8,7 @@ import com.dimafeng.testcontainers.munit.TestContainerForAll
 import kyo.compat.*
 
 import sage.{Bytes, Message}
-import sage.SageException.DecodeError
+import sage.SageException.{DecodeError, LockLost, TimedOut}
 import sage.client.{Endpoint, MasterReplicaConfig, ReadFrom, SageConfig, Topology}
 import sage.client.internal.Client
 import sage.commands.{Command, Commands}
@@ -110,6 +110,52 @@ abstract class MasterReplicaSuiteBase(image: String, serverBinary: String) exten
   * the replica: a read that sees it was served by the replica, and one that does not was served by the master, which never has it.
   */
 abstract class MasterReplicaSuite(image: String, serverBinary: String) extends MasterReplicaSuiteBase(image, serverBinary) {
+
+  for (duringRenewal <- Vector(false, true))
+    test(s"distributed locks fail when a replica stops acknowledging ${if (duringRenewal) "renewal" else "acquisition"}") {
+      withContainers { server =>
+        val host = server.host
+        val pm   = server.mappedPort(masterPort)
+        val pr   = server.mappedPort(replicaPort)
+        connectAndUse(standalone(host, pr)) { replica =>
+          ensureReplicating(replica, host, pr).flatMap { _ =>
+            connectAndUse(masterReplica(host, pm, ReadFrom.Replica)) { client =>
+              connectAndUse(standalone(host, pm)) { master =>
+                val key         = s"mr:unconfirmed-lock:$duringRenewal"
+                val bodyStarted = new java.util.concurrent.atomic.AtomicBoolean(false)
+                val bodyStopped = new java.util.concurrent.atomic.AtomicBoolean(false)
+                val detach      = replica.run(admin("REPLICAOF", "NO", "ONE"))
+                val attempt     = client.lock[String](3.seconds).tryWithLock(key) {
+                  CIO.defer(bodyStarted.set(true)).flatMap { _ =>
+                    if (duringRenewal)
+                      CIO.ensure(CIO.defer(bodyStopped.set(true)))(detach.flatMap(_ => CIO.never))
+                    else CIO.unit
+                  }
+                }
+                CIO.ensure(ensureReplicating(replica, host, pr)) {
+                  for {
+                    _      <- if (duringRenewal) CIO.unit else detach
+                    result <- attempt.liftToTry
+                    exists <- master.exists(s"4:lock:$key")
+                  } yield {
+                    if (duringRenewal) {
+                      assert(result.failed.get.isInstanceOf[LockLost], result.toString)
+                      assert(bodyStarted.get())
+                      assert(bodyStopped.get())
+                    } else {
+                      assert(result.failed.get.isInstanceOf[TimedOut], result.toString)
+                      assert(result.failed.get.getMessage.contains("replication confirmed by"), result.toString)
+                      assert(!bodyStarted.get())
+                    }
+                    assertEquals(exists, 0L)
+                  }
+                }
+              }
+            }
+          }
+        }.unsafeRun
+      }
+    }
 
   test("distributed locks acquire, renew, and release on the master with Replica reads") {
     withContainers { server =>

--- a/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
+++ b/integration-tests/zio/src/test/scala/sage/integration/ZioSmokeSuite.scala
@@ -20,6 +20,26 @@ class ZioSmokeSuite extends ServerSuite(Images.redis) {
       Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(program).getOrThrowFiberFailure())
     }
 
+  test("a distributed lock scopes native effects and skips contended bodies") {
+    withNativeClient { client =>
+      val locks     = client.lock[String]()
+      var evaluated = false
+      for {
+        busy     <- locks.withLock("native-lock", FiniteDuration(2L, TimeUnit.SECONDS)) {
+                      locks.tryWithLock("native-lock") {
+                        evaluated = true
+                        client.ping()
+                      }
+                    }
+        acquired <- locks.tryWithLock("native-lock")(client.ping())
+      } yield {
+        assertEquals(busy, None)
+        assertEquals(acquired, Some("PONG"))
+        assert(!evaluated)
+      }
+    }
+  }
+
   test("an end user connects and round-trips with native ZIO") {
     withNativeClient { client =>
       for {

--- a/sage-client/ce/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/ce/src/main/scala/sage/backend/SageClient.scala
@@ -212,8 +212,25 @@ object SageClient {
   def resource(config: SageConfig): Resource[IO, SageClient] =
     Resource.make(connect(config))(_.close.voidError)
 
-  final private class Lowered(underlying: Client[CIO, String]) extends LoweredClient[IO](underlying) {
+  final private[sage] class Lowered(underlying: Client[CIO, String]) extends LoweredClient[IO](underlying) {
     protected def lower[A](c: CIO[A]): IO[A] = c.lower
     protected def lift[A](fa: IO[A]): CIO[A] = CIO.lift(fa)
+
+    override protected def lockScope[A, B](body: () => IO[A])(runScope: CIO[A] => CIO[B]): IO[B] = {
+      val cancelled = new RuntimeException("lock body cancelled")
+      // Joining observes self-cancellation as an outcome. The bracket also cancels the body when ownership is lost.
+      val work      = IO
+        .defer(body())
+        .start
+        .bracket(_.join.flatMap {
+          case cats.effect.Outcome.Succeeded(value) => value
+          case cats.effect.Outcome.Errored(error)   => IO.raiseError(error)
+          case cats.effect.Outcome.Canceled()       => IO.raiseError(cancelled)
+        })(_.cancel)
+      runScope(CIO.lift(work)).lower.handleErrorWith {
+        case error if error eq cancelled => IO.canceled *> IO.never[B]
+        case other                       => IO.raiseError(other)
+      }
+    }
   }
 }

--- a/sage-client/ce/src/test/scala/sage/client/internal/CeLockCancellationSpec.scala
+++ b/sage-client/ce/src/test/scala/sage/client/internal/CeLockCancellationSpec.scala
@@ -1,0 +1,66 @@
+package sage.client.internal
+
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+
+import scala.concurrent.duration.*
+
+import cats.effect.{IO, Outcome}
+import kyo.compat.*
+
+import sage.SageException.{LockLost, ServerError, TimedOut}
+import sage.backend.SageClient
+import sage.commands.Command
+import sage.protocol.Frame
+
+class CeLockCancellationSpec extends LockCancellationSpec {
+  override protected def tryWithLock[A](commands: CommandRunner[CIO, String], lease: FiniteDuration)(body: CIO[A]): CIO[Option[A]] =
+    CIO.lift(new SageClient.Lowered(new LockTestClient(commands)).lock[String](lease).tryWithLock("key")(body.lower))
+
+  override protected def withLock[A](commands: CommandRunner[CIO, String], lease: FiniteDuration, wait: FiniteDuration)(body: CIO[A]): CIO[A] =
+    CIO.lift(new SageClient.Lowered(new LockTestClient(commands)).lock[String](lease).withLock("key", wait)(body.lower))
+
+  List("acquire", "renew", "release").foreach { stalled =>
+    test(s"a delayed $stalled callback does not hold up the lock deadline") {
+      val commands  = new CommandRunner[CIO, String] {
+        def run[A](command: Command[A]): CIO[A] = CIO.async { callback =>
+          val result = command.decode(Frame.Integer(1)).toTry
+          if (command.args(4).asUtf8String == stalled) Scheduler.real.after(2.seconds)(callback(result))
+          else callback(result)
+        }
+      }
+      val failure   = ServerError("ERR", "body failed")
+      val operation = stalled match {
+        case "acquire" => withLock(commands, 300.millis, 50.millis)(CIO.fail(new AssertionError("body ran after acquisition timeout")))
+        case "renew"   => tryWithLock(commands, 300.millis)(CIO.never).unit
+        case _         => tryWithLock(commands, 300.millis)(CIO.fail(failure)).unit
+      }
+      val check     = for {
+        started <- IO.monotonic
+        result  <- operation.lower.attempt
+        ended   <- IO.monotonic
+      } yield {
+        val error = result.swap.toOption.getOrElse(fail("expected the lock to fail"))
+        stalled match {
+          case "acquire" => assert(error.isInstanceOf[TimedOut], error.toString)
+          case "renew"   => assert(error.isInstanceOf[LockLost], error.toString)
+          case _         => assert(error eq failure)
+        }
+        assert(ended - started < 1.second, s"$stalled waited for its delayed callback: ${ended - started}")
+      }
+      CIO.lift(check).unsafeRun
+    }
+  }
+
+  test("a body that cancels itself still releases the lock") {
+    val released = new AtomicBoolean(false)
+    val body     = CIO.lift(IO.canceled *> IO.never[Unit])
+    val check    = tryWithLock(runner(released, new AtomicInteger(0), false), 300.millis)(body).lower.start.flatMap(_.join).map { outcome =>
+      outcome match {
+        case Outcome.Canceled() => ()
+        case other              => fail(s"expected cancellation, got $other")
+      }
+      assert(released.get())
+    }
+    CIO.lift(check.timeout(2.seconds)).unsafeRun
+  }
+}

--- a/sage-client/kyo/src/test/scala/sage/client/internal/KyoLockCancellationSpec.scala
+++ b/sage-client/kyo/src/test/scala/sage/client/internal/KyoLockCancellationSpec.scala
@@ -1,0 +1,3 @@
+package sage.client.internal
+
+class KyoLockCancellationSpec extends LockCancellationSpec

--- a/sage-client/ox/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/ox/src/main/scala/sage/backend/SageClient.scala
@@ -229,6 +229,8 @@ extension [K](client: Client[[A] =>> Ox ?=> A, K])(using @unused ev: KeyCodec[K]
 
 object SageClient {
 
+  final private class LockBodyFailure(val original: scala.util.control.ControlThrowable) extends RuntimeException
+
   /**
     * A client that uses `K` for keys, returned by `client.as[K]`. [[SageClient]] uses `String` keys by default. Calling `as` changes only
     * the key type and continues to use the same connection.
@@ -243,8 +245,17 @@ object SageClient {
       catch { case _: Throwable => () }
     }
 
-  final private class Lowered(underlying: Client[CIO, String]) extends LoweredClient[[X] =>> Ox ?=> X](underlying) {
+  final private[sage] class Lowered(underlying: Client[CIO, String]) extends LoweredClient[[X] =>> Ox ?=> X](underlying) {
     protected def lower[A](c: CIO[A]): Ox ?=> A = c.lower
     protected def lift[A](fa: Ox ?=> A): CIO[A] = CIO.lift(fa)
+
+    override protected def lockScope[A, B](body: () => (Ox ?=> A))(runScope: CIO[A] => CIO[B]): Ox ?=> B = {
+      val work: CIO[A] = CIO.deferLift {
+        try body()
+        catch { case control: scala.util.control.ControlThrowable => throw new LockBodyFailure(control) }
+      }
+      try runScope(work).lower
+      catch { case failure: LockBodyFailure => throw failure.original }
+    }
   }
 }

--- a/sage-client/ox/src/test/scala/sage/client/internal/OxLockCancellationSpec.scala
+++ b/sage-client/ox/src/test/scala/sage/client/internal/OxLockCancellationSpec.scala
@@ -1,0 +1,43 @@
+package sage.client.internal
+
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.*
+import scala.util.control.ControlThrowable
+
+import kyo.compat.*
+
+import sage.backend.SageClient
+
+class OxLockCancellationSpec extends LockCancellationSpec {
+  private given ExecutionContext = munitExecutionContext
+
+  override protected def tryWithLock[A](commands: CommandRunner[CIO, String], lease: FiniteDuration)(body: CIO[A]): CIO[Option[A]] =
+    CIO.deferLift(new SageClient.Lowered(new LockTestClient(commands)).lock[String](lease).tryWithLock("key")(body.lower))
+
+  override protected def withLock[A](commands: CommandRunner[CIO, String], lease: FiniteDuration, wait: FiniteDuration)(body: CIO[A]): CIO[A] =
+    CIO.deferLift(new SageClient.Lowered(new LockTestClient(commands)).lock[String](lease).withLock("key", wait)(body.lower))
+
+  test("a body control exception ends the scope and stops renewal") {
+    val released = new AtomicBoolean(false)
+    val renewals = new AtomicInteger(0)
+    val failure  = new ControlThrowable {}
+    CIO.deferLift {
+      val caught =
+        try {
+          ox.timeoutOption(2.seconds) {
+            tryWithLock(runner(released, renewals, false), 300.millis)(CIO.defer(throw failure)).lower
+          }
+          None
+        } catch {
+          case cause: ControlThrowable => Some(cause)
+        }
+      assertEquals(caught, Some(failure))
+      assert(released.get())
+      val count  = renewals.get()
+      ox.sleep(400.millis)
+      assertEquals(renewals.get(), count)
+    }.unsafeRun
+  }
+}

--- a/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/pekko/src/main/scala/sage/backend/SageClient.scala
@@ -260,7 +260,7 @@ object SageClient {
       case other                => Right(other)
     }
 
-  final private class Lowered(underlying: Client[CIO, String]) extends LoweredClient[Future](underlying) {
+  final private[sage] class Lowered(underlying: Client[CIO, String]) extends LoweredClient[Future](underlying) {
     protected def lower[A](c: CIO[A]): Future[A] = c.unsafeRun
     protected def lift[A](fa: Future[A]): CIO[A] = CIO.lift(fa)
   }

--- a/sage-client/pekko/src/test/scala/sage/client/internal/LockFutureSpec.scala
+++ b/sage-client/pekko/src/test/scala/sage/client/internal/LockFutureSpec.scala
@@ -7,13 +7,60 @@ import scala.concurrent.duration.*
 
 import kyo.compat.*
 
-import sage.SageException.LockLost
+import sage.SageException.{LockLost, TimedOut}
 import sage.backend.SageClient
-import sage.commands.Command
+import sage.client.{DedicatedPoolConfig, MasterReplicaConfig, SageConfig}
+import sage.cluster.Node
+import sage.commands.{Command, Connection, Execution}
 import sage.protocol.Frame
 
 class LockFutureSpec extends munit.FunSuite {
   private given ExecutionContext = munitExecutionContext
+
+  test("a confirmation timeout frees the dedicated connection when its Future never receives a reply") {
+    val master    = Node("master", 6379)
+    val replica   = Node("replica", 6380)
+    val evaluated = new AtomicBoolean(false)
+    val waiting   = new AtomicBoolean(false)
+    val live      = new MasterReplicaLive(
+      node =>
+        (onFrame, onClosed) =>
+          new FakeTransport(
+            onFrame,
+            onClosed,
+            payload => {
+              val text = payload.asUtf8String
+              if (text.contains("HELLO")) Seq(Replies.hello)
+              else if (text.contains("ROLE")) Seq(if (node == master) Replies.masterRole(replica) else Replies.replicaRole(master))
+              else if (text.contains("WAIT")) { waiting.set(true); Nil }
+              else if (text.contains("PING")) Seq(Frame.SimpleString("PONG"))
+              else if (text.contains("EVALSHA")) Seq(Frame.Integer(1))
+              else Seq(Replies.ok)
+            }
+          ),
+      Scheduler.real,
+      Vector(Connection.hello()),
+      SageConfig(dedicatedPool = DedicatedPoolConfig(maxConnections = 1, acquireTimeout = 200.millis), closeTimeout = Duration.Zero),
+      Vector(master),
+      MasterReplicaConfig()
+    )
+    live.bootstrapRoles()
+    val client    = new SageClient.Lowered(live)
+    val checked   = for {
+      error <- client
+                 .lock[String](3.seconds)
+                 .tryWithLock("key") {
+                   evaluated.set(true)
+                   scala.concurrent.Future.successful(42)
+                 }
+                 .failed
+      _      = assert(error.isInstanceOf[TimedOut], error.toString)
+      _      = assert(waiting.get(), "the test did not reach replication confirmation")
+      _      = assert(!evaluated.get())
+      pong  <- client.run(Connection.ping().copy(execution = Execution.Blocking))
+    } yield assertEquals(pong, "PONG")
+    checked.andThen { case _ => live.close.unsafeRun }
+  }
 
   test("lease loss stops renewal while a Future body keeps running") {
     val body      = Promise[Int]()

--- a/sage-client/pekko/src/test/scala/sage/client/internal/LockFutureSpec.scala
+++ b/sage-client/pekko/src/test/scala/sage/client/internal/LockFutureSpec.scala
@@ -1,0 +1,58 @@
+package sage.client.internal
+
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+
+import scala.concurrent.{ExecutionContext, Promise}
+import scala.concurrent.duration.*
+
+import kyo.compat.*
+
+import sage.SageException.LockLost
+import sage.backend.SageClient
+import sage.commands.Command
+import sage.protocol.Frame
+
+class LockFutureSpec extends munit.FunSuite {
+  private given ExecutionContext = munitExecutionContext
+
+  test("lease loss stops renewal while a Future body keeps running") {
+    val body      = Promise[Int]()
+    val continued = Promise[Int]()
+    val renewals  = new AtomicInteger(0)
+    val released  = new AtomicBoolean(false)
+    val commands  = new CommandRunner[CIO, String] {
+      def run[A](command: Command[A]): CIO[A] = CIO.defer(()).flatMap { _ =>
+        val reply = command.args(4).asUtf8String match {
+          case "renew"   =>
+            renewals.incrementAndGet()
+            0L
+          case "release" =>
+            released.set(true)
+            1L
+          case _         => 1L
+        }
+        command.decode(Frame.Integer(reply)).fold(CIO.fail(_), CIO.value(_))
+      }
+    }
+    val client    = new SageClient.Lowered(new LockTestClient(commands))
+    val scoped    = client.lock[String](300.millis).tryWithLock("key") {
+      body.future.map { value =>
+        continued.success(value)
+        value
+      }
+    }
+    for {
+      error <- scoped.failed
+      _      = assert(error.isInstanceOf[LockLost], error.toString)
+      _      = assert(!continued.isCompleted)
+      _      = assert(released.get())
+      count  = renewals.get()
+      _     <- CIO.sleep(400.millis).unsafeRun
+      _      = assertEquals(renewals.get(), count)
+      _      = body.success(42)
+      value <- continued.future
+      _      = assertEquals(value, 42)
+      _     <- CIO.sleep(400.millis).unsafeRun
+    } yield assertEquals(renewals.get(), count)
+  }
+}

--- a/sage-client/shared/src/main/scala/sage/client/LockClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/LockClient.scala
@@ -1,0 +1,29 @@
+package sage.client
+
+import scala.concurrent.duration.FiniteDuration
+
+import sage.client.internal.{Client, LockExecutor}
+
+/**
+  * A distributed mutex bound to a client. Each key has an expiring lease that Sage renews while the protected effect runs. All callers
+  * coordinating the same work must use the same namespace and key. Locks are not reentrant and do not guarantee acquisition order.
+  *
+  * Mutual exclusion depends on the lease remaining valid and Redis retaining its state. Process pauses beyond expiry and Redis failover
+  * can allow overlapping work. Cancellation after lease loss is cooperative and cannot undo completed external effects.
+  */
+final class LockClient[F[_], K] private[sage] (client: Client[F, ?], executor: LockExecutor[K]) {
+
+  /**
+    * Attempts acquisition once. Returns `None` when busy, without evaluating `body`. After acquisition, renews the lease and releases it
+    * when `body` finishes. Returns `Some(result)` on success. Ownership or renewal failure raises [[sage.SageException.LockLost]].
+    */
+  def tryWithLock[A](key: K)(body: => F[A]): F[Option[A]] = client.lockTryWith(executor, key)(body)
+
+  /**
+    * Retries acquisition with exponential backoff and jitter until `waitTimeout` elapses, then raises [[sage.SageException.TimedOut]]. The timeout
+    * must be positive and covers acquisition only. Once acquired, the lease is renewed for the duration of `body`. The body is evaluated
+    * only after acquisition and is never retried by Sage.
+    */
+  def withLock[A](key: K, waitTimeout: FiniteDuration)(body: => F[A]): F[A] =
+    client.lockWith(executor, key, waitTimeout)(body)
+}

--- a/sage-client/shared/src/main/scala/sage/client/LockClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/LockClient.scala
@@ -7,6 +7,7 @@ import sage.client.internal.{Client, LockExecutor}
 /**
   * A distributed mutex bound to a client. Each key has an expiring lease that Sage renews while the protected effect runs. All callers
   * coordinating the same work must use the same namespace and key. Locks are not reentrant and do not guarantee acquisition order.
+  * Master-replica and cluster clients require replica acknowledgement for acquisition and renewal.
   *
   * Mutual exclusion depends on the lease remaining valid and Redis retaining its state. Process pauses beyond expiry and Redis failover
   * can allow overlapping work. Cancellation after lease loss is cooperative and cannot undo completed external effects.

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -21,15 +21,17 @@ import sage.protocol.Frame
 import sage.ratelimit.{Decision, RateLimit, RateLimiter}
 
 /**
-  * Redis and Valkey command methods shared by [[Client]] and [[TransactionScope]]. Each method delegates to [[run]], allowing the same
-  * definitions to work with the real client, backend adapters, and test implementations.
+  * Redis and Valkey command methods shared by [[Client]] and [[TransactionScope]]. Public command methods delegate to [[run]], allowing
+  * the same definitions to work with the real client, backend adapters, and test implementations.
   */
 trait CommandRunner[F[_], K](using KeyCodec[K]) {
 
   /**
-    * Runs a [[sage.commands.Command]] and returns its decoded result. The other command methods delegate to this one.
+    * Runs a [[sage.commands.Command]] and returns its decoded result. Public command methods delegate to this one.
     */
   def run[A](command: Command[A]): F[A]
+
+  private[sage] def lockWrite(command: Command[Boolean], @scala.annotation.unused timeout: FiniteDuration): F[Boolean] = run(command)
 
   /**
     * Returns a view that uses another key type and reuses the same connection. Command builders encode keys before calling `run`, so the
@@ -40,7 +42,8 @@ trait CommandRunner[F[_], K](using KeyCodec[K]) {
   def as[K2](using KeyCodec[K2]): CommandRunner[F, K2] = {
     val self = this
     new CommandRunner[F, K2] {
-      def run[A](command: Command[A]): F[A] = self.run(command)
+      def run[A](command: Command[A]): F[A]                                                                = self.run(command)
+      override private[sage] def lockWrite(command: Command[Boolean], timeout: FiniteDuration): F[Boolean] = self.lockWrite(command, timeout)
     }
   }
 
@@ -2277,6 +2280,7 @@ trait Client[F[_], K] extends CommandRunner[F, K] {
     val self = this
     new Client[F, K2] {
       def run[A](command: Command[A]): F[A]                                                                                        = self.run(command)
+      override private[sage] def lockWrite(command: Command[Boolean], timeout: FiniteDuration): F[Boolean]                         = self.lockWrite(command, timeout)
       def cached[A](command: Command[A], ttl: FiniteDuration): F[A]                                                                = self.cached(command, ttl)
       private[sage] def pipeline[Out, R](p: Pipeline[Out, R]): F[Out]                                                              = self.pipeline(p)
       private[sage] def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R]                                                         = self.pipelineAttempt(p)
@@ -2317,7 +2321,18 @@ object Client {
   private[internal] def withLeaseIfBlocking[A](command: Command[?])(body: DedicatedPool.Lease => CIO[A]): CIO[A] =
     command.execution match {
       case Execution.Ordinary => body(null)
-      case Execution.Blocking => CIO.acquireReleaseWith(CIO.defer(new DedicatedPool.Lease))(lease => CIO.blocking(lease.cancel()))(body)
+      case Execution.Blocking => withLease(body)
+    }
+
+  private[internal] def withLease[A](body: DedicatedPool.Lease => CIO[A]): CIO[A] =
+    CIO.acquireReleaseWith(CIO.defer(new DedicatedPool.Lease))(lease => CIO.blocking(lease.cancel()))(body)
+
+  // Keep the timeout inside the lease scope so Future also frees its pool slot when a reply never arrives.
+  private[internal] def withLockLease[A](timeout: FiniteDuration, scheduler: Scheduler)(body: (DedicatedPool.Lease, Long) => CIO[A]): CIO[A] =
+    withLease { lease =>
+      CIO.defer(scheduler.nowMillis + timeout.toMillis).flatMap { deadlineMillis =>
+        CIO.timeoutWithError(timeout)(TimedOut("distributed lock replication timed out"))(body(lease, deadlineMillis))
+      }
     }
 
   // attribute the node at completion. A batch that never reaches the wire leaves its callbacks unattributed.

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -2227,6 +2227,20 @@ trait Client[F[_], K] extends CommandRunner[F, K] {
   ): RateLimiterClient[F, RK] =
     new RateLimiterClient[F, RK](this, RateLimitExecutor(RateLimiter[RK](limit, namespace)))
 
+  /**
+    * Creates a distributed mutex for keys of type `LK`. The lease is renewed automatically while a protected effect runs. `leaseDuration`
+    * defaults to 30 seconds and must be at least 30 milliseconds. See [[LockClient]] for ownership and failover limits.
+    */
+  def lock[LK](
+    leaseDuration: FiniteDuration = FiniteDuration(30L, java.util.concurrent.TimeUnit.SECONDS),
+    namespace: String = "lock"
+  )(using KeyCodec[LK]): LockClient[F, LK] =
+    new LockClient[F, LK](this, new LockExecutor[LK](leaseDuration, namespace))
+
+  private[sage] def lockTryWith[LK, A](executor: LockExecutor[LK], key: LK)(body: => F[A]): F[Option[A]]
+
+  private[sage] def lockWith[LK, A](executor: LockExecutor[LK], key: LK, waitTimeout: FiniteDuration)(body: => F[A]): F[A]
+
   // implementations validate the request, then execute the rate-limit script with EVALSHA and reload it after NOSCRIPT
   private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long, peek: Boolean): F[Decision]
 
@@ -2274,6 +2288,10 @@ trait Client[F[_], K] extends CommandRunner[F, K] {
       private[sage] def runOn[A](target: ScanTarget, command: Command[A]): F[A]                                                    = self.runOn(target, command)
       private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long, peek: Boolean): F[Decision] =
         self.rateLimitAcquire(executor, subject, cost, peek)
+      private[sage] def lockTryWith[LK, A](executor: LockExecutor[LK], key: LK)(body: => F[A]): F[Option[A]]                       =
+        self.lockTryWith(executor, key)(body)
+      private[sage] def lockWith[LK, A](executor: LockExecutor[LK], key: LK, waitTimeout: FiniteDuration)(body: => F[A]): F[A]     =
+        self.lockWith(executor, key, waitTimeout)(body)
       def close: F[Unit]                                                                                                           = self.close
     }
   }
@@ -2532,6 +2550,12 @@ object Client {
 
     private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long, peek: Boolean): CIO[Decision] =
       executor.evalSha(this, subject, cost, peek)
+
+    private[sage] def lockTryWith[LK, A](executor: LockExecutor[LK], key: LK)(body: => CIO[A]): CIO[Option[A]] =
+      executor.tryWithLock(this, key)(body)
+
+    private[sage] def lockWith[LK, A](executor: LockExecutor[LK], key: LK, waitTimeout: FiniteDuration)(body: => CIO[A]): CIO[A] =
+      executor.withLock(this, key, waitTimeout)(body)
 
     private[sage] def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out] =
       submitPipeline(p).flatMap(TxSupport.collapseStrict(_, p.toOut))

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -135,6 +135,16 @@ final private[client] class ClusterLive(
     Client.withLeaseIfBlocking(command)(body)
   }
 
+  override private[sage] def lockWrite(command: Command[Boolean], timeout: FiniteDuration): CIO[Boolean] =
+    Client.withLockLease(timeout, scheduler) { (lease, deadlineMillis) =>
+      CIO.async { complete =>
+        val tracked = Events.trackCommand(events, command, complete)
+        Client.completing(tracked) {
+          dispatch(command, cluster.maxRedirects, tracked, allowReplica = false, lease = lease, mode = DispatchMode.Confirmed(deadlineMillis))
+        }
+      }
+    }
+
   def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =
     if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command))
     else if (!cachingEnabled)
@@ -146,7 +156,7 @@ final private[client] class ClusterLive(
       CIO.async[A] { complete =>
         val deferred = Events.deferSpan(events, command)
         Client.completing(complete)(
-          dispatch(command, cluster.maxRedirects, complete, allowReplica = false, cacheCtx = Cached(ttl.toMillis, deferred))
+          dispatch(command, cluster.maxRedirects, complete, allowReplica = false, mode = DispatchMode.Cached(ttl.toMillis, deferred))
         )
       }
 
@@ -204,10 +214,15 @@ final private[client] class ClusterLive(
 
   // --- routing -------------------------------------------------------------------------------------------------------------------------
 
-  final private case class Cached(ttlMillis: Long, deferred: () => CommandSpan)
+  private enum DispatchMode {
+    case Ordinary
+    case Cached(ttlMillis: Long, deferred: () => CommandSpan)
+    case Confirmed(deadlineMillis: Long)
+  }
+  import DispatchMode.*
 
-  // a cached read is master-pinned, so it may use a replica only when there is no cache context
-  private def replicaAllowed(cacheCtx: Cached): Boolean = cacheCtx == null
+  // Both cached reads and confirmed writes require the master.
+  private def replicaAllowed(mode: DispatchMode): Boolean = mode == Ordinary
 
   private def dispatch[A](
     command: Command[A],
@@ -215,7 +230,7 @@ final private[client] class ClusterLive(
     complete: Try[A] => Unit,
     allowReplica: Boolean = true,
     lease: DedicatedPool.Lease = null,
-    cacheCtx: Cached = null
+    mode: DispatchMode = Ordinary
   ): Unit =
     if (closed) complete(Failure(NotConnected()))
     else {
@@ -226,14 +241,14 @@ final private[client] class ClusterLive(
         else scheduler.offload(broadcast(topology, command, redirectsLeft, complete, masterPool.getOrEstablishOrNull))
       else
         topology.route(command) match {
-          case Route.ToNode(node, slot) => sendOwned(command, node, slot, redirectsLeft, complete, allowReplica, lease, cacheCtx)
+          case Route.ToNode(node, slot) => sendOwned(command, node, slot, redirectsLeft, complete, allowReplica, lease, mode)
           case Route.Keyless            =>
             if (servesFromReplica(command, allowReplica)) sendKeylessRead(topology, command, redirectsLeft, complete)
-            else sendToAny(topology, command, redirectsLeft, complete, lease, cacheCtx)
-          case Route.Unowned(_)         => scheduler.offload(onUnowned(command, redirectsLeft, complete, lease, cacheCtx))
+            else sendToAny(topology, command, redirectsLeft, complete, lease, mode)
+          case Route.Unowned(_)         => scheduler.offload(onUnowned(command, redirectsLeft, complete, lease, mode))
           case Route.CrossSlot(slots)   =>
             multiSlotPolicy(command) match {
-              case Some(policy) => scatterMultiSlot(command, policy, redirectsLeft, complete, allowReplica, cacheCtx)
+              case Some(policy) => scatterMultiSlot(command, policy, redirectsLeft, complete, allowReplica, mode)
               case None         => complete(Failure(crossSlot(command.name, slots)))
             }
           case Route.Malformed          =>
@@ -249,10 +264,10 @@ final private[client] class ClusterLive(
     complete: Try[A] => Unit,
     allowReplica: Boolean,
     lease: DedicatedPool.Lease,
-    cacheCtx: Cached
+    mode: DispatchMode
   ): Unit =
     if (servesFromReplica(command, allowReplica)) sendRead(command, node, slot, redirectsLeft, complete)
-    else sendTo(node, command, asking = false, redirectsLeft, complete, lease, cacheCtx)
+    else sendTo(node, command, asking = false, redirectsLeft, complete, lease, mode)
 
   private def servesFromReplica(command: Command[?], allowReplica: Boolean): Boolean =
     allowReplica && readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command)
@@ -275,7 +290,7 @@ final private[client] class ClusterLive(
     redirectsLeft: Int,
     complete: Try[A] => Unit,
     allowReplica: Boolean,
-    cacheCtx: Cached
+    mode: DispatchMode
   ): Unit = {
     val bySlot = mutable.LinkedHashMap.empty[Slot, mutable.ArrayBuffer[MultiSlotEntry]]
     command.keyIndices.iterator.zipWithIndex.foreach { case (argIndex, resultIndex) =>
@@ -341,7 +356,7 @@ final private[client] class ClusterLive(
         keyIndices = Vector.tabulate(group.size)(_ * policy.argsPerKey),
         args = args.result()
       )
-      dispatch(sub, redirectsLeft, result => settle(group, result), allowReplica = allowReplica, cacheCtx = cacheCtx)
+      dispatch(sub, redirectsLeft, result => settle(group, result), allowReplica = allowReplica, mode = mode)
     }
   }
 
@@ -566,10 +581,10 @@ final private[client] class ClusterLive(
     redirectsLeft: Int,
     complete: Try[A] => Unit,
     lease: DedicatedPool.Lease = null,
-    cacheCtx: Cached = null
+    mode: DispatchMode = Ordinary
   ): Unit =
     pickNode(topology) match {
-      case Some(node) => sendTo(node, command, asking = false, redirectsLeft, complete, lease, cacheCtx)
+      case Some(node) => sendTo(node, command, asking = false, redirectsLeft, complete, lease, mode)
       case None       => complete(Failure(NotConnected()))
     }
 
@@ -580,15 +595,15 @@ final private[client] class ClusterLive(
     redirectsLeft: Int,
     complete: Try[A] => Unit,
     lease: DedicatedPool.Lease,
-    cacheCtx: Cached = null
+    mode: DispatchMode = Ordinary
   ): Unit = {
     val existing = masterPool.existing(node)
-    if (existing != null) submitTo(existing, node, command, asking, redirectsLeft, complete, lease, cacheCtx)
+    if (existing != null) submitTo(existing, node, command, asking, redirectsLeft, complete, lease, mode)
     else
       scheduler.offload {
         val nc = masterPool.getOrEstablishOrNull(node)
-        if (nc == null) onUnreachable(command, redirectsLeft, complete, lease, cacheCtx)
-        else submitTo(nc, node, command, asking, redirectsLeft, complete, lease, cacheCtx)
+        if (nc == null) onUnreachable(command, redirectsLeft, complete, lease, mode)
+        else submitTo(nc, node, command, asking, redirectsLeft, complete, lease, mode)
       }
   }
 
@@ -600,16 +615,21 @@ final private[client] class ClusterLive(
     redirectsLeft: Int,
     complete: Try[A] => Unit,
     lease: DedicatedPool.Lease,
-    cacheCtx: Cached
+    mode: DispatchMode
   ): Unit = {
     val onReply: Try[A] => Unit = {
       case Success(value) =>
         Events.attributeNode(complete, node)
         complete(Success(value))
-      case Failure(error) => scheduler.offload(onFailure(node, command, error, redirectsLeft, complete, lease, cacheCtx))
+      case Failure(error) => scheduler.offload(onFailure(node, command, error, redirectsLeft, complete, lease, mode))
     }
-    if (cacheCtx != null && !asking) nc.cachedSubmit[A](command, cacheCtx.ttlMillis, onReply, cacheCtx.deferred)
-    else nc.submit[A](command, asking, onReply, lease)
+    mode match {
+      case Cached(ttlMillis, deferred) if !asking => nc.cachedSubmit[A](command, ttlMillis, onReply, deferred)
+      case Confirmed(deadlineMillis)              =>
+        val replicas = topologyRef.get().replicasForMaster(node).size
+        nc.submitLockWrite(command, asking, replicas, deadlineMillis, onReply, lease, () => refreshThrottle.request(refreshWork))
+      case Ordinary | Cached(_, _)                => nc.submit[A](command, asking, onReply, lease)
+    }
   }
 
   private def onFailure[A](
@@ -619,13 +639,13 @@ final private[client] class ClusterLive(
     redirectsLeft: Int,
     complete: Try[A] => Unit,
     lease: DedicatedPool.Lease,
-    cacheCtx: Cached
+    mode: DispatchMode
   ): Unit =
     Fault.categorize(error) match {
-      case Fault.Redirected(redirect)       => onRedirect(node, redirect, command, redirectsLeft, complete, lease, cacheCtx)
-      case Fault.Lost(false)                => onUnreachable(command, redirectsLeft, complete, lease, cacheCtx)
-      case Fault.TryAgain                   => onRetryable(command, error, refreshFirst = false, redirectsLeft, complete, lease, cacheCtx)
-      case Fault.Unavailable(clusterWide)   => onRetryable(command, error, clusterWide, redirectsLeft, complete, lease, cacheCtx)
+      case Fault.Redirected(redirect)       => onRedirect(node, redirect, command, redirectsLeft, complete, lease, mode)
+      case Fault.Lost(false)                => onUnreachable(command, redirectsLeft, complete, lease, mode)
+      case Fault.TryAgain                   => onRetryable(command, error, refreshFirst = false, redirectsLeft, complete, lease, mode)
+      case Fault.Unavailable(clusterWide)   => onRetryable(command, error, clusterWide, redirectsLeft, complete, lease, mode)
       case Fault.Demoted | Fault.Lost(true) =>
         triggerRefresh()
         Events.attributeNode(complete, node)
@@ -642,7 +662,7 @@ final private[client] class ClusterLive(
     redirectsLeft: Int,
     complete: Try[A] => Unit,
     lease: DedicatedPool.Lease = null,
-    cacheCtx: Cached = null
+    mode: DispatchMode = Ordinary
   ): Unit = {
     // a MOVED proves `from` lost the slot; retire its cache even if the retry budget is now exhausted
     if (redirect.kind == RedirectKind.Moved) flushNode(from)
@@ -654,8 +674,8 @@ final private[client] class ClusterLive(
       redirect.kind match {
         case RedirectKind.Moved =>
           triggerRefresh()
-          sendTo(target, command, asking = false, redirectsLeft - 1, complete, lease, cacheCtx)
-        case RedirectKind.Ask   => sendTo(target, command, asking = true, redirectsLeft - 1, complete, lease, cacheCtx)
+          sendTo(target, command, asking = false, redirectsLeft - 1, complete, lease, mode)
+        case RedirectKind.Ask   => sendTo(target, command, asking = true, redirectsLeft - 1, complete, lease, mode)
       }
     }
   }
@@ -667,8 +687,8 @@ final private[client] class ClusterLive(
     redirectsLeft: Int,
     complete: Try[A] => Unit,
     lease: DedicatedPool.Lease = null,
-    cacheCtx: Cached = null
-  ): Unit = onRetryable(command, NotConnected(), refreshFirst = true, redirectsLeft, complete, lease, cacheCtx)
+    mode: DispatchMode = Ordinary
+  ): Unit = onRetryable(command, NotConnected(), refreshFirst = true, redirectsLeft, complete, lease, mode)
 
   // retry temporary refusals such as TRYAGAIN, LOADING, MASTERDOWN, and CLUSTERDOWN with bounded jitter
   private def onRetryable[A](
@@ -678,7 +698,7 @@ final private[client] class ClusterLive(
     redirectsLeft: Int,
     complete: Try[A] => Unit,
     lease: DedicatedPool.Lease = null,
-    cacheCtx: Cached = null
+    mode: DispatchMode = Ordinary
   ): Unit =
     if (redirectsLeft <= 0) {
       if (refreshFirst) refreshBeforeFailing()
@@ -686,7 +706,7 @@ final private[client] class ClusterLive(
     } else {
       if (refreshFirst) refresh(force = true)
       afterBackoff(redirectsLeft)(
-        dispatch(command, redirectsLeft - 1, complete, allowReplica = replicaAllowed(cacheCtx), lease = lease, cacheCtx = cacheCtx)
+        dispatch(command, redirectsLeft - 1, complete, allowReplica = replicaAllowed(mode), lease = lease, mode = mode)
       )
     }
 
@@ -697,19 +717,25 @@ final private[client] class ClusterLive(
   // refresh immediately before returning an error on paths where no later retry can trigger another refresh
   private def refreshBeforeFailing(): Unit = refresh(force = true)
 
-  private def onUnowned[A](command: Command[A], redirectsLeft: Int, complete: Try[A] => Unit, lease: DedicatedPool.Lease, cacheCtx: Cached): Unit = {
+  private def onUnowned[A](
+    command: Command[A],
+    redirectsLeft: Int,
+    complete: Try[A] => Unit,
+    lease: DedicatedPool.Lease,
+    mode: DispatchMode
+  ): Unit = {
     refresh(force = false)
     val topology     = topologyRef.get()
-    val allowReplica = replicaAllowed(cacheCtx)
+    val allowReplica = replicaAllowed(mode)
     topology.route(command) match {
       // apply the read policy after the slot resolves. Eligible reads still use replica routing.
       case Route.ToNode(node, slot)                                                                  =>
-        sendOwned(command, node, slot, redirectsLeft, complete, allowReplica, lease, cacheCtx)
+        sendOwned(command, node, slot, redirectsLeft, complete, allowReplica, lease, mode)
       // ReadFrom.Replica has no master fallback. Refresh and retry within the configured limit.
       case _ if allowReplica && readFrom == ReadFrom.Replica && ReadRouting.replicaEligible(command) =>
-        onUnreachable(command, redirectsLeft, complete, lease, cacheCtx)
+        onUnreachable(command, redirectsLeft, complete, lease, mode)
       // if the refreshed topology still has no owner, send to any master and handle its MOVED or CLUSTERDOWN reply
-      case _                                                                                         => sendToAny(topology, command, redirectsLeft, complete, lease, cacheCtx)
+      case _                                                                                         => sendToAny(topology, command, redirectsLeft, complete, lease, mode)
     }
   }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -153,6 +153,12 @@ final private[client] class ClusterLive(
   private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long, peek: Boolean): CIO[Decision] =
     executor.evalSha(this, subject, cost, peek)
 
+  private[sage] def lockTryWith[LK, A](executor: LockExecutor[LK], key: LK)(body: => CIO[A]): CIO[Option[A]] =
+    executor.tryWithLock(this, key)(body)
+
+  private[sage] def lockWith[LK, A](executor: LockExecutor[LK], key: LK, waitTimeout: FiniteDuration)(body: => CIO[A]): CIO[A] =
+    executor.withLock(this, key, waitTimeout)(body)
+
   // SCAN cursors are node-local. A full scan visits every master that owns slots. Resharding during the scan can still miss or duplicate keys.
   def scanTargets: CIO[Vector[ScanTarget]] =
     CIO.blocking {

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -1,25 +1,26 @@
 package sage.client.internal
 
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.collection.mutable
 import scala.concurrent.duration.*
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
 import sage.SageException
-import sage.SageException.{ConnectionLost, NotConnected, TimedOut}
+import sage.SageException.{ConnectionLost, LockLost, NotConnected, TimedOut}
 import sage.client.DedicatedPoolConfig
-import sage.commands.{Command, Connection}
+import sage.commands.{Command, Connection, Reply, Role, Server}
 
 /**
-  * A pool of dedicated connections for blocking commands. Connections are created when needed, used by one command at a time, and returned
-  * to the pool while healthy. A lost connection is discarded. When no idle connection is available, the pool opens a new one.
+  * A pool of dedicated connections for blocking commands, transactions, and lock replication checks. Connections are created when needed,
+  * used by one caller, and returned to the pool while healthy. A lost connection is discarded. When no idle connection is available, the
+  * pool opens a new one.
   *
   * A request made while the client is disconnected fails immediately with `NotConnected`. When all connections are busy, acquisition
-  * waits up to `acquireTimeout` and then fails with `TimedOut`. Closing the pool also closes connections in use, causing their commands to
-  * fail with `ConnectionLost(true)`.
+  * waits up to `acquireTimeout`, shortened by a lock write's deadline, and then fails with `TimedOut`. Closing the pool also closes connections
+  * in use, causing their commands to fail with `ConnectionLost(true)`.
   */
 final private[client] class DedicatedPool(
   factory: MultiplexedConnection.TransportFactory,
@@ -62,24 +63,103 @@ final private[client] class DedicatedPool(
     leaseAndSubmit(command, asking = true, callback, lease)
 
   private def leaseAndSubmit[A](command: Command[A], asking: Boolean, callback: Try[A] => Unit, lease: DedicatedPool.Lease): Unit =
-    if (!isLive()) callback(scala.util.Failure(NotConnected()))
+    useConnection(callback, lease) { (conn, complete) =>
+      if (asking) conn.submit[Unit](Connection.asking, _ => ())
+      conn.submit(command, complete)
+    }
+
+  // WAIT blocks its socket. Keep the write and confirmation on one leased connection so other commands can proceed independently.
+  def useLockWrite[A](
+    command: Command[A],
+    asking: Boolean,
+    replicas: Int,
+    deadlineMillis: Long,
+    callback: Try[A] => Unit,
+    lease: DedicatedPool.Lease,
+    onConfirmationFailure: () => Unit
+  ): Unit = {
+    val confirming = new AtomicBoolean(false)
+    useConnection(callback, lease, () => if (confirming.get()) onConfirmationFailure(), Some(deadlineMillis)) { (conn, complete) =>
+      // Once the write succeeds, a failed confirmation cannot make it safe to replay the write.
+      def confirmationFailed(error: Throwable): Unit = {
+        onConfirmationFailure()
+        val failure = Fault.categorize(error) match {
+          case Fault.Lost(_) | Fault.Redirected(_) | Fault.TryAgain | Fault.Unavailable(_) =>
+            val lost = ConnectionLost(mayHaveExecuted = true)
+            lost.initCause(error)
+            lost
+          case _                                                                           => error
+        }
+        complete(Failure(failure))
+      }
+
+      def confirm(value: A): Unit = {
+        confirming.set(true)
+        conn.submit(
+          Server.role,
+          {
+            case Success(Role.Master(_, connected)) =>
+              val required = math.max(replicas, connected.size)
+              if (required == 0) complete(Success(value))
+              else {
+                // Reserve half the remaining budget for the server's timeout processing and the reply's transit.
+                val waitMillis = (deadlineMillis - scheduler.nowMillis) / 2L
+                if (waitMillis <= 0L) confirmationFailed(TimedOut("distributed lock replication deadline reached before WAIT"))
+                else
+                  conn.submit(
+                    Server.waitReplicas(required.toLong, waitMillis.millis),
+                    {
+                      case Success(count) if count >= required => complete(Success(value))
+                      case Success(count)                      => confirmationFailed(TimedOut(s"replication confirmed by $count of $required required replicas"))
+                      case Failure(error)                      => confirmationFailed(error)
+                    }
+                  )
+              }
+            case Success(_)                         => confirmationFailed(LockLost("the granting node is no longer a master"))
+            case Failure(error)                     => confirmationFailed(error)
+          }
+        )
+      }
+
+      val onReply: Try[A] => Unit = {
+        case Success(value) if value == true => confirm(value)
+        case result                          => complete(result)
+      }
+      if (asking)
+        conn.submitRaw(Vector(Connection.asking, command.rawFrame), result => onReply(result.flatMap(frames => Reply.decode(command, frames.last))))
+      else conn.submit(command, onReply)
+    }
+  }
+
+  private def useConnection[A](
+    callback: Try[A] => Unit,
+    lease: DedicatedPool.Lease,
+    onCancel: () => Unit = () => (),
+    deadlineMillis: Option[Long] = None
+  )(submit: (DedicatedConnection, Try[A] => Unit) => Unit): Unit =
+    if (!isLive()) callback(Failure(NotConnected()))
+    else if (!lease.beginAcquire(this)) callback(Failure(ConnectionLost(mayHaveExecuted = true)))
     else
       scheduler.after(Duration.Zero) {
         val acquired =
-          try Right(acquire())
+          try Right(acquire(Some(lease), deadlineMillis))
           catch {
             case e: SageException => Left(e)
-            case NonFatal(_)      => Left(ConnectionLost(mayHaveExecuted = false)) // never reached the wire
+            case NonFatal(_)      => Left(ConnectionLost(mayHaveExecuted = false))
           }
         acquired match {
-          case Left(error) => callback(scala.util.Failure(error))
+          case Left(error) =>
+            lease.endAcquire()
+            callback(Failure(error))
           case Right(conn) =>
-            // attach fails only when already cancelled (interrupt before/between attaches); settle the callback here since cancel found no Held to settle
-            val onInterrupt = () => callback(scala.util.Failure(ConnectionLost(mayHaveExecuted = true)))
+            // Cancellation can precede attachment while acquisition waits for a socket or pool slot.
+            val onInterrupt = () => {
+              onCancel()
+              callback(Failure(ConnectionLost(mayHaveExecuted = true)))
+            }
             if (lease.attach(this, conn, onInterrupt)) {
-              if (asking) conn.submit[Unit](Connection.asking, _ => ())
-              conn.submit(
-                command,
+              submit(
+                conn,
                 result =>
                   if (lease.finish(conn)) {
                     release(conn)
@@ -126,21 +206,28 @@ final private[client] class DedicatedPool(
     toClose.foreach(_.close())
   }
 
-  private def acquire(): DedicatedConnection = {
-    val deadlineNanos = System.nanoTime() + config.acquireTimeout.toNanos
+  private def acquire(lease: Option[DedicatedPool.Lease] = None, deadlineMillis: Option[Long] = None): DedicatedConnection = {
+    val budgetNanos   = deadlineMillis.fold(config.acquireTimeout.toNanos) { deadline =>
+      math.min(config.acquireTimeout.toNanos, (deadline - scheduler.nowMillis).millis.toNanos)
+    }
+    // Condition waits use real nanoseconds, so only the remaining duration crosses from the scheduler's monotonic clock.
+    val deadlineNanos = System.nanoTime() + budgetNanos
     locked {
       while (true) {
+        if (lease.exists(_.isCancelled)) throw ConnectionLost(mayHaveExecuted = true)
         if (closing) throw NotConnected()
         // reject acquisition while the shared connection is reconnecting; repeat the liveness check after each wake-up
         if (!isLive()) throw NotConnected()
+        val remaining = deadlineNanos - System.nanoTime()
+        // A lock deadline limits the write itself. An expired write must not take a slot even when one is immediately available.
+        if (deadlineMillis.isDefined && remaining <= 0L) throw acquireTimedOut(budgetNanos.nanos)
         val reused    = takeIdleLocked()
         if (reused != null) return reused
         if (live.size + reserved < config.maxConnections) {
           reserved += 1
           return establishOutsideLock()
         }
-        val remaining = deadlineNanos - System.nanoTime()
-        if (remaining <= 0L) throw acquireTimedOut
+        if (remaining <= 0L) throw acquireTimedOut(budgetNanos.nanos)
         available.awaitNanos(remaining): Unit
       }
       throw new IllegalStateException("unreachable")
@@ -185,8 +272,8 @@ final private[client] class DedicatedPool(
     }
   }
 
-  private def acquireTimedOut: TimedOut =
-    TimedOut(s"dedicated pool acquire timed out after ${config.acquireTimeout.toMillis}ms")
+  private def acquireTimedOut(budget: FiniteDuration): TimedOut =
+    TimedOut(s"dedicated pool acquire timed out after ${math.max(0L, budget.toMillis)}ms")
 
   private def takeIdleLocked(): DedicatedConnection = {
     var result: DedicatedConnection = null
@@ -274,19 +361,31 @@ private[client] object DedicatedPool {
   final case class Idle(connection: DedicatedConnection, idleSinceMillis: Long)
 
   /**
-    * Tracks the connection held by one blocking command, including after redirects. `attach` records a leased connection and its interruption
+    * Tracks the connection held by one operation, including after redirects. `attach` records a leased connection and its interruption
     * callback. `finish` clears the lease after a reply. `cancel` discards the current connection and invokes the callback, which completes
-    * tracing and events for the interrupted command. Once cancelled, any later attachment is discarded immediately.
+    * tracing and events for the interrupted command. Cancellation wakes pool waiters. A connection acquired after cancellation is returned
+    * to the pool because it has received no command from this operation.
     */
   final class Lease {
-    private val state = new AtomicReference[AnyRef]() // null idle, a Held while leased, Cancelled terminal
+    private val state = new AtomicReference[AnyRef]() // null idle, Waiting during acquisition, Held while leased, Cancelled terminal
 
-    private[internal] def attach(pool: DedicatedPool, conn: DedicatedConnection, onInterrupt: () => Unit): Boolean =
-      if (state.compareAndSet(null, Held(pool, conn, onInterrupt))) true
-      else {
-        pool.releaseTransaction(conn, reusable = false)
-        false
+    private[internal] def beginAcquire(pool: DedicatedPool): Boolean = state.compareAndSet(null, Waiting(pool))
+
+    private[internal] def endAcquire(): Unit = state.get() match {
+      case w: Waiting => state.compareAndSet(w, null): Unit
+      case _          => ()
+    }
+
+    private[internal] def isCancelled: Boolean = state.get() == Cancelled
+
+    private[internal] def attach(pool: DedicatedPool, conn: DedicatedConnection, onInterrupt: () => Unit): Boolean = {
+      val attached = state.get() match {
+        case w: Waiting => state.compareAndSet(w, Held(pool, conn, onInterrupt))
+        case _          => false
       }
+      if (!attached) pool.releaseTransaction(conn, reusable = true)
+      attached
+    }
 
     private[internal] def finish(conn: DedicatedConnection): Boolean =
       state.get() match {
@@ -295,13 +394,15 @@ private[client] object DedicatedPool {
       }
 
     def cancel(): Unit = state.getAndSet(Cancelled) match {
-      case h: Held =>
+      case w: Waiting => w.pool.wakeWaiters()
+      case h: Held    =>
         h.pool.releaseTransaction(h.conn, reusable = false)
         h.onInterrupt()
-      case _       => ()
+      case _          => ()
     }
   }
 
+  final private case class Waiting(pool: DedicatedPool)
   final private case class Held(pool: DedicatedPool, conn: DedicatedConnection, onInterrupt: () => Unit)
   private case object Cancelled
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/LockCommands.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LockCommands.scala
@@ -1,0 +1,58 @@
+package sage.client.internal
+
+import scala.concurrent.duration.FiniteDuration
+
+import sage.Bytes
+import sage.SageException.DecodeError
+import sage.codec.KeyCodec
+import sage.commands.*
+
+final private[client] class LockCommands[K](leaseDuration: FiniteDuration, namespace: String)(using codec: KeyCodec[K]) {
+  private val prefix = {
+    val ns = Bytes.utf8(namespace)
+    Bytes.concat(Vector(Bytes.utf8(s"${ns.length}:"), ns, Bytes.utf8(":")))
+  }
+
+  def key(value: K): Bytes = Bytes.concat(Vector(prefix, codec.encode(value)))
+
+  def command(key: Bytes, token: String, operation: String, cached: Boolean): Command[Boolean] =
+    Command(
+      if (cached) "EVALSHA" else "EVAL",
+      Vector(2),
+      Vector(
+        if (cached) LockCommands.digest else LockCommands.body,
+        Bytes.utf8("1"),
+        key,
+        Bytes.utf8(token),
+        Bytes.utf8(operation),
+        Bytes.utf8(leaseDuration.toMillis.toString)
+      ),
+      _.asLong.flatMap {
+        case 0 => Right(false)
+        case 1 => Right(true)
+        case n => Left(DecodeError("lock result 0 or 1", n.toString))
+      }
+    )
+}
+
+private[client] object LockCommands {
+  val script: String =
+    """local token = ARGV[1]
+      |local operation = ARGV[2]
+      |if operation == 'acquire' then
+      |  if redis.call('SET', KEYS[1], token, 'NX', 'PX', ARGV[3]) then return 1 end
+      |  return 0
+      |end
+      |if operation ~= 'renew' and operation ~= 'release' then
+      |  return redis.error_reply('SAGE invalid lock operation')
+      |end
+      |if redis.call('GET', KEYS[1]) ~= token then return 0 end
+      |if operation == 'renew' then return redis.call('PEXPIRE', KEYS[1], ARGV[3]) end
+      |return redis.call('DEL', KEYS[1])
+      |""".stripMargin
+
+  val body: Bytes   = Bytes.utf8(script)
+  val digest: Bytes = Bytes.utf8(
+    java.security.MessageDigest.getInstance("SHA-1").digest(body.toArray).iterator.map(b => f"${b & 0xff}%02x").mkString
+  )
+}

--- a/sage-client/shared/src/main/scala/sage/client/internal/LockExecutor.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LockExecutor.scala
@@ -1,0 +1,175 @@
+package sage.client.internal
+
+import java.util.UUID
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong, AtomicReference}
+
+import scala.concurrent.duration.*
+
+import kyo.compat.*
+
+import sage.Bytes
+import sage.SageException.{InvalidArgument, LockLost, ServerError, TimedOut}
+import sage.client.BackoffConfig
+import sage.codec.KeyCodec
+
+final private[client] class LockExecutor[K](leaseDuration: FiniteDuration, namespace: String)(using KeyCodec[K]) {
+  private val commands          = new LockCommands[K](leaseDuration, namespace)
+  // The usable lease accounts for millisecond rounding, scheduling, clock drift, and time spent waiting for replies.
+  private val leaseNanos        = leaseDuration.toMillis * 1000000L
+  private val usableNanos       = leaseNanos - leaseNanos / 10L
+  private val renewalDelay      = (leaseNanos / 3L).nanos
+  private val cleanupTimeout    = math.min(usableNanos, 1.second.toNanos).nanos
+  private val contentionBackoff = BackoffConfig(initialDelay = 50.millis, maxDelay = 500.millis, multiplier = 2.0)
+
+  final private case class Deadline(startedAtNanos: Long, durationNanos: Long) {
+    def remainingAt(nowNanos: Long): Long = durationNanos - (nowNanos - startedAtNanos)
+  }
+
+  final private class Attempt(val key: Bytes) {
+    val token: String   = UUID.randomUUID().toString
+    val stopped         = new AtomicBoolean(false)
+    val mayOwn          = new AtomicBoolean(false)
+    val renewedAt       = new AtomicLong(0L)
+    val releaseDeadline = new AtomicReference[Deadline]()
+  }
+
+  def tryWithLock[A](runner: CommandRunner[CIO, String], key: K)(body: => CIO[A]): CIO[Option[A]] = {
+    val bodyThunk = () => body
+    validate(None).flatMap(_ => attempt(runner, commands.key(key), None)(bodyThunk))
+  }
+
+  def withLock[A](runner: CommandRunner[CIO, String], key: K, waitTimeout: FiniteDuration)(body: => CIO[A]): CIO[A] = {
+    val bodyThunk = () => body
+    validate(Some(waitTimeout)).flatMap { _ =>
+      CIO.nowMonotonic.flatMap { started =>
+        val encoded                  = commands.key(key)
+        val wait                     = Deadline(started.toNanos, waitTimeout.toNanos)
+        def loop(retry: Int): CIO[A] = attempt(runner, encoded, Some(wait))(bodyThunk).flatMap {
+          case Some(value) => CIO.value(value)
+          case None        =>
+            remainingWait(wait).flatMap { remaining =>
+              val delay = math.min(remaining, Backoff.jitteredMillis(contentionBackoff, retry, Scheduler.real).millis.toNanos)
+              CIO.sleep(delay.nanos).flatMap(_ => loop(if (retry < Int.MaxValue) retry + 1 else retry))
+            }
+        }
+        loop(0)
+      }
+    }
+
+  }
+
+  private def validate(wait: Option[FiniteDuration]): CIO[Unit] =
+    if (leaseDuration < 30.millis) CIO.fail(InvalidArgument("leaseDuration must be at least 30 milliseconds"))
+    else if (wait.exists(_ <= Duration.Zero)) CIO.fail(InvalidArgument("waitTimeout must be positive"))
+    else CIO.unit
+
+  private def remainingWait(wait: Deadline): CIO[Long] = CIO.nowMonotonic.flatMap { now =>
+    val remaining = wait.remainingAt(now.toNanos)
+    if (remaining <= 0) CIO.fail(TimedOut("distributed lock acquisition timed out"))
+    else CIO.value(remaining)
+  }
+
+  private def remainingLease(state: Attempt): CIO[Long] = CIO.nowMonotonic.flatMap { now =>
+    val remaining = usableNanos - (now.toNanos - state.renewedAt.get())
+    if (remaining <= 0) CIO.fail(LockLost("distributed lock lease expired before ownership could be confirmed"))
+    else CIO.value(remaining)
+  }
+
+  private def remainingRelease(state: Attempt): CIO[Long] = CIO.nowMonotonic.map { now =>
+    val deadline = state.releaseDeadline.updateAndGet { current =>
+      if (current == null) Deadline(now.toNanos, cleanupTimeout.toNanos) else current
+    }
+    deadline.remainingAt(now.toNanos)
+  }
+
+  private def eval(runner: CommandRunner[CIO, String], state: Attempt, operation: String): CIO[Boolean] =
+    runner.run(commands.command(state.key, state.token, operation, cached = true)).recover {
+      case ServerError("NOSCRIPT", _) => runner.run(commands.command(state.key, state.token, operation, cached = false))
+      case other                      => CIO.fail(other)
+    }
+
+  private def attempt[A](runner: CommandRunner[CIO, String], key: Bytes, wait: Option[Deadline])(body: () => CIO[A]): CIO[Option[A]] =
+    // Allocate only local state during acquisition so a contended or unresponsive server never masks cancellation of the wait loop.
+    CIO.acquireReleaseWith(CIO.defer(new Attempt(key)))(cleanup(runner, _)) { state =>
+      val budget = wait.fold(CIO.value(usableNanos))(remainingWait)
+      budget.flatMap { waitRemaining =>
+        CIO.nowMonotonic.flatMap { started =>
+          state.renewedAt.set(started.toNanos)
+          state.mayOwn.set(true)
+          CIO
+            .timeoutWithError(math.min(waitRemaining, usableNanos).nanos)(TimedOut("distributed lock acquisition timed out"))(
+              eval(runner, state, "acquire")
+            )
+            .flatMap {
+              case false =>
+                state.mayOwn.set(false)
+                CIO.value(None)
+              case true  =>
+                val checkWait = wait.fold(CIO.unit)(remainingWait(_).unit)
+                checkWait.flatMap(_ => remainingLease(state)).flatMap { _ =>
+                  val work = CIO.defer(()).flatMap(_ => body()).flatMap(value => remainingLease(state).map(_ => value))
+                  // Returning errors as values lets first-success races stop on either body failure or lock loss.
+                  CIO.race(work.liftToTry, renew[A](runner, state).liftToTry).flatMap(CIO.get(_)).flatMap { value =>
+                    state.stopped.set(true)
+                    remainingLease(state).flatMap { remaining =>
+                      remainingRelease(state).flatMap { releaseRemaining =>
+                        CIO
+                          .timeoutWithError(math.min(remaining, releaseRemaining).nanos)(LockLost("distributed lock release timed out"))(
+                            eval(runner, state, "release")
+                          )
+                          .flatMap { released =>
+                            state.mayOwn.set(false)
+                            if (released) CIO.value(Some(value))
+                            else CIO.fail(LockLost("distributed lock ownership was lost before release"))
+                          }
+                      }
+                    }
+                  }
+                }
+            }
+        }
+      }
+    }
+
+  private def renew[A](runner: CommandRunner[CIO, String], state: Attempt): CIO[A] =
+    CIO.sleep(renewalDelay).flatMap { _ =>
+      if (state.stopped.get()) CIO.never
+      else
+        remainingLease(state).flatMap { remaining =>
+          CIO.nowMonotonic.flatMap { started =>
+            CIO
+              .timeoutWithError(remaining.nanos)(LockLost("distributed lock renewal timed out"))(
+                eval(runner, state, "renew")
+              )
+              .recover(renewalFailed)
+              .flatMap { renewed =>
+                if (!renewed) CIO.fail(LockLost("distributed lock ownership was lost during renewal"))
+                else
+                  remainingLease(state).flatMap { _ =>
+                    state.renewedAt.set(started.toNanos)
+                    renew[A](runner, state)
+                  }
+              }
+          }
+        }
+    }
+
+  private def renewalFailed(cause: Throwable): CIO[Nothing] = cause match {
+    case lost: LockLost => CIO.fail(lost)
+    case other          =>
+      val lost = LockLost("distributed lock renewal failed")
+      lost.initCause(other)
+      CIO.fail(lost)
+  }
+
+  private def cleanup(runner: CommandRunner[CIO, String], state: Attempt): CIO[Unit] = CIO.defer(()).flatMap { _ =>
+    // Future/Pekko cannot cancel the losing race branch. This flag also stops their renewal loop after the scope has finished.
+    state.stopped.set(true)
+    if (!state.mayOwn.get()) CIO.unit
+    else
+      remainingRelease(state).flatMap { remaining =>
+        if (remaining <= 0) CIO.unit
+        else CIO.timeout(remaining.nanos)(eval(runner, state, "release")).unit.recover(_ => CIO.unit)
+      }
+  }
+}

--- a/sage-client/shared/src/main/scala/sage/client/internal/LockExecutor.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LockExecutor.scala
@@ -18,7 +18,7 @@ final private[client] class LockExecutor[K](leaseDuration: FiniteDuration, names
   private val leaseNanos        = leaseDuration.toMillis * 1000000L
   private val usableNanos       = leaseNanos - leaseNanos / 10L
   private val renewalDelay      = (leaseNanos / 3L).nanos
-  private val cleanupTimeout    = math.min(usableNanos, 1.second.toNanos).nanos
+  private val operationTimeout  = math.min(usableNanos, 1.second.toNanos).nanos
   private val contentionBackoff = BackoffConfig(initialDelay = 50.millis, maxDelay = 500.millis, multiplier = 2.0)
 
   final private case class Deadline(startedAtNanos: Long, durationNanos: Long) {
@@ -77,16 +77,34 @@ final private[client] class LockExecutor[K](leaseDuration: FiniteDuration, names
 
   private def remainingRelease(state: Attempt): CIO[Long] = CIO.nowMonotonic.map { now =>
     val deadline = state.releaseDeadline.updateAndGet { current =>
-      if (current == null) Deadline(now.toNanos, cleanupTimeout.toNanos) else current
+      if (current == null) Deadline(now.toNanos, operationTimeout.toNanos) else current
     }
     deadline.remainingAt(now.toNanos)
   }
 
-  private def eval(runner: CommandRunner[CIO, String], state: Attempt, operation: String): CIO[Boolean] =
-    runner.run(commands.command(state.key, state.token, operation, cached = true)).recover {
-      case ServerError("NOSCRIPT", _) => runner.run(commands.command(state.key, state.token, operation, cached = false))
+  private def eval(
+    runner: CommandRunner[CIO, String],
+    state: Attempt,
+    operation: String,
+    confirmationDeadline: Option[Deadline] = None
+  ): CIO[Boolean] = {
+    def run(cached: Boolean): CIO[Boolean] = {
+      val command = commands.command(state.key, state.token, operation, cached)
+      confirmationDeadline match {
+        case None           => runner.run(command)
+        case Some(deadline) =>
+          CIO.nowMonotonic.flatMap { now =>
+            val remaining = math.min(operationTimeout.toNanos, deadline.remainingAt(now.toNanos))
+            if (remaining <= 0L) CIO.fail(TimedOut("distributed lock write timed out"))
+            else runner.lockWrite(command, remaining.nanos)
+          }
+      }
+    }
+    run(cached = true).recover {
+      case ServerError("NOSCRIPT", _) => run(cached = false)
       case other                      => CIO.fail(other)
     }
+  }
 
   private def attempt[A](runner: CommandRunner[CIO, String], key: Bytes, wait: Option[Deadline])(body: () => CIO[A]): CIO[Option[A]] =
     // Allocate only local state during acquisition so a contended or unresponsive server never masks cancellation of the wait loop.
@@ -96,9 +114,10 @@ final private[client] class LockExecutor[K](leaseDuration: FiniteDuration, names
         CIO.nowMonotonic.flatMap { started =>
           state.renewedAt.set(started.toNanos)
           state.mayOwn.set(true)
+          val duration = math.min(waitRemaining, usableNanos)
           CIO
-            .timeoutWithError(math.min(waitRemaining, usableNanos).nanos)(TimedOut("distributed lock acquisition timed out"))(
-              eval(runner, state, "acquire")
+            .timeoutWithError(duration.nanos)(TimedOut("distributed lock acquisition timed out"))(
+              eval(runner, state, "acquire", Some(Deadline(started.toNanos, duration)))
             )
             .flatMap {
               case false =>
@@ -139,7 +158,7 @@ final private[client] class LockExecutor[K](leaseDuration: FiniteDuration, names
           CIO.nowMonotonic.flatMap { started =>
             CIO
               .timeoutWithError(remaining.nanos)(LockLost("distributed lock renewal timed out"))(
-                eval(runner, state, "renew")
+                eval(runner, state, "renew", Some(Deadline(started.toNanos, remaining)))
               )
               .recover(renewalFailed)
               .flatMap { renewed =>

--- a/sage-client/shared/src/main/scala/sage/client/internal/LoweredClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LoweredClient.scala
@@ -26,8 +26,13 @@ abstract class LoweredClient[F[_]](underlying: Client[CIO, String]) extends Clie
 
   protected def lockCommand[A](command: Command[A]): CIO[A] = underlying.run(command)
 
+  protected def confirmedLockCommand(command: Command[Boolean], timeout: FiniteDuration): CIO[Boolean] =
+    underlying.lockWrite(command, timeout)
+
   private val lockRunner: CommandRunner[CIO, String] = new CommandRunner[CIO, String] {
-    def run[A](command: Command[A]): CIO[A] = lockCommand(command)
+    def run[A](command: Command[A]): CIO[A]                                                                = lockCommand(command)
+    override private[sage] def lockWrite(command: Command[Boolean], timeout: FiniteDuration): CIO[Boolean] =
+      confirmedLockCommand(command, timeout)
   }
 
   final def run[A](command: Command[A]): F[A] = lower(underlying.run(command))

--- a/sage-client/shared/src/main/scala/sage/client/internal/LoweredClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LoweredClient.scala
@@ -19,6 +19,17 @@ abstract class LoweredClient[F[_]](underlying: Client[CIO, String]) extends Clie
 
   protected def lift[A](fa: F[A]): CIO[A]
 
+  // Native adapters encode failure and cancellation for the shared race, then restore the original outcome after cleanup.
+  // Explicit deferral is required because mapping CIO.unit can evaluate immediately in Kyo.
+  protected def lockScope[A, B](body: () => F[A])(runScope: CIO[A] => CIO[B]): F[B] =
+    lower(runScope(CIO.defer(()).flatMap(_ => lift(body()))))
+
+  protected def lockCommand[A](command: Command[A]): CIO[A] = underlying.run(command)
+
+  private val lockRunner: CommandRunner[CIO, String] = new CommandRunner[CIO, String] {
+    def run[A](command: Command[A]): CIO[A] = lockCommand(command)
+  }
+
   final def run[A](command: Command[A]): F[A] = lower(underlying.run(command))
 
   final def cached[A](command: Command[A], ttl: FiniteDuration): F[A] = lower(underlying.cached(command, ttl))
@@ -45,6 +56,16 @@ abstract class LoweredClient[F[_]](underlying: Client[CIO, String]) extends Clie
 
   final private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long, peek: Boolean): F[Decision] =
     lower(underlying.rateLimitAcquire(executor, subject, cost, peek))
+
+  final private[sage] def lockTryWith[LK, A](executor: LockExecutor[LK], key: LK)(body: => F[A]): F[Option[A]] = {
+    val bodyThunk = () => body
+    lockScope(bodyThunk)(executor.tryWithLock(lockRunner, key)(_))
+  }
+
+  final private[sage] def lockWith[LK, A](executor: LockExecutor[LK], key: LK, waitTimeout: FiniteDuration)(body: => F[A]): F[A] = {
+    val bodyThunk = () => body
+    lockScope(bodyThunk)(executor.withLock(lockRunner, key, waitTimeout)(_))
+  }
 
   final def close: F[Unit] = lower(underlying.close)
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -244,6 +244,26 @@ final private[client] class MasterReplicaLive(
     Client.withLeaseIfBlocking(command)(body)
   }
 
+  override private[sage] def lockWrite(command: Command[Boolean], timeout: FiniteDuration): CIO[Boolean] =
+    Client.withLockLease(timeout, scheduler) { (lease, deadlineMillis) =>
+      CIO.async { complete =>
+        val tracked = Events.trackCommand(events, command, complete)
+        Client.completing(tracked) {
+          onMaster(tracked) { (nc, _, cb) =>
+            nc.submitLockWrite(
+              command,
+              asking = false,
+              replicasRef.get().size,
+              deadlineMillis,
+              cb,
+              lease,
+              () => refreshThrottle.request(rediscoverWork)
+            )
+          }
+        }
+      }
+    }
+
   def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A] =
     if (!Client.cacheable(command)) CIO.fail(Client.notCacheable(command))
     else if (!cachingEnabled)

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -517,6 +517,12 @@ final private[client] class MasterReplicaLive(
   private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long, peek: Boolean): CIO[Decision] =
     executor.evalSha(this, subject, cost, peek)
 
+  private[sage] def lockTryWith[LK, A](executor: LockExecutor[LK], key: LK)(body: => CIO[A]): CIO[Option[A]] =
+    executor.tryWithLock(this, key)(body)
+
+  private[sage] def lockWith[LK, A](executor: LockExecutor[LK], key: LK, waitTimeout: FiniteDuration)(body: => CIO[A]): CIO[A] =
+    executor.withLock(this, key, waitTimeout)(body)
+
   def close: CIO[Unit] = CIO.blocking(closeAll())
 
   private def closeAll(): Unit = {

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
@@ -14,13 +14,23 @@ import sage.commands.Command
   */
 final private[client] class NodeClient(connection: MultiplexedConnection, pool: DedicatedPool) {
 
-  // `lease` (blocking only) lets an interrupted caller release the leased slot; null falls back to a private, uncancellable lease
+  // A supplied lease lets an interrupted caller release the slot; blocking commands without one use a private lease.
   def submit[A](command: Command[A], asking: Boolean, callback: Try[A] => Unit, lease: DedicatedPool.Lease = null): Unit =
     if (command.isBlocking) {
       val l = if (lease != null) lease else new DedicatedPool.Lease
       if (asking) pool.useAsking(command, callback, l) else pool.use(command, callback, l)
     } else if (asking) connection.submitAsking(command, callback)
     else connection.submit(command, callback)
+
+  def submitLockWrite[A](
+    command: Command[A],
+    asking: Boolean,
+    replicas: Int,
+    deadlineMillis: Long,
+    callback: Try[A] => Unit,
+    lease: DedicatedPool.Lease,
+    onConfirmationFailure: () => Unit
+  ): Unit = pool.useLockWrite(command, asking, replicas, deadlineMillis, callback, lease, onConfirmationFailure)
 
   def cachedSubmit[A](command: Command[A], ttlMillis: Long, callback: Try[A] => Unit, deferred: () => CommandSpan = null): Unit =
     connection.cachedSubmit(command, ttlMillis, callback, deferred)

--- a/sage-client/shared/src/main/scala/sage/client/internal/RefreshThrottle.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/RefreshThrottle.scala
@@ -2,12 +2,12 @@ package sage.client.internal
 
 import java.util.concurrent.locks.ReentrantLock
 
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.duration.*
 
 /**
   * Coordinates discovery refreshes for the cluster and master-replica runtimes. Only one refresh runs at a time. [[apply]] waits for a current
-  * refresh to finish and then returns. Non-forced calls within `minRefreshMs` of the previous refresh are skipped. A forced call ignores this
-  * minimum interval. The initial completion time allows the first refresh to run immediately.
+  * refresh to finish and then returns. Non-forced calls to `apply` and `trigger` within `minRefreshMs` of the previous refresh are skipped.
+  * `request` retains work until it can run. A forced call ignores the minimum interval. The first refresh can run immediately.
   *
   * It also starts and stops the optional background polling task.
   */
@@ -20,14 +20,16 @@ final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: 
   @volatile private var lastRefreshMs = scheduler.nowMillis - minRefreshMs
   private var ticker                  = null: Scheduler.Cancelable
   private var stopped                 = false
+  private var requested: () => Unit   = null
+  private var requestScheduled        = false
 
   def apply(force: Boolean)(work: => Unit): Unit =
     if (claim(force, wait = true)) run(work)
 
   /**
     * Schedules a non-forced refresh when no refresh is active and the minimum interval has passed. It returns immediately while another
-    * refresh is active or the interval has not passed. Routing may call this for every read when no replica is available. Taking a pre-created
-    * callback avoids allocating a new closure for each call that returns without scheduling work.
+    * refresh is active, a retained request is already scheduled, or the interval has not passed. Routing may call this for every read when no
+    * replica is available. Taking a pre-created callback avoids allocating a new closure for each call that returns without scheduling work.
     */
   def trigger(work: () => Unit): Unit =
     if (claim(force = false, wait = false))
@@ -37,6 +39,50 @@ final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: 
           finish()
           throw error
       }
+
+  /**
+    * Retains a refresh request until it can run. Requests during a refresh or its minimum interval coalesce into one later refresh.
+    */
+  def request(work: () => Unit): Unit = {
+    lock.lock()
+    try
+      if (!stopped) {
+        requested = work
+        scheduleRequest()
+      }
+    finally lock.unlock()
+  }
+
+  // Called under the mutex so concurrent confirmation failures share one scheduled refresh.
+  private def scheduleRequest(): Unit =
+    if (!refreshing && !requestScheduled && requested != null && !stopped) {
+      requestScheduled = true
+      val delayMillis = math.max(0L, minRefreshMs - (scheduler.nowMillis - lastRefreshMs))
+      try scheduler.after(delayMillis.millis)(runRequested())
+      catch {
+        case error: Throwable =>
+          requestScheduled = false
+          throw error
+      }
+    }
+
+  private def runRequested(): Unit = {
+    lock.lock()
+    val work = try {
+      requestScheduled = false
+      if (stopped || refreshing) null
+      else if (scheduler.nowMillis - lastRefreshMs < minRefreshMs) {
+        scheduleRequest()
+        null
+      } else {
+        val next = requested
+        requested = null
+        if (next != null) refreshing = true
+        next
+      }
+    } finally lock.unlock()
+    if (work != null) run(work())
+  }
 
   /**
     * Starts the background poll when an interval is configured; `tick` runs on the timer thread, so it must only queue work.
@@ -61,6 +107,7 @@ final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: 
     val handle =
       try {
         stopped = true
+        requested = null
         val current = ticker
         ticker = null
         current
@@ -75,7 +122,7 @@ final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: 
       if (refreshing && wait) {
         while (refreshing) done.awaitUninterruptibly()
         false
-      } else if (refreshing || (!force && scheduler.nowMillis - lastRefreshMs < minRefreshMs)) false
+      } else if (refreshing || (!wait && requestScheduled) || (!force && scheduler.nowMillis - lastRefreshMs < minRefreshMs)) false
       else {
         refreshing = true
         true
@@ -97,6 +144,7 @@ final private[client] class RefreshThrottle(scheduler: Scheduler, minRefreshMs: 
       lastRefreshMs = scheduler.nowMillis
       refreshing = false
       done.signalAll()
+      scheduleRequest()
     } finally lock.unlock()
   }
 }

--- a/sage-client/shared/src/main/scala/sage/exports.scala
+++ b/sage-client/shared/src/main/scala/sage/exports.scala
@@ -26,7 +26,7 @@ export sage.client.{
   TrustSource,
   WatchdogConfig
 }
-export sage.client.RateLimiterClient
+export sage.client.{LockClient, RateLimiterClient}
 // the cluster node a Listener observes (SageEvent), the only cluster type users name
 export sage.cluster.Node
 // codec typeclasses (built-in givens live in their companions, already in implicit scope)

--- a/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
@@ -9,7 +9,8 @@ import Replies.bulk
 import sage.Bytes
 import sage.SageException.{ConnectionLost, NotConnected, TimedOut}
 import sage.client.{BackoffConfig, DedicatedPoolConfig, WatchdogConfig}
-import sage.commands.{BlockTimeout, Connection, Lists}
+import sage.cluster.Node
+import sage.commands.{BlockTimeout, Connection, Lists, Server}
 import sage.protocol.Frame
 
 class DedicatedPoolSpec extends munit.FunSuite {
@@ -38,6 +39,154 @@ class DedicatedPoolSpec extends munit.FunSuite {
     val pool                                                   =
       new DedicatedPool(factory, Vector(Connection.hello()), scheduler, isLive, liveGeneration, isCurrent, config, 1000L)
     (pool, scheduler, transports)
+  }
+
+  private val lockWrite = new LockCommands[String](3.seconds, "lock").command(Bytes.utf8("key"), "owner", "acquire", cached = true)
+
+  test("WAIT accounts for elapsed work and leaves time to return a shortfall on a reusable socket") {
+    val (pool, scheduler, transports) = make(replyWith(Nil))
+    var result: Option[Try[Boolean]]  = None
+    pool.useLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => ())
+    scheduler.advance(40.millis)
+    val transport                     = transports.head
+    transport.emit(Frame.Integer(1))
+    scheduler.advance(20.millis)
+    transport.emit(Replies.masterRole(Node("replica", 6380)))
+    assert(transport.written.last.sameBytes(Server.waitReplicas(1, 20.millis).encode))
+    scheduler.advance(20.millis)
+    transport.emit(Frame.Integer(0))
+    assert(result.get.failed.get.isInstanceOf[TimedOut])
+    pool.useLockWrite(lockWrite, false, 0, 200L, _ => (), new DedicatedPool.Lease, () => ())
+    scheduler.advance(Duration.Zero)
+    assertEquals(transports.size, 1)
+    pool.close()
+  }
+
+  test("an exhausted confirmation budget never sends an unbounded WAIT") {
+    val (pool, scheduler, transports) = make(replyWith(Nil))
+    var result: Option[Try[Boolean]]  = None
+    pool.useLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => ())
+    scheduler.advance(Duration.Zero)
+    transports.head.emit(Frame.Integer(1))
+    scheduler.advance(99.millis)
+    transports.head.emit(Replies.masterRole(Node("replica", 6380)))
+    assert(result.get.failed.get.isInstanceOf[TimedOut])
+    assert(!transports.head.written.exists(_.asUtf8String.contains("WAIT")))
+    pool.close()
+  }
+
+  test("lock writes keep their socket until every required replica acknowledges") {
+    val (pool, scheduler, transports) = make(replyWith(Nil))
+    var result: Option[Try[Boolean]]  = None
+    pool.useLockWrite(lockWrite, false, 2, 100L, r => result = Some(r), new DedicatedPool.Lease, () => ())
+    scheduler.advance(Duration.Zero)
+    val transport                     = transports.head
+    transport.emit(Frame.Integer(1))
+    assertEquals(result, None)
+    assert(transport.written.last.asUtf8String.contains("ROLE"))
+    transport.emit(Replies.masterRole(Node("replica", 6380)))
+    assert(transport.written.last.sameBytes(Server.waitReplicas(2, 50.millis).encode))
+    assertEquals(result, None)
+    transport.emit(Frame.Integer(2))
+    assertEquals(result, Some(Success(true)))
+    pool.useLockWrite(lockWrite, false, 0, 100L, _ => (), new DedicatedPool.Lease, () => ())
+    scheduler.advance(Duration.Zero)
+    assertEquals(transports.size, 1)
+    pool.close()
+  }
+
+  for ((known, connected) <- Vector((0, Vector(Node("replica", 6380))), (1, Vector.empty[Node])))
+    test(s"lock confirmation requires discovered replicas when topology has $known and ROLE has ${connected.size}") {
+      val (pool, scheduler, transports) = make(replyWith(Nil))
+      var result: Option[Try[Boolean]]  = None
+      var refreshed                     = false
+      pool.useLockWrite(lockWrite, false, known, 100L, r => result = Some(r), new DedicatedPool.Lease, () => refreshed = true)
+      scheduler.advance(Duration.Zero)
+      transports.head.emit(Frame.Integer(1))
+      transports.head.emit(Replies.masterRole(connected*))
+      assert(transports.head.written.last.sameBytes(Server.waitReplicas(1, 50.millis).encode))
+      transports.head.emit(Frame.Integer(0))
+      assert(result.get.failed.get.isInstanceOf[TimedOut])
+      assert(refreshed)
+      pool.close()
+    }
+
+  test("busy locks skip confirmation and masters without replicas skip WAIT") {
+    val (pool, scheduler, transports) = make(replyWith(Nil))
+    var result: Option[Try[Boolean]]  = None
+    pool.useLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => ())
+    scheduler.advance(Duration.Zero)
+    transports.head.emit(Frame.Integer(0))
+    assertEquals(result, Some(Success(false)))
+    assert(!transports.head.written.exists(_.asUtf8String.contains("ROLE")))
+    pool.useLockWrite(lockWrite, false, 0, 100L, r => result = Some(r), new DedicatedPool.Lease, () => ())
+    scheduler.advance(Duration.Zero)
+    transports.head.emit(Frame.Integer(1))
+    transports.head.emit(Replies.masterRole())
+    assertEquals(result, Some(Success(true)))
+    assert(!transports.head.written.exists(_.asUtf8String.contains("WAIT")))
+    pool.close()
+  }
+
+  test("ASKING precedes the lock write on the socket that confirms it") {
+    val (pool, scheduler, transports) = make(replyWith(Nil))
+    var result: Option[Try[Boolean]]  = None
+    pool.useLockWrite(lockWrite, true, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => ())
+    scheduler.advance(Duration.Zero)
+    assert(transports.head.written.last.sameBytes(Bytes.concat(Vector(Connection.asking.encode, lockWrite.encode))))
+    transports.head.emit(Replies.ok)
+    transports.head.emit(Frame.Integer(1))
+    transports.head.emit(Replies.masterRole(Node("replica", 6380)))
+    transports.head.emit(Frame.Integer(1))
+    assertEquals(result, Some(Success(true)))
+    pool.close()
+  }
+
+  test("connection loss during confirmation keeps the write ambiguous and refreshes topology") {
+    val (pool, scheduler, transports) = make(replyWith(Nil))
+    var result: Option[Try[Boolean]]  = None
+    var refreshed                     = false
+    pool.useLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => refreshed = true)
+    scheduler.advance(Duration.Zero)
+    transports.head.emit(Frame.Integer(1))
+    transports.head.close()
+    assertEquals(result, Some(Failure(ConnectionLost(mayHaveExecuted = true))))
+    assert(refreshed)
+    pool.close()
+  }
+
+  test("a stalled confirmation leaves ordinary commands free and cancellation releases the pool slot") {
+    val (pool, scheduler, transports) = make(replyWith(Nil), config = DedicatedPoolConfig(maxConnections = 1))
+    val shared                        = MultiplexedConnection.connect(
+      (onFrame, onClosed) => new FakeTransport(onFrame, onClosed, _ => Seq(Frame.SimpleString("PONG"))),
+      scheduler,
+      Vector.empty,
+      BackoffConfig(),
+      WatchdogConfig(enabled = false),
+      1.second,
+      Duration.Zero
+    )
+    val node                          = new NodeClient(shared, pool)
+    val lease                         = new DedicatedPool.Lease
+    var result: Option[Try[Boolean]]  = None
+    var refreshed                     = false
+    node.submitLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), lease, () => refreshed = true)
+    scheduler.advance(Duration.Zero)
+    transports.head.emit(Frame.Integer(1))
+    transports.head.emit(Replies.masterRole(Node("replica", 6380)))
+    var ping: Option[Try[String]]     = None
+    node.submit(Connection.ping(), false, r => ping = Some(r))
+    assertEquals(ping, Some(Success("PONG")))
+    assertEquals(result, None)
+    lease.cancel()
+    scheduler.advance(Duration.Zero)
+    assertEquals(result, Some(Failure(ConnectionLost(mayHaveExecuted = true))))
+    assert(refreshed)
+    node.submitLockWrite(lockWrite, false, 0, 100L, _ => (), new DedicatedPool.Lease, () => ())
+    scheduler.advance(Duration.Zero)
+    assertEquals(transports.size, 2)
+    assertEquals(transports.head.closeCount, 1)
+    node.close()
   }
 
   private val blPop = Lists.blPop[String, String]("k")(BlockTimeout.Forever)
@@ -106,7 +255,86 @@ class DedicatedPoolSpec extends munit.FunSuite {
     scheduler.advance(Duration.Zero)
     assertEquals(result, Some(Failure(ConnectionLost(mayHaveExecuted = true))))
     scheduler.advance(Duration.Zero)
-    assertEquals(transports.headOption.map(_.closeCount), Some(1))
+    assertEquals(transports.size, 0)
+  }
+
+  test("cancelling a parked acquisition wakes it without consuming the next available connection") {
+    val config                                                  = DedicatedPoolConfig(maxConnections = 1, acquireTimeout = 5.seconds, idleTimeout = Duration.Inf)
+    val (pool, scheduler, transports)                           = make(replyWith(Seq(popReply)), config = config)
+    val held                                                    = pool.acquireForTransaction()
+    val lease                                                   = new DedicatedPool.Lease
+    @volatile var result: Option[Try[Option[(String, String)]]] = None
+    pool.use(blPop, r => result = Some(r), lease)
+    val waiter                                                  = new Thread(() => scheduler.advance(Duration.Zero))
+    waiter.start()
+    try {
+      val deadline = System.nanoTime() + 2.seconds.toNanos
+      while (waiter.getState != Thread.State.TIMED_WAITING && waiter.isAlive && System.nanoTime() < deadline) Thread.sleep(1)
+      assertEquals(waiter.getState, Thread.State.TIMED_WAITING)
+      lease.cancel()
+      waiter.join(2000)
+      assert(!waiter.isAlive, "cancellation must wake acquisition while the slot is still occupied")
+      assertEquals(result, Some(Failure(ConnectionLost(mayHaveExecuted = true))))
+      pool.releaseTransaction(held, reusable = true)
+      pool.use(blPop, _ => ())
+      scheduler.advance(Duration.Zero)
+      assertEquals(transports.size, 1)
+      assertEquals(transports.head.closeCount, 0)
+    } finally {
+      pool.close()
+      waiter.join(2000)
+    }
+  }
+
+  test("a lock deadline ends pool acquisition before acquireTimeout and leaves the occupied connection reusable") {
+    val config                        = DedicatedPoolConfig(maxConnections = 1, acquireTimeout = 5.seconds, idleTimeout = Duration.Inf)
+    val (pool, scheduler, transports) = make(replyWith(Seq(popReply)), config = config)
+    val held                          = pool.acquireForTransaction()
+    var result: Option[Try[Boolean]]  = None
+    pool.useLockWrite(lockWrite, false, 0, 40L, r => result = Some(r), new DedicatedPool.Lease, () => ())
+    val started                       = System.nanoTime()
+    scheduler.advance(Duration.Zero)
+    assert((System.nanoTime() - started).nanos < 1.second)
+    assert(result.get.failed.get.isInstanceOf[TimedOut])
+    pool.releaseTransaction(held, reusable = true)
+    pool.use(blPop, _ => ())
+    scheduler.advance(Duration.Zero)
+    assertEquals(transports.size, 1)
+    assertEquals(transports.head.closeCount, 0)
+    assert(!transports.head.written.exists(_.asUtf8String.contains("EVALSHA")))
+    pool.close()
+  }
+
+  test("cancellation during bootstrap returns the unused healthy connection to the pool") {
+    val bootstrapping                 = new java.util.concurrent.CountDownLatch(1)
+    val proceed                       = new java.util.concurrent.CountDownLatch(1)
+    val (pool, scheduler, transports) = make { payload =>
+      if (payload.asUtf8String.contains("HELLO")) {
+        bootstrapping.countDown()
+        assert(proceed.await(2, java.util.concurrent.TimeUnit.SECONDS))
+        Seq(Replies.hello)
+      } else Seq(popReply)
+    }
+    val lease                         = new DedicatedPool.Lease
+    pool.use(blPop, _ => (), lease)
+    val acquirer                      = new Thread(() => scheduler.advance(Duration.Zero))
+    acquirer.start()
+    try {
+      assert(bootstrapping.await(2, java.util.concurrent.TimeUnit.SECONDS))
+      lease.cancel()
+      proceed.countDown()
+      acquirer.join(2000)
+      assert(!acquirer.isAlive)
+      assert(!transports.head.written.exists(_.asUtf8String.contains("BLPOP")))
+      pool.use(blPop, _ => ())
+      scheduler.advance(Duration.Zero)
+      assertEquals(transports.size, 1)
+      assertEquals(transports.head.closeCount, 0)
+    } finally {
+      proceed.countDown()
+      acquirer.join(2000)
+      pool.close()
+    }
   }
 
   test("cancelling a lease after the blocking reply landed does not re-fire the callback") {

--- a/sage-client/shared/src/test/scala/sage/client/internal/LockCancellationSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/LockCancellationSpec.scala
@@ -1,0 +1,110 @@
+package sage.client.internal
+
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.*
+
+import kyo.compat.*
+
+import sage.{Message, PatternMessage}
+import sage.SageException.{LockLost, ServerError}
+import sage.codec.ValueCodec
+import sage.commands.{Command, Pipeline}
+import sage.protocol.Frame
+import sage.ratelimit.Decision
+
+abstract class LockCancellationSpec extends munit.FunSuite {
+  override val munitTimeout      = 10.seconds
+  private given ExecutionContext = munitExecutionContext
+
+  protected def tryWithLock[A](commands: CommandRunner[CIO, String], lease: FiniteDuration)(body: CIO[A]): CIO[Option[A]] =
+    new LockExecutor[String](lease, "cancel").tryWithLock(commands, "key")(body)
+
+  protected def withLock[A](commands: CommandRunner[CIO, String], lease: FiniteDuration, wait: FiniteDuration)(body: CIO[A]): CIO[A] =
+    new LockExecutor[String](lease, "cancel").withLock(commands, "key", wait)(body)
+
+  protected def runner(released: AtomicBoolean, renewals: AtomicInteger, stallRelease: Boolean): CommandRunner[CIO, String] =
+    new CommandRunner[CIO, String] {
+      def run[A](command: Command[A]): CIO[A] = CIO.defer(()).flatMap { _ =>
+        command.args(4).asUtf8String match {
+          case "renew"   => renewals.incrementAndGet()
+          case "release" => released.set(true)
+          case _         => ()
+        }
+        if (stallRelease && command.args(4).asUtf8String == "release") CIO.never
+        else command.decode(Frame.Integer(1)).fold(CIO.fail(_), CIO.value(_))
+      }
+    }
+
+  test("cancelling a protected body releases ownership and stops renewal") {
+    val released    = new AtomicBoolean(false)
+    val renewals    = new AtomicInteger(0)
+    val bodyStopped = new AtomicBoolean(false)
+    val body        = CIO.ensure(CIO.defer(bodyStopped.set(true)))(CIO.never)
+    CIO
+      .timeout(150.millis)(tryWithLock(runner(released, renewals, false), 300.millis)(body))
+      .flatMap { result =>
+        assertEquals(result, None)
+        // Kyo runs interrupt finalizers asynchronously.
+        CIO.sleep(100.millis).flatMap { _ =>
+          assert(released.get())
+          assert(bodyStopped.get())
+          val count = renewals.get()
+          CIO.sleep(400.millis).map(_ => assertEquals(renewals.get(), count))
+        }
+      }
+      .unsafeRun
+  }
+
+  test("losing ownership cancels the protected body") {
+    val bodyStopped = new AtomicBoolean(false)
+    val commands    = new CommandRunner[CIO, String] {
+      def run[A](command: Command[A]): CIO[A] =
+        command.decode(Frame.Integer(if (command.args(4).asUtf8String == "renew") 0 else 1)).fold(CIO.fail(_), CIO.value(_))
+    }
+    val body        = CIO.ensure(CIO.defer(bodyStopped.set(true)))(CIO.never)
+    tryWithLock(commands, 300.millis)(body).liftToTry.flatMap { result =>
+      assert(result.failed.get.isInstanceOf[LockLost], result.toString)
+      CIO.sleep(100.millis).map(_ => assert(bodyStopped.get()))
+    }.unsafeRun
+  }
+
+  test("cleanup stays bounded when the release command never replies") {
+    val released = new AtomicBoolean(false)
+    val renewals = new AtomicInteger(0)
+    val failure  = ServerError("ERR", "body failed")
+    tryWithLock(runner(released, renewals, true), 300.millis)(CIO.fail(failure)).unsafeRun.failed.map { error =>
+      assert(error eq failure)
+      assert(released.get())
+    }
+  }
+
+  test("a contended acquisition can be cancelled before its wait timeout") {
+    val busy = new CommandRunner[CIO, String] {
+      def run[A](command: Command[A]): CIO[A] = command.decode(Frame.Integer(0)).fold(CIO.fail(_), CIO.value(_))
+    }
+    CIO.timeout(100.millis)(withLock(busy, 3.seconds, 30.seconds)(CIO.unit)).unsafeRun.map(result => assertEquals(result, None))
+  }
+}
+
+final class LockTestClient(runner: CommandRunner[CIO, String]) extends Client[CIO, String] {
+  private def unsupported[A]: CIO[A] = CIO.fail(new AssertionError("unexpected client operation in a lock test"))
+
+  def run[A](command: Command[A]): CIO[A]                                                                                        = runner.run(command)
+  def cached[A](command: Command[A], ttl: FiniteDuration): CIO[A]                                                                = unsupported
+  private[sage] def pipeline[Out, R](p: Pipeline[Out, R]): CIO[Out]                                                              = unsupported
+  private[sage] def pipelineAttempt[Out, R](p: Pipeline[Out, R]): CIO[R]                                                         = unsupported
+  def transaction[A](body: TransactionScope[CIO, String] => CIO[A]): CIO[A]                                                      = unsupported
+  def subscribeChannels[V: ValueCodec](channel: String, rest: String*): CIO[Subscription[CIO, Message[V]]]                       = unsupported
+  def subscribePatterns[V: ValueCodec](pattern: String, rest: String*): CIO[Subscription[CIO, PatternMessage[V]]]                = unsupported
+  def subscribeShardChannels[V: ValueCodec](channel: String, rest: String*): CIO[Subscription[CIO, Message[V]]]                  = unsupported
+  private[sage] def scanTargets: CIO[Vector[ScanTarget]]                                                                         = unsupported
+  private[sage] def runOn[A](target: ScanTarget, command: Command[A]): CIO[A]                                                    = unsupported
+  private[sage] def rateLimitAcquire[RK](executor: RateLimitExecutor[RK], subject: RK, cost: Long, peek: Boolean): CIO[Decision] = unsupported
+  private[sage] def lockTryWith[LK, A](executor: LockExecutor[LK], key: LK)(body: => CIO[A]): CIO[Option[A]]                     =
+    executor.tryWithLock(this, key)(body)
+  private[sage] def lockWith[LK, A](executor: LockExecutor[LK], key: LK, waitTimeout: FiniteDuration)(body: => CIO[A]): CIO[A]   =
+    executor.withLock(this, key, waitTimeout)(body)
+  def close: CIO[Unit]                                                                                                           = CIO.unit
+}

--- a/sage-client/shared/src/test/scala/sage/client/internal/LockExecutorSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/LockExecutorSpec.scala
@@ -1,0 +1,308 @@
+package sage.client.internal
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+
+import kyo.compat.*
+
+import sage.Bytes
+import sage.SageException.{InvalidArgument, LockLost, ServerError, TimedOut}
+import sage.commands.Command
+import sage.protocol.Frame
+
+class LockExecutorSpec extends munit.FunSuite {
+  override val munitTimeout = 10.seconds
+
+  private given ExecutionContext = munitExecutionContext
+
+  private class Store extends CommandRunner[CIO, String] {
+    private var entries                               = Map.empty[String, (String, Long)]
+    private var loaded                                = false
+    val operations                                    = new ConcurrentLinkedQueue[String]()
+    val tokens                                        = new ConcurrentLinkedQueue[String]()
+    @volatile var rejectRenewal                       = false
+    @volatile var stallRenewal                        = false
+    @volatile var failRelease                         = false
+    @volatile var stallRelease                        = false
+    @volatile var acquisitionDelay                    = Duration.Zero
+    @volatile var acquisitionError: Option[Throwable] = None
+
+    def held: Boolean = synchronized(entries.values.exists(_._2 > System.nanoTime()))
+
+    def run[A](command: Command[A]): CIO[A] = CIO.defer(()).flatMap { _ =>
+      assertEquals(command.keyIndices, Vector(2))
+      assert(!command.isReadOnly && !command.cacheable && !command.allMasters)
+      val operation = command.args(4).asUtf8String
+      val key       = command.args(2).asUtf8String
+      val token     = command.args(3).asUtf8String
+      operations.add(s"${command.name}:$operation")
+      if (operation == "renew" && stallRenewal) CIO.never
+      else if (operation == "release" && stallRelease) CIO.never
+      else if (operation == "release" && failRelease) CIO.fail(ServerError("ERR", "release unavailable"))
+      else if (operation == "acquire" && acquisitionError.isDefined) CIO.fail(acquisitionError.get)
+      else {
+        val result = synchronized {
+          if (command.name == "EVALSHA" && !loaded) Left(ServerError("NOSCRIPT", ""))
+          else {
+            loaded = true
+            val now     = System.nanoTime()
+            entries = entries.filter(_._2._2 > now)
+            val owns    = entries.get(key).exists(_._1 == token)
+            val expiry  = now + command.args(5).asUtf8String.toLong.millis.toNanos
+            val success = operation match {
+              case "acquire" if !entries.contains(key) =>
+                entries += key -> (token, expiry)
+                tokens.add(token)
+                true
+              case "renew" if owns && !rejectRenewal   =>
+                entries += key -> (token, expiry)
+                true
+              case "release" if owns                   =>
+                entries -= key
+                true
+              case _                                   => false
+            }
+            command.decode(Frame.Integer(if (success) 1L else 0L))
+          }
+        }
+        val delay  = if (operation == "acquire" && command.name == "EVAL") acquisitionDelay else Duration.Zero
+        CIO.sleep(delay).flatMap(_ => result.fold(CIO.fail(_), CIO.value(_)))
+      }
+    }
+  }
+
+  private def executor(lease: FiniteDuration = 3.seconds, namespace: String = "lock") = new LockExecutor[String](lease, namespace)
+
+  test("namespace framing distinguishes ambiguous prefixes and preserves binary key bytes") {
+    val a      = new LockCommands[String](1.second, "a").key("b:c")
+    val b      = new LockCommands[String](1.second, "a:b").key("c")
+    assert(!a.sameBytes(b))
+    val raw    = Array[Byte](0, -1, 42)
+    val binary = new LockCommands[Array[Byte]](1.second, "é").key(raw)
+    assert(binary.sameBytes(Bytes.concat(Vector(Bytes.utf8("2:é:"), Bytes.fromArray(raw)))))
+  }
+
+  test("all scripts route to one key on its master and decode only valid outcomes") {
+    val commands = new LockCommands[String](1.second, "lock")
+    for (operation <- List("acquire", "renew", "release")) {
+      val command = commands.command(commands.key("subject"), "owner", operation, cached = true)
+      assertEquals(command.name, "EVALSHA")
+      assertEquals(command.keys.map(_.asUtf8String), Vector("4:lock:subject"))
+      assert(!command.cacheable && !command.isReadOnly && !command.isBlocking && !command.allMasters)
+      assertEquals(command.decode(Frame.Integer(0)), Right(false))
+      assertEquals(command.decode(Frame.Integer(1)), Right(true))
+      assert(command.decode(Frame.Integer(2)).isLeft)
+      assert(command.decode(Frame.Null).isLeft)
+    }
+  }
+
+  test("contended tryWithLock never evaluates the body, and successful scopes release") {
+    val store     = new Store
+    val lock      = executor()
+    var evaluated = false
+    lock
+      .tryWithLock(store, "key") {
+        lock.tryWithLock(store, "key") {
+          evaluated = true
+          CIO.value(42)
+        }
+      }
+      .unsafeRun
+      .map { result =>
+        assertEquals(result, Some(None))
+        assert(!evaluated)
+        assert(!store.held)
+      }
+  }
+
+  test("competing scopes serialize non-atomic updates") {
+    val store  = new Store
+    val active = new AtomicInteger(0)
+    var total  = 0
+    CIO
+      .foreach(1 to 12) { _ =>
+        executor().withLock(store, "key", 5.seconds) {
+          CIO
+            .defer {
+              assertEquals(active.incrementAndGet(), 1)
+              total
+            }
+            .flatMap { before =>
+              CIO.sleep(5.millis).map { _ =>
+                total = before + 1
+                active.decrementAndGet()
+              }
+            }
+        }
+      }
+      .unsafeRun
+      .map { _ =>
+        assertEquals(total, 12)
+        assert(!store.held)
+      }
+  }
+
+  test("renewal keeps a body running beyond the original lease, then stops") {
+    val store = new Store
+    executor(300.millis)
+      .tryWithLock(store, "key") {
+        CIO.sleep(1.second).map(_ => assert(store.held))
+      }
+      .flatMap { result =>
+        assertEquals(result, Some(()))
+        assert(!store.held)
+        val renewals = store.operations.asScala.count(_.endsWith(":renew"))
+        assert(renewals >= 2)
+        CIO.sleep(400.millis).map(_ => assertEquals(store.operations.asScala.count(_.endsWith(":renew")), renewals))
+      }
+      .unsafeRun
+  }
+
+  test("renewal refusal fails even while the protected effect never succeeds") {
+    val store = new Store
+    store.rejectRenewal = true
+    executor(300.millis).tryWithLock(store, "key")(CIO.never).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[LockLost], error.toString)
+      assert(!store.held)
+    }
+  }
+
+  test("an unresponsive renewal is bounded by the remaining lease") {
+    val store = new Store
+    store.stallRenewal = true
+    executor(300.millis).tryWithLock(store, "key")(CIO.never).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[LockLost], error.toString)
+      assert(!store.held)
+    }
+  }
+
+  test("a body error survives cleanup failure") {
+    val store   = new Store
+    store.failRelease = true
+    val failure = new IllegalStateException("body failed")
+    executor().tryWithLock(store, "key")(CIO.fail(failure)).unsafeRun.failed.map { error =>
+      assert(error eq failure)
+      assert(store.operations.asScala.exists(_.endsWith(":release")))
+    }
+  }
+
+  test("a successful body does not hide release failure") {
+    val store = new Store
+    store.failRelease = true
+    executor().tryWithLock(store, "key")(CIO.value(42)).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[ServerError], error.toString)
+    }
+  }
+
+  test("checked release and fallback cleanup share one time budget") {
+    val store   = new Store
+    store.stallRelease = true
+    val started = System.nanoTime()
+    executor().tryWithLock(store, "key")(CIO.value(42)).unsafeRun.failed.map { error =>
+      val elapsed = (System.nanoTime() - started).nanos
+      assert(error.isInstanceOf[LockLost], error.toString)
+      assert(elapsed < 1500.millis, s"release exceeded its shared budget: $elapsed")
+      assertEquals(store.operations.asScala.count(_.endsWith(":release")), 1)
+    }
+  }
+
+  test("withLock times out under contention without evaluating its body") {
+    val store     = new Store
+    val lock      = executor()
+    var evaluated = false
+    lock
+      .tryWithLock(store, "key") {
+        lock
+          .withLock(store, "key", 100.millis) {
+            evaluated = true
+            CIO.unit
+          }
+          .liftToTry
+      }
+      .unsafeRun
+      .map { result =>
+        assert(result.get.failed.get.isInstanceOf[TimedOut])
+        assert(!evaluated)
+        assert(!store.held)
+      }
+  }
+
+  test("a delayed acquisition never starts the body and attempts ownership-checked cleanup") {
+    val store     = new Store
+    store.acquisitionDelay = 400.millis
+    var evaluated = false
+    executor()
+      .withLock(store, "key", 100.millis) {
+        evaluated = true
+        CIO.unit
+      }
+      .unsafeRun
+      .failed
+      .map { error =>
+        assert(error.isInstanceOf[TimedOut], error.toString)
+        assert(!evaluated)
+        assert(!store.held)
+      }
+  }
+
+  test("sustained contention reduces acquisition requests while respecting the wait timeout") {
+    val attempts = new AtomicInteger(0)
+    val commands = new CommandRunner[CIO, String] {
+      def run[A](command: Command[A]): CIO[A] = CIO.defer(()).flatMap { _ =>
+        attempts.incrementAndGet()
+        command.decode(Frame.Integer(0)).fold(CIO.fail(_), CIO.value(_))
+      }
+    }
+    val started  = System.nanoTime()
+    executor().withLock(commands, "key", 1.second)(CIO.fail(new AssertionError("contended body ran"))).unsafeRun.failed.map { error =>
+      val elapsed = (System.nanoTime() - started).nanos
+      assert(error.isInstanceOf[TimedOut], error.toString)
+      assert(attempts.get() >= 2, s"acquisition was not retried: ${attempts.get()}")
+      assert(attempts.get() <= 20, s"contention generated too many acquisition requests: ${attempts.get()}")
+      assert(elapsed >= 1.second && elapsed < 1500.millis, s"wait timeout was not respected: $elapsed")
+    }
+  }
+
+  test("NOSCRIPT falls back to EVAL once and subsequent operations use the digest") {
+    val store = new Store
+    executor().tryWithLock(store, "key")(CIO.value(42)).unsafeRun.map { result =>
+      assertEquals(result, Some(42))
+      assertEquals(store.operations.asScala.toList, List("EVALSHA:acquire", "EVAL:acquire", "EVALSHA:release"))
+    }
+  }
+
+  test("other acquisition errors propagate without being retried as contention") {
+    val store   = new Store
+    val failure = ServerError("READONLY", "demoted")
+    store.acquisitionError = Some(failure)
+    executor().withLock(store, "key", 1.second)(CIO.unit).unsafeRun.failed.map { error =>
+      assertEquals(error, failure)
+      assertEquals(store.operations.asScala.count(_.endsWith(":acquire")), 1)
+    }
+  }
+
+  test("reevaluating a lock effect generates a fresh owner token") {
+    val store  = new Store
+    val effect = executor().tryWithLock(store, "key")(CIO.value(42))
+    effect.flatMap(_ => effect).unsafeRun.map { _ =>
+      assertEquals(store.tokens.size(), 2)
+      assertEquals(store.tokens.asScala.toSet.size, 2)
+    }
+  }
+
+  test("invalid lease or wait duration fails before any server command") {
+    val store = new Store
+    for {
+      lease <- executor(1.millis).tryWithLock(store, "key")(CIO.unit).unsafeRun.failed
+      wait  <- executor().withLock(store, "key", Duration.Zero)(CIO.unit).unsafeRun.failed
+    } yield {
+      assert(lease.isInstanceOf[InvalidArgument])
+      assert(wait.isInstanceOf[InvalidArgument])
+      assert(store.operations.isEmpty)
+    }
+  }
+}

--- a/sage-client/shared/src/test/scala/sage/client/internal/LockExecutorSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/LockExecutorSpec.scala
@@ -11,6 +11,7 @@ import kyo.compat.*
 
 import sage.Bytes
 import sage.SageException.{InvalidArgument, LockLost, ServerError, TimedOut}
+import sage.client.SageConfig
 import sage.commands.Command
 import sage.protocol.Frame
 
@@ -18,6 +19,34 @@ class LockExecutorSpec extends munit.FunSuite {
   override val munitTimeout = 10.seconds
 
   private given ExecutionContext = munitExecutionContext
+
+  test("standalone lock scopes use only the shared connection and do not send ROLE or WAIT") {
+    val written                                         = new ConcurrentLinkedQueue[String]()
+    val factory: MultiplexedConnection.TransportFactory = (onFrame, onClosed) =>
+      new FakeTransport(
+        onFrame,
+        onClosed,
+        payload => {
+          val text = payload.asUtf8String
+          written.add(text)
+          if (text.contains("HELLO")) Seq(Replies.hello)
+          else if (text.contains("EVALSHA")) Seq(Frame.Integer(1))
+          else Seq(Replies.ok)
+        }
+      )
+    Client
+      .connectWith(factory, Scheduler.real, SageConfig(closeTimeout = Duration.Zero))
+      .flatMap { client =>
+        CIO.ensure(client.close) {
+          client.lock[String]().tryWithLock("key")(CIO.value(42)).map { result =>
+            assertEquals(result, Some(42))
+            assertEquals(written.asScala.count(_.contains("HELLO")), 1)
+            assert(!written.asScala.exists(text => text.contains("ROLE") || text.contains("WAIT")))
+          }
+        }
+      }
+      .unsafeRun
+  }
 
   private class Store extends CommandRunner[CIO, String] {
     private var entries                               = Map.empty[String, (String, Long)]
@@ -176,6 +205,39 @@ class LockExecutorSpec extends munit.FunSuite {
     store.stallRenewal = true
     executor(300.millis).tryWithLock(store, "key")(CIO.never).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[LockLost], error.toString)
+      assert(!store.held)
+    }
+  }
+
+  test("a renewal acknowledgement shortfall becomes LockLost and releases ownership") {
+    val shortfall = TimedOut("replication confirmed by 0 of 1 required replicas")
+    val store     = new Store {
+      override def lockWrite(command: Command[Boolean], timeout: FiniteDuration): CIO[Boolean] =
+        run(command).flatMap { renewed =>
+          if (command.args(4).asUtf8String == "renew") CIO.fail(shortfall)
+          else CIO.value(renewed)
+        }
+    }
+    executor(300.millis).tryWithLock(store, "key")(CIO.never).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[LockLost], error.toString)
+      assert(error.getCause eq shortfall)
+      assert(store.operations.asScala.exists(_.endsWith(":renew")))
+      assert(store.operations.asScala.exists(_.endsWith(":release")))
+      assert(!store.held)
+    }
+  }
+
+  test("replication checks respect a short acquisition wait and the remaining renewal lease") {
+    val store = new Store {
+      override def lockWrite(command: Command[Boolean], timeout: FiniteDuration): CIO[Boolean] = {
+        val operation = command.args(4).asUtf8String
+        if (operation == "acquire") assert(timeout > Duration.Zero && timeout <= 200.millis, timeout.toString)
+        if (operation == "renew") assert(timeout > Duration.Zero && timeout <= 170.millis, timeout.toString)
+        run(command)
+      }
+    }
+    executor(300.millis).withLock(store, "key", 200.millis)(CIO.sleep(400.millis)).unsafeRun.map { _ =>
+      assert(store.operations.asScala.exists(_.endsWith(":renew")))
       assert(!store.held)
     }
   }

--- a/sage-client/shared/src/test/scala/sage/client/internal/RefreshThrottleSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/RefreshThrottleSpec.scala
@@ -7,6 +7,47 @@ import scala.concurrent.duration.*
 
 class RefreshThrottleSpec extends munit.FunSuite {
 
+  test("retained requests coalesce and run after the minimum interval without another failure") {
+    val scheduler = new ManualScheduler
+    val throttle  = new RefreshThrottle(scheduler, minRefreshMs = 1000L)
+    var runs      = 0
+    val work      = () => runs += 1
+    throttle.request(work)
+    throttle.trigger(() => fail("an ordinary trigger duplicated an immediate retained refresh"))
+    scheduler.advance(Duration.Zero)
+    (1 to 100).foreach(_ => throttle.request(work))
+    throttle.trigger(() => fail("an ordinary trigger duplicated a retained refresh"))
+    scheduler.advance(999.millis)
+    assertEquals(runs, 1)
+    scheduler.advance(1.milli)
+    assertEquals(runs, 2)
+    scheduler.advance(2.seconds)
+    assertEquals(runs, 2)
+  }
+
+  test("a retained request during refresh runs after completion and respects a later forced refresh") {
+    val scheduler = new ManualScheduler
+    val throttle  = new RefreshThrottle(scheduler, minRefreshMs = 1000L)
+    var runs      = 0
+    throttle.trigger(() => throttle.request(() => runs += 1))
+    scheduler.advance(Duration.Zero)
+    scheduler.advance(500.millis)
+    throttle(force = true)(())
+    scheduler.advance(999.millis)
+    assertEquals(runs, 0)
+    scheduler.advance(1.milli)
+    assertEquals(runs, 1)
+  }
+
+  test("closing discards a retained refresh") {
+    val scheduler = new ManualScheduler
+    val throttle  = new RefreshThrottle(scheduler, minRefreshMs = 1000L)
+    throttle(force = true)(())
+    throttle.request(() => fail("refresh ran after close"))
+    throttle.stopPolling()
+    scheduler.advance(2.seconds)
+  }
+
   test("a non-blocking trigger schedules once while a refresh is in flight without changing blocking callers") {
     val scheduler = new CountingScheduler
     val throttle  = new RefreshThrottle(scheduler, minRefreshMs = 0L)

--- a/sage-client/zio/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/zio/src/main/scala/sage/backend/SageClient.scala
@@ -250,5 +250,8 @@ object SageClient {
 
     // Release runs in a masked finalizer. Its command must remain interruptible for CIO.timeout to finish.
     override protected def lockCommand[A](command: Command[A]): CIO[A] = CIO.lift(underlying.run(command).lower.interruptible)
+
+    override protected def confirmedLockCommand(command: Command[Boolean], timeout: FiniteDuration): CIO[Boolean] =
+      CIO.lift(underlying.lockWrite(command, timeout).lower.interruptible)
   }
 }

--- a/sage-client/zio/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/zio/src/main/scala/sage/backend/SageClient.scala
@@ -215,6 +215,8 @@ extension [K](client: Client[IO[SageException, *], K])(using @unused ev: KeyCode
 
 object SageClient {
 
+  final private class LockBodyFailure(val cause: Cause[SageException]) extends RuntimeException
+
   /**
     * A client that uses `K` for keys, returned by `client.as[K]`. [[SageClient]] uses `String` keys by default. Calling `as` changes only
     * the key type and continues to use the same connection.
@@ -229,8 +231,24 @@ object SageClient {
   def layer(config: SageConfig): ZLayer[Any, SageException, SageClient] =
     ZLayer.scoped(scoped(config))
 
-  final private class Lowered(underlying: Client[CIO, String]) extends LoweredClient[IO[SageException, *]](underlying) {
+  final private[sage] class Lowered(underlying: Client[CIO, String]) extends LoweredClient[IO[SageException, *]](underlying) {
     protected def lower[A](c: CIO[A]): IO[SageException, A] = c.lower.refineToOrDie[SageException]
     protected def lift[A](fa: IO[SageException, A]): CIO[A] = CIO.lift(fa)
+
+    override protected def lockScope[A, B](body: () => IO[SageException, A])(runScope: CIO[A] => CIO[B]): IO[SageException, B] = {
+      val work = ZIO.suspendSucceed(body()).exit.flatMap {
+        case Exit.Success(value) => ZIO.succeed(value)
+        case Exit.Failure(cause) => ZIO.fail(new LockBodyFailure(cause))
+      }
+      runScope(CIO.lift(work)).lower
+        .catchAll {
+          case failure: LockBodyFailure => ZIO.refailCause(failure.cause)
+          case other                    => ZIO.fail(other)
+        }
+        .refineToOrDie[SageException]
+    }
+
+    // Release runs in a masked finalizer. Its command must remain interruptible for CIO.timeout to finish.
+    override protected def lockCommand[A](command: Command[A]): CIO[A] = CIO.lift(underlying.run(command).lower.interruptible)
   }
 }

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration.*
 import kyo.compat.*
 
 import sage.Bytes
-import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, InvalidArgument, NotConnected, ServerError, UnsupportedServer}
+import sage.SageException.{ConnectionLost, CrossSlot, DecodeError, InvalidArgument, NotConnected, ServerError, TimedOut, UnsupportedServer}
 import sage.client.internal.{
   ClusterLive,
   CountingScheduler,
@@ -137,6 +137,114 @@ class ClusterClientSpec extends munit.FunSuite {
   private val mid: Int = Slot.Count / 2
 
   private val splitCluster: Frame = Replies.clusterSlots((nodeA, 0, mid - 1), (nodeB, mid, Slot.Count - 1))
+
+  for (redirect <- Vector("MOVED", "ASK"))
+    test(s"lock confirmation follows $redirect to the granting master and its replicas") {
+      val key     = "lock-key"
+      val slot    = Slot.of(Bytes.utf8(s"4:lock:$key")).value
+      val fixture = new Fixture(
+        (node, text) =>
+          if (text.contains("CLUSTER")) Seq(wholeClusterOn(nodeA))
+          else if (node == nodeA) Seq(Frame.SimpleError(s"$redirect $slot b:6379"))
+          else if (text.contains("ROLE")) Seq(Replies.masterRole(nodeDead))
+          else if (text.contains("WAIT")) Seq(Frame.Integer(1))
+          else if (text.contains("ASKING")) Seq(Replies.ok, Frame.Integer(1))
+          else Seq(Frame.Integer(1)),
+        Vector(nodeA)
+      )
+      fixture.live
+        .lock[String]()
+        .tryWithLock(key)(CIO.value(42))
+        .unsafeRun
+        .map { result =>
+          assertEquals(result, Some(42))
+          assert(fixture.written(nodeB).exists(_.contains("WAIT")))
+          assert(!fixture.written(nodeA).exists(_.contains("WAIT")))
+          assert(fixture.written(nodeDead).isEmpty)
+        }
+        .andThen { case _ => fixture.live.close.unsafeRun }
+    }
+
+  test("cluster locks reject acquisition when a known replica does not acknowledge") {
+    var evaluated = false
+    val fixture   = new Fixture(
+      (_, text) =>
+        if (text.contains("CLUSTER")) Seq(Replies.clusterShard(nodeA, nodeB))
+        else if (text.contains("ROLE")) Seq(Replies.masterRole())
+        else if (text.contains("WAIT")) Seq(Frame.Integer(0))
+        else Seq(Frame.Integer(1)),
+      Vector(nodeA),
+      readFrom = ReadFrom.Replica
+    )
+    fixture.live
+      .lock[String]()
+      .tryWithLock("key") {
+        evaluated = true
+        CIO.value(42)
+      }
+      .unsafeRun
+      .failed
+      .map { error =>
+        assert(error.isInstanceOf[TimedOut], error.toString)
+        assert(!evaluated)
+        assert(fixture.written(nodeA).exists(_.contains("WAIT")))
+        assert(fixture.written(nodeB).isEmpty)
+      }
+      .andThen { case _ => fixture.live.close.unsafeRun }
+  }
+
+  test("cluster locks recover after confirmation failure refreshes a removed replica") {
+    val removed = new java.util.concurrent.atomic.AtomicBoolean(false)
+    val fixture = new Fixture(
+      (_, text) =>
+        if (text.contains("CLUSTER")) Seq(if (removed.get()) wholeClusterOn(nodeA) else Replies.clusterShard(nodeA, nodeB))
+        else if (text.contains("ROLE")) Seq(Replies.masterRole())
+        else if (text.contains("WAIT")) { removed.set(true); Seq(Frame.Integer(0)) }
+        else Seq(Frame.Integer(1)),
+      Vector(nodeA)
+    )
+    fixture.live
+      .lock[String]()
+      .tryWithLock("key")(CIO.value(42))
+      .unsafeRun
+      .failed
+      .map { error =>
+        assert(error.isInstanceOf[TimedOut])
+        awaitRefreshed(fixture, nodeA)
+        await("lock acquisition did not recover after the replica was removed") {
+          scala.util
+            .Try(scala.concurrent.Await.result(fixture.live.lock[String]().tryWithLock("key")(CIO.value(42)).unsafeRun, 5.seconds))
+            .toOption
+            .contains(Some(42))
+        }
+      }
+      .andThen { case _ => fixture.live.close.unsafeRun }
+  }
+
+  test("cluster locks do not replay an acquisition after a retryable confirmation error") {
+    val writes  = new java.util.concurrent.atomic.AtomicInteger(0)
+    val fixture = new Fixture(
+      (_, text) =>
+        if (text.contains("CLUSTER")) Seq(Replies.clusterShard(nodeA, nodeB))
+        else if (text.contains("ROLE")) Seq(Replies.masterRole(nodeB))
+        else if (text.contains("WAIT")) Seq(Frame.SimpleError("TRYAGAIN confirmation unavailable"))
+        else {
+          if (text.contains("acquire")) { writes.incrementAndGet(): Unit }
+          Seq(Frame.Integer(1))
+        },
+      Vector(nodeA)
+    )
+    fixture.live
+      .lock[String]()
+      .tryWithLock("key")(CIO.value(42))
+      .unsafeRun
+      .failed
+      .map { error =>
+        assertEquals(error, ConnectionLost(mayHaveExecuted = true))
+        assertEquals(writes.get(), 1)
+      }
+      .andThen { case _ => fixture.live.close.unsafeRun }
+  }
 
   test("a seed that owns no slots fails the bootstrap rather than adopting an empty topology") {
     val behaviour = (_: Node, text: String) => if (text.contains("CLUSTER")) Seq(Frame.Array(Vector.empty)) else Seq(Frame.Null)

--- a/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/MasterReplicaTopologySpec.scala
@@ -72,6 +72,7 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
     val roles                                                           = TrieMap.from(initialRoles)
     @volatile var writesFailReadonly                                    = false
     @volatile var diesOnRead: Node                                      = null
+    @volatile var lockAcknowledgements: Long                            = 1L
     private val dials                                                   = new ConcurrentLinkedQueue[Node]()
     private val roleRequests                                            = new ConcurrentLinkedQueue[Node]()
     private val transports                                              = new ConcurrentLinkedQueue[(Node, FakeTransport)]()
@@ -87,7 +88,9 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
           else if (text.contains("ROLE")) {
             roleRequests.add(node)
             roles.get(node).toSeq
-          } else if (reads > 0 && node == diesOnRead) {
+          } else if (text.contains("EVALSHA")) Seq(Frame.Integer(1))
+          else if (text.contains("WAIT")) Seq(Frame.Integer(lockAcknowledgements))
+          else if (reads > 0 && node == diesOnRead) {
             kill(node)
             Nil
           } else if (reads > 0) Seq.fill(reads)(Frame.Integer(1L))
@@ -122,6 +125,11 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
         transport.written.count(_.asUtf8String.contains("ZSCORE"))
       }.sum
 
+    def lockConfirmations(node: Node): Int =
+      transports.asScala.toVector.collect { case (`node`, transport) =>
+        transport.written.count(_.asUtf8String.contains("WAIT"))
+      }.sum
+
     def read(): Long =
       scala.concurrent.Await.result(live.run(readCommand).unsafeRun, 10.seconds)
 
@@ -142,6 +150,55 @@ class MasterReplicaTopologySpec extends munit.FunSuite {
 
     def close(): Unit =
       scala.concurrent.Await.result(live.close.unsafeRun, 10.seconds)
+  }
+
+  test("master-replica locks confirm acquisition and renewal on the master with replica reads") {
+    val fixture = new Fixture(Vector(primary), Map(primary -> masterRole(reader), reader -> replicaRole(primary)))
+    fixture.live.bootstrapRoles()
+    try {
+      val result = scala.concurrent.Await.result(
+        fixture.live
+          .lock[String](3.seconds)
+          .tryWithLock("key") {
+            CIO.blocking(fixture.awaitTrue(fixture.lockConfirmations(primary) >= 2, "renewal was not confirmed"))
+          }
+          .unsafeRun,
+        5.seconds
+      )
+      assertEquals(result, Some(()))
+      assert(fixture.lockConfirmations(primary) >= 2)
+      assertEquals(fixture.lockConfirmations(reader), 0)
+    } finally fixture.close()
+  }
+
+  test("master-replica locks reject a missing replica and recover after refreshing its removal") {
+    val fixture   = new Fixture(Vector(primary), Map(primary -> masterRole(reader), reader -> replicaRole(primary)))
+    fixture.live.bootstrapRoles()
+    fixture.roles(primary) = masterRole()
+    fixture.lockAcknowledgements = 0
+    var evaluated = false
+    try {
+      val result = Try(
+        scala.concurrent.Await.result(
+          fixture.live
+            .lock[String]()
+            .tryWithLock("key") {
+              evaluated = true
+              CIO.value(42)
+            }
+            .unsafeRun,
+          5.seconds
+        )
+      )
+      assert(result.failed.get.isInstanceOf[TimedOut], result.toString)
+      assert(!evaluated)
+      assertEquals(fixture.lockConfirmations(primary), 1)
+      fixture.awaitTrue(
+        Try(scala.concurrent.Await.result(fixture.live.lock[String]().tryWithLock("key")(CIO.value(42)).unsafeRun, 5.seconds)).toOption
+          .contains(Some(42)),
+        "lock acquisition did not recover after the replica was removed"
+      )
+    } finally fixture.close()
   }
 
   test("several seeds keep the supplied addresses and never dial a ROLE-advertised address") {

--- a/sage-client/zio/src/test/scala/sage/client/internal/ZioLockCancellationSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/internal/ZioLockCancellationSpec.scala
@@ -1,0 +1,38 @@
+package sage.client.internal
+
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+
+import scala.concurrent.duration.*
+
+import kyo.compat.*
+import zio.ZIO
+
+import sage.SageException
+import sage.backend.SageClient
+
+class ZioLockCancellationSpec extends LockCancellationSpec {
+  override protected def tryWithLock[A](commands: CommandRunner[CIO, String], lease: FiniteDuration)(body: CIO[A]): CIO[Option[A]] =
+    CIO.lift(new SageClient.Lowered(new LockTestClient(commands)).lock[String](lease).tryWithLock("key")(body.lower.refineToOrDie[SageException]))
+
+  override protected def withLock[A](commands: CommandRunner[CIO, String], lease: FiniteDuration, wait: FiniteDuration)(body: CIO[A]): CIO[A] =
+    CIO.lift(new SageClient.Lowered(new LockTestClient(commands)).lock[String](lease).withLock("key", wait)(body.lower.refineToOrDie[SageException]))
+
+  test("a body defect ends the scope and releases ownership") {
+    val released = new AtomicBoolean(false)
+    val failure  = new IllegalStateException("body defect")
+    val check    = tryWithLock(runner(released, new AtomicInteger(0), false), 300.millis)(CIO.lift(ZIO.die(failure))).lower.exit.map { exit =>
+      assert(exit.causeOption.exists(_.defects.contains(failure)))
+      assert(released.get())
+    }
+    CIO.lift(check.timeoutFail(new AssertionError("defect left the lock scope running"))(zio.Duration.fromSeconds(2))).unsafeRun
+  }
+
+  test("a body that interrupts itself ends the scope and releases ownership") {
+    val released = new AtomicBoolean(false)
+    val check    = tryWithLock(runner(released, new AtomicInteger(0), false), 300.millis)(CIO.lift(ZIO.interrupt)).lower.exit.map { exit =>
+      assert(exit.isInterrupted)
+      assert(released.get())
+    }
+    CIO.lift(check.timeoutFail(new AssertionError("interruption left the lock scope running"))(zio.Duration.fromSeconds(2))).unsafeRun
+  }
+}

--- a/sage-compat-ce/README.md
+++ b/sage-compat-ce/README.md
@@ -6,7 +6,9 @@ This module implements the full [kyo-compat](https://github.com/getkyo/kyo/tree/
 
 Kyo removed its Cats Effect integrations in 1.0.0-RC6 in [kyo#1779](https://github.com/getkyo/kyo/pull/1779) and moved community bindings outside the project in [kyo#1840](https://github.com/getkyo/kyo/pull/1840). This module vendors the last upstream Cats Effect binding from commit [`eae31e1d`](https://github.com/getkyo/kyo/tree/eae31e1d39d4b8ff2df168272e60b38d9e9dd502/kyo-compat/bindings/ce). Those sources match `io.getkyo:kyo-compat-ce_3:1.0.0-RC5`.
 
-The vendored copy merges the `shared` and `jvm` source trees because Sage supports only the JVM. It also uses this repository's brace-based formatting and corrects several comments. The conformance suite checks that the API and behavior remain compatible with upstream.
+The vendored copy merges the `shared` and `jvm` source trees because Sage supports only the JVM. It also uses this repository's brace-based formatting and corrects several comments.
+
+Sage changes `CIO.async` from `IO.async_` to `IO.async` with a cancellation token so a timeout or cancellation can stop waiting for a callback. This applies to every CE command wait, including distributed lock acquisition, renewal, and release. Cancellation does not stop the external operation or retract a command already sent to the server. The transport still consumes its reply in order. The conformance suite checks compatibility with the shared API, and lock regression tests cover delayed callbacks.
 
 Kyo is licensed under [Apache 2.0](https://github.com/getkyo/kyo/blob/main/LICENSE), the same license as Sage.
 

--- a/sage-compat-ce/src/main/scala/kyo/compat/CIO.scala
+++ b/sage-compat-ce/src/main/scala/kyo/compat/CIO.scala
@@ -305,12 +305,16 @@ object CIO {
     * Bridges a one-shot completion callback into `CIO`; `register` receives a `Try[A] => Unit`.
     */
   inline def async[A](inline register: ((scala.util.Try[A] => Unit) => Unit)): CIO[A] =
-    lift(IO.async_[A] { k =>
-      val cb: scala.util.Try[A] => Unit = {
-        case scala.util.Success(a) => k(Right(a))
-        case scala.util.Failure(e) => k(Left(e))
+    lift(IO.async[A] { k =>
+      IO.delay {
+        val cb: scala.util.Try[A] => Unit = {
+          case scala.util.Success(a) => k(Right(a))
+          case scala.util.Failure(e) => k(Left(e))
+        }
+        register(cb)
+        // A cancel token makes callback waiting cancelable even when the external operation cannot be stopped.
+        Some(IO.unit)
       }
-      register(cb)
     })
 
   /**

--- a/sage-core/src/main/scala/sage/SageException.scala
+++ b/sage-core/src/main/scala/sage/SageException.scala
@@ -86,9 +86,15 @@ object SageException {
   /**
     * A wait exceeded its configured limit. This applies when a blocking command or transaction waits longer than
     * `dedicatedPool.acquireTimeout` for a pooled connection, or when a topology probe (`ROLE` or `CLUSTER SLOTS`) exceeds `connectTimeout`.
-    * Regular commands do not use this timeout.
+    * It also applies when distributed lock acquisition exceeds its wait or lease budget. Regular commands do not use this timeout.
     */
   final case class TimedOut(message: String) extends SageException(message)
+
+  /**
+    * A distributed lock expired, changed owner, or could not confirm renewal or release within its deadline. Sage attempts to cancel the
+    * protected effect, but cancellation depends on the backend and cannot undo completed work.
+    */
+  final case class LockLost(message: String) extends SageException(message)
 
   /**
     * The server discarded a transaction because a command could not be queued (`EXECABORT`). The transaction did not run. Execution-phase

--- a/sage-core/src/main/scala/sage/cluster/Topology.scala
+++ b/sage-core/src/main/scala/sage/cluster/Topology.scala
@@ -32,6 +32,8 @@ final private[sage] class ClusterTopology private (val shards: Vector[Shard], pr
   // the core only locates the owning shard; selecting a live replica and applying the read policy is the runtime's job
   def shardForSlot(slot: Slot): Option[Shard] = Option(shardOwners(slot.value))
 
+  def replicasForMaster(master: Node): Vector[Node] = shards.find(_.master == master).fold(Vector.empty[Node])(_.replicas)
+
   // masters in `previous` that no longer own a slot they hold in this (new) topology
   def mastersLosingSlots(previous: ClusterTopology): Set[Node] = {
     val losing = mutable.Set.empty[Node]


### PR DESCRIPTION
Adds distributed locks through `client.lock[K]` for Redis and Valkey, across all five backends and standalone, master-replica, and cluster deployments.

- `tryWithLock(key)(body)` attempts acquisition once and returns `None` when busy.
- `withLock(key, waitTimeout)(body)` retries acquisition with exponential backoff and jitter.
- Sage renews the lease while the body runs and uses ownership checks for renewal and release.
- Lease duration and namespace are configurable. Keys support any `KeyCodec`.
- Ownership or renewal failure raises `LockLost` and attempts to cancel the body. Sage never retries the body.

Master-replica and cluster clients confirm acquisition and renewal with `ROLE` and `WAIT` on the same dedicated connection as the write. Confirmation respects the remaining deadline, and failures request a topology refresh. Cancelled pool acquisitions stop waiting and preserve unused healthy connections.