### PR TITLE
Run the conformance suite after the parallel unit test block

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,8 @@ addCommandAlias(
     "clientFuture/Test/compile integrationTestsFuture/Test/compile integrationTestsPekko/Test/compile " +
     s"benchmarksZio/compile benchmarksCe/compile benchmarksOx/compile benchmarksPekko/compile benchmarksKyo$scala3NextSuffix/compile " +
     "examplesZio/Compile/compile examplesCe/Compile/compile examplesOx/Compile/compile examplesPekko/Compile/compile " +
-    s"examplesKyo$scala3NextSuffix/Compile/compile examplesFuture/Compile/compile " +
+    s"examplesKyo$scala3NextSuffix/Compile/compile examplesFuture/Compile/compile; " +
+    // The conformance suite has wall-clock parallelism checks. Run it after the parallel block so five forked test cells do not starve it.
     "ceConformanceCe/test"
 )
 addCommandAlias("conformanceCe", "ceConformanceCe/test")


### PR DESCRIPTION
The kyo compat conformance suite includes a parallelism canary: two concurrent sleeps of 50ms and 100ms must complete in under 250ms. In `testUnit` it ran inside the `all` block alongside five forked test cells and a set of compiles, and on a two-core runner it took 582ms (run 33932654302 on #257). The suite alone takes about 100ms for that test.

This moves `ceConformanceCe/test` after the parallel block so it runs on an idle runner. The bound itself lives in the upstream testkit; a separate change there will replace the wall-clock check with an ordering check that cannot be starved.
