### PR TITLE
Retry transient lock failures and make replica acknowledgement optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Sage is a Redis and Valkey client for Scala 3. It implements the Redis protocol 
 
 - Choose the artifact for [ZIO](https://zio.dev), [Cats Effect](https://typelevel.org/cats-effect/), [Kyo](https://getkyo.io), [Ox](https://ox.softwaremill.com), or [Pekko](https://pekko.apache.org). Each artifact uses its ecosystem's native types.
 - The core implements RESP3, commands, and codecs in Scala 3.
-- Redis 8+ and Valkey 8+ support includes auto-pipelining, transactions, cluster routing, sharded pub/sub, client-side caching, and TLS.
+- Redis 8+ and Valkey 8+ support includes auto-pipelining, transactions, cluster routing, sharded pub/sub, client-side caching, rate limiting, distributed locks, and TLS.
 
 Sage supports Scala 3.3.x LTS and later and requires JDK 21 or later.
 

--- a/build.sbt
+++ b/build.sbt
@@ -185,8 +185,8 @@ lazy val client = (projectMatrix in file("sage-client"))
   .compatLibrary(ZioLib, CeLib, OxLib, PekkoLib)(VirtualAxis.jvm)(Seq(scala3Version))
   .bindLocally(CeLib, compatCe)
 
-// Run the shared testcontainers suite for every backend to test each backend against real servers. Run command behavior, security, cluster,
-// master-replica, and rate-limit suites on one backend because those features use the same shared implementation in every backend.
+// Run each backend's smoke suite against a real server. Run the shared command, security, cluster, master-replica, rate-limit, and lock suites
+// on one backend because those features use the same implementation in every backend.
 lazy val integrationTests = (projectMatrix in file("integration-tests"))
   .dependsOn(client, core % "test->test")
   .settings(name := "integration-tests")
@@ -207,6 +207,7 @@ lazy val integrationTests = (projectMatrix in file("integration-tests"))
           "sage.integration.commands.",
           "sage.integration.security.",
           "sage.integration.cluster.",
+          "sage.integration.locking.",
           "sage.integration.masterreplica.",
           "sage.integration.ratelimit."
         )

--- a/docs/distributed-locks.md
+++ b/docs/distributed-locks.md
@@ -19,9 +19,11 @@ The body returns your backend's native effect. With Ox, it is a direct-style blo
 ## Waiting for a lock
 
 - `withLock(key, waitTimeout)(body)` waits for the lock and returns the body's result. Retries back off under contention to reduce server traffic. If acquisition times out, it raises `SageException.TimedOut`.
-- `tryWithLock(key)(body)` attempts acquisition once. It returns `None` when busy, without evaluating the body, or `Some(result)` after successful execution and release. It still waits for a server reply.
+- `tryWithLock(key)(body)` attempts acquisition once. It returns `None` when busy, without evaluating the body, or `Some(result)` after successful execution and release. It waits up to about one second for the server and raises `SageException.TimedOut` after that.
 
 `waitTimeout` must be positive. It covers acquisition, including server replies and retry delays, but does not limit the body's runtime. Cleanup can add up to one second before a timeout returns.
+
+Sage retries temporary connection and routing failures within the acquisition wait. Other server errors return immediately.
 
 Sage never retries the body. Locks do not guarantee acquisition order. Acquiring the same key inside its own lock scope contends with the outer scope.
 
@@ -37,17 +39,21 @@ Choose a lease comfortably longer than expected network latency and process paus
 
 All processes protecting the same resource must use the same deployment, namespace, and compatible key encoding. Keys support any `KeyCodec`. The default namespace is `lock`; reserve it for locks and give other application data separate namespaces.
 
-The same code works with standalone, master-replica, and cluster clients, including clients configured for replica reads.
+The same code works with standalone, master-replica, and cluster clients. By default, replicated deployments wait for replicas to acknowledge acquisition and renewal. A slow or unavailable replica can therefore delay acquisition or cause a running lock to be lost.
 
-In master-replica and cluster mode, acquisition and renewal require acknowledgement from at least as many replicas as the client discovered for the granting master, including any additional replicas that master now reports. Sage allows up to one second for each write and its replication check, bounded by the remaining acquisition wait or lease. This includes waiting for a dedicated connection and receiving replies. A disconnected replica or one still synchronizing can prevent acquisition or cause a running lock to be lost. Failed confirmation requests a topology refresh so later attempts can account for removed replicas.
+You can favor availability over failover safety by disabling replica acknowledgement:
 
-These checks require permission to run `ROLE` and `WAIT`. Each write and its confirmation briefly borrow a dedicated connection, which is returned when confirmation finishes. Masters without replicas continue to work. Standalone clients do not check replication.
+```scala
+val locks = client.lock[String](replicaAcknowledgement = false)
+```
+
+Replicated deployments always require permission to run `ROLE`. The default acknowledgement mode also requires `WAIT`. Standalone clients do not run either command.
 
 Lock checks share `dedicatedPool` with blocking commands and transactions. A full pool can prevent acquisition or renewal, even for different lock keys. Increasing `dedicatedPool.maxConnections` allows more of these operations to run concurrently.
 
 ## Failure and cancellation
 
-If replicas do not acknowledge acquisition in time, Sage raises `SageException.TimedOut` without starting the body. Acquisition can also raise `SageException.LockLost` if the granting master changes role or the lease expires before the body starts. If Sage loses ownership or cannot confirm renewal, the operation fails with `SageException.LockLost` and attempts to cancel the body. Successful completion requires the master to acknowledge release. Server and connection errors propagate through your backend's normal failure channel. Cleanup preserves an existing body failure or cancellation.
+If replicas do not acknowledge acquisition in time, Sage raises `SageException.TimedOut` without starting the body. Acquisition can also raise `SageException.LockLost` if the granting master changes role or the lease expires before the body starts. Sage retries temporary renewal failures while the usable lease remains. If it cannot recover, or loses ownership, the operation fails with `SageException.LockLost` and attempts to cancel the body. Server and connection errors propagate through your backend's normal failure channel. Cleanup preserves an existing body failure or cancellation.
 
 Cancellation is cooperative and cannot undo completed work. Uninterruptible work can delay completion. Pekko uses `Future`, so its body may continue after lock loss even though Sage stops renewing the lock. A timed-out or cancelled acquisition can leave the lock held until its lease expires.
 

--- a/docs/distributed-locks.md
+++ b/docs/distributed-locks.md
@@ -19,7 +19,7 @@ The body returns your backend's native effect. With Ox, it is a direct-style blo
 ## Waiting for a lock
 
 - `withLock(key, waitTimeout)(body)` waits for the lock and returns the body's result. Retries back off under contention to reduce server traffic. If acquisition times out, it raises `SageException.TimedOut`.
-- `tryWithLock(key)(body)` checks contention once. It returns `None` when busy, without evaluating the body, or `Some(result)` after successful execution and release. It may retry temporary failures for about one second, then raises `SageException.TimedOut`.
+- `tryWithLock(key)(body)` does not wait for a busy lock. It returns `None` when busy, without evaluating the body, or `Some(result)` after successful execution and release. Sage retries temporary failures for about one second, then raises `SageException.TimedOut`.
 
 `waitTimeout` must be positive. It covers acquisition, including server replies and retry delays, but does not limit the body's runtime. Cleanup can add up to one second before a timeout returns.
 

--- a/docs/distributed-locks.md
+++ b/docs/distributed-locks.md
@@ -19,11 +19,11 @@ The body returns your backend's native effect. With Ox, it is a direct-style blo
 ## Waiting for a lock
 
 - `withLock(key, waitTimeout)(body)` waits for the lock and returns the body's result. Retries back off under contention to reduce server traffic. If acquisition times out, it raises `SageException.TimedOut`.
-- `tryWithLock(key)(body)` attempts acquisition once. It returns `None` when busy, without evaluating the body, or `Some(result)` after successful execution and release. It waits up to about one second for the server and raises `SageException.TimedOut` after that.
+- `tryWithLock(key)(body)` checks contention once. It returns `None` when busy, without evaluating the body, or `Some(result)` after successful execution and release. It may retry temporary failures for about one second, then raises `SageException.TimedOut`.
 
 `waitTimeout` must be positive. It covers acquisition, including server replies and retry delays, but does not limit the body's runtime. Cleanup can add up to one second before a timeout returns.
 
-Sage retries temporary connection and routing failures within the acquisition wait. Other server errors return immediately.
+Sage retries connection failures, routing changes, and temporary server refusals within the acquisition wait. Other failures return immediately.
 
 Sage never retries the body. Locks do not guarantee acquisition order. Acquiring the same key inside its own lock scope contends with the outer scope.
 

--- a/integration-tests/shared/src/test/scala/sage/integration/Eventually.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/Eventually.scala
@@ -28,4 +28,20 @@ object Eventually {
     value(attempts, interval)(action)(holds).flatMap { seen =>
       if (holds(seen)) CIO.value(()) else CIO.fail(new RuntimeException(orFail(seen)))
     }
+
+  /**
+    * Polls until two consecutive results satisfy `changed`.
+    */
+  def changes[A](attempts: Int, interval: FiniteDuration = 100.millis)(action: () => CIO[A])(changed: (A, A) => Boolean)(
+    orFail: A => String
+  ): CIO[Unit] = {
+    def loop(remaining: Int, previous: A): CIO[Unit] =
+      if (remaining <= 0) CIO.fail(new RuntimeException(orFail(previous)))
+      else
+        CIO.sleep(interval).flatMap(_ => action()).flatMap { current =>
+          if (changed(previous, current)) CIO.unit else loop(remaining - 1, current)
+        }
+
+    action().flatMap(loop(attempts - 1, _))
+  }
 }

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterFailoverSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterFailoverSuite.scala
@@ -154,10 +154,13 @@ abstract class ClusterFailoverSuite(val image: String, val serverBinary: String)
                                      "cluster replica did not connect"
                                    )
                     waitsBefore <- CIO.blocking(replicationWaits(container, owner.port))
-                    _           <- client.lock[String](3.seconds).withLock(key, 5.seconds) {
+                    _           <- client.lock[String](900.millis).withLock(key, 5.seconds) {
                                      for {
                                        before     <- reader.exists(s"4:lock:$key")
-                                       _          <- CIO.sleep(3200.millis)
+                                       _          <-
+                                         Eventually.converges(30, 50.millis)(() => CIO.blocking(replicationWaits(container, owner.port)))(_ >= waitsBefore + 2)(
+                                           waits => s"acquisition and renewal did not both wait for replication: $waits"
+                                         )
                                        after      <- reader.exists(s"4:lock:$key")
                                        waitsAfter <- CIO.blocking(replicationWaits(container, owner.port))
                                      } yield {

--- a/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterMultiMasterSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/cluster/ClusterMultiMasterSuite.scala
@@ -52,7 +52,7 @@ abstract class ClusterMultiMasterSuite(val image: String, val serverBinary: Stri
       formCluster(container).flatMap(_ => connectAndUse(config)(client => body(container, client))).unsafeRun
     }
 
-  test("distributed locks acquire, renew, and release keys owned by different masters") {
+  test("distributed locks acquire and release keys owned by different masters") {
     onCluster { (container, first) =>
       val keys = Vector("orders", "delta", "epsilon").map(tag => s"distributed:{$tag}")
       assertEquals(keys.map(key => slotOwner(container, s"4:lock:$key")).toSet, ports.toSet)
@@ -62,17 +62,11 @@ abstract class ClusterMultiMasterSuite(val image: String, val serverBinary: Stri
             val holder    = first.lock[String](leaseDuration = 600.millis)
             val contender = second.lock[String]()
             for {
-              denied   <- holder.withLock(key, 2.seconds) {
-                            for {
-                              before <- contender.tryWithLock(key)(CIO.value(1))
-                              _      <- CIO.sleep(1500.millis)
-                              after  <- contender.tryWithLock(key)(CIO.value(2))
-                            } yield (before, after)
-                          }
+              denied   <- holder.withLock(key, 2.seconds)(contender.tryWithLock(key)(CIO.value(1)))
               acquired <- contender.tryWithLock(key)(CIO.value(42))
               exists   <- first.exists(s"4:lock:$key")
             } yield {
-              assertEquals(denied, (None, None))
+              assertEquals(denied, None)
               assertEquals(acquired, Some(42))
               assertEquals(exists, 0L)
             }

--- a/integration-tests/shared/src/test/scala/sage/integration/locking/LockSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/locking/LockSuite.scala
@@ -9,7 +9,7 @@ import sage.Bytes
 import sage.SageException.LockLost
 import sage.client.internal.Client
 import sage.commands.Command
-import sage.integration.{Images, ServerSuite}
+import sage.integration.{Eventually, Images, ServerSuite, Ttls}
 
 abstract class LockSuite(image: String) extends ServerSuite(image) {
   private def killClient(id: Long): Command[Unit] =
@@ -24,7 +24,7 @@ abstract class LockSuite(image: String) extends ServerSuite(image) {
     Command(
       "CLIENT",
       Command.NoKeys,
-      Vector("PAUSE", "450", "ALL").map(Bytes.utf8),
+      Vector("PAUSE", "600", "ALL").map(Bytes.utf8),
       _ => Right(())
     )
 
@@ -34,6 +34,19 @@ abstract class LockSuite(image: String) extends ServerSuite(image) {
         connectAndUse(configOf(server))(second => body(first, second))
       }.unsafeRun
     }
+
+  private def awaitRenewal(client: Client[CIO, String], key: String): CIO[Unit] =
+    Eventually.changes(30, 50.millis)(() => client.pTtl(key))((before, after) =>
+      (Ttls.remaining(before), Ttls.remaining(after)) match {
+        case (Some(previous), Some(current)) => current > previous + 100.millis
+        case _                               => false
+      }
+    )(ttl => s"$key was not renewed; its TTL was $ttl")
+
+  private def commandCalls(info: String, command: String): Long =
+    info.linesIterator
+      .find(_.startsWith(s"cmdstat_${command.toLowerCase}:calls="))
+      .fold(0L)(_.dropWhile(_ != '=').drop(1).takeWhile(_ != ',').toLong)
 
   test("independent clients contend on the same key and acquire after release") {
     withClients { (first, second) =>
@@ -61,7 +74,7 @@ abstract class LockSuite(image: String) extends ServerSuite(image) {
             val client = if (i % 2 == 0) first else second
             client.lock[String]().withLock("counter", 5.seconds) {
               client.get[Int]("counter").flatMap { current =>
-                CIO.sleep(5.millis).flatMap(_ => client.set("counter", current.get + 1))
+                client.ping().flatMap(_ => client.set("counter", current.get + 1))
               }
             }
           }
@@ -71,14 +84,14 @@ abstract class LockSuite(image: String) extends ServerSuite(image) {
     }
   }
 
-  test("automatic renewal excludes another client after the initial lease would have expired") {
+  test("automatic renewal extends the lease and excludes another client") {
     withClients { (first, second) =>
       first
-        .lock[String](leaseDuration = 600.millis)
+        .lock[String](leaseDuration = 900.millis)
         .withLock("long", 2.seconds) {
-          CIO.sleep(1500.millis).flatMap { _ =>
-            second.lock[String]().tryWithLock("long")(CIO.value(42)).map(result => assertEquals(result, None))
-          }
+          awaitRenewal(second, "4:lock:long")
+            .flatMap(_ => second.lock[String]().tryWithLock("long")(CIO.value(42)))
+            .map(result => assertEquals(result, None))
         }
         .flatMap(_ => second.lock[String]().tryWithLock("long")(CIO.value(42)))
         .map(result => assertEquals(result, Some(42)))
@@ -92,10 +105,15 @@ abstract class LockSuite(image: String) extends ServerSuite(image) {
       first.clientId.flatMap { id =>
         holder
           .withLock("reconnect", 2.seconds) {
-            CIO
-              .sleep(250.millis)
-              .flatMap(_ => second.pipeline((killClient(id), pauseClients)))
-              .flatMap(_ => CIO.sleep(1400.millis))
+            second
+              .info("commandstats")
+              .flatMap { before =>
+                second.pipeline((killClient(id), pauseClients)).flatMap { _ =>
+                  Eventually.converges(30, 50.millis)(() => second.info("commandstats"))(
+                    commandCalls(_, "evalsha") > commandCalls(before, "evalsha")
+                  )(info => s"the lock was not renewed after reconnecting: $info")
+                }
+              }
               .flatMap(_ => contender.tryWithLock("reconnect")(CIO.value(1)))
               .map(result => assertEquals(result, None))
           }
@@ -136,8 +154,11 @@ abstract class LockSuite(image: String) extends ServerSuite(image) {
       client
         .scriptFlush()
         .flatMap { _ =>
-          client.lock[String](leaseDuration = 600.millis).withLock("flush", 2.seconds) {
-            client.scriptFlush().flatMap(_ => CIO.sleep(1.second)).flatMap(_ => client.scriptFlush())
+          client.lock[String](leaseDuration = 900.millis).withLock("flush", 2.seconds) {
+            client
+              .scriptFlush()
+              .flatMap(_ => awaitRenewal(client, "4:lock:flush"))
+              .flatMap(_ => client.scriptFlush())
           }
         }
         .flatMap(_ => client.exists("4:lock:flush"))

--- a/integration-tests/shared/src/test/scala/sage/integration/locking/LockSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/locking/LockSuite.scala
@@ -5,11 +5,29 @@ import scala.concurrent.duration.*
 
 import kyo.compat.*
 
+import sage.Bytes
 import sage.SageException.LockLost
 import sage.client.internal.Client
+import sage.commands.Command
 import sage.integration.{Images, ServerSuite}
 
 abstract class LockSuite(image: String) extends ServerSuite(image) {
+  private def killClient(id: Long): Command[Unit] =
+    Command(
+      "CLIENT",
+      Command.NoKeys,
+      Vector("KILL", "ID", id.toString).map(Bytes.utf8),
+      _ => Right(())
+    )
+
+  private val pauseClients: Command[Unit] =
+    Command(
+      "CLIENT",
+      Command.NoKeys,
+      Vector("PAUSE", "450", "ALL").map(Bytes.utf8),
+      _ => Right(())
+    )
+
   private def withClients[A](body: (Client[CIO, String], Client[CIO, String]) => CIO[A]): Future[A] =
     withContainers { server =>
       connectAndUse(configOf(server)) { first =>
@@ -64,6 +82,26 @@ abstract class LockSuite(image: String) extends ServerSuite(image) {
         }
         .flatMap(_ => second.lock[String]().tryWithLock("long")(CIO.value(42)))
         .map(result => assertEquals(result, Some(42)))
+    }
+  }
+
+  test("a standalone lock survives connection loss during renewal") {
+    withClients { (first, second) =>
+      val holder    = first.lock[String](leaseDuration = 1500.millis)
+      val contender = second.lock[String]()
+      first.clientId.flatMap { id =>
+        holder
+          .withLock("reconnect", 2.seconds) {
+            CIO
+              .sleep(250.millis)
+              .flatMap(_ => second.pipeline((killClient(id), pauseClients)))
+              .flatMap(_ => CIO.sleep(1400.millis))
+              .flatMap(_ => contender.tryWithLock("reconnect")(CIO.value(1)))
+              .map(result => assertEquals(result, None))
+          }
+          .flatMap(_ => contender.tryWithLock("reconnect")(CIO.value(42)))
+          .map(result => assertEquals(result, Some(42)))
+      }
     }
   }
 

--- a/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
@@ -56,6 +56,11 @@ abstract class MasterReplicaSuiteBase(image: String, serverBinary: String) exten
       }
     )
 
+  protected def commandCalls(info: String, command: String): Long =
+    info.linesIterator
+      .find(_.startsWith(s"cmdstat_${command.toLowerCase}:calls="))
+      .fold(0L)(_.dropWhile(_ != '=').drop(1).takeWhile(_ != ',').toLong)
+
   // Follow the master and announce the host-mapped port, then write a marker key the master never has, so a read's origin is observable. The
   // marker goes in after the link is up, since REPLICAOF triggers a full resync that would wipe an earlier write. Idempotent across a suite's tests.
   protected def ensureReplicating(replica: Client[CIO, String], announceHost: String, announcePort: Int): CIO[Unit] =
@@ -191,6 +196,32 @@ abstract class MasterReplicaSuite(image: String, serverBinary: String) extends M
           }
         }
       program.unsafeRun
+    }
+  }
+
+  test("distributed locks can skip replica acknowledgement") {
+    withContainers { server =>
+      val host = server.host
+      val pm   = server.mappedPort(masterPort)
+      val pr   = server.mappedPort(replicaPort)
+
+      connectAndUse(standalone(host, pr))(ensureReplicating(_, host, pr)).flatMap { _ =>
+        connectAndUse(masterReplica(host, pm, ReadFrom.Replica)) { client =>
+          connectAndUse(standalone(host, pm)) { master =>
+            for {
+              before <- master.info("commandstats")
+              result <- client
+                          .lock[String](leaseDuration = 600.millis, replicaAcknowledgement = false)
+                          .tryWithLock("mr:no-replica-ack")(CIO.sleep(900.millis).map(_ => 42))
+              after  <- master.info("commandstats")
+            } yield {
+              assertEquals(result, Some(42))
+              assertEquals(commandCalls(after, "wait"), commandCalls(before, "wait"))
+              assert(commandCalls(after, "role") > commandCalls(before, "role"))
+            }
+          }
+        }
+      }.unsafeRun
     }
   }
 

--- a/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
+++ b/integration-tests/shared/src/test/scala/sage/integration/masterreplica/MasterReplicaSuite.scala
@@ -12,7 +12,7 @@ import sage.SageException.{DecodeError, LockLost, TimedOut}
 import sage.client.{Endpoint, MasterReplicaConfig, ReadFrom, SageConfig, Topology}
 import sage.client.internal.Client
 import sage.commands.{Command, Commands}
-import sage.integration.{ContainerClient, Eventually, Images}
+import sage.integration.{ContainerClient, Eventually, Images, Ttls}
 import sage.protocol.Frame
 
 /**
@@ -29,8 +29,8 @@ abstract class MasterReplicaSuiteBase(image: String, serverBinary: String) exten
 
   // --protected-mode no admits the testcontainers-mapped (non-loopback) connection; --save '' / --appendonly no keep the nodes in-memory
   override val containerDef: GenericContainer.Def[GenericContainer] = {
-    val master                   = s"$serverBinary --port 6379 --save '' --appendonly no --protected-mode no"
-    val replica                  = s"$serverBinary --port 6380 --save '' --appendonly no --protected-mode no"
+    val master                   = s"$serverBinary --port 6379 --save '' --appendonly no --protected-mode no --repl-diskless-sync-delay 0"
+    val replica                  = s"$serverBinary --port 6380 --save '' --appendonly no --protected-mode no --repl-diskless-sync-delay 0"
     val (background, foreground) = if (masterRunsInForeground) (replica, master) else (master, replica)
     GenericContainer.Def(image, exposedPorts = Seq(6379, 6380), command = Seq("sh", "-c", s"$background & exec $foreground"))
   }
@@ -129,17 +129,17 @@ abstract class MasterReplicaSuite(image: String, serverBinary: String) extends M
                 val key         = s"mr:unconfirmed-lock:$duringRenewal"
                 val bodyStarted = new java.util.concurrent.atomic.AtomicBoolean(false)
                 val bodyStopped = new java.util.concurrent.atomic.AtomicBoolean(false)
-                val detach      = replica.run(admin("REPLICAOF", "NO", "ONE"))
-                val attempt     = client.lock[String](3.seconds).tryWithLock(key) {
+                val pause       = replica.run(admin("CLIENT", "PAUSE", "800", "ALL"))
+                val attempt     = client.lock[String](600.millis).tryWithLock(key) {
                   CIO.defer(bodyStarted.set(true)).flatMap { _ =>
                     if (duringRenewal)
-                      CIO.ensure(CIO.defer(bodyStopped.set(true)))(detach.flatMap(_ => CIO.never))
+                      CIO.ensure(CIO.defer(bodyStopped.set(true)))(pause.flatMap(_ => CIO.never))
                     else CIO.unit
                   }
                 }
-                CIO.ensure(ensureReplicating(replica, host, pr)) {
+                CIO.ensure(replica.run(admin("CLIENT", "UNPAUSE"))) {
                   for {
-                    _      <- if (duringRenewal) CIO.unit else detach
+                    _      <- if (duringRenewal) CIO.unit else pause
                     result <- attempt.liftToTry
                     exists <- master.exists(s"4:lock:$key")
                   } yield {
@@ -173,14 +173,17 @@ abstract class MasterReplicaSuite(image: String, serverBinary: String) extends M
           connectAndUse(masterReplica(host, pm, ReadFrom.Replica)) { client =>
             connectAndUse(standalone(host, pm)) { master =>
               val key       = "mr:distributed-lock"
-              val holder    = client.lock[String](leaseDuration = 600.millis)
+              val holder    = client.lock[String](leaseDuration = 900.millis)
               val contender = master.lock[String]()
               for {
                 fromReplica <- client.get[String](marker)
+                waitsBefore <- master.info("commandstats")
                 denied      <- holder.withLock(key, 2.seconds) {
                                  for {
                                    before <- contender.tryWithLock(key)(CIO.value(1))
-                                   _      <- CIO.sleep(1500.millis)
+                                   _      <- Eventually.converges(30, 50.millis)(() => master.info("commandstats"))(
+                                               commandCalls(_, "wait") >= commandCalls(waitsBefore, "wait") + 2
+                                             )(info => s"acquisition and renewal did not both wait for replication: $info")
                                    after  <- contender.tryWithLock(key)(CIO.value(2))
                                  } yield (before, after)
                                }
@@ -211,8 +214,17 @@ abstract class MasterReplicaSuite(image: String, serverBinary: String) extends M
             for {
               before <- master.info("commandstats")
               result <- client
-                          .lock[String](leaseDuration = 600.millis, replicaAcknowledgement = false)
-                          .tryWithLock("mr:no-replica-ack")(CIO.sleep(900.millis).map(_ => 42))
+                          .lock[String](leaseDuration = 900.millis, replicaAcknowledgement = false)
+                          .tryWithLock("mr:no-replica-ack") {
+                            Eventually
+                              .changes(30, 50.millis)(() => master.pTtl("4:lock:mr:no-replica-ack"))((before, current) =>
+                                (Ttls.remaining(before), Ttls.remaining(current)) match {
+                                  case (Some(previous), Some(renewed)) => renewed > previous + 100.millis
+                                  case _                               => false
+                                }
+                              )(ttl => s"lock was not renewed; its TTL was $ttl")
+                              .map(_ => 42)
+                          }
               after  <- master.info("commandstats")
             } yield {
               assertEquals(result, Some(42))

--- a/sage-client/ce/src/test/scala/sage/client/internal/CeLockCancellationSpec.scala
+++ b/sage-client/ce/src/test/scala/sage/client/internal/CeLockCancellationSpec.scala
@@ -24,7 +24,7 @@ class CeLockCancellationSpec extends LockCancellationSpec {
       val commands  = new CommandRunner[CIO, String] {
         def run[A](command: Command[A]): CIO[A] = CIO.async { callback =>
           val result = command.decode(Frame.Integer(1)).toTry
-          if (command.args(4).asUtf8String == stalled) Scheduler.real.after(2.seconds)(callback(result))
+          if (command.args(4).asUtf8String == stalled) Scheduler.real.after(5.seconds)(callback(result))
           else callback(result)
         }
       }
@@ -45,7 +45,7 @@ class CeLockCancellationSpec extends LockCancellationSpec {
           case "renew"   => assert(error.isInstanceOf[LockLost], error.toString)
           case _         => assert(error eq failure)
         }
-        assert(ended - started < 1.second, s"$stalled waited for its delayed callback: ${ended - started}")
+        assert(ended - started < 2.seconds, s"$stalled waited for its delayed callback: ${ended - started}")
       }
       CIO.lift(check).unsafeRun
     }

--- a/sage-client/ox/src/test/scala/sage/client/internal/OxLockCancellationSpec.scala
+++ b/sage-client/ox/src/test/scala/sage/client/internal/OxLockCancellationSpec.scala
@@ -19,7 +19,7 @@ class OxLockCancellationSpec extends LockCancellationSpec {
   override protected def withLock[A](commands: CommandRunner[CIO, String], lease: FiniteDuration, wait: FiniteDuration)(body: CIO[A]): CIO[A] =
     CIO.deferLift(new SageClient.Lowered(new LockTestClient(commands)).lock[String](lease).withLock("key", wait)(body.lower))
 
-  test("a body control exception ends the scope and stops renewal") {
+  test("a body control exception ends the scope and releases ownership") {
     val released = new AtomicBoolean(false)
     val renewals = new AtomicInteger(0)
     val failure  = new ControlThrowable {}
@@ -35,9 +35,6 @@ class OxLockCancellationSpec extends LockCancellationSpec {
         }
       assertEquals(caught, Some(failure))
       assert(released.get())
-      val count  = renewals.get()
-      ox.sleep(400.millis)
-      assertEquals(renewals.get(), count)
     }.unsafeRun
   }
 }

--- a/sage-client/pekko/src/test/scala/sage/client/internal/LockFutureSpec.scala
+++ b/sage-client/pekko/src/test/scala/sage/client/internal/LockFutureSpec.scala
@@ -1,6 +1,6 @@
 package sage.client.internal
 
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.concurrent.{ExecutionContext, Promise}
 import scala.concurrent.duration.*
@@ -62,16 +62,14 @@ class LockFutureSpec extends munit.FunSuite {
     checked.andThen { case _ => live.close.unsafeRun }
   }
 
-  test("lease loss stops renewal while a Future body keeps running") {
+  test("lease loss fails the scope while a Future body keeps running") {
     val body      = Promise[Int]()
     val continued = Promise[Int]()
-    val renewals  = new AtomicInteger(0)
     val released  = new AtomicBoolean(false)
     val commands  = new CommandRunner[CIO, String] {
       def run[A](command: Command[A]): CIO[A] = CIO.defer(()).flatMap { _ =>
         val reply = command.args(4).asUtf8String match {
           case "renew"   =>
-            renewals.incrementAndGet()
             0L
           case "release" =>
             released.set(true)
@@ -93,9 +91,6 @@ class LockFutureSpec extends munit.FunSuite {
       _      = assert(error.isInstanceOf[LockLost], error.toString)
       _      = assert(!continued.isCompleted)
       _      = assert(released.get())
-      count  = renewals.get()
-      _     <- CIO.sleep(400.millis).unsafeRun
-      _      = assertEquals(renewals.get(), count)
       _      = body.success(42)
       value <- continued.future
     } yield assertEquals(value, 42)

--- a/sage-client/pekko/src/test/scala/sage/client/internal/LockFutureSpec.scala
+++ b/sage-client/pekko/src/test/scala/sage/client/internal/LockFutureSpec.scala
@@ -48,7 +48,7 @@ class LockFutureSpec extends munit.FunSuite {
     val client    = new SageClient.Lowered(live)
     val checked   = for {
       error <- client
-                 .lock[String](3.seconds)
+                 .lock[String](300.millis)
                  .tryWithLock("key") {
                    evaluated.set(true)
                    scala.concurrent.Future.successful(42)
@@ -98,8 +98,6 @@ class LockFutureSpec extends munit.FunSuite {
       _      = assertEquals(renewals.get(), count)
       _      = body.success(42)
       value <- continued.future
-      _      = assertEquals(value, 42)
-      _     <- CIO.sleep(400.millis).unsafeRun
-    } yield assertEquals(renewals.get(), count)
+    } yield assertEquals(value, 42)
   }
 }

--- a/sage-client/shared/src/main/scala/sage/client/LockClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/LockClient.scala
@@ -15,9 +15,9 @@ import sage.client.internal.{Client, LockExecutor}
 final class LockClient[F[_], K] private[sage] (client: Client[F, ?], executor: LockExecutor[K]) {
 
   /**
-    * Checks contention once and returns `None` when busy, without evaluating `body`. Temporary failures may be retried for about one second,
-    * after which acquisition raises [[sage.SageException.TimedOut]]. After acquisition, renews the lease and releases it when `body`
-    * finishes. Returns `Some(result)` on success. Ownership or renewal failure raises [[sage.SageException.LockLost]].
+    * Does not wait for a busy lock. Returns `None` when busy, without evaluating `body`, or `Some(result)` after successful execution and
+    * release. Sage retries temporary failures for about one second, then raises [[sage.SageException.TimedOut]]. After acquisition, renews
+    * the lease while `body` runs and releases it when `body` finishes. Ownership or renewal failure raises [[sage.SageException.LockLost]].
     */
   def tryWithLock[A](key: K)(body: => F[A]): F[Option[A]] = client.lockTryWith(executor, key)(body)
 

--- a/sage-client/shared/src/main/scala/sage/client/LockClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/LockClient.scala
@@ -15,16 +15,18 @@ import sage.client.internal.{Client, LockExecutor}
 final class LockClient[F[_], K] private[sage] (client: Client[F, ?], executor: LockExecutor[K]) {
 
   /**
-    * Does not wait for a busy lock. Returns `None` when busy, without evaluating `body`, or `Some(result)` after successful execution and
-    * release. Sage retries temporary failures for about one second, then raises [[sage.SageException.TimedOut]]. After acquisition, renews
-    * the lease while `body` runs and releases it when `body` finishes. Ownership or renewal failure raises [[sage.SageException.LockLost]].
+    * Runs `body` while holding the lock and returns its result in `Some` after releasing the lock. If the lock is busy, returns `None`
+    * without evaluating `body`. The lease is renewed while `body` runs. A body failure is propagated after cleanup, and an ownership or
+    * renewal failure raises [[sage.SageException.LockLost]]. Temporary acquisition failures are retried for about one second before raising
+    * [[sage.SageException.TimedOut]].
     */
   def tryWithLock[A](key: K)(body: => F[A]): F[Option[A]] = client.lockTryWith(executor, key)(body)
 
   /**
-    * Retries acquisition with exponential backoff and jitter until `waitTimeout` elapses, then raises [[sage.SageException.TimedOut]]. The timeout
-    * must be positive and covers acquisition only. Once acquired, the lease is renewed for the duration of `body`. The body is evaluated
-    * only after acquisition and is never retried by Sage.
+    * Waits up to `waitTimeout` to acquire the lock, runs `body` while holding it, and returns the body's result after releasing the lock. If
+    * the lock cannot be acquired in time, raises [[sage.SageException.TimedOut]] without evaluating `body`. The lease is renewed while `body`
+    * runs. Sage never retries the body. A body failure is propagated after cleanup, and an ownership or renewal failure raises
+    * [[sage.SageException.LockLost]]. The timeout must be positive and covers acquisition only.
     */
   def withLock[A](key: K, waitTimeout: FiniteDuration)(body: => F[A]): F[A] =
     client.lockWith(executor, key, waitTimeout)(body)

--- a/sage-client/shared/src/main/scala/sage/client/LockClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/LockClient.scala
@@ -5,9 +5,9 @@ import scala.concurrent.duration.FiniteDuration
 import sage.client.internal.{Client, LockExecutor}
 
 /**
-  * A distributed mutex bound to a client. Each key has an expiring lease that Sage renews while the protected effect runs. All callers
-  * coordinating the same work must use the same namespace and key. Locks are not reentrant and do not guarantee acquisition order.
-  * Master-replica and cluster clients require replica acknowledgement for acquisition and renewal.
+  * `LockClient` provides a distributed mutex bound to a client. Each key has an expiring lease that Sage renews while the protected effect
+  * runs. All callers coordinating the same work must use the same namespace and key. Locks are not reentrant and do not guarantee
+  * acquisition order. Master-replica and cluster clients wait for replica acknowledgement by default.
   *
   * Mutual exclusion depends on the lease remaining valid and Redis retaining its state. Process pauses beyond expiry and Redis failover
   * can allow overlapping work. Cancellation after lease loss is cooperative and cannot undo completed external effects.

--- a/sage-client/shared/src/main/scala/sage/client/LockClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/LockClient.scala
@@ -15,8 +15,9 @@ import sage.client.internal.{Client, LockExecutor}
 final class LockClient[F[_], K] private[sage] (client: Client[F, ?], executor: LockExecutor[K]) {
 
   /**
-    * Attempts acquisition once. Returns `None` when busy, without evaluating `body`. After acquisition, renews the lease and releases it
-    * when `body` finishes. Returns `Some(result)` on success. Ownership or renewal failure raises [[sage.SageException.LockLost]].
+    * Checks contention once and returns `None` when busy, without evaluating `body`. Temporary failures may be retried for about one second,
+    * after which acquisition raises [[sage.SageException.TimedOut]]. After acquisition, renews the lease and releases it when `body`
+    * finishes. Returns `Some(result)` on success. Ownership or renewal failure raises [[sage.SageException.LockLost]].
     */
   def tryWithLock[A](key: K)(body: => F[A]): F[Option[A]] = client.lockTryWith(executor, key)(body)
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/Client.scala
@@ -31,7 +31,11 @@ trait CommandRunner[F[_], K](using KeyCodec[K]) {
     */
   def run[A](command: Command[A]): F[A]
 
-  private[sage] def lockWrite(command: Command[Boolean], @scala.annotation.unused timeout: FiniteDuration): F[Boolean] = run(command)
+  private[sage] def lockWrite(
+    command: Command[Boolean],
+    @scala.annotation.unused timeout: FiniteDuration,
+    @scala.annotation.unused replicaAcknowledgement: Boolean
+  ): F[Boolean] = run(command)
 
   /**
     * Returns a view that uses another key type and reuses the same connection. Command builders encode keys before calling `run`, so the
@@ -42,8 +46,12 @@ trait CommandRunner[F[_], K](using KeyCodec[K]) {
   def as[K2](using KeyCodec[K2]): CommandRunner[F, K2] = {
     val self = this
     new CommandRunner[F, K2] {
-      def run[A](command: Command[A]): F[A]                                                                = self.run(command)
-      override private[sage] def lockWrite(command: Command[Boolean], timeout: FiniteDuration): F[Boolean] = self.lockWrite(command, timeout)
+      def run[A](command: Command[A]): F[A] = self.run(command)
+      override private[sage] def lockWrite(
+        command: Command[Boolean],
+        timeout: FiniteDuration,
+        replicaAcknowledgement: Boolean
+      ): F[Boolean]                         = self.lockWrite(command, timeout, replicaAcknowledgement)
     }
   }
 
@@ -2232,13 +2240,16 @@ trait Client[F[_], K] extends CommandRunner[F, K] {
 
   /**
     * Creates a distributed mutex for keys of type `LK`. The lease is renewed automatically while a protected effect runs. `leaseDuration`
-    * defaults to 30 seconds and must be at least 30 milliseconds. See [[LockClient]] for ownership and failover limits.
+    * defaults to 30 seconds and must be at least 30 milliseconds. In master-replica and cluster deployments, `replicaAcknowledgement`
+    * waits for replicas by default. Disabling it improves availability but increases the chance of losing a lock during failover. See
+    * [[LockClient]] for ownership and failover limits.
     */
   def lock[LK](
     leaseDuration: FiniteDuration = FiniteDuration(30L, java.util.concurrent.TimeUnit.SECONDS),
-    namespace: String = "lock"
+    namespace: String = "lock",
+    replicaAcknowledgement: Boolean = true
   )(using KeyCodec[LK]): LockClient[F, LK] =
-    new LockClient[F, LK](this, new LockExecutor[LK](leaseDuration, namespace))
+    new LockClient[F, LK](this, new LockExecutor[LK](leaseDuration, namespace, replicaAcknowledgement))
 
   private[sage] def lockTryWith[LK, A](executor: LockExecutor[LK], key: LK)(body: => F[A]): F[Option[A]]
 
@@ -2280,7 +2291,11 @@ trait Client[F[_], K] extends CommandRunner[F, K] {
     val self = this
     new Client[F, K2] {
       def run[A](command: Command[A]): F[A]                                                                                        = self.run(command)
-      override private[sage] def lockWrite(command: Command[Boolean], timeout: FiniteDuration): F[Boolean]                         = self.lockWrite(command, timeout)
+      override private[sage] def lockWrite(
+        command: Command[Boolean],
+        timeout: FiniteDuration,
+        replicaAcknowledgement: Boolean
+      ): F[Boolean]                                                                                                                = self.lockWrite(command, timeout, replicaAcknowledgement)
       def cached[A](command: Command[A], ttl: FiniteDuration): F[A]                                                                = self.cached(command, ttl)
       private[sage] def pipeline[Out, R](p: Pipeline[Out, R]): F[Out]                                                              = self.pipeline(p)
       private[sage] def pipelineAttempt[Out, R](p: Pipeline[Out, R]): F[R]                                                         = self.pipelineAttempt(p)

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -697,6 +697,7 @@ final private[client] class ClusterLive(
     if (redirectsLeft <= 0) {
       if (redirect.kind == RedirectKind.Moved) refreshBeforeFailing()
       val limitFailure = ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")
+      // Lock writes retry redirect faults within their lock budget after the topology refresh. Ordinary commands report the redirect limit.
       val failure      = context.mode match {
         case Confirmed(_, _) => exhaustedFailure.getOrElse(limitFailure)
         case _               => limitFailure

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -643,16 +643,19 @@ final private[client] class ClusterLive(
     context.mode match {
       case Cached(ttlMillis, deferred) if !asking            => nc.cachedSubmit[A](command, ttlMillis, onReply, deferred)
       case Confirmed(deadlineMillis, replicaAcknowledgement) =>
-        val replicas = topologyRef.get().replicasForMaster(node).size
+        val replication = new LockReplication(
+          scheduler,
+          topologyRef.get().replicasForMaster(node).size,
+          deadlineMillis,
+          () => refreshThrottle.request(refreshWork),
+          replicaAcknowledgement
+        )
         nc.submitLockWrite(
           command,
           asking,
-          replicas,
-          deadlineMillis,
           onReply,
           context.lease,
-          () => refreshThrottle.request(refreshWork),
-          replicaAcknowledgement
+          replication
         )
       case Ordinary | Cached(_, _)                           => nc.submit[A](command, asking, onReply, context.lease)
     }
@@ -667,7 +670,7 @@ final private[client] class ClusterLive(
     context: DispatchContext
   ): Unit =
     Fault.categorize(error) match {
-      case Fault.Redirected(redirect)       => onRedirect(node, redirect, command, redirectsLeft, complete, context)
+      case Fault.Redirected(redirect)       => onRedirect(node, redirect, command, redirectsLeft, complete, context, Some(error))
       case Fault.Lost(false)                => onUnreachable(command, redirectsLeft, complete, context)
       case Fault.TryAgain                   => onRetryable(command, error, refreshFirst = false, redirectsLeft, complete, context)
       case Fault.Unavailable(clusterWide)   => onRetryable(command, error, clusterWide, redirectsLeft, complete, context)
@@ -686,13 +689,19 @@ final private[client] class ClusterLive(
     command: Command[A],
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    context: DispatchContext = DispatchContext.Default
+    context: DispatchContext = DispatchContext.Default,
+    exhaustedFailure: Option[Throwable] = None
   ): Unit = {
     // a MOVED proves `from` lost the slot; retire its cache even if the retry budget is now exhausted
     if (redirect.kind == RedirectKind.Moved) flushNode(from)
     if (redirectsLeft <= 0) {
       if (redirect.kind == RedirectKind.Moved) refreshBeforeFailing()
-      complete(Failure(ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")))
+      val limitFailure = ServerError("ERR", s"exceeded ${cluster.maxRedirects} cluster redirects for ${command.name}")
+      val failure      = context.mode match {
+        case Confirmed(_, _) => exhaustedFailure.getOrElse(limitFailure)
+        case _               => limitFailure
+      }
+      complete(Failure(failure))
     } else {
       val target = resolve(redirect.target, from)
       redirect.kind match {

--- a/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/ClusterLive.scala
@@ -130,17 +130,27 @@ final private[client] class ClusterLive(
     def body(lease: DedicatedPool.Lease): CIO[A] =
       CIO.async[A] { complete =>
         val tracked = Events.trackCommand(events, command, complete)
-        Client.completing(tracked)(dispatch(command, cluster.maxRedirects, tracked, lease = lease))
+        Client.completing(tracked)(dispatch(command, cluster.maxRedirects, tracked, context = DispatchContext.withLease(lease)))
       }
     Client.withLeaseIfBlocking(command)(body)
   }
 
-  override private[sage] def lockWrite(command: Command[Boolean], timeout: FiniteDuration): CIO[Boolean] =
+  override private[sage] def lockWrite(
+    command: Command[Boolean],
+    timeout: FiniteDuration,
+    replicaAcknowledgement: Boolean
+  ): CIO[Boolean] =
     Client.withLockLease(timeout, scheduler) { (lease, deadlineMillis) =>
       CIO.async { complete =>
         val tracked = Events.trackCommand(events, command, complete)
         Client.completing(tracked) {
-          dispatch(command, cluster.maxRedirects, tracked, allowReplica = false, lease = lease, mode = DispatchMode.Confirmed(deadlineMillis))
+          dispatch(
+            command,
+            cluster.maxRedirects,
+            tracked,
+            allowReplica = false,
+            context = DispatchContext(lease, DispatchMode.Confirmed(deadlineMillis, replicaAcknowledgement))
+          )
         }
       }
     }
@@ -156,7 +166,13 @@ final private[client] class ClusterLive(
       CIO.async[A] { complete =>
         val deferred = Events.deferSpan(events, command)
         Client.completing(complete)(
-          dispatch(command, cluster.maxRedirects, complete, allowReplica = false, mode = DispatchMode.Cached(ttl.toMillis, deferred))
+          dispatch(
+            command,
+            cluster.maxRedirects,
+            complete,
+            allowReplica = false,
+            context = DispatchContext(null, DispatchMode.Cached(ttl.toMillis, deferred))
+          )
         )
       }
 
@@ -187,7 +203,7 @@ final private[client] class ClusterLive(
         def body(lease: DedicatedPool.Lease): CIO[A] =
           CIO.async[A] { complete =>
             val tracked = Events.trackCommand(events, command, complete)
-            Client.completing(tracked)(sendTo(node, command, asking = false, redirectsLeft = 0, tracked, lease))
+            Client.completing(tracked)(sendTo(node, command, asking = false, redirectsLeft = 0, tracked, DispatchContext.withLease(lease)))
           }
         Client.withLeaseIfBlocking(command)(body)
       case None       => run(command)
@@ -217,9 +233,15 @@ final private[client] class ClusterLive(
   private enum DispatchMode {
     case Ordinary
     case Cached(ttlMillis: Long, deferred: () => CommandSpan)
-    case Confirmed(deadlineMillis: Long)
+    case Confirmed(deadlineMillis: Long, replicaAcknowledgement: Boolean)
   }
   import DispatchMode.*
+
+  final private case class DispatchContext(lease: DedicatedPool.Lease, mode: DispatchMode)
+  private object DispatchContext {
+    val Default: DispatchContext                               = DispatchContext(null, Ordinary)
+    def withLease(lease: DedicatedPool.Lease): DispatchContext = DispatchContext(lease, Ordinary)
+  }
 
   // Both cached reads and confirmed writes require the master.
   private def replicaAllowed(mode: DispatchMode): Boolean = mode == Ordinary
@@ -229,8 +251,7 @@ final private[client] class ClusterLive(
     redirectsLeft: Int,
     complete: Try[A] => Unit,
     allowReplica: Boolean = true,
-    lease: DedicatedPool.Lease = null,
-    mode: DispatchMode = Ordinary
+    context: DispatchContext = DispatchContext.Default
   ): Unit =
     if (closed) complete(Failure(NotConnected()))
     else {
@@ -241,14 +262,14 @@ final private[client] class ClusterLive(
         else scheduler.offload(broadcast(topology, command, redirectsLeft, complete, masterPool.getOrEstablishOrNull))
       else
         topology.route(command) match {
-          case Route.ToNode(node, slot) => sendOwned(command, node, slot, redirectsLeft, complete, allowReplica, lease, mode)
+          case Route.ToNode(node, slot) => sendOwned(command, node, slot, redirectsLeft, complete, allowReplica, context)
           case Route.Keyless            =>
             if (servesFromReplica(command, allowReplica)) sendKeylessRead(topology, command, redirectsLeft, complete)
-            else sendToAny(topology, command, redirectsLeft, complete, lease, mode)
-          case Route.Unowned(_)         => scheduler.offload(onUnowned(command, redirectsLeft, complete, lease, mode))
+            else sendToAny(topology, command, redirectsLeft, complete, context)
+          case Route.Unowned(_)         => scheduler.offload(onUnowned(command, redirectsLeft, complete, context))
           case Route.CrossSlot(slots)   =>
             multiSlotPolicy(command) match {
-              case Some(policy) => scatterMultiSlot(command, policy, redirectsLeft, complete, allowReplica, mode)
+              case Some(policy) => scatterMultiSlot(command, policy, redirectsLeft, complete, allowReplica, context)
               case None         => complete(Failure(crossSlot(command.name, slots)))
             }
           case Route.Malformed          =>
@@ -263,11 +284,10 @@ final private[client] class ClusterLive(
     redirectsLeft: Int,
     complete: Try[A] => Unit,
     allowReplica: Boolean,
-    lease: DedicatedPool.Lease,
-    mode: DispatchMode
+    context: DispatchContext
   ): Unit =
     if (servesFromReplica(command, allowReplica)) sendRead(command, node, slot, redirectsLeft, complete)
-    else sendTo(node, command, asking = false, redirectsLeft, complete, lease, mode)
+    else sendTo(node, command, asking = false, redirectsLeft, complete, context)
 
   private def servesFromReplica(command: Command[?], allowReplica: Boolean): Boolean =
     allowReplica && readFrom != ReadFrom.Master && ReadRouting.replicaEligible(command)
@@ -290,7 +310,7 @@ final private[client] class ClusterLive(
     redirectsLeft: Int,
     complete: Try[A] => Unit,
     allowReplica: Boolean,
-    mode: DispatchMode
+    context: DispatchContext
   ): Unit = {
     val bySlot = mutable.LinkedHashMap.empty[Slot, mutable.ArrayBuffer[MultiSlotEntry]]
     command.keyIndices.iterator.zipWithIndex.foreach { case (argIndex, resultIndex) =>
@@ -356,7 +376,7 @@ final private[client] class ClusterLive(
         keyIndices = Vector.tabulate(group.size)(_ * policy.argsPerKey),
         args = args.result()
       )
-      dispatch(sub, redirectsLeft, result => settle(group, result), allowReplica = allowReplica, mode = mode)
+      dispatch(sub, redirectsLeft, result => settle(group, result), allowReplica = allowReplica, context = context)
     }
   }
 
@@ -580,11 +600,10 @@ final private[client] class ClusterLive(
     command: Command[A],
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    lease: DedicatedPool.Lease = null,
-    mode: DispatchMode = Ordinary
+    context: DispatchContext = DispatchContext.Default
   ): Unit =
     pickNode(topology) match {
-      case Some(node) => sendTo(node, command, asking = false, redirectsLeft, complete, lease, mode)
+      case Some(node) => sendTo(node, command, asking = false, redirectsLeft, complete, context)
       case None       => complete(Failure(NotConnected()))
     }
 
@@ -594,16 +613,15 @@ final private[client] class ClusterLive(
     asking: Boolean,
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    lease: DedicatedPool.Lease,
-    mode: DispatchMode = Ordinary
+    context: DispatchContext
   ): Unit = {
     val existing = masterPool.existing(node)
-    if (existing != null) submitTo(existing, node, command, asking, redirectsLeft, complete, lease, mode)
+    if (existing != null) submitTo(existing, node, command, asking, redirectsLeft, complete, context)
     else
       scheduler.offload {
         val nc = masterPool.getOrEstablishOrNull(node)
-        if (nc == null) onUnreachable(command, redirectsLeft, complete, lease, mode)
-        else submitTo(nc, node, command, asking, redirectsLeft, complete, lease, mode)
+        if (nc == null) onUnreachable(command, redirectsLeft, complete, context)
+        else submitTo(nc, node, command, asking, redirectsLeft, complete, context)
       }
   }
 
@@ -614,21 +632,29 @@ final private[client] class ClusterLive(
     asking: Boolean,
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    lease: DedicatedPool.Lease,
-    mode: DispatchMode
+    context: DispatchContext
   ): Unit = {
     val onReply: Try[A] => Unit = {
       case Success(value) =>
         Events.attributeNode(complete, node)
         complete(Success(value))
-      case Failure(error) => scheduler.offload(onFailure(node, command, error, redirectsLeft, complete, lease, mode))
+      case Failure(error) => scheduler.offload(onFailure(node, command, error, redirectsLeft, complete, context))
     }
-    mode match {
-      case Cached(ttlMillis, deferred) if !asking => nc.cachedSubmit[A](command, ttlMillis, onReply, deferred)
-      case Confirmed(deadlineMillis)              =>
+    context.mode match {
+      case Cached(ttlMillis, deferred) if !asking            => nc.cachedSubmit[A](command, ttlMillis, onReply, deferred)
+      case Confirmed(deadlineMillis, replicaAcknowledgement) =>
         val replicas = topologyRef.get().replicasForMaster(node).size
-        nc.submitLockWrite(command, asking, replicas, deadlineMillis, onReply, lease, () => refreshThrottle.request(refreshWork))
-      case Ordinary | Cached(_, _)                => nc.submit[A](command, asking, onReply, lease)
+        nc.submitLockWrite(
+          command,
+          asking,
+          replicas,
+          deadlineMillis,
+          onReply,
+          context.lease,
+          () => refreshThrottle.request(refreshWork),
+          replicaAcknowledgement
+        )
+      case Ordinary | Cached(_, _)                           => nc.submit[A](command, asking, onReply, context.lease)
     }
   }
 
@@ -638,14 +664,13 @@ final private[client] class ClusterLive(
     error: Throwable,
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    lease: DedicatedPool.Lease,
-    mode: DispatchMode
+    context: DispatchContext
   ): Unit =
     Fault.categorize(error) match {
-      case Fault.Redirected(redirect)       => onRedirect(node, redirect, command, redirectsLeft, complete, lease, mode)
-      case Fault.Lost(false)                => onUnreachable(command, redirectsLeft, complete, lease, mode)
-      case Fault.TryAgain                   => onRetryable(command, error, refreshFirst = false, redirectsLeft, complete, lease, mode)
-      case Fault.Unavailable(clusterWide)   => onRetryable(command, error, clusterWide, redirectsLeft, complete, lease, mode)
+      case Fault.Redirected(redirect)       => onRedirect(node, redirect, command, redirectsLeft, complete, context)
+      case Fault.Lost(false)                => onUnreachable(command, redirectsLeft, complete, context)
+      case Fault.TryAgain                   => onRetryable(command, error, refreshFirst = false, redirectsLeft, complete, context)
+      case Fault.Unavailable(clusterWide)   => onRetryable(command, error, clusterWide, redirectsLeft, complete, context)
       case Fault.Demoted | Fault.Lost(true) =>
         triggerRefresh()
         Events.attributeNode(complete, node)
@@ -661,8 +686,7 @@ final private[client] class ClusterLive(
     command: Command[A],
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    lease: DedicatedPool.Lease = null,
-    mode: DispatchMode = Ordinary
+    context: DispatchContext = DispatchContext.Default
   ): Unit = {
     // a MOVED proves `from` lost the slot; retire its cache even if the retry budget is now exhausted
     if (redirect.kind == RedirectKind.Moved) flushNode(from)
@@ -674,8 +698,8 @@ final private[client] class ClusterLive(
       redirect.kind match {
         case RedirectKind.Moved =>
           triggerRefresh()
-          sendTo(target, command, asking = false, redirectsLeft - 1, complete, lease, mode)
-        case RedirectKind.Ask   => sendTo(target, command, asking = true, redirectsLeft - 1, complete, lease, mode)
+          sendTo(target, command, asking = false, redirectsLeft - 1, complete, context)
+        case RedirectKind.Ask   => sendTo(target, command, asking = true, redirectsLeft - 1, complete, context)
       }
     }
   }
@@ -686,9 +710,8 @@ final private[client] class ClusterLive(
     command: Command[A],
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    lease: DedicatedPool.Lease = null,
-    mode: DispatchMode = Ordinary
-  ): Unit = onRetryable(command, NotConnected(), refreshFirst = true, redirectsLeft, complete, lease, mode)
+    context: DispatchContext = DispatchContext.Default
+  ): Unit = onRetryable(command, NotConnected(), refreshFirst = true, redirectsLeft, complete, context)
 
   // retry temporary refusals such as TRYAGAIN, LOADING, MASTERDOWN, and CLUSTERDOWN with bounded jitter
   private def onRetryable[A](
@@ -697,8 +720,7 @@ final private[client] class ClusterLive(
     refreshFirst: Boolean,
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    lease: DedicatedPool.Lease = null,
-    mode: DispatchMode = Ordinary
+    context: DispatchContext = DispatchContext.Default
   ): Unit =
     if (redirectsLeft <= 0) {
       if (refreshFirst) refreshBeforeFailing()
@@ -706,7 +728,7 @@ final private[client] class ClusterLive(
     } else {
       if (refreshFirst) refresh(force = true)
       afterBackoff(redirectsLeft)(
-        dispatch(command, redirectsLeft - 1, complete, allowReplica = replicaAllowed(mode), lease = lease, mode = mode)
+        dispatch(command, redirectsLeft - 1, complete, allowReplica = replicaAllowed(context.mode), context = context)
       )
     }
 
@@ -721,21 +743,20 @@ final private[client] class ClusterLive(
     command: Command[A],
     redirectsLeft: Int,
     complete: Try[A] => Unit,
-    lease: DedicatedPool.Lease,
-    mode: DispatchMode
+    context: DispatchContext
   ): Unit = {
     refresh(force = false)
     val topology     = topologyRef.get()
-    val allowReplica = replicaAllowed(mode)
+    val allowReplica = replicaAllowed(context.mode)
     topology.route(command) match {
       // apply the read policy after the slot resolves. Eligible reads still use replica routing.
       case Route.ToNode(node, slot)                                                                  =>
-        sendOwned(command, node, slot, redirectsLeft, complete, allowReplica, lease, mode)
+        sendOwned(command, node, slot, redirectsLeft, complete, allowReplica, context)
       // ReadFrom.Replica has no master fallback. Refresh and retry within the configured limit.
       case _ if allowReplica && readFrom == ReadFrom.Replica && ReadRouting.replicaEligible(command) =>
-        onUnreachable(command, redirectsLeft, complete, lease, mode)
+        onUnreachable(command, redirectsLeft, complete, context)
       // if the refreshed topology still has no owner, send to any master and handle its MOVED or CLUSTERDOWN reply
-      case _                                                                                         => sendToAny(topology, command, redirectsLeft, complete, lease, mode)
+      case _                                                                                         => sendToAny(topology, command, redirectsLeft, complete, context)
     }
   }
 

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -1,17 +1,17 @@
 package sage.client.internal
 
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.collection.mutable
 import scala.concurrent.duration.*
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Try}
 import scala.util.control.NonFatal
 
 import sage.SageException
-import sage.SageException.{ConnectionLost, LockLost, NotConnected, TimedOut}
+import sage.SageException.{ConnectionLost, NotConnected, TimedOut}
 import sage.client.DedicatedPoolConfig
-import sage.commands.{Command, Connection, Reply, Role, Server}
+import sage.commands.{Command, Connection}
 
 /**
   * A pool of dedicated connections for blocking commands, transactions, and lock replication checks. Connections are created when needed,
@@ -76,59 +76,11 @@ final private[client] class DedicatedPool(
     deadlineMillis: Long,
     callback: Try[A] => Unit,
     lease: DedicatedPool.Lease,
-    onConfirmationFailure: () => Unit
+    onConfirmationFailure: () => Unit,
+    replicaAcknowledgement: Boolean
   ): Unit = {
-    val confirming = new AtomicBoolean(false)
-    useConnection(callback, lease, () => if (confirming.get()) onConfirmationFailure(), Some(deadlineMillis)) { (conn, complete) =>
-      // Once the write succeeds, a failed confirmation cannot make it safe to replay the write.
-      def confirmationFailed(error: Throwable): Unit = {
-        onConfirmationFailure()
-        val failure = Fault.categorize(error) match {
-          case Fault.Lost(_) | Fault.Redirected(_) | Fault.TryAgain | Fault.Unavailable(_) =>
-            val lost = ConnectionLost(mayHaveExecuted = true)
-            lost.initCause(error)
-            lost
-          case _                                                                           => error
-        }
-        complete(Failure(failure))
-      }
-
-      def confirm(value: A): Unit = {
-        confirming.set(true)
-        conn.submit(
-          Server.role,
-          {
-            case Success(Role.Master(_, connected)) =>
-              val required = math.max(replicas, connected.size)
-              if (required == 0) complete(Success(value))
-              else {
-                // Reserve half the remaining budget for the server's timeout processing and the reply's transit.
-                val waitMillis = (deadlineMillis - scheduler.nowMillis) / 2L
-                if (waitMillis <= 0L) confirmationFailed(TimedOut("distributed lock replication deadline reached before WAIT"))
-                else
-                  conn.submit(
-                    Server.waitReplicas(required.toLong, waitMillis.millis),
-                    {
-                      case Success(count) if count >= required => complete(Success(value))
-                      case Success(count)                      => confirmationFailed(TimedOut(s"replication confirmed by $count of $required required replicas"))
-                      case Failure(error)                      => confirmationFailed(error)
-                    }
-                  )
-              }
-            case Success(_)                         => confirmationFailed(LockLost("the granting node is no longer a master"))
-            case Failure(error)                     => confirmationFailed(error)
-          }
-        )
-      }
-
-      val onReply: Try[A] => Unit = {
-        case Success(value) if value == true => confirm(value)
-        case result                          => complete(result)
-      }
-      if (asking)
-        conn.submitRaw(Vector(Connection.asking, command.rawFrame), result => onReply(result.flatMap(frames => Reply.decode(command, frames.last))))
-      else conn.submit(command, onReply)
-    }
+    val replication = new LockReplication(scheduler, replicas, deadlineMillis, onConfirmationFailure, replicaAcknowledgement)
+    useConnection(callback, lease, replication.cancelled, Some(deadlineMillis))(replication.submit(_, command, asking, _))
   }
 
   private def useConnection[A](

--- a/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/DedicatedPool.scala
@@ -72,16 +72,11 @@ final private[client] class DedicatedPool(
   def useLockWrite[A](
     command: Command[A],
     asking: Boolean,
-    replicas: Int,
-    deadlineMillis: Long,
     callback: Try[A] => Unit,
     lease: DedicatedPool.Lease,
-    onConfirmationFailure: () => Unit,
-    replicaAcknowledgement: Boolean
-  ): Unit = {
-    val replication = new LockReplication(scheduler, replicas, deadlineMillis, onConfirmationFailure, replicaAcknowledgement)
-    useConnection(callback, lease, replication.cancelled, Some(deadlineMillis))(replication.submit(_, command, asking, _))
-  }
+    replication: LockReplication
+  ): Unit =
+    useConnection(callback, lease, replication.cancelled, Some(replication.deadlineMillis))(replication.submit(_, command, asking, _))
 
   private def useConnection[A](
     callback: Try[A] => Unit,

--- a/sage-client/shared/src/main/scala/sage/client/internal/LockCommands.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LockCommands.scala
@@ -8,6 +8,8 @@ import sage.codec.KeyCodec
 import sage.commands.*
 
 final private[client] class LockCommands[K](leaseDuration: FiniteDuration, namespace: String)(using codec: KeyCodec[K]) {
+  import LockCommands.Operation
+
   private val prefix = {
     val ns = Bytes.utf8(namespace)
     Bytes.concat(Vector(Bytes.utf8(s"${ns.length}:"), ns, Bytes.utf8(":")))
@@ -15,7 +17,7 @@ final private[client] class LockCommands[K](leaseDuration: FiniteDuration, names
 
   def key(value: K): Bytes = Bytes.concat(Vector(prefix, codec.encode(value)))
 
-  def command(key: Bytes, token: String, operation: String, cached: Boolean): Command[Boolean] =
+  def command(key: Bytes, token: String, operation: Operation, cached: Boolean): Command[Boolean] =
     Command(
       if (cached) "EVALSHA" else "EVAL",
       Vector(2),
@@ -24,7 +26,7 @@ final private[client] class LockCommands[K](leaseDuration: FiniteDuration, names
         Bytes.utf8("1"),
         key,
         Bytes.utf8(token),
-        Bytes.utf8(operation),
+        Bytes.utf8(operation.wireName),
         Bytes.utf8(leaseDuration.toMillis.toString)
       ),
       _.asLong.flatMap {
@@ -36,11 +38,18 @@ final private[client] class LockCommands[K](leaseDuration: FiniteDuration, names
 }
 
 private[client] object LockCommands {
+  enum Operation(val wireName: String) {
+    case Acquire extends Operation("acquire")
+    case Renew   extends Operation("renew")
+    case Release extends Operation("release")
+  }
+
   val script: String =
     """local token = ARGV[1]
       |local operation = ARGV[2]
       |if operation == 'acquire' then
       |  if redis.call('SET', KEYS[1], token, 'NX', 'PX', ARGV[3]) then return 1 end
+      |  if redis.call('GET', KEYS[1]) == token then return redis.call('PEXPIRE', KEYS[1], ARGV[3]) end
       |  return 0
       |end
       |if operation ~= 'renew' and operation ~= 'release' then

--- a/sage-client/shared/src/main/scala/sage/client/internal/LockExecutor.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LockExecutor.scala
@@ -15,7 +15,7 @@ import sage.codec.KeyCodec
 final private[client] class LockExecutor[K](
   leaseDuration: FiniteDuration,
   namespace: String,
-  replicaAcknowledgement: Boolean = true
+  replicaAcknowledgement: Boolean
 )(using KeyCodec[K]) {
   import LockCommands.Operation
 
@@ -55,8 +55,7 @@ final private[client] class LockExecutor[K](
           case Some(value) => CIO.value(value)
           case None        =>
             remainingWait(wait).flatMap { remaining =>
-              val delay = math.min(remaining, Backoff.jitteredMillis(contentionBackoff, retry, Scheduler.real).millis.toNanos)
-              CIO.sleep(delay.nanos).flatMap(_ => loop(if (retry < Int.MaxValue) retry + 1 else retry))
+              retryAfter(remaining, contentionBackoff, retry)(loop)
             }
         }
         loop(0)
@@ -119,9 +118,8 @@ final private[client] class LockExecutor[K](
       val budget = wait.fold(CIO.value(operationTimeout.toNanos))(remainingWait)
       budget.flatMap { waitRemaining =>
         CIO.nowMonotonic.flatMap { started =>
-          state.renewedAt.set(started.toNanos)
           state.mayOwn.set(true)
-          val duration = math.min(waitRemaining, usableNanos)
+          val duration = waitRemaining
           val deadline = Deadline(started.toNanos, duration)
           CIO
             .timeoutWithError(duration.nanos)(TimedOut("distributed lock acquisition timed out"))(
@@ -135,8 +133,7 @@ final private[client] class LockExecutor[K](
                 val checkWait = wait.fold(CIO.unit)(remainingWait(_).unit)
                 checkWait.flatMap(_ => remainingLease(state)).flatMap { _ =>
                   val work = CIO.defer(()).flatMap(_ => body()).flatMap(value => remainingLease(state).map(_ => value))
-                  // The renewal branch starts before the lease midpoint and bounds its write by the remaining lease, so it also watches the
-                  // body deadline. Returning errors as values lets the race stop on either body failure or lock loss.
+                  // Returning errors as values lets the race stop on either body failure or lock loss.
                   CIO.race(work.liftToTry, renew[A](runner, state).liftToTry).flatMap(CIO.get(_)).flatMap { value =>
                     state.stopped.set(true)
                     remainingLease(state).flatMap { remaining =>
@@ -165,17 +162,17 @@ final private[client] class LockExecutor[K](
     deadline: Deadline,
     retry: Int
   ): CIO[Boolean] =
-    eval(runner, state, Operation.Acquire, Some(deadline)).recover {
-      case error if retryableAcquisitionFailure(error) =>
-        CIO.nowMonotonic.flatMap { now =>
-          val remaining = deadline.remainingAt(now.toNanos)
-          if (remaining <= 0L) CIO.fail(TimedOut("distributed lock acquisition timed out"))
-          else {
-            val delay = math.min(remaining, Backoff.jitteredMillis(failureBackoff, retry, Scheduler.real).millis.toNanos)
-            CIO.sleep(delay.nanos).flatMap(_ => acquire(runner, state, deadline, if (retry < Int.MaxValue) retry + 1 else retry))
+    CIO.nowMonotonic.flatMap { started =>
+      state.renewedAt.set(started.toNanos)
+      eval(runner, state, Operation.Acquire, Some(deadline)).recover {
+        case error if retryableFailure(error) =>
+          CIO.nowMonotonic.flatMap { now =>
+            val remaining = deadline.remainingAt(now.toNanos)
+            if (remaining <= 0L) CIO.fail(TimedOut("distributed lock acquisition timed out"))
+            else retryAfter(remaining, failureBackoff, retry)(acquire(runner, state, deadline, _))
           }
-        }
-      case error                                       => CIO.fail(error)
+        case error                            => CIO.fail(error)
+      }
     }
 
   private def renew[A](runner: CommandRunner[CIO, String], state: Attempt): CIO[A] =
@@ -204,8 +201,8 @@ final private[client] class LockExecutor[K](
               }
           }
           .recover {
-            case error if retryableLockFailure(error) => retryRenewal(runner, state, retry, error)
-            case error                                => renewalFailed(error)
+            case error if retryableFailure(error) => retryRenewal(runner, state, retry, error)
+            case error                            => renewalFailed(error)
           }
       }
     }
@@ -216,33 +213,30 @@ final private[client] class LockExecutor[K](
     retry: Int,
     lastError: Throwable
   ): CIO[Unit] =
-    CIO.nowMonotonic.flatMap { now =>
-      val remaining = usableNanos - (now.toNanos - state.renewedAt.get())
-      if (remaining <= 0L) renewalFailed(lastError)
-      else {
-        val delay = math.min(remaining, Backoff.jitteredMillis(failureBackoff, retry, Scheduler.real).millis.toNanos)
-        CIO.sleep(delay.nanos).flatMap { _ =>
+    retryRemainingLease(state, lastError).flatMap { remaining =>
+      retryAfter(remaining, failureBackoff, retry) { nextRetry =>
+        CIO.defer(()).flatMap { _ =>
           if (state.stopped.get()) CIO.never
-          else
-            CIO.nowMonotonic.flatMap { afterDelay =>
-              if (usableNanos - (afterDelay.toNanos - state.renewedAt.get()) <= 0L) renewalFailed(lastError)
-              else renewAttempt(runner, state, if (retry < Int.MaxValue) retry + 1 else retry)
-            }
+          else retryRemainingLease(state, lastError).flatMap(_ => renewAttempt(runner, state, nextRetry))
         }
       }
     }
 
-  private def retryableLockFailure(error: Throwable): Boolean =
-    error.isInstanceOf[TimedOut] || (Fault.categorize(error) match {
-      case Fault.Redirected(_) | Fault.Demoted | Fault.Lost(_) | Fault.TryAgain | Fault.Unavailable(_) => true
-      case Fault.Fatal                                                                                 => false
-    })
+  private def retryRemainingLease(state: Attempt, lastError: Throwable): CIO[Long] =
+    remainingLease(state).recover { case _ => renewalFailed(lastError) }
 
-  private def retryableAcquisitionFailure(error: Throwable): Boolean =
-    Fault.categorize(error) match {
-      case Fault.Redirected(_) | Fault.Demoted | Fault.Lost(_) | Fault.TryAgain | Fault.Unavailable(_) => true
-      case Fault.Fatal                                                                                 => false
-    }
+  private def retryAfter[A](remainingNanos: Long, config: BackoffConfig, retry: Int)(next: Int => CIO[A]): CIO[A] = {
+    val delay = math.min(remainingNanos, Backoff.jitteredMillis(config, retry, Scheduler.real).millis.toNanos)
+    CIO.sleep(delay.nanos).flatMap(_ => next(if (retry < Int.MaxValue) retry + 1 else retry))
+  }
+
+  private def retryableFailure(error: Throwable): Boolean =
+    if (error.isInstanceOf[TimedOut]) !LockReplication.isAcknowledgementFailure(error)
+    else
+      Fault.categorize(error) match {
+        case Fault.Redirected(_) | Fault.Demoted | Fault.Lost(_) | Fault.TryAgain | Fault.Unavailable(_) => true
+        case Fault.Fatal                                                                                 => false
+      }
 
   private def renewalFailed(cause: Throwable): CIO[Nothing] = cause match {
     case lost: LockLost => CIO.fail(lost)

--- a/sage-client/shared/src/main/scala/sage/client/internal/LockExecutor.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LockExecutor.scala
@@ -12,7 +12,13 @@ import sage.SageException.{InvalidArgument, LockLost, ServerError, TimedOut}
 import sage.client.BackoffConfig
 import sage.codec.KeyCodec
 
-final private[client] class LockExecutor[K](leaseDuration: FiniteDuration, namespace: String)(using KeyCodec[K]) {
+final private[client] class LockExecutor[K](
+  leaseDuration: FiniteDuration,
+  namespace: String,
+  replicaAcknowledgement: Boolean = true
+)(using KeyCodec[K]) {
+  import LockCommands.Operation
+
   private val commands          = new LockCommands[K](leaseDuration, namespace)
   // The usable lease accounts for millisecond rounding, scheduling, clock drift, and time spent waiting for replies.
   private val leaseNanos        = leaseDuration.toMillis * 1000000L
@@ -20,6 +26,7 @@ final private[client] class LockExecutor[K](leaseDuration: FiniteDuration, names
   private val renewalDelay      = (leaseNanos / 3L).nanos
   private val operationTimeout  = math.min(usableNanos, 1.second.toNanos).nanos
   private val contentionBackoff = BackoffConfig(initialDelay = 50.millis, maxDelay = 500.millis, multiplier = 2.0)
+  private val failureBackoff    = BackoffConfig(initialDelay = 10.millis, maxDelay = 100.millis, multiplier = 2.0)
 
   final private case class Deadline(startedAtNanos: Long, durationNanos: Long) {
     def remainingAt(nowNanos: Long): Long = durationNanos - (nowNanos - startedAtNanos)
@@ -85,7 +92,7 @@ final private[client] class LockExecutor[K](leaseDuration: FiniteDuration, names
   private def eval(
     runner: CommandRunner[CIO, String],
     state: Attempt,
-    operation: String,
+    operation: Operation,
     confirmationDeadline: Option[Deadline] = None
   ): CIO[Boolean] = {
     def run(cached: Boolean): CIO[Boolean] = {
@@ -96,7 +103,7 @@ final private[client] class LockExecutor[K](leaseDuration: FiniteDuration, names
           CIO.nowMonotonic.flatMap { now =>
             val remaining = math.min(operationTimeout.toNanos, deadline.remainingAt(now.toNanos))
             if (remaining <= 0L) CIO.fail(TimedOut("distributed lock write timed out"))
-            else runner.lockWrite(command, remaining.nanos)
+            else runner.lockWrite(command, remaining.nanos, replicaAcknowledgement)
           }
       }
     }
@@ -109,15 +116,16 @@ final private[client] class LockExecutor[K](leaseDuration: FiniteDuration, names
   private def attempt[A](runner: CommandRunner[CIO, String], key: Bytes, wait: Option[Deadline])(body: () => CIO[A]): CIO[Option[A]] =
     // Allocate only local state during acquisition so a contended or unresponsive server never masks cancellation of the wait loop.
     CIO.acquireReleaseWith(CIO.defer(new Attempt(key)))(cleanup(runner, _)) { state =>
-      val budget = wait.fold(CIO.value(usableNanos))(remainingWait)
+      val budget = wait.fold(CIO.value(operationTimeout.toNanos))(remainingWait)
       budget.flatMap { waitRemaining =>
         CIO.nowMonotonic.flatMap { started =>
           state.renewedAt.set(started.toNanos)
           state.mayOwn.set(true)
           val duration = math.min(waitRemaining, usableNanos)
+          val deadline = Deadline(started.toNanos, duration)
           CIO
             .timeoutWithError(duration.nanos)(TimedOut("distributed lock acquisition timed out"))(
-              eval(runner, state, "acquire", Some(Deadline(started.toNanos, duration)))
+              acquire(runner, state, deadline, retry = 0)
             )
             .flatMap {
               case false =>
@@ -127,14 +135,15 @@ final private[client] class LockExecutor[K](leaseDuration: FiniteDuration, names
                 val checkWait = wait.fold(CIO.unit)(remainingWait(_).unit)
                 checkWait.flatMap(_ => remainingLease(state)).flatMap { _ =>
                   val work = CIO.defer(()).flatMap(_ => body()).flatMap(value => remainingLease(state).map(_ => value))
-                  // Returning errors as values lets first-success races stop on either body failure or lock loss.
+                  // The renewal branch starts before the lease midpoint and bounds its write by the remaining lease, so it also watches the
+                  // body deadline. Returning errors as values lets the race stop on either body failure or lock loss.
                   CIO.race(work.liftToTry, renew[A](runner, state).liftToTry).flatMap(CIO.get(_)).flatMap { value =>
                     state.stopped.set(true)
                     remainingLease(state).flatMap { remaining =>
                       remainingRelease(state).flatMap { releaseRemaining =>
                         CIO
                           .timeoutWithError(math.min(remaining, releaseRemaining).nanos)(LockLost("distributed lock release timed out"))(
-                            eval(runner, state, "release")
+                            eval(runner, state, Operation.Release)
                           )
                           .flatMap { released =>
                             state.mayOwn.set(false)
@@ -150,27 +159,89 @@ final private[client] class LockExecutor[K](leaseDuration: FiniteDuration, names
       }
     }
 
-  private def renew[A](runner: CommandRunner[CIO, String], state: Attempt): CIO[A] =
-    CIO.sleep(renewalDelay).flatMap { _ =>
-      if (state.stopped.get()) CIO.never
-      else
-        remainingLease(state).flatMap { remaining =>
-          CIO.nowMonotonic.flatMap { started =>
-            CIO
-              .timeoutWithError(remaining.nanos)(LockLost("distributed lock renewal timed out"))(
-                eval(runner, state, "renew", Some(Deadline(started.toNanos, remaining)))
-              )
-              .recover(renewalFailed)
-              .flatMap { renewed =>
-                if (!renewed) CIO.fail(LockLost("distributed lock ownership was lost during renewal"))
-                else
-                  remainingLease(state).flatMap { _ =>
-                    state.renewedAt.set(started.toNanos)
-                    renew[A](runner, state)
-                  }
-              }
+  private def acquire(
+    runner: CommandRunner[CIO, String],
+    state: Attempt,
+    deadline: Deadline,
+    retry: Int
+  ): CIO[Boolean] =
+    eval(runner, state, Operation.Acquire, Some(deadline)).recover {
+      case error if retryableAcquisitionFailure(error) =>
+        CIO.nowMonotonic.flatMap { now =>
+          val remaining = deadline.remainingAt(now.toNanos)
+          if (remaining <= 0L) CIO.fail(TimedOut("distributed lock acquisition timed out"))
+          else {
+            val delay = math.min(remaining, Backoff.jitteredMillis(failureBackoff, retry, Scheduler.real).millis.toNanos)
+            CIO.sleep(delay.nanos).flatMap(_ => acquire(runner, state, deadline, if (retry < Int.MaxValue) retry + 1 else retry))
           }
         }
+      case error                                       => CIO.fail(error)
+    }
+
+  private def renew[A](runner: CommandRunner[CIO, String], state: Attempt): CIO[A] =
+    remainingLease(state).flatMap { beforeDelay =>
+      // Acquisition confirmation can leave less than the usual renewal delay. Wake by the midpoint of the remaining conservative lease.
+      val delay = math.min(renewalDelay.toNanos, math.max(1L, beforeDelay / 2L)).nanos
+      CIO.sleep(delay).flatMap { _ =>
+        if (state.stopped.get()) CIO.never
+        else
+          renewAttempt(runner, state, retry = 0).flatMap(_ => renew[A](runner, state))
+      }
+    }
+
+  private def renewAttempt(runner: CommandRunner[CIO, String], state: Attempt, retry: Int): CIO[Unit] =
+    remainingLease(state).flatMap { remaining =>
+      CIO.nowMonotonic.flatMap { started =>
+        CIO
+          .timeoutWithError(remaining.nanos)(LockLost("distributed lock renewal timed out"))(
+            eval(runner, state, Operation.Renew, Some(Deadline(started.toNanos, remaining)))
+          )
+          .flatMap { renewed =>
+            if (!renewed) CIO.fail(LockLost("distributed lock ownership was lost during renewal"))
+            else
+              remainingLease(state).map { _ =>
+                state.renewedAt.set(started.toNanos)
+              }
+          }
+          .recover {
+            case error if retryableLockFailure(error) => retryRenewal(runner, state, retry, error)
+            case error                                => renewalFailed(error)
+          }
+      }
+    }
+
+  private def retryRenewal(
+    runner: CommandRunner[CIO, String],
+    state: Attempt,
+    retry: Int,
+    lastError: Throwable
+  ): CIO[Unit] =
+    CIO.nowMonotonic.flatMap { now =>
+      val remaining = usableNanos - (now.toNanos - state.renewedAt.get())
+      if (remaining <= 0L) renewalFailed(lastError)
+      else {
+        val delay = math.min(remaining, Backoff.jitteredMillis(failureBackoff, retry, Scheduler.real).millis.toNanos)
+        CIO.sleep(delay.nanos).flatMap { _ =>
+          if (state.stopped.get()) CIO.never
+          else
+            CIO.nowMonotonic.flatMap { afterDelay =>
+              if (usableNanos - (afterDelay.toNanos - state.renewedAt.get()) <= 0L) renewalFailed(lastError)
+              else renewAttempt(runner, state, if (retry < Int.MaxValue) retry + 1 else retry)
+            }
+        }
+      }
+    }
+
+  private def retryableLockFailure(error: Throwable): Boolean =
+    error.isInstanceOf[TimedOut] || (Fault.categorize(error) match {
+      case Fault.Redirected(_) | Fault.Demoted | Fault.Lost(_) | Fault.TryAgain | Fault.Unavailable(_) => true
+      case Fault.Fatal                                                                                 => false
+    })
+
+  private def retryableAcquisitionFailure(error: Throwable): Boolean =
+    Fault.categorize(error) match {
+      case Fault.Redirected(_) | Fault.Demoted | Fault.Lost(_) | Fault.TryAgain | Fault.Unavailable(_) => true
+      case Fault.Fatal                                                                                 => false
     }
 
   private def renewalFailed(cause: Throwable): CIO[Nothing] = cause match {
@@ -188,7 +259,7 @@ final private[client] class LockExecutor[K](leaseDuration: FiniteDuration, names
     else
       remainingRelease(state).flatMap { remaining =>
         if (remaining <= 0) CIO.unit
-        else CIO.timeout(remaining.nanos)(eval(runner, state, "release")).unit.recover(_ => CIO.unit)
+        else CIO.timeout(remaining.nanos)(eval(runner, state, Operation.Release)).unit.recover(_ => CIO.unit)
       }
   }
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/LockReplication.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LockReplication.scala
@@ -88,7 +88,7 @@ final private[client] class LockReplication(
 }
 
 private[client] object LockReplication {
-  final private class AcknowledgementFailure extends Exception
+  final private class AcknowledgementFailure extends Exception("replica acknowledgement shortfall")
 
   def acknowledgementTimedOut(message: String): TimedOut = {
     val timeout = TimedOut(message)

--- a/sage-client/shared/src/main/scala/sage/client/internal/LockReplication.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LockReplication.scala
@@ -1,0 +1,86 @@
+package sage.client.internal
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.concurrent.duration.*
+import scala.util.{Failure, Success, Try}
+
+import sage.SageException.{ConnectionLost, LockLost, TimedOut}
+import sage.commands.{Command, Connection, Reply, Role, Server}
+
+/**
+  * Confirms a lock write on the connection that executed it. Each instance handles one write and its replication check.
+  */
+final private[client] class LockReplication(
+  scheduler: Scheduler,
+  replicas: Int,
+  deadlineMillis: Long,
+  onConfirmationFailure: () => Unit,
+  replicaAcknowledgement: Boolean
+) {
+  private val confirming = new AtomicBoolean(false)
+
+  def cancelled(): Unit = if (confirming.get()) onConfirmationFailure()
+
+  def submit[A](conn: DedicatedConnection, command: Command[A], asking: Boolean, complete: Try[A] => Unit): Unit = {
+    // Report that the write may have executed. Lock acquisition retries are safe because they reuse the same ownership token.
+    def confirmationFailed(error: Throwable): Unit = {
+      onConfirmationFailure()
+      val failure = Fault.categorize(error) match {
+        case Fault.Lost(_) | Fault.Redirected(_) | Fault.TryAgain | Fault.Unavailable(_) =>
+          val lost = ConnectionLost(mayHaveExecuted = true)
+          lost.initCause(error)
+          lost
+        case _                                                                           => error
+      }
+      complete(Failure(failure))
+    }
+
+    def confirm(value: A): Unit = {
+      confirming.set(true)
+      conn.submit(
+        Server.role,
+        {
+          case Success(Role.Master(_, connected)) =>
+            if (replicaAcknowledgement) waitForReplicas(conn, value, connected.size, complete, confirmationFailed)
+            else complete(Success(value))
+          case Success(_)                         => confirmationFailed(LockLost("the granting node is no longer a master"))
+          case Failure(error)                     => confirmationFailed(error)
+        }
+      )
+    }
+
+    val onReply: Try[A] => Unit = {
+      case Success(value) if value == true => confirm(value)
+      case result                          => complete(result)
+    }
+    if (asking)
+      conn.submitRaw(Vector(Connection.asking, command.rawFrame), result => onReply(result.flatMap(frames => Reply.decode(command, frames.last))))
+    else conn.submit(command, onReply)
+  }
+
+  private def waitForReplicas[A](
+    conn: DedicatedConnection,
+    value: A,
+    connected: Int,
+    complete: Try[A] => Unit,
+    confirmationFailed: Throwable => Unit
+  ): Unit = {
+    val required = math.max(replicas, connected)
+    if (required == 0) complete(Success(value))
+    else {
+      // Reserve half the remaining budget for the server's timeout processing and the reply's transit.
+      val waitMillis = (deadlineMillis - scheduler.nowMillis) / 2L
+      if (waitMillis <= 0L) confirmationFailed(TimedOut("distributed lock replication deadline reached before WAIT"))
+      else
+        conn.submit(
+          Server.waitReplicas(required.toLong, waitMillis.millis),
+          {
+            case Success(count) if count >= required => complete(Success(value))
+            case Success(count)                      => confirmationFailed(TimedOut(s"replication confirmed by $count of $required required replicas"))
+            case Failure(error)                      => confirmationFailed(error)
+          }
+        )
+    }
+  }
+}

--- a/sage-client/shared/src/main/scala/sage/client/internal/LockReplication.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LockReplication.scala
@@ -13,8 +13,8 @@ import sage.commands.{Command, Connection, Reply, Role, Server}
   */
 final private[client] class LockReplication(
   scheduler: Scheduler,
-  replicas: Int,
-  deadlineMillis: Long,
+  knownReplicaCount: Int,
+  val deadlineMillis: Long,
   onConfirmationFailure: () => Unit,
   replicaAcknowledgement: Boolean
 ) {
@@ -23,7 +23,7 @@ final private[client] class LockReplication(
   def cancelled(): Unit = if (confirming.get()) onConfirmationFailure()
 
   def submit[A](conn: DedicatedConnection, command: Command[A], asking: Boolean, complete: Try[A] => Unit): Unit = {
-    // Report that the write may have executed. Lock acquisition retries are safe because they reuse the same ownership token.
+    // Lock acquisition retries are safe because they reuse the same ownership token.
     def confirmationFailed(error: Throwable): Unit = {
       onConfirmationFailure()
       val failure = Fault.categorize(error) match {
@@ -41,11 +41,11 @@ final private[client] class LockReplication(
       conn.submit(
         Server.role,
         {
-          case Success(Role.Master(_, connected)) =>
-            if (replicaAcknowledgement) waitForReplicas(conn, value, connected.size, complete, confirmationFailed)
+          case Success(Role.Master(_, connectedReplicas)) =>
+            if (replicaAcknowledgement) waitForReplicas(conn, value, connectedReplicas.size, complete, confirmationFailed)
             else complete(Success(value))
-          case Success(_)                         => confirmationFailed(LockLost("the granting node is no longer a master"))
-          case Failure(error)                     => confirmationFailed(error)
+          case Success(_)                                 => confirmationFailed(LockLost("the granting node is no longer a master"))
+          case Failure(error)                             => confirmationFailed(error)
         }
       )
     }
@@ -62,25 +62,40 @@ final private[client] class LockReplication(
   private def waitForReplicas[A](
     conn: DedicatedConnection,
     value: A,
-    connected: Int,
+    connectedReplicaCount: Int,
     complete: Try[A] => Unit,
     confirmationFailed: Throwable => Unit
   ): Unit = {
-    val required = math.max(replicas, connected)
+    val required = math.max(knownReplicaCount, connectedReplicaCount)
     if (required == 0) complete(Success(value))
     else {
       // Reserve half the remaining budget for the server's timeout processing and the reply's transit.
       val waitMillis = (deadlineMillis - scheduler.nowMillis) / 2L
-      if (waitMillis <= 0L) confirmationFailed(TimedOut("distributed lock replication deadline reached before WAIT"))
+      if (waitMillis <= 0L)
+        confirmationFailed(LockReplication.acknowledgementTimedOut("distributed lock replication deadline reached before WAIT"))
       else
         conn.submit(
           Server.waitReplicas(required.toLong, waitMillis.millis),
           {
             case Success(count) if count >= required => complete(Success(value))
-            case Success(count)                      => confirmationFailed(TimedOut(s"replication confirmed by $count of $required required replicas"))
+            case Success(count)                      =>
+              confirmationFailed(LockReplication.acknowledgementTimedOut(s"replication confirmed by $count of $required required replicas"))
             case Failure(error)                      => confirmationFailed(error)
           }
         )
     }
   }
+}
+
+private[client] object LockReplication {
+  final private class AcknowledgementFailure extends Exception
+
+  def acknowledgementTimedOut(message: String): TimedOut = {
+    val timeout = TimedOut(message)
+    timeout.initCause(new AcknowledgementFailure)
+    timeout
+  }
+
+  def isAcknowledgementFailure(error: Throwable): Boolean =
+    error.isInstanceOf[TimedOut] && error.getCause.isInstanceOf[AcknowledgementFailure]
 }

--- a/sage-client/shared/src/main/scala/sage/client/internal/LoweredClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/LoweredClient.scala
@@ -26,13 +26,21 @@ abstract class LoweredClient[F[_]](underlying: Client[CIO, String]) extends Clie
 
   protected def lockCommand[A](command: Command[A]): CIO[A] = underlying.run(command)
 
-  protected def confirmedLockCommand(command: Command[Boolean], timeout: FiniteDuration): CIO[Boolean] =
-    underlying.lockWrite(command, timeout)
+  protected def confirmedLockCommand(
+    command: Command[Boolean],
+    timeout: FiniteDuration,
+    replicaAcknowledgement: Boolean
+  ): CIO[Boolean] =
+    underlying.lockWrite(command, timeout, replicaAcknowledgement)
 
   private val lockRunner: CommandRunner[CIO, String] = new CommandRunner[CIO, String] {
-    def run[A](command: Command[A]): CIO[A]                                                                = lockCommand(command)
-    override private[sage] def lockWrite(command: Command[Boolean], timeout: FiniteDuration): CIO[Boolean] =
-      confirmedLockCommand(command, timeout)
+    def run[A](command: Command[A]): CIO[A] = lockCommand(command)
+    override private[sage] def lockWrite(
+      command: Command[Boolean],
+      timeout: FiniteDuration,
+      replicaAcknowledgement: Boolean
+    ): CIO[Boolean]                         =
+      confirmedLockCommand(command, timeout, replicaAcknowledgement)
   }
 
   final def run[A](command: Command[A]): F[A] = lower(underlying.run(command))

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -244,7 +244,11 @@ final private[client] class MasterReplicaLive(
     Client.withLeaseIfBlocking(command)(body)
   }
 
-  override private[sage] def lockWrite(command: Command[Boolean], timeout: FiniteDuration): CIO[Boolean] =
+  override private[sage] def lockWrite(
+    command: Command[Boolean],
+    timeout: FiniteDuration,
+    replicaAcknowledgement: Boolean
+  ): CIO[Boolean] =
     Client.withLockLease(timeout, scheduler) { (lease, deadlineMillis) =>
       CIO.async { complete =>
         val tracked = Events.trackCommand(events, command, complete)
@@ -257,7 +261,8 @@ final private[client] class MasterReplicaLive(
               deadlineMillis,
               cb,
               lease,
-              () => refreshThrottle.request(rediscoverWork)
+              () => refreshThrottle.request(rediscoverWork),
+              replicaAcknowledgement
             )
           }
         }

--- a/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/MasterReplicaLive.scala
@@ -254,15 +254,19 @@ final private[client] class MasterReplicaLive(
         val tracked = Events.trackCommand(events, command, complete)
         Client.completing(tracked) {
           onMaster(tracked) { (nc, _, cb) =>
+            val replication = new LockReplication(
+              scheduler,
+              replicasRef.get().size,
+              deadlineMillis,
+              () => refreshThrottle.request(rediscoverWork),
+              replicaAcknowledgement
+            )
             nc.submitLockWrite(
               command,
               asking = false,
-              replicasRef.get().size,
-              deadlineMillis,
               cb,
               lease,
-              () => refreshThrottle.request(rediscoverWork),
-              replicaAcknowledgement
+              replication
             )
           }
         }

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
@@ -25,13 +25,10 @@ final private[client] class NodeClient(connection: MultiplexedConnection, pool: 
   def submitLockWrite[A](
     command: Command[A],
     asking: Boolean,
-    replicas: Int,
-    deadlineMillis: Long,
     callback: Try[A] => Unit,
     lease: DedicatedPool.Lease,
-    onConfirmationFailure: () => Unit,
-    replicaAcknowledgement: Boolean
-  ): Unit = pool.useLockWrite(command, asking, replicas, deadlineMillis, callback, lease, onConfirmationFailure, replicaAcknowledgement)
+    replication: LockReplication
+  ): Unit = pool.useLockWrite(command, asking, callback, lease, replication)
 
   def cachedSubmit[A](command: Command[A], ttlMillis: Long, callback: Try[A] => Unit, deferred: () => CommandSpan = null): Unit =
     connection.cachedSubmit(command, ttlMillis, callback, deferred)

--- a/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
+++ b/sage-client/shared/src/main/scala/sage/client/internal/NodeClient.scala
@@ -29,8 +29,9 @@ final private[client] class NodeClient(connection: MultiplexedConnection, pool: 
     deadlineMillis: Long,
     callback: Try[A] => Unit,
     lease: DedicatedPool.Lease,
-    onConfirmationFailure: () => Unit
-  ): Unit = pool.useLockWrite(command, asking, replicas, deadlineMillis, callback, lease, onConfirmationFailure)
+    onConfirmationFailure: () => Unit,
+    replicaAcknowledgement: Boolean
+  ): Unit = pool.useLockWrite(command, asking, replicas, deadlineMillis, callback, lease, onConfirmationFailure, replicaAcknowledgement)
 
   def cachedSubmit[A](command: Command[A], ttlMillis: Long, callback: Try[A] => Unit, deferred: () => CommandSpan = null): Unit =
     connection.cachedSubmit(command, ttlMillis, callback, deferred)

--- a/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
@@ -44,10 +44,18 @@ class DedicatedPoolSpec extends munit.FunSuite {
   private val lockWrite =
     new LockCommands[String](3.seconds, "lock").command(Bytes.utf8("key"), "owner", LockCommands.Operation.Acquire, cached = true)
 
+  private def replication(
+    scheduler: Scheduler,
+    knownReplicaCount: Int,
+    deadlineMillis: Long,
+    onConfirmationFailure: () => Unit = () => ()
+  ): LockReplication =
+    new LockReplication(scheduler, knownReplicaCount, deadlineMillis, onConfirmationFailure, replicaAcknowledgement = true)
+
   test("WAIT accounts for elapsed work and leaves time to return a shortfall on a reusable socket") {
     val (pool, scheduler, transports) = make(replyWith(Nil))
     var result: Option[Try[Boolean]]  = None
-    pool.useLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => (), true)
+    pool.useLockWrite(lockWrite, false, r => result = Some(r), new DedicatedPool.Lease, replication(scheduler, 1, 100L))
     scheduler.advance(40.millis)
     val transport                     = transports.head
     transport.emit(Frame.Integer(1))
@@ -57,7 +65,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
     scheduler.advance(20.millis)
     transport.emit(Frame.Integer(0))
     assert(result.get.failed.get.isInstanceOf[TimedOut])
-    pool.useLockWrite(lockWrite, false, 0, 200L, _ => (), new DedicatedPool.Lease, () => (), true)
+    pool.useLockWrite(lockWrite, false, _ => (), new DedicatedPool.Lease, replication(scheduler, 0, 200L))
     scheduler.advance(Duration.Zero)
     assertEquals(transports.size, 1)
     pool.close()
@@ -66,7 +74,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
   test("an exhausted confirmation budget never sends an unbounded WAIT") {
     val (pool, scheduler, transports) = make(replyWith(Nil))
     var result: Option[Try[Boolean]]  = None
-    pool.useLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => (), true)
+    pool.useLockWrite(lockWrite, false, r => result = Some(r), new DedicatedPool.Lease, replication(scheduler, 1, 100L))
     scheduler.advance(Duration.Zero)
     transports.head.emit(Frame.Integer(1))
     scheduler.advance(99.millis)
@@ -79,7 +87,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
   test("lock writes keep their socket until every required replica acknowledges") {
     val (pool, scheduler, transports) = make(replyWith(Nil))
     var result: Option[Try[Boolean]]  = None
-    pool.useLockWrite(lockWrite, false, 2, 100L, r => result = Some(r), new DedicatedPool.Lease, () => (), true)
+    pool.useLockWrite(lockWrite, false, r => result = Some(r), new DedicatedPool.Lease, replication(scheduler, 2, 100L))
     scheduler.advance(Duration.Zero)
     val transport                     = transports.head
     transport.emit(Frame.Integer(1))
@@ -90,7 +98,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
     assertEquals(result, None)
     transport.emit(Frame.Integer(2))
     assertEquals(result, Some(Success(true)))
-    pool.useLockWrite(lockWrite, false, 0, 100L, _ => (), new DedicatedPool.Lease, () => (), true)
+    pool.useLockWrite(lockWrite, false, _ => (), new DedicatedPool.Lease, replication(scheduler, 0, 100L))
     scheduler.advance(Duration.Zero)
     assertEquals(transports.size, 1)
     pool.close()
@@ -101,7 +109,13 @@ class DedicatedPoolSpec extends munit.FunSuite {
       val (pool, scheduler, transports) = make(replyWith(Nil))
       var result: Option[Try[Boolean]]  = None
       var refreshed                     = false
-      pool.useLockWrite(lockWrite, false, known, 100L, r => result = Some(r), new DedicatedPool.Lease, () => refreshed = true, true)
+      pool.useLockWrite(
+        lockWrite,
+        false,
+        r => result = Some(r),
+        new DedicatedPool.Lease,
+        replication(scheduler, known, 100L, () => refreshed = true)
+      )
       scheduler.advance(Duration.Zero)
       transports.head.emit(Frame.Integer(1))
       transports.head.emit(Replies.masterRole(connected*))
@@ -115,12 +129,12 @@ class DedicatedPoolSpec extends munit.FunSuite {
   test("busy locks skip confirmation and masters without replicas skip WAIT") {
     val (pool, scheduler, transports) = make(replyWith(Nil))
     var result: Option[Try[Boolean]]  = None
-    pool.useLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => (), true)
+    pool.useLockWrite(lockWrite, false, r => result = Some(r), new DedicatedPool.Lease, replication(scheduler, 1, 100L))
     scheduler.advance(Duration.Zero)
     transports.head.emit(Frame.Integer(0))
     assertEquals(result, Some(Success(false)))
     assert(!transports.head.written.exists(_.asUtf8String.contains("ROLE")))
-    pool.useLockWrite(lockWrite, false, 0, 100L, r => result = Some(r), new DedicatedPool.Lease, () => (), true)
+    pool.useLockWrite(lockWrite, false, r => result = Some(r), new DedicatedPool.Lease, replication(scheduler, 0, 100L))
     scheduler.advance(Duration.Zero)
     transports.head.emit(Frame.Integer(1))
     transports.head.emit(Replies.masterRole())
@@ -132,7 +146,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
   test("ASKING precedes the lock write on the socket that confirms it") {
     val (pool, scheduler, transports) = make(replyWith(Nil))
     var result: Option[Try[Boolean]]  = None
-    pool.useLockWrite(lockWrite, true, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => (), true)
+    pool.useLockWrite(lockWrite, true, r => result = Some(r), new DedicatedPool.Lease, replication(scheduler, 1, 100L))
     scheduler.advance(Duration.Zero)
     assert(transports.head.written.last.sameBytes(Bytes.concat(Vector(Connection.asking.encode, lockWrite.encode))))
     transports.head.emit(Replies.ok)
@@ -147,7 +161,13 @@ class DedicatedPoolSpec extends munit.FunSuite {
     val (pool, scheduler, transports) = make(replyWith(Nil))
     var result: Option[Try[Boolean]]  = None
     var refreshed                     = false
-    pool.useLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => refreshed = true, true)
+    pool.useLockWrite(
+      lockWrite,
+      false,
+      r => result = Some(r),
+      new DedicatedPool.Lease,
+      replication(scheduler, 1, 100L, () => refreshed = true)
+    )
     scheduler.advance(Duration.Zero)
     transports.head.emit(Frame.Integer(1))
     transports.head.close()
@@ -171,7 +191,13 @@ class DedicatedPoolSpec extends munit.FunSuite {
     val lease                         = new DedicatedPool.Lease
     var result: Option[Try[Boolean]]  = None
     var refreshed                     = false
-    node.submitLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), lease, () => refreshed = true, true)
+    node.submitLockWrite(
+      lockWrite,
+      false,
+      r => result = Some(r),
+      lease,
+      replication(scheduler, 1, 100L, () => refreshed = true)
+    )
     scheduler.advance(Duration.Zero)
     transports.head.emit(Frame.Integer(1))
     transports.head.emit(Replies.masterRole(Node("replica", 6380)))
@@ -183,7 +209,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
     scheduler.advance(Duration.Zero)
     assertEquals(result, Some(Failure(ConnectionLost(mayHaveExecuted = true))))
     assert(refreshed)
-    node.submitLockWrite(lockWrite, false, 0, 100L, _ => (), new DedicatedPool.Lease, () => (), true)
+    node.submitLockWrite(lockWrite, false, _ => (), new DedicatedPool.Lease, replication(scheduler, 0, 100L))
     scheduler.advance(Duration.Zero)
     assertEquals(transports.size, 2)
     assertEquals(transports.head.closeCount, 1)
@@ -292,7 +318,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
     val (pool, scheduler, transports) = make(replyWith(Seq(popReply)), config = config)
     val held                          = pool.acquireForTransaction()
     var result: Option[Try[Boolean]]  = None
-    pool.useLockWrite(lockWrite, false, 0, 40L, r => result = Some(r), new DedicatedPool.Lease, () => (), true)
+    pool.useLockWrite(lockWrite, false, r => result = Some(r), new DedicatedPool.Lease, replication(scheduler, 0, 40L))
     val started                       = System.nanoTime()
     scheduler.advance(Duration.Zero)
     assert((System.nanoTime() - started).nanos < 1.second)

--- a/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/DedicatedPoolSpec.scala
@@ -41,12 +41,13 @@ class DedicatedPoolSpec extends munit.FunSuite {
     (pool, scheduler, transports)
   }
 
-  private val lockWrite = new LockCommands[String](3.seconds, "lock").command(Bytes.utf8("key"), "owner", "acquire", cached = true)
+  private val lockWrite =
+    new LockCommands[String](3.seconds, "lock").command(Bytes.utf8("key"), "owner", LockCommands.Operation.Acquire, cached = true)
 
   test("WAIT accounts for elapsed work and leaves time to return a shortfall on a reusable socket") {
     val (pool, scheduler, transports) = make(replyWith(Nil))
     var result: Option[Try[Boolean]]  = None
-    pool.useLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => ())
+    pool.useLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => (), true)
     scheduler.advance(40.millis)
     val transport                     = transports.head
     transport.emit(Frame.Integer(1))
@@ -56,7 +57,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
     scheduler.advance(20.millis)
     transport.emit(Frame.Integer(0))
     assert(result.get.failed.get.isInstanceOf[TimedOut])
-    pool.useLockWrite(lockWrite, false, 0, 200L, _ => (), new DedicatedPool.Lease, () => ())
+    pool.useLockWrite(lockWrite, false, 0, 200L, _ => (), new DedicatedPool.Lease, () => (), true)
     scheduler.advance(Duration.Zero)
     assertEquals(transports.size, 1)
     pool.close()
@@ -65,7 +66,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
   test("an exhausted confirmation budget never sends an unbounded WAIT") {
     val (pool, scheduler, transports) = make(replyWith(Nil))
     var result: Option[Try[Boolean]]  = None
-    pool.useLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => ())
+    pool.useLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => (), true)
     scheduler.advance(Duration.Zero)
     transports.head.emit(Frame.Integer(1))
     scheduler.advance(99.millis)
@@ -78,7 +79,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
   test("lock writes keep their socket until every required replica acknowledges") {
     val (pool, scheduler, transports) = make(replyWith(Nil))
     var result: Option[Try[Boolean]]  = None
-    pool.useLockWrite(lockWrite, false, 2, 100L, r => result = Some(r), new DedicatedPool.Lease, () => ())
+    pool.useLockWrite(lockWrite, false, 2, 100L, r => result = Some(r), new DedicatedPool.Lease, () => (), true)
     scheduler.advance(Duration.Zero)
     val transport                     = transports.head
     transport.emit(Frame.Integer(1))
@@ -89,7 +90,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
     assertEquals(result, None)
     transport.emit(Frame.Integer(2))
     assertEquals(result, Some(Success(true)))
-    pool.useLockWrite(lockWrite, false, 0, 100L, _ => (), new DedicatedPool.Lease, () => ())
+    pool.useLockWrite(lockWrite, false, 0, 100L, _ => (), new DedicatedPool.Lease, () => (), true)
     scheduler.advance(Duration.Zero)
     assertEquals(transports.size, 1)
     pool.close()
@@ -100,7 +101,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
       val (pool, scheduler, transports) = make(replyWith(Nil))
       var result: Option[Try[Boolean]]  = None
       var refreshed                     = false
-      pool.useLockWrite(lockWrite, false, known, 100L, r => result = Some(r), new DedicatedPool.Lease, () => refreshed = true)
+      pool.useLockWrite(lockWrite, false, known, 100L, r => result = Some(r), new DedicatedPool.Lease, () => refreshed = true, true)
       scheduler.advance(Duration.Zero)
       transports.head.emit(Frame.Integer(1))
       transports.head.emit(Replies.masterRole(connected*))
@@ -114,12 +115,12 @@ class DedicatedPoolSpec extends munit.FunSuite {
   test("busy locks skip confirmation and masters without replicas skip WAIT") {
     val (pool, scheduler, transports) = make(replyWith(Nil))
     var result: Option[Try[Boolean]]  = None
-    pool.useLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => ())
+    pool.useLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => (), true)
     scheduler.advance(Duration.Zero)
     transports.head.emit(Frame.Integer(0))
     assertEquals(result, Some(Success(false)))
     assert(!transports.head.written.exists(_.asUtf8String.contains("ROLE")))
-    pool.useLockWrite(lockWrite, false, 0, 100L, r => result = Some(r), new DedicatedPool.Lease, () => ())
+    pool.useLockWrite(lockWrite, false, 0, 100L, r => result = Some(r), new DedicatedPool.Lease, () => (), true)
     scheduler.advance(Duration.Zero)
     transports.head.emit(Frame.Integer(1))
     transports.head.emit(Replies.masterRole())
@@ -131,7 +132,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
   test("ASKING precedes the lock write on the socket that confirms it") {
     val (pool, scheduler, transports) = make(replyWith(Nil))
     var result: Option[Try[Boolean]]  = None
-    pool.useLockWrite(lockWrite, true, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => ())
+    pool.useLockWrite(lockWrite, true, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => (), true)
     scheduler.advance(Duration.Zero)
     assert(transports.head.written.last.sameBytes(Bytes.concat(Vector(Connection.asking.encode, lockWrite.encode))))
     transports.head.emit(Replies.ok)
@@ -146,7 +147,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
     val (pool, scheduler, transports) = make(replyWith(Nil))
     var result: Option[Try[Boolean]]  = None
     var refreshed                     = false
-    pool.useLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => refreshed = true)
+    pool.useLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), new DedicatedPool.Lease, () => refreshed = true, true)
     scheduler.advance(Duration.Zero)
     transports.head.emit(Frame.Integer(1))
     transports.head.close()
@@ -170,7 +171,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
     val lease                         = new DedicatedPool.Lease
     var result: Option[Try[Boolean]]  = None
     var refreshed                     = false
-    node.submitLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), lease, () => refreshed = true)
+    node.submitLockWrite(lockWrite, false, 1, 100L, r => result = Some(r), lease, () => refreshed = true, true)
     scheduler.advance(Duration.Zero)
     transports.head.emit(Frame.Integer(1))
     transports.head.emit(Replies.masterRole(Node("replica", 6380)))
@@ -182,7 +183,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
     scheduler.advance(Duration.Zero)
     assertEquals(result, Some(Failure(ConnectionLost(mayHaveExecuted = true))))
     assert(refreshed)
-    node.submitLockWrite(lockWrite, false, 0, 100L, _ => (), new DedicatedPool.Lease, () => ())
+    node.submitLockWrite(lockWrite, false, 0, 100L, _ => (), new DedicatedPool.Lease, () => (), true)
     scheduler.advance(Duration.Zero)
     assertEquals(transports.size, 2)
     assertEquals(transports.head.closeCount, 1)
@@ -291,7 +292,7 @@ class DedicatedPoolSpec extends munit.FunSuite {
     val (pool, scheduler, transports) = make(replyWith(Seq(popReply)), config = config)
     val held                          = pool.acquireForTransaction()
     var result: Option[Try[Boolean]]  = None
-    pool.useLockWrite(lockWrite, false, 0, 40L, r => result = Some(r), new DedicatedPool.Lease, () => ())
+    pool.useLockWrite(lockWrite, false, 0, 40L, r => result = Some(r), new DedicatedPool.Lease, () => (), true)
     val started                       = System.nanoTime()
     scheduler.advance(Duration.Zero)
     assert((System.nanoTime() - started).nanos < 1.second)

--- a/sage-client/shared/src/test/scala/sage/client/internal/LockCancellationSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/LockCancellationSpec.scala
@@ -57,15 +57,13 @@ abstract class LockCancellationSpec extends munit.FunSuite {
     })(CIO.never)
     CIO
       .timeout(150.millis)(tryWithLock(runner(released, renewals, false, releaseCompleted), 300.millis)(body))
-      .flatMap { result =>
-        assertEquals(result, None)
-        CIO.blocking {
-          assert(cleanupCompleted.await(2, TimeUnit.SECONDS), "lock cleanup did not complete")
-          assert(released.get())
-          assert(bodyStopped.get())
-        }
-      }
       .unsafeRun
+      .map { result =>
+        assertEquals(result, None)
+        assert(cleanupCompleted.await(2, TimeUnit.SECONDS), "lock cleanup did not complete")
+        assert(released.get())
+        assert(bodyStopped.get())
+      }
   }
 
   test("losing ownership cancels the protected body") {
@@ -79,13 +77,11 @@ abstract class LockCancellationSpec extends munit.FunSuite {
       bodyStopped.set(true)
       cleanupCompleted.countDown()
     })(CIO.never)
-    tryWithLock(commands, 300.millis)(body).liftToTry.flatMap { result =>
+    tryWithLock(commands, 300.millis)(body).liftToTry.unsafeRun.map { result =>
       assert(result.failed.get.isInstanceOf[LockLost], result.toString)
-      CIO.blocking {
-        assert(cleanupCompleted.await(2, TimeUnit.SECONDS), "body finalizer did not complete")
-        assert(bodyStopped.get())
-      }
-    }.unsafeRun
+      assert(cleanupCompleted.await(2, TimeUnit.SECONDS), "body finalizer did not complete")
+      assert(bodyStopped.get())
+    }
   }
 
   test("cleanup stays bounded when the release command never replies") {

--- a/sage-client/shared/src/test/scala/sage/client/internal/LockCancellationSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/LockCancellationSpec.scala
@@ -19,10 +19,10 @@ abstract class LockCancellationSpec extends munit.FunSuite {
   private given ExecutionContext = munitExecutionContext
 
   protected def tryWithLock[A](commands: CommandRunner[CIO, String], lease: FiniteDuration)(body: CIO[A]): CIO[Option[A]] =
-    new LockExecutor[String](lease, "cancel").tryWithLock(commands, "key")(body)
+    new LockExecutor[String](lease, "cancel", replicaAcknowledgement = true).tryWithLock(commands, "key")(body)
 
   protected def withLock[A](commands: CommandRunner[CIO, String], lease: FiniteDuration, wait: FiniteDuration)(body: CIO[A]): CIO[A] =
-    new LockExecutor[String](lease, "cancel").withLock(commands, "key", wait)(body)
+    new LockExecutor[String](lease, "cancel", replicaAcknowledgement = true).withLock(commands, "key", wait)(body)
 
   protected def runner(released: AtomicBoolean, renewals: AtomicInteger, stallRelease: Boolean): CommandRunner[CIO, String] =
     new CommandRunner[CIO, String] {

--- a/sage-client/shared/src/test/scala/sage/client/internal/LockCancellationSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/LockCancellationSpec.scala
@@ -1,9 +1,8 @@
 package sage.client.internal
 
-import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Promise}
 import scala.concurrent.duration.*
 
 import kyo.compat.*
@@ -49,18 +48,27 @@ abstract class LockCancellationSpec extends munit.FunSuite {
     val released         = new AtomicBoolean(false)
     val renewals         = new AtomicInteger(0)
     val bodyStopped      = new AtomicBoolean(false)
-    val cleanupCompleted = new CountDownLatch(2)
-    val releaseCompleted = () => cleanupCompleted.countDown()
+    val remainingCleanup = new AtomicInteger(2)
+    val cleanupCompleted = Promise[Unit]()
+    val signalCleanup    = () => {
+      if (remainingCleanup.decrementAndGet() == 0) {
+        val _ = cleanupCompleted.trySuccess(())
+      }
+      ()
+    }
+    val releaseCompleted = () => signalCleanup()
     val body             = CIO.ensure(CIO.defer {
       bodyStopped.set(true)
-      cleanupCompleted.countDown()
+      signalCleanup()
     })(CIO.never)
     CIO
       .timeout(150.millis)(tryWithLock(runner(released, renewals, false, releaseCompleted), 300.millis)(body))
       .unsafeRun
       .map { result =>
         assertEquals(result, None)
-        assert(cleanupCompleted.await(2, TimeUnit.SECONDS), "lock cleanup did not complete")
+      }
+      .flatMap(_ => cleanupCompleted.future)
+      .map { _ =>
         assert(released.get())
         assert(bodyStopped.get())
       }
@@ -68,20 +76,20 @@ abstract class LockCancellationSpec extends munit.FunSuite {
 
   test("losing ownership cancels the protected body") {
     val bodyStopped      = new AtomicBoolean(false)
-    val cleanupCompleted = new CountDownLatch(1)
+    val cleanupCompleted = Promise[Unit]()
     val commands         = new CommandRunner[CIO, String] {
       def run[A](command: Command[A]): CIO[A] =
         command.decode(Frame.Integer(if (command.args(4).asUtf8String == "renew") 0 else 1)).fold(CIO.fail(_), CIO.value(_))
     }
     val body             = CIO.ensure(CIO.defer {
       bodyStopped.set(true)
-      cleanupCompleted.countDown()
+      val _ = cleanupCompleted.trySuccess(())
+      ()
     })(CIO.never)
-    tryWithLock(commands, 300.millis)(body).liftToTry.unsafeRun.map { result =>
-      assert(result.failed.get.isInstanceOf[LockLost], result.toString)
-      assert(cleanupCompleted.await(2, TimeUnit.SECONDS), "body finalizer did not complete")
-      assert(bodyStopped.get())
-    }
+    tryWithLock(commands, 300.millis)(body).liftToTry.unsafeRun
+      .map(result => assert(result.failed.get.isInstanceOf[LockLost], result.toString))
+      .flatMap(_ => cleanupCompleted.future)
+      .map(_ => assert(bodyStopped.get()))
   }
 
   test("cleanup stays bounded when the release command never replies") {

--- a/sage-client/shared/src/test/scala/sage/client/internal/LockCancellationSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/LockCancellationSpec.scala
@@ -1,5 +1,6 @@
 package sage.client.internal
 
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
 import scala.concurrent.ExecutionContext
@@ -24,12 +25,19 @@ abstract class LockCancellationSpec extends munit.FunSuite {
   protected def withLock[A](commands: CommandRunner[CIO, String], lease: FiniteDuration, wait: FiniteDuration)(body: CIO[A]): CIO[A] =
     new LockExecutor[String](lease, "cancel", replicaAcknowledgement = true).withLock(commands, "key", wait)(body)
 
-  protected def runner(released: AtomicBoolean, renewals: AtomicInteger, stallRelease: Boolean): CommandRunner[CIO, String] =
+  protected def runner(
+    released: AtomicBoolean,
+    renewals: AtomicInteger,
+    stallRelease: Boolean,
+    releaseCompleted: () => Unit = () => ()
+  ): CommandRunner[CIO, String] =
     new CommandRunner[CIO, String] {
       def run[A](command: Command[A]): CIO[A] = CIO.defer(()).flatMap { _ =>
         command.args(4).asUtf8String match {
           case "renew"   => renewals.incrementAndGet()
-          case "release" => released.set(true)
+          case "release" =>
+            released.set(true)
+            releaseCompleted()
           case _         => ()
         }
         if (stallRelease && command.args(4).asUtf8String == "release") CIO.never
@@ -37,36 +45,46 @@ abstract class LockCancellationSpec extends munit.FunSuite {
       }
     }
 
-  test("cancelling a protected body releases ownership and stops renewal") {
-    val released    = new AtomicBoolean(false)
-    val renewals    = new AtomicInteger(0)
-    val bodyStopped = new AtomicBoolean(false)
-    val body        = CIO.ensure(CIO.defer(bodyStopped.set(true)))(CIO.never)
+  test("cancelling a protected body releases ownership and runs its finalizer") {
+    val released         = new AtomicBoolean(false)
+    val renewals         = new AtomicInteger(0)
+    val bodyStopped      = new AtomicBoolean(false)
+    val cleanupCompleted = new CountDownLatch(2)
+    val releaseCompleted = () => cleanupCompleted.countDown()
+    val body             = CIO.ensure(CIO.defer {
+      bodyStopped.set(true)
+      cleanupCompleted.countDown()
+    })(CIO.never)
     CIO
-      .timeout(150.millis)(tryWithLock(runner(released, renewals, false), 300.millis)(body))
+      .timeout(150.millis)(tryWithLock(runner(released, renewals, false, releaseCompleted), 300.millis)(body))
       .flatMap { result =>
         assertEquals(result, None)
-        // Kyo runs interrupt finalizers asynchronously.
-        CIO.sleep(100.millis).flatMap { _ =>
+        CIO.blocking {
+          assert(cleanupCompleted.await(2, TimeUnit.SECONDS), "lock cleanup did not complete")
           assert(released.get())
           assert(bodyStopped.get())
-          val count = renewals.get()
-          CIO.sleep(400.millis).map(_ => assertEquals(renewals.get(), count))
         }
       }
       .unsafeRun
   }
 
   test("losing ownership cancels the protected body") {
-    val bodyStopped = new AtomicBoolean(false)
-    val commands    = new CommandRunner[CIO, String] {
+    val bodyStopped      = new AtomicBoolean(false)
+    val cleanupCompleted = new CountDownLatch(1)
+    val commands         = new CommandRunner[CIO, String] {
       def run[A](command: Command[A]): CIO[A] =
         command.decode(Frame.Integer(if (command.args(4).asUtf8String == "renew") 0 else 1)).fold(CIO.fail(_), CIO.value(_))
     }
-    val body        = CIO.ensure(CIO.defer(bodyStopped.set(true)))(CIO.never)
+    val body             = CIO.ensure(CIO.defer {
+      bodyStopped.set(true)
+      cleanupCompleted.countDown()
+    })(CIO.never)
     tryWithLock(commands, 300.millis)(body).liftToTry.flatMap { result =>
       assert(result.failed.get.isInstanceOf[LockLost], result.toString)
-      CIO.sleep(100.millis).map(_ => assert(bodyStopped.get()))
+      CIO.blocking {
+        assert(cleanupCompleted.await(2, TimeUnit.SECONDS), "body finalizer did not complete")
+        assert(bodyStopped.get())
+      }
     }.unsafeRun
   }
 

--- a/sage-client/shared/src/test/scala/sage/client/internal/LockExecutorSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/LockExecutorSpec.scala
@@ -10,7 +10,7 @@ import scala.jdk.CollectionConverters.*
 import kyo.compat.*
 
 import sage.Bytes
-import sage.SageException.{InvalidArgument, LockLost, ServerError, TimedOut}
+import sage.SageException.{ConnectionLost, InvalidArgument, LockLost, NotConnected, ServerError, TimedOut}
 import sage.client.SageConfig
 import sage.commands.Command
 import sage.protocol.Frame
@@ -55,10 +55,13 @@ class LockExecutorSpec extends munit.FunSuite {
     val tokens                                        = new ConcurrentLinkedQueue[String]()
     @volatile var rejectRenewal                       = false
     @volatile var stallRenewal                        = false
+    val renewalErrors                                 = new ConcurrentLinkedQueue[Throwable]()
     @volatile var failRelease                         = false
     @volatile var stallRelease                        = false
     @volatile var acquisitionDelay                    = Duration.Zero
     @volatile var acquisitionError: Option[Throwable] = None
+    val acquisitionErrors                             = new ConcurrentLinkedQueue[Throwable]()
+    val acquisitionReplyErrors                        = new ConcurrentLinkedQueue[Throwable]()
 
     def held: Boolean = synchronized(entries.values.exists(_._2 > System.nanoTime()))
 
@@ -70,8 +73,10 @@ class LockExecutorSpec extends munit.FunSuite {
       val token     = command.args(3).asUtf8String
       operations.add(s"${command.name}:$operation")
       if (operation == "renew" && stallRenewal) CIO.never
+      else if (operation == "renew" && !renewalErrors.isEmpty) CIO.fail(renewalErrors.remove())
       else if (operation == "release" && stallRelease) CIO.never
       else if (operation == "release" && failRelease) CIO.fail(ServerError("ERR", "release unavailable"))
+      else if (operation == "acquire" && !acquisitionErrors.isEmpty) CIO.fail(acquisitionErrors.remove())
       else if (operation == "acquire" && acquisitionError.isDefined) CIO.fail(acquisitionError.get)
       else {
         val result = synchronized {
@@ -87,6 +92,9 @@ class LockExecutorSpec extends munit.FunSuite {
                 entries += key -> (token, expiry)
                 tokens.add(token)
                 true
+              case "acquire" if owns                   =>
+                entries += key -> (token, expiry)
+                true
               case "renew" if owns && !rejectRenewal   =>
                 entries += key -> (token, expiry)
                 true
@@ -99,7 +107,11 @@ class LockExecutorSpec extends munit.FunSuite {
           }
         }
         val delay  = if (operation == "acquire" && command.name == "EVAL") acquisitionDelay else Duration.Zero
-        CIO.sleep(delay).flatMap(_ => result.fold(CIO.fail(_), CIO.value(_)))
+        CIO.sleep(delay).flatMap { _ =>
+          if (operation == "acquire" && result.toOption.contains(true) && !acquisitionReplyErrors.isEmpty)
+            CIO.fail(acquisitionReplyErrors.remove())
+          else result.fold(CIO.fail(_), CIO.value(_))
+        }
       }
     }
   }
@@ -117,7 +129,7 @@ class LockExecutorSpec extends munit.FunSuite {
 
   test("all scripts route to one key on its master and decode only valid outcomes") {
     val commands = new LockCommands[String](1.second, "lock")
-    for (operation <- List("acquire", "renew", "release")) {
+    for (operation <- LockCommands.Operation.values) {
       val command = commands.command(commands.key("subject"), "owner", operation, cached = true)
       assertEquals(command.name, "EVALSHA")
       assertEquals(command.keys.map(_.asUtf8String), Vector("4:lock:subject"))
@@ -191,6 +203,36 @@ class LockExecutorSpec extends munit.FunSuite {
       .unsafeRun
   }
 
+  test("a slow successful acquisition renews before the remaining lease expires") {
+    val store = new Store
+    store.acquisitionDelay = 900.millis
+    executor(1200.millis)
+      .tryWithLock(store, "key") {
+        CIO.sleep(350.millis).map(_ => assert(store.held, "the lock expired while its body was still running"))
+      }
+      .unsafeRun
+      .map { result =>
+        assertEquals(result, Some(()))
+        assert(store.operations.asScala.exists(_.endsWith(":renew")))
+        assert(!store.held)
+      }
+  }
+
+  test("renewal retries a transient connection failure while the lease remains valid") {
+    val store = new Store
+    store.renewalErrors.add(NotConnected())
+    executor(300.millis)
+      .tryWithLock(store, "key") {
+        CIO.sleep(450.millis).map(_ => assert(store.held, "the lock expired while renewal was retrying"))
+      }
+      .unsafeRun
+      .map { result =>
+        assertEquals(result, Some(()))
+        assert(store.operations.asScala.count(_.endsWith(":renew")) >= 2)
+        assert(!store.held)
+      }
+  }
+
   test("renewal refusal fails even while the protected effect never succeeds") {
     val store = new Store
     store.rejectRenewal = true
@@ -212,7 +254,11 @@ class LockExecutorSpec extends munit.FunSuite {
   test("a renewal acknowledgement shortfall becomes LockLost and releases ownership") {
     val shortfall = TimedOut("replication confirmed by 0 of 1 required replicas")
     val store     = new Store {
-      override def lockWrite(command: Command[Boolean], timeout: FiniteDuration): CIO[Boolean] =
+      override def lockWrite(
+        command: Command[Boolean],
+        timeout: FiniteDuration,
+        replicaAcknowledgement: Boolean
+      ): CIO[Boolean] =
         run(command).flatMap { renewed =>
           if (command.args(4).asUtf8String == "renew") CIO.fail(shortfall)
           else CIO.value(renewed)
@@ -229,7 +275,11 @@ class LockExecutorSpec extends munit.FunSuite {
 
   test("replication checks respect a short acquisition wait and the remaining renewal lease") {
     val store = new Store {
-      override def lockWrite(command: Command[Boolean], timeout: FiniteDuration): CIO[Boolean] = {
+      override def lockWrite(
+        command: Command[Boolean],
+        timeout: FiniteDuration,
+        replicaAcknowledgement: Boolean
+      ): CIO[Boolean] = {
         val operation = command.args(4).asUtf8String
         if (operation == "acquire") assert(timeout > Duration.Zero && timeout <= 200.millis, timeout.toString)
         if (operation == "renew") assert(timeout > Duration.Zero && timeout <= 170.millis, timeout.toString)
@@ -329,6 +379,39 @@ class LockExecutorSpec extends munit.FunSuite {
     }
   }
 
+  test("withLock retries a transient acquisition failure within the wait timeout") {
+    val store = new Store
+    store.acquisitionErrors.add(NotConnected())
+    executor().withLock(store, "key", 1.second)(CIO.value(42)).unsafeRun.map { result =>
+      assertEquals(result, 42)
+      assert(store.operations.asScala.count(_.endsWith(":acquire")) >= 2)
+      assert(!store.held)
+    }
+  }
+
+  test("tryWithLock caps transient acquisition retries at the operation timeout") {
+    val store   = new Store
+    store.acquisitionError = Some(NotConnected())
+    val started = System.nanoTime()
+    executor(2.seconds).tryWithLock(store, "key")(CIO.value(42)).unsafeRun.failed.map { error =>
+      val elapsed = (System.nanoTime() - started).nanos
+      assert(error.isInstanceOf[TimedOut], error.toString)
+      assert(store.operations.asScala.count(_.endsWith(":acquire")) >= 2)
+      assert(elapsed >= 900.millis && elapsed < 1500.millis, s"tryWithLock retry budget was not one second: $elapsed")
+    }
+  }
+
+  test("an acquisition retry reuses its ownership token after an uncertain reply") {
+    val store = new Store
+    store.acquisitionReplyErrors.add(ConnectionLost(mayHaveExecuted = true))
+    executor().withLock(store, "key", 1.second)(CIO.value(42)).unsafeRun.map { result =>
+      assertEquals(result, 42)
+      assertEquals(store.tokens.asScala.size, 1)
+      assert(store.operations.asScala.count(_.endsWith(":acquire")) >= 3)
+      assert(!store.held)
+    }
+  }
+
   test("NOSCRIPT falls back to EVAL once and subsequent operations use the digest") {
     val store = new Store
     executor().tryWithLock(store, "key")(CIO.value(42)).unsafeRun.map { result =>
@@ -337,9 +420,19 @@ class LockExecutorSpec extends munit.FunSuite {
     }
   }
 
-  test("other acquisition errors propagate without being retried as contention") {
+  test("retryable acquisition errors are retried until the wait timeout") {
     val store   = new Store
     val failure = ServerError("READONLY", "demoted")
+    store.acquisitionError = Some(failure)
+    executor().withLock(store, "key", 1.second)(CIO.unit).unsafeRun.failed.map { error =>
+      assert(error.isInstanceOf[TimedOut], error.toString)
+      assert(store.operations.asScala.count(_.endsWith(":acquire")) >= 2)
+    }
+  }
+
+  test("non-retryable acquisition errors propagate") {
+    val store   = new Store
+    val failure = ServerError("ERR", "lock command is not permitted")
     store.acquisitionError = Some(failure)
     executor().withLock(store, "key", 1.second)(CIO.unit).unsafeRun.failed.map { error =>
       assertEquals(error, failure)

--- a/sage-client/shared/src/test/scala/sage/client/internal/LockExecutorSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/LockExecutorSpec.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.*
 import scala.jdk.CollectionConverters.*
+import scala.util.{Success, Try}
 
 import kyo.compat.*
 
@@ -59,10 +60,33 @@ class LockExecutorSpec extends munit.FunSuite {
     @volatile var failRelease                         = false
     @volatile var stallRelease                        = false
     @volatile var acquisitionDelay                    = Duration.Zero
+    @volatile var acquisitionFailureDelay             = Duration.Zero
     @volatile var acquisitionError: Option[Throwable] = None
-    @volatile var acquisitionUnavailableUntilNanos    = 0L
     val acquisitionErrors                             = new ConcurrentLinkedQueue[Throwable]()
     val acquisitionReplyErrors                        = new ConcurrentLinkedQueue[Throwable]()
+    private var renewed                               = false
+    private var renewalWaiter: Try[Unit] => Unit      = null
+
+    def awaitRenewal: CIO[Unit] = CIO.async { callback =>
+      val completeNow = synchronized {
+        if (renewed) true
+        else {
+          renewalWaiter = callback
+          false
+        }
+      }
+      if (completeNow) callback(Success(()))
+    }
+
+    private def markRenewed(): Unit = {
+      val callback = synchronized {
+        renewed = true
+        val waiting = renewalWaiter
+        renewalWaiter = null
+        waiting
+      }
+      if (callback != null) callback(Success(()))
+    }
 
     def held: Boolean = synchronized(entries.values.exists(_._2 > System.nanoTime()))
 
@@ -77,9 +101,10 @@ class LockExecutorSpec extends munit.FunSuite {
       else if (operation == "renew" && !renewalErrors.isEmpty) CIO.fail(renewalErrors.remove())
       else if (operation == "release" && stallRelease) CIO.never
       else if (operation == "release" && failRelease) CIO.fail(ServerError("ERR", "release unavailable"))
-      else if (operation == "acquire" && System.nanoTime() < acquisitionUnavailableUntilNanos) CIO.fail(NotConnected())
-      else if (operation == "acquire" && !acquisitionErrors.isEmpty) CIO.fail(acquisitionErrors.remove())
-      else if (operation == "acquire" && acquisitionError.isDefined) CIO.fail(acquisitionError.get)
+      else if (operation == "acquire" && !acquisitionErrors.isEmpty) {
+        val error = acquisitionErrors.remove()
+        CIO.sleep(acquisitionFailureDelay).flatMap(_ => CIO.fail(error))
+      } else if (operation == "acquire" && acquisitionError.isDefined) CIO.fail(acquisitionError.get)
       else {
         val result = synchronized {
           if (command.name == "EVALSHA" && !loaded) Left(ServerError("NOSCRIPT", ""))
@@ -99,6 +124,7 @@ class LockExecutorSpec extends munit.FunSuite {
                 true
               case "renew" if owns && !rejectRenewal   =>
                 entries += key -> (token, expiry)
+                markRenewed()
                 true
               case "release" if owns                   =>
                 entries -= key
@@ -163,55 +189,26 @@ class LockExecutorSpec extends munit.FunSuite {
       }
   }
 
-  test("competing scopes serialize non-atomic updates") {
-    val store  = new Store
-    val active = new AtomicInteger(0)
-    var total  = 0
-    CIO
-      .foreach(1 to 12) { _ =>
-        executor().withLock(store, "key", 5.seconds) {
-          CIO
-            .defer {
-              assertEquals(active.incrementAndGet(), 1)
-              total
-            }
-            .flatMap { before =>
-              CIO.sleep(5.millis).map { _ =>
-                total = before + 1
-                active.decrementAndGet()
-              }
-            }
-        }
-      }
-      .unsafeRun
-      .map { _ =>
-        assertEquals(total, 12)
-        assert(!store.held)
-      }
-  }
-
-  test("renewal keeps a body running beyond the original lease, then stops") {
+  test("a successful renewal keeps the scope running and releases it afterwards") {
     val store = new Store
     executor(300.millis)
       .tryWithLock(store, "key") {
-        CIO.sleep(1.second).map(_ => assert(store.held))
-      }
-      .flatMap { result =>
-        assertEquals(result, Some(()))
-        assert(!store.held)
-        val renewals = store.operations.asScala.count(_.endsWith(":renew"))
-        assert(renewals >= 2)
-        CIO.sleep(400.millis).map(_ => assertEquals(store.operations.asScala.count(_.endsWith(":renew")), renewals))
+        store.awaitRenewal.map(_ => assert(store.held))
       }
       .unsafeRun
+      .map { result =>
+        assertEquals(result, Some(()))
+        assert(!store.held)
+        assert(store.operations.asScala.exists(_.endsWith(":renew")))
+      }
   }
 
   test("a slow successful acquisition renews before the remaining lease expires") {
     val store = new Store
-    store.acquisitionDelay = 900.millis
-    executor(1200.millis)
+    store.acquisitionDelay = 500.millis
+    executor(900.millis)
       .tryWithLock(store, "key") {
-        CIO.sleep(350.millis).map(_ => assert(store.held, "the lock expired while its body was still running"))
+        store.awaitRenewal.map(_ => assert(store.held, "the lock expired while its body was still running"))
       }
       .unsafeRun
       .map { result =>
@@ -227,7 +224,7 @@ class LockExecutorSpec extends munit.FunSuite {
       store.renewalErrors.add(failure)
       executor(300.millis)
         .tryWithLock(store, "key") {
-          CIO.sleep(450.millis).map(_ => assert(store.held, "the lock expired while renewal was retrying"))
+          store.awaitRenewal.map(_ => assert(store.held, "the lock expired while renewal was retrying"))
         }
         .unsafeRun
         .map { result =>
@@ -290,7 +287,7 @@ class LockExecutorSpec extends munit.FunSuite {
         run(command)
       }
     }
-    executor(300.millis).withLock(store, "key", 200.millis)(CIO.sleep(400.millis)).unsafeRun.map { _ =>
+    executor(300.millis).withLock(store, "key", 200.millis)(store.awaitRenewal).unsafeRun.map { _ =>
       assert(store.operations.asScala.exists(_.endsWith(":renew")))
       assert(!store.held)
     }
@@ -318,10 +315,10 @@ class LockExecutorSpec extends munit.FunSuite {
     val store   = new Store
     store.stallRelease = true
     val started = System.nanoTime()
-    executor().tryWithLock(store, "key")(CIO.value(42)).unsafeRun.failed.map { error =>
+    executor(300.millis).tryWithLock(store, "key")(CIO.value(42)).unsafeRun.failed.map { error =>
       val elapsed = (System.nanoTime() - started).nanos
       assert(error.isInstanceOf[LockLost], error.toString)
-      assert(elapsed < 1500.millis, s"release exceeded its shared budget: $elapsed")
+      assert(elapsed < 2.seconds, s"release exceeded its shared budget: $elapsed")
       assertEquals(store.operations.asScala.count(_.endsWith(":release")), 1)
     }
   }
@@ -374,12 +371,12 @@ class LockExecutorSpec extends munit.FunSuite {
       }
     }
     val started  = System.nanoTime()
-    executor().withLock(commands, "key", 1.second)(CIO.fail(new AssertionError("contended body ran"))).unsafeRun.failed.map { error =>
+    executor().withLock(commands, "key", 200.millis)(CIO.fail(new AssertionError("contended body ran"))).unsafeRun.failed.map { error =>
       val elapsed = (System.nanoTime() - started).nanos
       assert(error.isInstanceOf[TimedOut], error.toString)
       assert(attempts.get() >= 2, s"acquisition was not retried: ${attempts.get()}")
-      assert(attempts.get() <= 20, s"contention generated too many acquisition requests: ${attempts.get()}")
-      assert(elapsed >= 1.second && elapsed < 1500.millis, s"wait timeout was not respected: $elapsed")
+      assert(attempts.get() <= 10, s"contention generated too many acquisition requests: ${attempts.get()}")
+      assert(elapsed >= 180.millis && elapsed < 1.second, s"wait timeout was not respected: $elapsed")
     }
   }
 
@@ -395,8 +392,10 @@ class LockExecutorSpec extends munit.FunSuite {
 
   test("withLock keeps retrying transient acquisition failures when the wait is longer than the lease") {
     val store = new Store
-    store.acquisitionUnavailableUntilNanos = System.nanoTime() + 500.millis.toNanos
-    executor(300.millis).withLock(store, "key", 2.seconds)(CIO.value(42)).unsafeRun.map { result =>
+    store.acquisitionFailureDelay = 150.millis
+    store.acquisitionErrors.add(NotConnected())
+    store.acquisitionErrors.add(NotConnected())
+    executor(300.millis).withLock(store, "key", 1.second)(CIO.value(42)).unsafeRun.map { result =>
       assertEquals(result, 42)
       assert(store.operations.asScala.count(_.endsWith(":acquire")) >= 3)
       assert(!store.held)
@@ -407,11 +406,11 @@ class LockExecutorSpec extends munit.FunSuite {
     val store   = new Store
     store.acquisitionError = Some(NotConnected())
     val started = System.nanoTime()
-    executor(2.seconds).tryWithLock(store, "key")(CIO.value(42)).unsafeRun.failed.map { error =>
+    executor(300.millis).tryWithLock(store, "key")(CIO.value(42)).unsafeRun.failed.map { error =>
       val elapsed = (System.nanoTime() - started).nanos
       assert(error.isInstanceOf[TimedOut], error.toString)
       assert(store.operations.asScala.count(_.endsWith(":acquire")) >= 2)
-      assert(elapsed >= 900.millis && elapsed < 1500.millis, s"tryWithLock retry budget was not one second: $elapsed")
+      assert(elapsed >= 240.millis && elapsed < 1.second, s"tryWithLock did not use its operation timeout: $elapsed")
     }
   }
 
@@ -438,7 +437,7 @@ class LockExecutorSpec extends munit.FunSuite {
     val store   = new Store
     val failure = ServerError("READONLY", "demoted")
     store.acquisitionError = Some(failure)
-    executor().withLock(store, "key", 1.second)(CIO.unit).unsafeRun.failed.map { error =>
+    executor().withLock(store, "key", 200.millis)(CIO.unit).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[TimedOut], error.toString)
       assert(store.operations.asScala.count(_.endsWith(":acquire")) >= 2)
     }

--- a/sage-client/shared/src/test/scala/sage/client/internal/LockExecutorSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/LockExecutorSpec.scala
@@ -315,10 +315,10 @@ class LockExecutorSpec extends munit.FunSuite {
     val store   = new Store
     store.stallRelease = true
     val started = System.nanoTime()
-    executor(300.millis).tryWithLock(store, "key")(CIO.value(42)).unsafeRun.failed.map { error =>
+    executor().tryWithLock(store, "key")(CIO.value(42)).unsafeRun.failed.map { error =>
       val elapsed = (System.nanoTime() - started).nanos
       assert(error.isInstanceOf[LockLost], error.toString)
-      assert(elapsed < 2.seconds, s"release exceeded its shared budget: $elapsed")
+      assert(elapsed < 1500.millis, s"release exceeded its shared budget: $elapsed")
       assertEquals(store.operations.asScala.count(_.endsWith(":release")), 1)
     }
   }

--- a/sage-client/shared/src/test/scala/sage/client/internal/LockExecutorSpec.scala
+++ b/sage-client/shared/src/test/scala/sage/client/internal/LockExecutorSpec.scala
@@ -60,6 +60,7 @@ class LockExecutorSpec extends munit.FunSuite {
     @volatile var stallRelease                        = false
     @volatile var acquisitionDelay                    = Duration.Zero
     @volatile var acquisitionError: Option[Throwable] = None
+    @volatile var acquisitionUnavailableUntilNanos    = 0L
     val acquisitionErrors                             = new ConcurrentLinkedQueue[Throwable]()
     val acquisitionReplyErrors                        = new ConcurrentLinkedQueue[Throwable]()
 
@@ -76,6 +77,7 @@ class LockExecutorSpec extends munit.FunSuite {
       else if (operation == "renew" && !renewalErrors.isEmpty) CIO.fail(renewalErrors.remove())
       else if (operation == "release" && stallRelease) CIO.never
       else if (operation == "release" && failRelease) CIO.fail(ServerError("ERR", "release unavailable"))
+      else if (operation == "acquire" && System.nanoTime() < acquisitionUnavailableUntilNanos) CIO.fail(NotConnected())
       else if (operation == "acquire" && !acquisitionErrors.isEmpty) CIO.fail(acquisitionErrors.remove())
       else if (operation == "acquire" && acquisitionError.isDefined) CIO.fail(acquisitionError.get)
       else {
@@ -116,7 +118,8 @@ class LockExecutorSpec extends munit.FunSuite {
     }
   }
 
-  private def executor(lease: FiniteDuration = 3.seconds, namespace: String = "lock") = new LockExecutor[String](lease, namespace)
+  private def executor(lease: FiniteDuration = 3.seconds, namespace: String = "lock") =
+    new LockExecutor[String](lease, namespace, replicaAcknowledgement = true)
 
   test("namespace framing distinguishes ambiguous prefixes and preserves binary key bytes") {
     val a      = new LockCommands[String](1.second, "a").key("b:c")
@@ -218,20 +221,21 @@ class LockExecutorSpec extends munit.FunSuite {
       }
   }
 
-  test("renewal retries a transient connection failure while the lease remains valid") {
-    val store = new Store
-    store.renewalErrors.add(NotConnected())
-    executor(300.millis)
-      .tryWithLock(store, "key") {
-        CIO.sleep(450.millis).map(_ => assert(store.held, "the lock expired while renewal was retrying"))
-      }
-      .unsafeRun
-      .map { result =>
-        assertEquals(result, Some(()))
-        assert(store.operations.asScala.count(_.endsWith(":renew")) >= 2)
-        assert(!store.held)
-      }
-  }
+  for ((failureName, failure) <- Vector("connection failure" -> NotConnected(), "operation timeout" -> TimedOut("lock write timed out")))
+    test(s"renewal retries a transient $failureName while the lease remains valid") {
+      val store = new Store
+      store.renewalErrors.add(failure)
+      executor(300.millis)
+        .tryWithLock(store, "key") {
+          CIO.sleep(450.millis).map(_ => assert(store.held, "the lock expired while renewal was retrying"))
+        }
+        .unsafeRun
+        .map { result =>
+          assertEquals(result, Some(()))
+          assert(store.operations.asScala.count(_.endsWith(":renew")) >= 2)
+          assert(!store.held)
+        }
+    }
 
   test("renewal refusal fails even while the protected effect never succeeds") {
     val store = new Store
@@ -252,7 +256,7 @@ class LockExecutorSpec extends munit.FunSuite {
   }
 
   test("a renewal acknowledgement shortfall becomes LockLost and releases ownership") {
-    val shortfall = TimedOut("replication confirmed by 0 of 1 required replicas")
+    val shortfall = LockReplication.acknowledgementTimedOut("replication confirmed by 0 of 1 required replicas")
     val store     = new Store {
       override def lockWrite(
         command: Command[Boolean],
@@ -267,7 +271,7 @@ class LockExecutorSpec extends munit.FunSuite {
     executor(300.millis).tryWithLock(store, "key")(CIO.never).unsafeRun.failed.map { error =>
       assert(error.isInstanceOf[LockLost], error.toString)
       assert(error.getCause eq shortfall)
-      assert(store.operations.asScala.exists(_.endsWith(":renew")))
+      assertEquals(store.operations.asScala.count(_.endsWith(":renew")), 1)
       assert(store.operations.asScala.exists(_.endsWith(":release")))
       assert(!store.held)
     }
@@ -385,6 +389,16 @@ class LockExecutorSpec extends munit.FunSuite {
     executor().withLock(store, "key", 1.second)(CIO.value(42)).unsafeRun.map { result =>
       assertEquals(result, 42)
       assert(store.operations.asScala.count(_.endsWith(":acquire")) >= 2)
+      assert(!store.held)
+    }
+  }
+
+  test("withLock keeps retrying transient acquisition failures when the wait is longer than the lease") {
+    val store = new Store
+    store.acquisitionUnavailableUntilNanos = System.nanoTime() + 500.millis.toNanos
+    executor(300.millis).withLock(store, "key", 2.seconds)(CIO.value(42)).unsafeRun.map { result =>
+      assertEquals(result, 42)
+      assert(store.operations.asScala.count(_.endsWith(":acquire")) >= 3)
       assert(!store.held)
     }
   }

--- a/sage-client/zio/src/main/scala/sage/backend/SageClient.scala
+++ b/sage-client/zio/src/main/scala/sage/backend/SageClient.scala
@@ -251,7 +251,11 @@ object SageClient {
     // Release runs in a masked finalizer. Its command must remain interruptible for CIO.timeout to finish.
     override protected def lockCommand[A](command: Command[A]): CIO[A] = CIO.lift(underlying.run(command).lower.interruptible)
 
-    override protected def confirmedLockCommand(command: Command[Boolean], timeout: FiniteDuration): CIO[Boolean] =
-      CIO.lift(underlying.lockWrite(command, timeout).lower.interruptible)
+    override protected def confirmedLockCommand(
+      command: Command[Boolean],
+      timeout: FiniteDuration,
+      replicaAcknowledgement: Boolean
+    ): CIO[Boolean] =
+      CIO.lift(underlying.lockWrite(command, timeout, replicaAcknowledgement).lower.interruptible)
   }
 }

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -193,6 +193,27 @@ class ClusterClientSpec extends munit.FunSuite {
       .andThen { case _ => fixture.live.close.unsafeRun }
   }
 
+  test("cluster locks can skip replica acknowledgement while still checking the master role") {
+    val fixture = new Fixture(
+      (_, text) =>
+        if (text.contains("CLUSTER")) Seq(Replies.clusterShard(nodeA, nodeB))
+        else if (text.contains("ROLE")) Seq(Replies.masterRole(nodeB))
+        else if (text.contains("WAIT")) Seq(Frame.Integer(0))
+        else Seq(Frame.Integer(1)),
+      Vector(nodeA)
+    )
+    fixture.live
+      .lock[String](replicaAcknowledgement = false)
+      .tryWithLock("key")(CIO.value(42))
+      .unsafeRun
+      .map { result =>
+        assertEquals(result, Some(42))
+        assert(fixture.written(nodeA).exists(_.contains("ROLE")))
+        assert(!fixture.written(nodeA).exists(_.contains("WAIT")))
+      }
+      .andThen { case _ => fixture.live.close.unsafeRun }
+  }
+
   test("cluster locks recover after confirmation failure refreshes a removed replica") {
     val removed = new java.util.concurrent.atomic.AtomicBoolean(false)
     val fixture = new Fixture(
@@ -221,13 +242,16 @@ class ClusterClientSpec extends munit.FunSuite {
       .andThen { case _ => fixture.live.close.unsafeRun }
   }
 
-  test("cluster locks do not replay an acquisition after a retryable confirmation error") {
-    val writes  = new java.util.concurrent.atomic.AtomicInteger(0)
-    val fixture = new Fixture(
+  test("cluster locks safely retry acquisition after a transient confirmation error") {
+    val writes        = new java.util.concurrent.atomic.AtomicInteger(0)
+    val confirmations = new java.util.concurrent.atomic.AtomicInteger(0)
+    val fixture       = new Fixture(
       (_, text) =>
         if (text.contains("CLUSTER")) Seq(Replies.clusterShard(nodeA, nodeB))
         else if (text.contains("ROLE")) Seq(Replies.masterRole(nodeB))
-        else if (text.contains("WAIT")) Seq(Frame.SimpleError("TRYAGAIN confirmation unavailable"))
+        else if (text.contains("WAIT") && confirmations.getAndIncrement() == 0)
+          Seq(Frame.SimpleError("TRYAGAIN confirmation unavailable"))
+        else if (text.contains("WAIT")) Seq(Frame.Integer(1))
         else {
           if (text.contains("acquire")) { writes.incrementAndGet(): Unit }
           Seq(Frame.Integer(1))
@@ -238,10 +262,9 @@ class ClusterClientSpec extends munit.FunSuite {
       .lock[String]()
       .tryWithLock("key")(CIO.value(42))
       .unsafeRun
-      .failed
-      .map { error =>
-        assertEquals(error, ConnectionLost(mayHaveExecuted = true))
-        assertEquals(writes.get(), 1)
+      .map { result =>
+        assertEquals(result, Some(42))
+        assertEquals(writes.get(), 2)
       }
       .andThen { case _ => fixture.live.close.unsafeRun }
   }

--- a/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
+++ b/sage-client/zio/src/test/scala/sage/client/ClusterClientSpec.scala
@@ -165,6 +165,31 @@ class ClusterClientSpec extends munit.FunSuite {
         .andThen { case _ => fixture.live.close.unsafeRun }
     }
 
+  test("cluster locks retry after the per-command redirect limit is exhausted") {
+    val key     = "lock-key"
+    val slot    = Slot.of(Bytes.utf8(s"4:lock:$key")).value
+    val moved   = new java.util.concurrent.atomic.AtomicBoolean(false)
+    val fixture = new Fixture(
+      (node, text) =>
+        if (text.contains("CLUSTER")) Seq(wholeClusterOn(if (moved.get()) nodeB else nodeA))
+        else if (node == nodeA && text.contains("EVAL") && moved.compareAndSet(false, true))
+          Seq(Frame.SimpleError(s"MOVED $slot b:6379"))
+        else if (text.contains("ROLE")) Seq(Replies.masterRole())
+        else Seq(Frame.Integer(1)),
+      Vector(nodeA),
+      cluster = ClusterConfig(maxRedirects = 0)
+    )
+    fixture.live
+      .lock[String]()
+      .tryWithLock(key)(CIO.value(42))
+      .unsafeRun
+      .map { result =>
+        assertEquals(result, Some(42))
+        assert(fixture.written(nodeB).exists(_.contains("EVAL")))
+      }
+      .andThen { case _ => fixture.live.close.unsafeRun }
+  }
+
   test("cluster locks reject acquisition when a known replica does not acknowledge") {
     var evaluated = false
     val fixture   = new Fixture(


### PR DESCRIPTION
Follow-up to #254.

A single failed renewal used to fail the whole lock scope, even with most of the lease left. Since the connection rejects commands while it reconnects, a short socket drop at the renewal tick was enough. Renewal now retries connection, redirect, and cluster faults until the usable lease runs out. Acquisition does the same within `waitTimeout`, and `tryWithLock` caps its retries at one second. The acquire script treats a repeated write from the current owner as success, so a retry after an uncertain reply does not leak the lock. A replica acknowledgement shortfall is not retried: it still fails acquisition with `TimedOut` and renewal with `LockLost`.

Renewal now wakes at the midpoint of the remaining usable lease after a slow acquisition instead of always waiting the normal interval, so a long confirmation cannot sleep past the lease. In cluster mode, a lock write that exhausts the redirect limit is retried after the topology refresh instead of failing.

`client.lock` gains `replicaAcknowledgement`, default true. Setting it to false skips `WAIT` while still checking that the granting node is a master. One dead or lagging replica no longer has to block every lock in the shard.

Also: lock operations are a typed enum, the replication check moved out of `DedicatedPool` into `LockReplication`, and the README mentions rate limiting and locks.
